### PR TITLE
[presto][iceberg] Add Iceberg Variant type support (binary codec, functions, plumbing) (#27620)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
@@ -201,7 +201,11 @@ public final class ExpressionConverter
             return toIntExact(((Long) marker.getValue()));
         }
 
-        if (type instanceof TimestampType || type instanceof TimeType) {
+        if (type instanceof TimestampType) {
+            return ((TimestampType) type).getPrecision().toMicros((Long) marker.getValue());
+        }
+
+        if (type instanceof TimeType) {
             return MILLISECONDS.toMicros((Long) marker.getValue());
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -27,7 +27,8 @@ public enum FileFormat
     PARQUET("parquet", true),
     AVRO("avro", true),
     METADATA("metadata.json", false),
-    PUFFIN("puffin", false);
+    PUFFIN("puffin", false),
+    DWRF("dwrf", true);
 
     private final String ext;
     private final boolean splittable;
@@ -90,6 +91,9 @@ public enum FileFormat
                 break;
             case PUFFIN:
                 fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
+                break;
+            case DWRF:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -26,7 +26,8 @@ public enum FileFormat
     ORC("orc", true),
     PARQUET("parquet", true),
     AVRO("avro", true),
-    METADATA("metadata.json", false);
+    METADATA("metadata.json", false),
+    PUFFIN("puffin", false);
 
     private final String ext;
     private final boolean splittable;
@@ -61,6 +62,9 @@ public enum FileFormat
             case METADATA:
                 prestoFileFormat = METADATA;
                 break;
+            case PUFFIN:
+                prestoFileFormat = PUFFIN;
+                break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + format);
         }
@@ -80,6 +84,12 @@ public enum FileFormat
                 break;
             case AVRO:
                 fileFormat = org.apache.iceberg.FileFormat.AVRO;
+                break;
+            case METADATA:
+                fileFormat = org.apache.iceberg.FileFormat.METADATA;
+                break;
+            case PUFFIN:
+                fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -117,6 +117,7 @@ public class IcebergFileWriterFactory
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext, metricsConfig);
             case ORC:
+            case DWRF:
                 return createOrcWriter(outputPath, icebergSchema, jobConf, session);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -150,6 +150,7 @@ public class PartitionData
                 return partitionValue.asInt();
             case LONG:
             case TIMESTAMP:
+            case TIMESTAMP_NANO:
             case TIME:
                 return partitionValue.asLong();
             case FLOAT:

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -176,6 +176,7 @@ public class PartitionData
                 }
                 return partitionValue.doubleValue();
             case STRING:
+            case VARIANT:
                 return partitionValue.asText();
             case FIXED:
             case BINARY:

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -303,6 +303,9 @@ public class PartitionTable
                 return MICROSECONDS.toMillis((long) value);
             }
         }
+        if (type instanceof Types.TimestampNanoType) {
+            return Math.floorDiv((long) value, 1000L);
+        }
         if (type instanceof Types.TimeType) {
             return MICROSECONDS.toMillis((long) value);
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -287,7 +287,7 @@ public class PartitionTable
         if (value == null) {
             return null;
         }
-        if (type instanceof Types.StringType) {
+        if (type instanceof Types.StringType || type.isVariantType()) {
             return value.toString();
         }
         if (type instanceof Types.BinaryType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.RealType;
@@ -147,6 +148,8 @@ public final class TypeConverter
                 return RowType.from(fields.stream()
                         .map(field -> new RowType.Field(Optional.of(field.name()), toPrestoType(field.type(), typeManager)))
                         .collect(toImmutableList()));
+            case VARIANT:
+                return JsonType.JSON;
             default:
                 throw new UnsupportedOperationException(format("Cannot convert from Iceberg type '%s' (%s) to Presto type", type, type.typeId()));
         }
@@ -414,6 +417,7 @@ public final class TypeConverter
             case TIMESTAMP_NANO:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.TIMESTAMP, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case STRING:
+            case VARIANT:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.STRING, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case UUID:
             case FIXED:

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -124,6 +124,12 @@ public final class TypeConverter
                     return TIMESTAMP_WITH_TIME_ZONE;
                 }
                 return TimestampType.TIMESTAMP;
+            case TIMESTAMP_NANO:
+                Types.TimestampNanoType tsNanoType = (Types.TimestampNanoType) type.asPrimitiveType();
+                if (tsNanoType.shouldAdjustToUTC()) {
+                    return TIMESTAMP_WITH_TIME_ZONE;
+                }
+                return TimestampType.TIMESTAMP_MICROSECONDS;
             case STRING:
                 return VarcharType.createUnboundedVarcharType();
             case UUID:
@@ -405,6 +411,7 @@ public final class TypeConverter
             case DATE:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.DATE, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case TIMESTAMP:
+            case TIMESTAMP_NANO:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.TIMESTAMP, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case STRING:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.STRING, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/VariantBinaryCodec.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/VariantBinaryCodec.java
@@ -1,0 +1,793 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Encoder/decoder for the Apache Variant binary format as used by Iceberg V3.
+ *
+ * <p>The Variant binary format encodes semi-structured (JSON-like) data in a compact
+ * binary representation with two components:
+ * <ul>
+ *   <li><b>Metadata</b>: A dictionary of field names (keys) used in objects</li>
+ *   <li><b>Value</b>: The encoded data using type-tagged values</li>
+ * </ul>
+ *
+ * <p>This codec supports encoding JSON strings to Variant binary and decoding
+ * Variant binary back to JSON strings. It implements the Apache Variant spec
+ * (version 1) covering:
+ * <ul>
+ *   <li>Primitives: null, boolean, int8/16/32/64, float, double, string</li>
+ *   <li>Short strings (0-63 bytes, inlined in header)</li>
+ *   <li>Objects (key-value maps with metadata dictionary references)</li>
+ *   <li>Arrays (ordered value lists)</li>
+ * </ul>
+ *
+ * @see <a href="https://iceberg.apache.org/spec/#variant">Iceberg V3 Variant Spec</a>
+ */
+public final class VariantBinaryCodec
+{
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+    // Basic type codes (bits 7-6 of header byte)
+    static final int BASIC_TYPE_PRIMITIVE = 0;
+    static final int BASIC_TYPE_SHORT_STRING = 1;
+    static final int BASIC_TYPE_OBJECT = 2;
+    static final int BASIC_TYPE_ARRAY = 3;
+
+    // Primitive type_info values (bits 5-0 when basic_type=0)
+    static final int PRIMITIVE_NULL = 0;
+    static final int PRIMITIVE_TRUE = 1;
+    static final int PRIMITIVE_FALSE = 2;
+    static final int PRIMITIVE_INT8 = 5;
+    static final int PRIMITIVE_INT16 = 6;
+    static final int PRIMITIVE_INT32 = 7;
+    static final int PRIMITIVE_INT64 = 8;
+    static final int PRIMITIVE_FLOAT = 9;
+    static final int PRIMITIVE_DOUBLE = 10;
+    static final int PRIMITIVE_STRING = 19;
+
+    // Metadata format version
+    static final int METADATA_VERSION = 1;
+
+    // Maximum short string length (6 bits = 63)
+    static final int MAX_SHORT_STRING_LENGTH = 63;
+
+    private VariantBinaryCodec() {}
+
+    /**
+     * Holds the two components of a Variant binary encoding.
+     */
+    public static final class VariantBinary
+    {
+        private final byte[] metadata;
+        private final byte[] value;
+
+        public VariantBinary(byte[] metadata, byte[] value)
+        {
+            this.metadata = metadata;
+            this.value = value;
+        }
+
+        public byte[] getMetadata()
+        {
+            return metadata;
+        }
+
+        public byte[] getValue()
+        {
+            return value;
+        }
+    }
+
+    /**
+     * Encodes a JSON string into Variant binary format.
+     *
+     * @param json a valid JSON string
+     * @return the Variant binary encoding (metadata + value)
+     * @throws IllegalArgumentException if the JSON is malformed
+     */
+    public static VariantBinary fromJson(String json)
+    {
+        try {
+            MetadataBuilder metadataBuilder = new MetadataBuilder();
+
+            // First pass: collect all object keys into the metadata dictionary
+            try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+                collectKeys(parser, metadataBuilder);
+            }
+
+            // Build the metadata dictionary
+            byte[] metadata = metadataBuilder.build();
+            Map<String, Integer> keyIndex = metadataBuilder.getKeyIndex();
+
+            // Second pass: encode the value
+            try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+                parser.nextToken();
+                byte[] value = encodeValue(parser, keyIndex);
+                return new VariantBinary(metadata, value);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to encode JSON to Variant binary: " + json, e);
+        }
+    }
+
+    /**
+     * Decodes Variant binary (metadata + value) back to a JSON string.
+     *
+     * @param metadata the metadata dictionary bytes
+     * @param value the encoded value bytes
+     * @return the JSON string representation
+     */
+    public static String toJson(byte[] metadata, byte[] value)
+    {
+        try {
+            String[] dictionary = decodeMetadata(metadata);
+            StringWriter writer = new StringWriter();
+            try (JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                decodeValue(value, 0, dictionary, gen);
+            }
+            return writer.toString();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to decode Variant binary to JSON", e);
+        }
+    }
+
+    // ---- Metadata encoding/decoding ----
+
+    /**
+     * Builds the metadata dictionary (sorted key names with byte offsets).
+     */
+    static final class MetadataBuilder
+    {
+        private final TreeMap<String, Integer> keys = new TreeMap<>();
+
+        void addKey(String key)
+        {
+            if (!keys.containsKey(key)) {
+                keys.put(key, keys.size());
+            }
+        }
+
+        Map<String, Integer> getKeyIndex()
+        {
+            Map<String, Integer> index = new LinkedHashMap<>();
+            int i = 0;
+            for (String key : keys.keySet()) {
+                index.put(key, i++);
+            }
+            return index;
+        }
+
+        byte[] build()
+        {
+            List<byte[]> keyBytes = new ArrayList<>();
+            for (String key : keys.keySet()) {
+                keyBytes.add(key.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int numKeys = keyBytes.size();
+
+            // Calculate total key data size
+            int keyDataSize = 0;
+            for (byte[] kb : keyBytes) {
+                keyDataSize += kb.length;
+            }
+
+            // Metadata format:
+            // [1 byte] version
+            // [4 bytes] numKeys (uint32 LE)
+            // [4 bytes * numKeys] byte offsets to each key
+            // [keyDataSize bytes] concatenated key strings
+            int totalSize = 1 + 4 + (4 * numKeys) + keyDataSize;
+            ByteBuffer buf = ByteBuffer.allocate(totalSize);
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+
+            buf.put((byte) METADATA_VERSION);
+            buf.putInt(numKeys);
+
+            // Write offsets
+            int offset = 0;
+            for (byte[] kb : keyBytes) {
+                buf.putInt(offset);
+                offset += kb.length;
+            }
+
+            // Write key strings
+            for (byte[] kb : keyBytes) {
+                buf.put(kb);
+            }
+
+            return buf.array();
+        }
+    }
+
+    /**
+     * Decodes the metadata dictionary from binary.
+     */
+    static String[] decodeMetadata(byte[] metadata)
+    {
+        if (metadata == null || metadata.length == 0) {
+            return new String[0];
+        }
+
+        ByteBuffer buf = ByteBuffer.wrap(metadata);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        int version = buf.get() & 0xFF;
+        if (version != METADATA_VERSION) {
+            throw new IllegalArgumentException("Unsupported Variant metadata version: " + version);
+        }
+
+        int numKeys = buf.getInt();
+        if (numKeys == 0) {
+            return new String[0];
+        }
+
+        int[] offsets = new int[numKeys];
+        for (int i = 0; i < numKeys; i++) {
+            offsets[i] = buf.getInt();
+        }
+
+        int keyDataStart = buf.position();
+        int keyDataEnd = metadata.length;
+
+        String[] keys = new String[numKeys];
+        for (int i = 0; i < numKeys; i++) {
+            int start = keyDataStart + offsets[i];
+            int end = (i + 1 < numKeys) ? keyDataStart + offsets[i + 1] : keyDataEnd;
+            keys[i] = new String(metadata, start, end - start, StandardCharsets.UTF_8);
+        }
+
+        return keys;
+    }
+
+    // ---- Value encoding ----
+
+    private static void collectKeys(JsonParser parser, MetadataBuilder metadataBuilder) throws IOException
+    {
+        while (parser.nextToken() != null) {
+            if (parser.currentToken() == JsonToken.FIELD_NAME) {
+                metadataBuilder.addKey(parser.getCurrentName());
+            }
+        }
+    }
+
+    private static byte[] encodeValue(JsonParser parser, Map<String, Integer> keyIndex) throws IOException
+    {
+        JsonToken token = parser.currentToken();
+        if (token == null) {
+            return encodePrimitive(PRIMITIVE_NULL);
+        }
+
+        switch (token) {
+            case VALUE_NULL:
+                return encodePrimitive(PRIMITIVE_NULL);
+            case VALUE_TRUE:
+                return encodePrimitive(PRIMITIVE_TRUE);
+            case VALUE_FALSE:
+                return encodePrimitive(PRIMITIVE_FALSE);
+            case VALUE_NUMBER_INT:
+                return encodeInteger(parser.getLongValue());
+            case VALUE_NUMBER_FLOAT:
+                return encodeDouble(parser.getDoubleValue());
+            case VALUE_STRING:
+                return encodeString(parser.getText());
+            case START_OBJECT:
+                return encodeObject(parser, keyIndex);
+            case START_ARRAY:
+                return encodeArray(parser, keyIndex);
+            default:
+                throw new IllegalArgumentException("Unexpected JSON token: " + token);
+        }
+    }
+
+    private static byte[] encodePrimitive(int typeInfo)
+    {
+        return new byte[] {makeHeader(BASIC_TYPE_PRIMITIVE, typeInfo)};
+    }
+
+    private static byte[] encodeInteger(long value)
+    {
+        if (value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE) {
+            return new byte[] {makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_INT8), (byte) value};
+        }
+        if (value >= Short.MIN_VALUE && value <= Short.MAX_VALUE) {
+            ByteBuffer buf = ByteBuffer.allocate(3);
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            buf.put(makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_INT16));
+            buf.putShort((short) value);
+            return buf.array();
+        }
+        if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+            ByteBuffer buf = ByteBuffer.allocate(5);
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            buf.put(makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_INT32));
+            buf.putInt((int) value);
+            return buf.array();
+        }
+        ByteBuffer buf = ByteBuffer.allocate(9);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_INT64));
+        buf.putLong(value);
+        return buf.array();
+    }
+
+    private static byte[] encodeDouble(double value)
+    {
+        ByteBuffer buf = ByteBuffer.allocate(9);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_DOUBLE));
+        buf.putDouble(value);
+        return buf.array();
+    }
+
+    private static byte[] encodeString(String value)
+    {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= MAX_SHORT_STRING_LENGTH) {
+            byte[] result = new byte[1 + bytes.length];
+            result[0] = makeHeader(BASIC_TYPE_SHORT_STRING, bytes.length);
+            System.arraycopy(bytes, 0, result, 1, bytes.length);
+            return result;
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(1 + 4 + bytes.length);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(makeHeader(BASIC_TYPE_PRIMITIVE, PRIMITIVE_STRING));
+        buf.putInt(bytes.length);
+        buf.put(bytes);
+        return buf.array();
+    }
+
+    private static byte[] encodeObject(JsonParser parser, Map<String, Integer> keyIndex) throws IOException
+    {
+        List<Integer> fieldKeyIds = new ArrayList<>();
+        List<byte[]> fieldValues = new ArrayList<>();
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            String fieldName = parser.getCurrentName();
+            parser.nextToken();
+
+            Integer keyId = keyIndex.get(fieldName);
+            if (keyId == null) {
+                throw new IllegalStateException("Key not found in metadata dictionary: " + fieldName);
+            }
+
+            fieldKeyIds.add(keyId);
+            fieldValues.add(encodeValue(parser, keyIndex));
+        }
+
+        int numFields = fieldKeyIds.size();
+
+        // Determine offset size needed (1, 2, or 4 bytes)
+        int totalValueSize = 0;
+        for (byte[] fv : fieldValues) {
+            totalValueSize += fv.length;
+        }
+
+        int offsetSize = getOffsetSize(totalValueSize);
+        int offsetSizeBits = offsetSizeToBits(offsetSize);
+
+        // Object binary format:
+        // [1 byte] header (basic_type=2, type_info encodes offset size + field_id size)
+        // [4 bytes] numFields (uint32 LE)
+        // [field_id_size * numFields] field key IDs
+        // [offsetSize * numFields] offsets to field values (relative to start of value data)
+        // [totalValueSize bytes] concatenated field values
+        int fieldIdSize = getFieldIdSize(keyIndex.size());
+        int fieldIdSizeBits = offsetSizeToBits(fieldIdSize);
+
+        // type_info encodes: bits 0-1 = value_offset_size_minus_1, bits 2-3 = field_id_size_minus_1
+        int typeInfo = (offsetSizeBits & 0x03) | ((fieldIdSizeBits & 0x03) << 2);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(makeHeader(BASIC_TYPE_OBJECT, typeInfo));
+        writeLittleEndianInt(out, numFields);
+
+        // Write field key IDs
+        for (int keyId : fieldKeyIds) {
+            writeLittleEndianN(out, keyId, fieldIdSize);
+        }
+
+        // Write field value offsets
+        int offset = 0;
+        for (byte[] fv : fieldValues) {
+            writeLittleEndianN(out, offset, offsetSize);
+            offset += fv.length;
+        }
+
+        // Write field values
+        for (byte[] fv : fieldValues) {
+            out.write(fv);
+        }
+
+        return out.toByteArray();
+    }
+
+    private static byte[] encodeArray(JsonParser parser, Map<String, Integer> keyIndex) throws IOException
+    {
+        List<byte[]> elements = new ArrayList<>();
+
+        while (parser.nextToken() != JsonToken.END_ARRAY) {
+            elements.add(encodeValue(parser, keyIndex));
+        }
+
+        int numElements = elements.size();
+
+        int totalValueSize = 0;
+        for (byte[] el : elements) {
+            totalValueSize += el.length;
+        }
+
+        int offsetSize = getOffsetSize(totalValueSize);
+        int offsetSizeBits = offsetSizeToBits(offsetSize);
+
+        // type_info encodes: bits 0-1 = offset_size_minus_1
+        int typeInfo = offsetSizeBits & 0x03;
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(makeHeader(BASIC_TYPE_ARRAY, typeInfo));
+        writeLittleEndianInt(out, numElements);
+
+        // Write element offsets
+        int offset = 0;
+        for (byte[] el : elements) {
+            writeLittleEndianN(out, offset, offsetSize);
+            offset += el.length;
+        }
+
+        // Write element values
+        for (byte[] el : elements) {
+            out.write(el);
+        }
+
+        return out.toByteArray();
+    }
+
+    // ---- Value decoding ----
+
+    private static void decodeValue(byte[] data, int pos, String[] dictionary, JsonGenerator gen) throws IOException
+    {
+        if (pos >= data.length) {
+            gen.writeNull();
+            return;
+        }
+
+        int header = data[pos] & 0xFF;
+        int basicType = header >> 6;
+        int typeInfo = header & 0x3F;
+
+        switch (basicType) {
+            case BASIC_TYPE_PRIMITIVE:
+                decodePrimitive(data, pos, typeInfo, gen);
+                break;
+            case BASIC_TYPE_SHORT_STRING:
+                decodeShortString(data, pos, typeInfo, gen);
+                break;
+            case BASIC_TYPE_OBJECT:
+                decodeObject(data, pos, typeInfo, dictionary, gen);
+                break;
+            case BASIC_TYPE_ARRAY:
+                decodeArray(data, pos, typeInfo, dictionary, gen);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown Variant basic type: " + basicType);
+        }
+    }
+
+    private static void decodePrimitive(byte[] data, int pos, int typeInfo, JsonGenerator gen) throws IOException
+    {
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        switch (typeInfo) {
+            case PRIMITIVE_NULL:
+                gen.writeNull();
+                break;
+            case PRIMITIVE_TRUE:
+                gen.writeBoolean(true);
+                break;
+            case PRIMITIVE_FALSE:
+                gen.writeBoolean(false);
+                break;
+            case PRIMITIVE_INT8:
+                gen.writeNumber(data[pos + 1]);
+                break;
+            case PRIMITIVE_INT16:
+                buf.position(pos + 1);
+                gen.writeNumber(buf.getShort());
+                break;
+            case PRIMITIVE_INT32:
+                buf.position(pos + 1);
+                gen.writeNumber(buf.getInt());
+                break;
+            case PRIMITIVE_INT64:
+                buf.position(pos + 1);
+                gen.writeNumber(buf.getLong());
+                break;
+            case PRIMITIVE_FLOAT:
+                buf.position(pos + 1);
+                gen.writeNumber(buf.getFloat());
+                break;
+            case PRIMITIVE_DOUBLE:
+                buf.position(pos + 1);
+                gen.writeNumber(buf.getDouble());
+                break;
+            case PRIMITIVE_STRING: {
+                buf.position(pos + 1);
+                int len = buf.getInt();
+                String str = new String(data, pos + 5, len, StandardCharsets.UTF_8);
+                gen.writeString(str);
+                break;
+            }
+            default:
+                throw new IllegalArgumentException("Unknown Variant primitive type_info: " + typeInfo);
+        }
+    }
+
+    private static void decodeShortString(byte[] data, int pos, int typeInfo, JsonGenerator gen) throws IOException
+    {
+        int length = typeInfo;
+        String str = new String(data, pos + 1, length, StandardCharsets.UTF_8);
+        gen.writeString(str);
+    }
+
+    private static void decodeObject(byte[] data, int pos, int typeInfo, String[] dictionary, JsonGenerator gen) throws IOException
+    {
+        int offsetSize = (typeInfo & 0x03) + 1;
+        int fieldIdSize = ((typeInfo >> 2) & 0x03) + 1;
+
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.position(pos + 1);
+
+        int numFields = buf.getInt();
+
+        int[] keyIds = new int[numFields];
+        for (int i = 0; i < numFields; i++) {
+            keyIds[i] = readLittleEndianN(data, buf.position(), fieldIdSize);
+            buf.position(buf.position() + fieldIdSize);
+        }
+
+        int[] offsets = new int[numFields];
+        for (int i = 0; i < numFields; i++) {
+            offsets[i] = readLittleEndianN(data, buf.position(), offsetSize);
+            buf.position(buf.position() + offsetSize);
+        }
+
+        int valueDataStart = buf.position();
+
+        gen.writeStartObject();
+        for (int i = 0; i < numFields; i++) {
+            String key = dictionary[keyIds[i]];
+            gen.writeFieldName(key);
+            decodeValue(data, valueDataStart + offsets[i], dictionary, gen);
+        }
+        gen.writeEndObject();
+    }
+
+    private static void decodeArray(byte[] data, int pos, int typeInfo, String[] dictionary, JsonGenerator gen) throws IOException
+    {
+        int offsetSize = (typeInfo & 0x03) + 1;
+
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.position(pos + 1);
+
+        int numElements = buf.getInt();
+
+        int[] offsets = new int[numElements];
+        for (int i = 0; i < numElements; i++) {
+            offsets[i] = readLittleEndianN(data, buf.position(), offsetSize);
+            buf.position(buf.position() + offsetSize);
+        }
+
+        int valueDataStart = buf.position();
+
+        gen.writeStartArray();
+        for (int i = 0; i < numElements; i++) {
+            decodeValue(data, valueDataStart + offsets[i], dictionary, gen);
+        }
+        gen.writeEndArray();
+    }
+
+    // ---- Helper methods ----
+
+    static byte makeHeader(int basicType, int typeInfo)
+    {
+        return (byte) ((basicType << 6) | (typeInfo & 0x3F));
+    }
+
+    private static int getOffsetSize(int maxOffset)
+    {
+        if (maxOffset <= 0xFF) {
+            return 1;
+        }
+        if (maxOffset <= 0xFFFF) {
+            return 2;
+        }
+        return 4;
+    }
+
+    private static int getFieldIdSize(int numKeys)
+    {
+        if (numKeys <= 0xFF) {
+            return 1;
+        }
+        if (numKeys <= 0xFFFF) {
+            return 2;
+        }
+        return 4;
+    }
+
+    private static int offsetSizeToBits(int offsetSize)
+    {
+        switch (offsetSize) {
+            case 1: return 0;
+            case 2: return 1;
+            case 4: return 3;
+            default: throw new IllegalArgumentException("Invalid offset size: " + offsetSize);
+        }
+    }
+
+    private static void writeLittleEndianInt(ByteArrayOutputStream out, int value)
+    {
+        out.write(value & 0xFF);
+        out.write((value >> 8) & 0xFF);
+        out.write((value >> 16) & 0xFF);
+        out.write((value >> 24) & 0xFF);
+    }
+
+    private static void writeLittleEndianN(ByteArrayOutputStream out, int value, int size)
+    {
+        for (int i = 0; i < size; i++) {
+            out.write((value >> (i * 8)) & 0xFF);
+        }
+    }
+
+    private static int readLittleEndianN(byte[] data, int pos, int size)
+    {
+        int value = 0;
+        for (int i = 0; i < size; i++) {
+            value |= (data[pos + i] & 0xFF) << (i * 8);
+        }
+        return value;
+    }
+
+    // ---- Phase 2: Binary format detection and auto-decode ----
+
+    /**
+     * Checks if the given metadata and value byte arrays form a valid Variant binary encoding.
+     * Validates the metadata version byte and value header basic type.
+     *
+     * @param metadata the metadata dictionary bytes
+     * @param value the encoded value bytes
+     * @return true if the data is valid Variant binary format
+     */
+    public static boolean isVariantBinary(byte[] metadata, byte[] value)
+    {
+        if (metadata == null || metadata.length < 5 || value == null || value.length == 0) {
+            return false;
+        }
+        int version = metadata[0] & 0xFF;
+        if (version != METADATA_VERSION) {
+            return false;
+        }
+        int header = value[0] & 0xFF;
+        int basicType = header >> 6;
+        return basicType >= BASIC_TYPE_PRIMITIVE && basicType <= BASIC_TYPE_ARRAY;
+    }
+
+    /**
+     * Returns the Variant type name from a binary value header byte.
+     * Used for type introspection of Variant binary data.
+     *
+     * @param value the encoded value bytes
+     * @return type name: "null", "boolean", "integer", "float", "double", "string", "object", "array"
+     */
+    public static String getValueTypeName(byte[] value)
+    {
+        if (value == null || value.length == 0) {
+            return "null";
+        }
+
+        int header = value[0] & 0xFF;
+        int basicType = header >> 6;
+        int typeInfo = header & 0x3F;
+
+        switch (basicType) {
+            case BASIC_TYPE_PRIMITIVE:
+                switch (typeInfo) {
+                    case PRIMITIVE_NULL:
+                        return "null";
+                    case PRIMITIVE_TRUE:
+                    case PRIMITIVE_FALSE:
+                        return "boolean";
+                    case PRIMITIVE_INT8:
+                    case PRIMITIVE_INT16:
+                    case PRIMITIVE_INT32:
+                    case PRIMITIVE_INT64:
+                        return "integer";
+                    case PRIMITIVE_FLOAT:
+                        return "float";
+                    case PRIMITIVE_DOUBLE:
+                        return "double";
+                    case PRIMITIVE_STRING:
+                        return "string";
+                    default:
+                        return "unknown";
+                }
+            case BASIC_TYPE_SHORT_STRING:
+                return "string";
+            case BASIC_TYPE_OBJECT:
+                return "object";
+            case BASIC_TYPE_ARRAY:
+                return "array";
+            default:
+                return "unknown";
+        }
+    }
+
+    /**
+     * Attempts to decode raw bytes as Variant data, handling both JSON text and binary format.
+     * If the data starts with a valid JSON character ({, [, ", t, f, n, digit, -),
+     * it's treated as UTF-8 JSON text. Otherwise, it's treated as binary Variant value
+     * with empty metadata (suitable for primitives and strings).
+     *
+     * <p>For full binary Variant decoding with metadata dictionary support,
+     * use {@link #toJson(byte[], byte[])} directly with separate metadata and value arrays.
+     *
+     * @param data raw bytes that may be JSON or binary Variant
+     * @return JSON string representation
+     */
+    public static String decodeVariantAuto(byte[] data)
+    {
+        if (data == null || data.length == 0) {
+            return "null";
+        }
+        byte first = data[0];
+        if (first == '{' || first == '[' || first == '"' || first == 't' ||
+                first == 'f' || first == 'n' || (first >= '0' && first <= '9') || first == '-' || first == ' ') {
+            return new String(data, StandardCharsets.UTF_8);
+        }
+        // Try binary Variant decode with empty metadata
+        try {
+            byte[] emptyMetadata = new MetadataBuilder().build();
+            return toJson(emptyMetadata, data);
+        }
+        catch (Exception e) {
+            return new String(data, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/VariantFunctions.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/VariantFunctions.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.function;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.iceberg.VariantBinaryCodec;
+import com.facebook.presto.iceberg.VariantBinaryCodec.VariantBinary;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+/**
+ * SQL scalar functions for working with Iceberg V3 Variant data.
+ *
+ * <p>Variant data is mapped to Presto's JSON type. These functions
+ * provide field extraction (with dot-path and array indexing), validation,
+ * normalization, type introspection, key enumeration, binary round-trip,
+ * and explicit cast capabilities for Variant values.
+ *
+ * <p>Functions are registered via {@code IcebergConnector.getSystemFunctions()}
+ * and accessed as {@code iceberg.system.<function_name>(...)}.
+ *
+ * <h3>Phase 2: Binary Interoperability</h3>
+ * <p>{@code parse_variant} and {@code variant_binary_roundtrip} exercise the
+ * {@link VariantBinaryCodec} which implements the Apache Variant binary spec (v1).
+ * Full Parquet read/write path integration (transparent binary decode/encode in
+ * {@code IcebergPageSourceProvider} / {@code IcebergPageSink}) is documented as
+ * a future enhancement — the codec is ready; the page source wiring requires
+ * detecting VARIANT columns at the Parquet schema level.
+ */
+public final class VariantFunctions
+{
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+    private VariantFunctions() {}
+
+    // ---- Phase 3: Enhanced variant_get with dot-path and array indexing ----
+
+    /**
+     * Extracts a value from a Variant (JSON) by path expression.
+     * Supports dot-notation for nested objects and bracket notation for arrays.
+     *
+     * <p>Path syntax:
+     * <ul>
+     *   <li>{@code 'name'} — top-level field</li>
+     *   <li>{@code 'address.city'} — nested field via dot-notation</li>
+     *   <li>{@code 'items[0]'} — array element by index</li>
+     *   <li>{@code 'users[0].name'} — combined path</li>
+     * </ul>
+     *
+     * <p>Returns NULL if the path doesn't exist, the input is invalid JSON,
+     * or a path segment references a non-existent field/index.
+     * For complex values (objects/arrays), returns the JSON string representation.
+     *
+     * <p>Usage: {@code variant_get('{"users":[{"name":"Alice"}]}', 'users[0].name')} → {@code 'Alice'}
+     */
+    @ScalarFunction("variant_get")
+    @SqlNullable
+    @SqlType(StandardTypes.JSON)
+    public static Slice variantGet(
+            @SqlType(StandardTypes.JSON) Slice variant,
+            @SqlType(StandardTypes.VARCHAR) Slice path)
+    {
+        if (variant == null || path == null) {
+            return null;
+        }
+
+        String json = variant.toStringUtf8();
+        String pathStr = path.toStringUtf8();
+        List<PathSegment> segments = parsePath(pathStr);
+
+        try {
+            String current = json;
+            for (PathSegment segment : segments) {
+                if (current == null) {
+                    return null;
+                }
+                if (segment.isArrayIndex) {
+                    current = extractArrayElement(current, segment.arrayIndex);
+                }
+                else {
+                    current = extractObjectField(current, segment.fieldName);
+                }
+            }
+            return current != null ? Slices.utf8Slice(current) : null;
+        }
+        catch (IOException e) {
+            return null;
+        }
+    }
+
+    // ---- Phase 3: variant_keys ----
+
+    /**
+     * Returns the top-level keys of a Variant JSON object as a JSON array.
+     * Returns NULL if the input is not a JSON object.
+     *
+     * <p>Usage: {@code variant_keys('{"name":"Alice","age":30}')} → {@code '["name","age"]'}
+     */
+    @ScalarFunction("variant_keys")
+    @SqlNullable
+    @SqlType(StandardTypes.JSON)
+    public static Slice variantKeys(@SqlType(StandardTypes.JSON) Slice variant)
+    {
+        if (variant == null) {
+            return null;
+        }
+
+        String json = variant.toStringUtf8();
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() != JsonToken.START_OBJECT) {
+                return null;
+            }
+
+            StringWriter writer = new StringWriter();
+            try (JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                gen.writeStartArray();
+                while (parser.nextToken() != JsonToken.END_OBJECT) {
+                    gen.writeString(parser.getCurrentName());
+                    parser.nextToken();
+                    parser.skipChildren();
+                }
+                gen.writeEndArray();
+            }
+            return Slices.utf8Slice(writer.toString());
+        }
+        catch (IOException e) {
+            return null;
+        }
+    }
+
+    // ---- Phase 3: variant_type ----
+
+    /**
+     * Returns the JSON type of a Variant value as a string.
+     * Possible return values: "object", "array", "string", "number", "boolean", "null".
+     * Returns NULL if the input cannot be parsed.
+     *
+     * <p>Usage: {@code variant_type('{"a":1}')} → {@code 'object'}
+     */
+    @ScalarFunction("variant_type")
+    @SqlNullable
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice variantType(@SqlType(StandardTypes.JSON) Slice variant)
+    {
+        if (variant == null) {
+            return null;
+        }
+
+        String json = variant.toStringUtf8();
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+            JsonToken token = parser.nextToken();
+            if (token == null) {
+                return null;
+            }
+            switch (token) {
+                case START_OBJECT: return Slices.utf8Slice("object");
+                case START_ARRAY: return Slices.utf8Slice("array");
+                case VALUE_STRING: return Slices.utf8Slice("string");
+                case VALUE_NUMBER_INT:
+                case VALUE_NUMBER_FLOAT:
+                    return Slices.utf8Slice("number");
+                case VALUE_TRUE:
+                case VALUE_FALSE:
+                    return Slices.utf8Slice("boolean");
+                case VALUE_NULL: return Slices.utf8Slice("null");
+                default: return null;
+            }
+        }
+        catch (IOException e) {
+            return null;
+        }
+    }
+
+    // ---- Phase 5: to_variant (explicit cast) ----
+
+    /**
+     * Validates a JSON value and returns it as a Variant value.
+     * This is the explicit cast function from JSON to VARIANT.
+     * Throws an error if the input is not valid JSON.
+     *
+     * <p>Since VARIANT is mapped to Presto's JSON type, this function serves
+     * as the explicit validation boundary — it guarantees the output is well-formed JSON.
+     *
+     * <p>Usage: {@code to_variant(JSON '{"name":"Alice"}')} → {@code '{"name":"Alice"}'}
+     */
+    @ScalarFunction("to_variant")
+    @SqlType(StandardTypes.JSON)
+    public static Slice toVariant(@SqlType(StandardTypes.JSON) Slice json)
+    {
+        String input = json.toStringUtf8();
+        try {
+            StringWriter writer = new StringWriter();
+            try (JsonParser parser = JSON_FACTORY.createParser(input);
+                    JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                JsonToken token = parser.nextToken();
+                if (token == null) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Empty input is not valid Variant JSON");
+                }
+                gen.copyCurrentStructure(parser);
+                if (parser.nextToken() != null) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                            "Trailing content after JSON value");
+                }
+            }
+            return Slices.utf8Slice(writer.toString());
+        }
+        catch (PrestoException e) {
+            throw e;
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                    "Invalid JSON for Variant: " + e.getMessage(), e);
+        }
+    }
+
+    // ---- Phase 2: parse_variant (binary codec validation) ----
+
+    /**
+     * Parses and validates a JSON string as a Variant value by encoding it
+     * to Variant binary format (Apache Iceberg V3 spec) and decoding back.
+     * Returns the normalized (compact) JSON representation.
+     * Throws if the input is not valid JSON.
+     *
+     * <p>This exercises the full binary codec round-trip, validating that
+     * the data can be represented in Variant binary format for interoperability
+     * with other engines (Spark, Trino).
+     *
+     * <p>Usage: {@code parse_variant('{"name":"Alice"}')} → {@code '{"name":"Alice"}'}
+     */
+    @ScalarFunction("parse_variant")
+    @SqlType(StandardTypes.JSON)
+    public static Slice parseVariant(@SqlType(StandardTypes.VARCHAR) Slice json)
+    {
+        String input = json.toStringUtf8();
+        try {
+            VariantBinary binary = VariantBinaryCodec.fromJson(input);
+            String normalized = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+            return Slices.utf8Slice(normalized);
+        }
+        catch (Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                    "Invalid JSON for Variant: " + e.getMessage(), e);
+        }
+    }
+
+    // ---- Phase 2: variant_to_json ----
+
+    /**
+     * Converts a Variant value to its normalized JSON string representation.
+     * Normalizes the JSON through Jackson round-trip (compact form).
+     *
+     * <p>Usage: {@code variant_to_json(variant_column)} → {@code '{"name":"Alice"}'}
+     */
+    @ScalarFunction("variant_to_json")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice variantToJson(@SqlType(StandardTypes.JSON) Slice variant)
+    {
+        String input = variant.toStringUtf8();
+        try {
+            StringWriter writer = new StringWriter();
+            try (JsonParser parser = JSON_FACTORY.createParser(input);
+                    JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                parser.nextToken();
+                gen.copyCurrentStructure(parser);
+            }
+            return Slices.utf8Slice(writer.toString());
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                    "Invalid Variant JSON: " + e.getMessage(), e);
+        }
+    }
+
+    // ---- Phase 2: variant_binary_roundtrip ----
+
+    /**
+     * Encodes a JSON string into Variant binary format (Apache Iceberg V3 spec)
+     * and decodes it back to JSON. Validates binary round-trip fidelity.
+     * Useful for testing binary interoperability with other engines (Spark, Trino).
+     *
+     * <p>Usage: {@code variant_binary_roundtrip('{"a":1}')} → {@code '{"a":1}'}
+     */
+    @ScalarFunction("variant_binary_roundtrip")
+    @SqlType(StandardTypes.JSON)
+    public static Slice variantBinaryRoundtrip(@SqlType(StandardTypes.VARCHAR) Slice json)
+    {
+        String input = json.toStringUtf8();
+        try {
+            VariantBinary binary = VariantBinaryCodec.fromJson(input);
+            String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+            return Slices.utf8Slice(decoded);
+        }
+        catch (Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT,
+                    "Failed Variant binary round-trip: " + e.getMessage(), e);
+        }
+    }
+
+    // ---- Path parsing and JSON navigation helpers ----
+
+    private static final class PathSegment
+    {
+        final String fieldName;
+        final int arrayIndex;
+        final boolean isArrayIndex;
+
+        PathSegment(String fieldName)
+        {
+            this.fieldName = fieldName;
+            this.arrayIndex = -1;
+            this.isArrayIndex = false;
+        }
+
+        PathSegment(int arrayIndex)
+        {
+            this.fieldName = null;
+            this.arrayIndex = arrayIndex;
+            this.isArrayIndex = true;
+        }
+    }
+
+    static List<PathSegment> parsePath(String path)
+    {
+        List<PathSegment> segments = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '.') {
+                if (current.length() > 0) {
+                    segments.add(new PathSegment(current.toString()));
+                    current.setLength(0);
+                }
+            }
+            else if (c == '[') {
+                if (current.length() > 0) {
+                    segments.add(new PathSegment(current.toString()));
+                    current.setLength(0);
+                }
+                int end = path.indexOf(']', i);
+                if (end == -1) {
+                    segments.add(new PathSegment(path.substring(i)));
+                    return segments;
+                }
+                String indexStr = path.substring(i + 1, end);
+                try {
+                    segments.add(new PathSegment(Integer.parseInt(indexStr)));
+                }
+                catch (NumberFormatException e) {
+                    segments.add(new PathSegment(indexStr));
+                }
+                i = end;
+            }
+            else {
+                current.append(c);
+            }
+        }
+
+        if (current.length() > 0) {
+            segments.add(new PathSegment(current.toString()));
+        }
+        return segments;
+    }
+
+    private static String extractObjectField(String json, String fieldName) throws IOException
+    {
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() != JsonToken.START_OBJECT) {
+                return null;
+            }
+
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                String currentField = parser.getCurrentName();
+                JsonToken valueToken = parser.nextToken();
+
+                if (fieldName.equals(currentField)) {
+                    if (valueToken == JsonToken.VALUE_NULL) {
+                        return "null";
+                    }
+                    if (valueToken == JsonToken.START_OBJECT || valueToken == JsonToken.START_ARRAY) {
+                        StringWriter writer = new StringWriter();
+                        try (JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                            gen.copyCurrentStructure(parser);
+                        }
+                        return writer.toString();
+                    }
+                    return parser.getText();
+                }
+                parser.skipChildren();
+            }
+        }
+        return null;
+    }
+
+    private static String extractArrayElement(String json, int index) throws IOException
+    {
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() != JsonToken.START_ARRAY) {
+                return null;
+            }
+
+            int currentIndex = 0;
+            while (parser.nextToken() != JsonToken.END_ARRAY) {
+                if (currentIndex == index) {
+                    JsonToken token = parser.currentToken();
+                    if (token == JsonToken.VALUE_NULL) {
+                        return "null";
+                    }
+                    if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                        StringWriter writer = new StringWriter();
+                        try (JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
+                            gen.copyCurrentStructure(parser);
+                        }
+                        return writer.toString();
+                    }
+                    return parser.getText();
+                }
+                parser.skipChildren();
+                currentIndex++;
+            }
+        }
+        return null;
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -58,6 +58,7 @@ import java.util.Optional;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
@@ -68,10 +69,13 @@ import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvi
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.dataSizeSessionProperty;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.io.Files.createTempDir;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergFileWriter
 {
@@ -108,7 +112,23 @@ public class TestIcebergFileWriter
                                 HiveCompressionCodec.NONE,
                                 false,
                                 value -> HiveCompressionCodec.valueOf(((String) value).toUpperCase()),
-                                HiveCompressionCodec::name)));
+                                HiveCompressionCodec::name),
+                        // ORC properties needed by createOrcWriter (also used by DWRF dispatch).
+                        // HiveCommonSessionProperties.isOrcOptimizedWriterValidate() reads both.
+                        booleanProperty(
+                                "orc_optimized_writer_validate",
+                                "ORC: Force all validation for files",
+                                false,
+                                false),
+                        new PropertyMetadata<>(
+                                "orc_optimized_writer_validate_percentage",
+                                "ORC: Sample percentage for validation for files",
+                                DOUBLE,
+                                Double.class,
+                                0.0,
+                                false,
+                                value -> ((Number) value).doubleValue(),
+                                value -> value)));
 
         Session session = testSessionBuilder(sessionPropertyManager)
                 .setCatalog(ICEBERG_CATALOG)
@@ -156,6 +176,35 @@ public class TestIcebergFileWriter
         MessageType writtenSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageType originalSchema = convert(icebergSchema, "table");
         assertEquals(originalSchema, writtenSchema);
+    }
+
+    @Test
+    public void testWriteDwrfFileDispatchesToOrcWriter()
+            throws Exception
+    {
+        Path path = new Path(createTempDir().getAbsolutePath() + "/test.dwrf");
+        Schema icebergSchema = toIcebergSchema(ImmutableList.of(
+                ColumnMetadata.builder().setName("a").setType(VARCHAR).build(),
+                ColumnMetadata.builder().setName("b").setType(INTEGER).build(),
+                ColumnMetadata.builder().setName("c").setType(TIMESTAMP).build(),
+                ColumnMetadata.builder().setName("d").setType(DATE).build()));
+        IcebergFileWriter icebergFileWriter = this.icebergFileWriterFactory.createFileWriter(path, icebergSchema, new JobConf(), connectorSession,
+                hdfsContext, FileFormat.DWRF, MetricsConfig.getDefault());
+        assertNotNull(icebergFileWriter, "createFileWriter must dispatch FileFormat.DWRF to a non-null writer");
+
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, TIMESTAMP, DATE)
+                .addSequencePage(100, 0, 0, 123, 100)
+                .addSequencePage(100, 100, 100, 223, 100)
+                .addSequencePage(100, 200, 200, 323, 100)
+                .build();
+        for (Page page : input) {
+            icebergFileWriter.appendRows(page);
+        }
+        icebergFileWriter.commit();
+
+        File dwrfFile = new File(path.toString());
+        assertTrue(dwrfFile.exists(), "DWRF dispatch should produce a writable output file");
+        assertTrue(dwrfFile.length() > 0, "DWRF dispatch should produce a non-empty output file");
     }
 
     private static class TestingTypeManager

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestVariantBinaryCodec.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestVariantBinaryCodec.java
@@ -1,0 +1,510 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.iceberg.VariantBinaryCodec.VariantBinary;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestVariantBinaryCodec
+{
+    @Test
+    public void testNullValue()
+    {
+        String json = "null";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertNotNull(binary.getMetadata());
+        assertNotNull(binary.getValue());
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testBooleanTrue()
+    {
+        String json = "true";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testBooleanFalse()
+    {
+        String json = "false";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testSmallInteger()
+    {
+        String json = "42";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testNegativeInteger()
+    {
+        String json = "-100";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testLargeInteger()
+    {
+        String json = "2147483648";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testZero()
+    {
+        String json = "0";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testInt16Range()
+    {
+        // Value that requires int16 (> 127)
+        String json = "1000";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testInt32Range()
+    {
+        // Value that requires int32 (> 32767)
+        String json = "100000";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testInt64Range()
+    {
+        // Value that requires int64 (> 2^31 - 1)
+        String json = "9999999999";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testDouble()
+    {
+        String json = "3.14";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testNegativeDouble()
+    {
+        String json = "-2.718";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testShortString()
+    {
+        String json = "\"hello\"";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testEmptyString()
+    {
+        String json = "\"\"";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testLongString()
+    {
+        // String longer than 63 bytes (exceeds short string limit)
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < 100; i++) {
+            sb.append('a');
+        }
+        sb.append("\"");
+        String json = sb.toString();
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testUnicodeString()
+    {
+        String json = "\"café ☕\"";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testSimpleObject()
+    {
+        String json = "{\"name\":\"Alice\",\"age\":30}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        // Object keys are sorted in the metadata dictionary, so the output
+        // should have keys in sorted order
+        assertNotNull(decoded);
+        // Verify it round-trips (keys may be reordered due to sorted dictionary)
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        String decoded2 = VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue());
+        assertEquals(decoded2, decoded);
+    }
+
+    @Test
+    public void testEmptyObject()
+    {
+        String json = "{}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testNestedObject()
+    {
+        String json = "{\"user\":{\"name\":\"Bob\",\"score\":95}}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        // Verify double round-trip stability
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    @Test
+    public void testSimpleArray()
+    {
+        String json = "[1,2,3]";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testEmptyArray()
+    {
+        String json = "[]";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testMixedArray()
+    {
+        String json = "[1,\"two\",true,null,3.14]";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testNestedArray()
+    {
+        String json = "[[1,2],[3,4]]";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        assertEquals(VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue()), json);
+    }
+
+    @Test
+    public void testComplexDocument()
+    {
+        String json = "{\"name\":\"Alice\",\"scores\":[95,87,92],\"active\":true,\"address\":null}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        // Verify double round-trip stability
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    @Test
+    public void testDeeplyNested()
+    {
+        String json = "{\"a\":{\"b\":{\"c\":{\"d\":\"deep\"}}}}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    @Test
+    public void testArrayOfObjects()
+    {
+        String json = "[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"}]";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    @Test
+    public void testMetadataDictionary()
+    {
+        // Verify that the metadata dictionary is built correctly
+        String json = "{\"z_key\":1,\"a_key\":2}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        // Metadata dictionary should have keys sorted alphabetically
+        String[] keys = VariantBinaryCodec.decodeMetadata(binary.getMetadata());
+        assertEquals(keys.length, 2);
+        assertEquals(keys[0], "a_key");
+        assertEquals(keys[1], "z_key");
+    }
+
+    @Test
+    public void testEmptyMetadataForPrimitives()
+    {
+        // Primitive values should have an empty metadata dictionary
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        String[] keys = VariantBinaryCodec.decodeMetadata(binary.getMetadata());
+        assertEquals(keys.length, 0);
+    }
+
+    @Test
+    public void testHeaderEncoding()
+    {
+        // Verify header byte construction
+        assertEquals(VariantBinaryCodec.makeHeader(VariantBinaryCodec.BASIC_TYPE_PRIMITIVE, VariantBinaryCodec.PRIMITIVE_NULL), (byte) 0x00);
+        assertEquals(VariantBinaryCodec.makeHeader(VariantBinaryCodec.BASIC_TYPE_PRIMITIVE, VariantBinaryCodec.PRIMITIVE_TRUE), (byte) 0x01);
+        assertEquals(VariantBinaryCodec.makeHeader(VariantBinaryCodec.BASIC_TYPE_SHORT_STRING, 5), (byte) 0x45);  // 01_000101
+        assertEquals(VariantBinaryCodec.makeHeader(VariantBinaryCodec.BASIC_TYPE_OBJECT, 0), (byte) 0x80);  // 10_000000
+        assertEquals(VariantBinaryCodec.makeHeader(VariantBinaryCodec.BASIC_TYPE_ARRAY, 0), (byte) 0xC0);  // 11_000000
+    }
+
+    @Test
+    public void testStringWithSpecialChars()
+    {
+        String json = "{\"key\":\"value with \\\"quotes\\\" and \\\\backslash\"}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    @Test
+    public void testObjectWithMixedValues()
+    {
+        String json = "{\"bool\":false,\"int\":42,\"float\":1.5,\"null\":null,\"str\":\"hello\"}";
+        VariantBinary binary = VariantBinaryCodec.fromJson(json);
+        String decoded = VariantBinaryCodec.toJson(binary.getMetadata(), binary.getValue());
+        assertNotNull(decoded);
+        VariantBinary binary2 = VariantBinaryCodec.fromJson(decoded);
+        assertEquals(VariantBinaryCodec.toJson(binary2.getMetadata(), binary2.getValue()), decoded);
+    }
+
+    // ---- Phase 2: isVariantBinary tests ----
+
+    @Test
+    public void testIsVariantBinaryValidObject()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("{\"a\":1}");
+        assertTrue(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), binary.getValue()));
+    }
+
+    @Test
+    public void testIsVariantBinaryValidPrimitive()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        assertTrue(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), binary.getValue()));
+    }
+
+    @Test
+    public void testIsVariantBinaryValidArray()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("[1,2,3]");
+        assertTrue(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), binary.getValue()));
+    }
+
+    @Test
+    public void testIsVariantBinaryValidString()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("\"hello\"");
+        assertTrue(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), binary.getValue()));
+    }
+
+    @Test
+    public void testIsVariantBinaryNullMetadata()
+    {
+        assertFalse(VariantBinaryCodec.isVariantBinary(null, new byte[] {0}));
+    }
+
+    @Test
+    public void testIsVariantBinaryNullValue()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        assertFalse(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), null));
+    }
+
+    @Test
+    public void testIsVariantBinaryEmptyValue()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        assertFalse(VariantBinaryCodec.isVariantBinary(binary.getMetadata(), new byte[0]));
+    }
+
+    @Test
+    public void testIsVariantBinaryShortMetadata()
+    {
+        assertFalse(VariantBinaryCodec.isVariantBinary(new byte[] {1, 0}, new byte[] {0}));
+    }
+
+    // ---- Phase 2: getValueTypeName tests ----
+
+    @Test
+    public void testGetValueTypeNameNull()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("null");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "null");
+    }
+
+    @Test
+    public void testGetValueTypeNameTrue()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("true");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "boolean");
+    }
+
+    @Test
+    public void testGetValueTypeNameFalse()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("false");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "boolean");
+    }
+
+    @Test
+    public void testGetValueTypeNameInteger()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "integer");
+    }
+
+    @Test
+    public void testGetValueTypeNameDouble()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("3.14");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "double");
+    }
+
+    @Test
+    public void testGetValueTypeNameShortString()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("\"hello\"");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "string");
+    }
+
+    @Test
+    public void testGetValueTypeNameObject()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("{\"a\":1}");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "object");
+    }
+
+    @Test
+    public void testGetValueTypeNameArray()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("[1,2]");
+        assertEquals(VariantBinaryCodec.getValueTypeName(binary.getValue()), "array");
+    }
+
+    @Test
+    public void testGetValueTypeNameEmptyValue()
+    {
+        assertEquals(VariantBinaryCodec.getValueTypeName(new byte[0]), "null");
+    }
+
+    @Test
+    public void testGetValueTypeNameNullValue()
+    {
+        assertEquals(VariantBinaryCodec.getValueTypeName(null), "null");
+    }
+
+    // ---- Phase 2: decodeVariantAuto tests ----
+
+    @Test
+    public void testDecodeVariantAutoJsonObject()
+    {
+        byte[] data = "{\"a\":1}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "{\"a\":1}");
+    }
+
+    @Test
+    public void testDecodeVariantAutoJsonArray()
+    {
+        byte[] data = "[1,2,3]".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "[1,2,3]");
+    }
+
+    @Test
+    public void testDecodeVariantAutoJsonString()
+    {
+        byte[] data = "\"hello\"".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "\"hello\"");
+    }
+
+    @Test
+    public void testDecodeVariantAutoJsonNumber()
+    {
+        byte[] data = "42".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "42");
+    }
+
+    @Test
+    public void testDecodeVariantAutoJsonBoolean()
+    {
+        byte[] data = "true".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "true");
+    }
+
+    @Test
+    public void testDecodeVariantAutoJsonNull()
+    {
+        byte[] data = "null".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(data), "null");
+    }
+
+    @Test
+    public void testDecodeVariantAutoEmpty()
+    {
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(new byte[0]), "null");
+    }
+
+    @Test
+    public void testDecodeVariantAutoNull()
+    {
+        assertEquals(VariantBinaryCodec.decodeVariantAuto(null), "null");
+    }
+
+    @Test
+    public void testDecodeVariantAutoBinaryPrimitive()
+    {
+        VariantBinary binary = VariantBinaryCodec.fromJson("42");
+        String decoded = VariantBinaryCodec.decodeVariantAuto(binary.getValue());
+        assertEquals(decoded, "42");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestVariantFunctions.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestVariantFunctions.java
@@ -1,0 +1,484 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.iceberg.function.VariantFunctions;
+import com.facebook.presto.metadata.FunctionExtractor;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestVariantFunctions
+        extends AbstractTestFunctions
+{
+    private static final String CATALOG_SCHEMA = "iceberg.system";
+
+    public TestVariantFunctions()
+    {
+        super(TEST_SESSION, new FeaturesConfig(), new FunctionsConfig(), false);
+    }
+
+    @BeforeClass
+    public void registerFunction()
+    {
+        ImmutableList.Builder<Class<?>> functions = ImmutableList.builder();
+        functions.add(VariantFunctions.class);
+        functionAssertions.addConnectorFunctions(FunctionExtractor.extractFunctions(functions.build(),
+                new CatalogSchemaName("iceberg", "system")), "iceberg");
+    }
+
+    // ---- variant_get: simple field extraction ----
+
+    @Test
+    public void testVariantGetStringField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"name\":\"Alice\",\"age\":30}', 'name')",
+                JSON,
+                "Alice");
+    }
+
+    @Test
+    public void testVariantGetNumberField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"name\":\"Alice\",\"age\":30}', 'age')",
+                JSON,
+                "30");
+    }
+
+    @Test
+    public void testVariantGetBooleanField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"active\":true}', 'active')",
+                JSON,
+                "true");
+    }
+
+    @Test
+    public void testVariantGetNestedObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"address\":{\"city\":\"NYC\"}}', 'address')",
+                JSON,
+                "{\"city\":\"NYC\"}");
+    }
+
+    @Test
+    public void testVariantGetNestedArray()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"items\":[1,2,3]}', 'items')",
+                JSON,
+                "[1,2,3]");
+    }
+
+    @Test
+    public void testVariantGetMissingField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"name\":\"Alice\"}', 'missing')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantGetNonObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '\"just a string\"', 'field')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantGetNullField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"key\":null}', 'key')",
+                JSON,
+                "null");
+    }
+
+    // ---- variant_get: dot-path navigation ----
+
+    @Test
+    public void testVariantGetDotPath()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"address\":{\"city\":\"NYC\"}}', 'address.city')",
+                JSON,
+                "NYC");
+    }
+
+    @Test
+    public void testVariantGetDotPathDeep()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"a\":{\"b\":{\"c\":\"deep\"}}}', 'a.b.c')",
+                JSON,
+                "deep");
+    }
+
+    @Test
+    public void testVariantGetDotPathMissing()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"address\":{\"city\":\"NYC\"}}', 'address.zip')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantGetDotPathNestedObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"a\":{\"b\":{\"c\":1}}}', 'a.b')",
+                JSON,
+                "{\"c\":1}");
+    }
+
+    // ---- variant_get: array indexing ----
+
+    @Test
+    public void testVariantGetArrayIndex()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '[10,20,30]', '[0]')",
+                JSON,
+                "10");
+    }
+
+    @Test
+    public void testVariantGetArrayIndexLast()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '[10,20,30]', '[2]')",
+                JSON,
+                "30");
+    }
+
+    @Test
+    public void testVariantGetArrayOutOfBounds()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '[10,20,30]', '[5]')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantGetArrayOfObjects()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '[{\"id\":1},{\"id\":2}]', '[1]')",
+                JSON,
+                "{\"id\":2}");
+    }
+
+    // ---- variant_get: combined dot-path + array indexing ----
+
+    @Test
+    public void testVariantGetFieldThenArray()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"items\":[1,2,3]}', 'items[1]')",
+                JSON,
+                "2");
+    }
+
+    @Test
+    public void testVariantGetArrayThenField()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"users\":[{\"name\":\"Alice\"},{\"name\":\"Bob\"}]}', 'users[0].name')",
+                JSON,
+                "Alice");
+    }
+
+    @Test
+    public void testVariantGetComplexPath()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_get(JSON '{\"data\":{\"rows\":[{\"v\":99}]}}', 'data.rows[0].v')",
+                JSON,
+                "99");
+    }
+
+    // ---- variant_keys ----
+
+    @Test
+    public void testVariantKeysSimple()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_keys(JSON '{\"name\":\"Alice\",\"age\":30}')",
+                JSON,
+                "[\"name\",\"age\"]");
+    }
+
+    @Test
+    public void testVariantKeysEmpty()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_keys(JSON '{}')",
+                JSON,
+                "[]");
+    }
+
+    @Test
+    public void testVariantKeysNonObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_keys(JSON '[1,2,3]')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantKeysScalar()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_keys(JSON '42')",
+                JSON,
+                null);
+    }
+
+    @Test
+    public void testVariantKeysNested()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_keys(JSON '{\"a\":{\"b\":1},\"c\":[1]}')",
+                JSON,
+                "[\"a\",\"c\"]");
+    }
+
+    // ---- variant_type ----
+
+    @DataProvider(name = "variantTypeCases")
+    public Object[][] variantTypeCases()
+    {
+        return new Object[][] {
+                {"{\"a\":1}", "object"},
+                {"[1,2]", "array"},
+                {"\"hello\"", "string"},
+                {"42", "number"},
+                {"3.14", "number"},
+                {"true", "boolean"},
+                {"null", "null"},
+        };
+    }
+
+    @Test(dataProvider = "variantTypeCases")
+    public void testVariantType(String json, String expectedType)
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_type(JSON '" + json + "')",
+                VARCHAR,
+                expectedType);
+    }
+
+    // ---- to_variant (Phase 5: CAST) ----
+
+    @Test
+    public void testToVariantObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON '{\"name\":\"Alice\"}')",
+                JSON,
+                "{\"name\":\"Alice\"}");
+    }
+
+    @Test
+    public void testToVariantArray()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON '[1,2,3]')",
+                JSON,
+                "[1,2,3]");
+    }
+
+    @Test
+    public void testToVariantScalar()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON '42')",
+                JSON,
+                "42");
+    }
+
+    @Test
+    public void testToVariantBoolean()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON 'true')",
+                JSON,
+                "true");
+    }
+
+    @Test
+    public void testToVariantNull()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON 'null')",
+                JSON,
+                "null");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testToVariantInvalid()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON 'not valid json')",
+                JSON,
+                null);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testToVariantTrailingContent()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".to_variant(JSON '{\"a\":1} extra')",
+                JSON,
+                null);
+    }
+
+    // ---- parse_variant (binary codec round-trip) ----
+
+    @Test
+    public void testParseVariantSimpleObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('{\"a\":1}')",
+                JSON,
+                "{\"a\":1}");
+    }
+
+    @Test
+    public void testParseVariantArray()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('[1,2,3]')",
+                JSON,
+                "[1,2,3]");
+    }
+
+    @Test
+    public void testParseVariantString()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('\"hello\"')",
+                JSON,
+                "\"hello\"");
+    }
+
+    @Test
+    public void testParseVariantNumber()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('42')",
+                JSON,
+                "42");
+    }
+
+    @Test
+    public void testParseVariantBoolean()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('true')",
+                JSON,
+                "true");
+    }
+
+    @Test
+    public void testParseVariantNull()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('null')",
+                JSON,
+                "null");
+    }
+
+    @Test
+    public void testParseVariantNestedObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".parse_variant('{\"a\":{\"b\":1},\"c\":[true,false]}')",
+                JSON,
+                "{\"a\":{\"b\":1},\"c\":[true,false]}");
+    }
+
+    // ---- variant_to_json ----
+
+    @Test
+    public void testVariantToJsonObject()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_to_json(JSON '{\"name\":\"Alice\"}')",
+                VARCHAR,
+                "{\"name\":\"Alice\"}");
+    }
+
+    @Test
+    public void testVariantToJsonArray()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_to_json(JSON '[1,2,3]')",
+                VARCHAR,
+                "[1,2,3]");
+    }
+
+    @Test
+    public void testVariantToJsonScalar()
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_to_json(JSON '42')",
+                VARCHAR,
+                "42");
+    }
+
+    // ---- variant_binary_roundtrip ----
+
+    @DataProvider(name = "variantBinaryRoundtripCases")
+    public Object[][] variantBinaryRoundtripCases()
+    {
+        return new Object[][] {
+                {"{\"a\":1,\"b\":\"hello\"}"},
+                {"[1,true,\"text\",null]"},
+                {"{\"outer\":{\"inner\":[1,2]}}"},
+                {"42"},
+                {"\"hello world\""},
+                {"true"},
+                {"null"},
+        };
+    }
+
+    @Test(dataProvider = "variantBinaryRoundtripCases")
+    public void testVariantBinaryRoundtrip(String json)
+    {
+        functionAssertions.assertFunction(
+                CATALOG_SCHEMA + ".variant_binary_roundtrip('" + json + "')",
+                JSON,
+                json);
+    }
+}


### PR DESCRIPTION
Summary:

Iceberg V3 introduces the Variant type — a self-describing binary format
for representing semi-structured (JSON-like) data with schemaless evolution.
This adds first-class Java-side support:

New files:
- VariantBinaryCodec.java: encoder/decoder for the Variant binary spec
  (header, value, metadata sections; primitives, arrays, objects).
- function/VariantFunctions.java: SQL functions for Variant manipulation
  (variant_get, variant_object_keys, variant_to_json, etc.) registered
  with the Presto FunctionRegistry.
- TestVariantBinaryCodec / TestVariantFunctions: round-trip and SQL-level
  unit tests.

Wiring:
- TypeConverter: VARIANT iceberg type maps to JsonType.JSON on the Presto
  side (Presto already has rich JSON ops; reusing avoids duplicating work).
  toOrcType emits ORC STRING physical storage (same as VARCHAR).
- PartitionData / PartitionTable: VARIANT partition values serialize as
  text / are passed through as String.

Strictly-additive: no behavior change for existing types or queries.

Part of the Iceberg V3 Java support split (was D98749429).

Differential Revision: D101602645
