### PR TITLE
test: Test for rewrite data files with zorder

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.table.Argument;
 import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
 import com.facebook.presto.spi.procedure.DistributedProcedure;
+import com.facebook.presto.spi.procedure.ProcedureAnalysisContext;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
@@ -180,11 +181,8 @@ public class Analysis
     private final Map<NodeRef<Table>, Map<String, Expression>> columnMasks = new LinkedHashMap<>();
 
     // for call distributed procedure
-    private Optional<DistributedProcedure.DistributedProcedureType> distributedProcedureType = Optional.empty();
     private Optional<QualifiedObjectName> procedureName = Optional.empty();
-    private Optional<Object[]> procedureArguments = Optional.empty();
-    private Optional<TableHandle> callTarget = Optional.empty();
-    private Optional<QuerySpecification> targetQuery = Optional.empty();
+    private Optional<CallDistributedProcedureAnalysis> callDistributedProcedureAnalysis = Optional.empty();
 
     // for create vector index
     private Optional<CreateVectorIndexAnalysis> createVectorIndexAnalysis = Optional.empty();
@@ -713,6 +711,16 @@ public class Analysis
         return createVectorIndexAnalysis;
     }
 
+    public void setCallDistributedProcedureAnalysis(CallDistributedProcedureAnalysis analysis)
+    {
+        this.callDistributedProcedureAnalysis = Optional.of(analysis);
+    }
+
+    public Optional<CallDistributedProcedureAnalysis> getCallDistributedProcedureAnalysis()
+    {
+        return this.callDistributedProcedureAnalysis;
+    }
+
     public Optional<QualifiedObjectName> getProcedureName()
     {
         return procedureName;
@@ -721,36 +729,6 @@ public class Analysis
     public void setProcedureName(Optional<QualifiedObjectName> procedureName)
     {
         this.procedureName = procedureName;
-    }
-
-    public Optional<DistributedProcedure.DistributedProcedureType> getDistributedProcedureType()
-    {
-        return distributedProcedureType;
-    }
-
-    public void setDistributedProcedureType(Optional<DistributedProcedure.DistributedProcedureType> distributedProcedureType)
-    {
-        this.distributedProcedureType = distributedProcedureType;
-    }
-
-    public Optional<Object[]> getProcedureArguments()
-    {
-        return procedureArguments;
-    }
-
-    public void setProcedureArguments(Optional<Object[]> procedureArguments)
-    {
-        this.procedureArguments = procedureArguments;
-    }
-
-    public Optional<TableHandle> getCallTarget()
-    {
-        return callTarget;
-    }
-
-    public void setCallTarget(TableHandle callTarget)
-    {
-        this.callTarget = Optional.of(callTarget);
     }
 
     public Optional<TableHandle> getAnalyzeTarget()
@@ -1151,16 +1129,6 @@ public class Analysis
     public Optional<Expression> getViewAccessorWhereClause()
     {
         return viewAccessorWhereClause;
-    }
-
-    public void setTargetQuery(QuerySpecification targetQuery)
-    {
-        this.targetQuery = Optional.of(targetQuery);
-    }
-
-    public Optional<QuerySpecification> getTargetQuery()
-    {
-        return this.targetQuery;
     }
 
     public Map<FunctionKind, Set<String>> getInvokedFunctions()
@@ -1948,6 +1916,39 @@ public class Analysis
         public Scope getTargetTableScope()
         {
             return targetTableScope;
+        }
+    }
+
+    @Immutable
+    public static final class CallDistributedProcedureAnalysis
+    {
+        private final DistributedProcedure.DistributedProcedureType distributedProcedureType;
+        private final Object[] procedureArguments;
+        private final Optional<ProcedureAnalysisContext> procedureAnalysisContext;
+
+        public CallDistributedProcedureAnalysis(
+                DistributedProcedure.DistributedProcedureType distributedProcedureType,
+                Object[] procedureArguments,
+                Optional<ProcedureAnalysisContext> procedureAnalysisContext)
+        {
+            this.distributedProcedureType = requireNonNull(distributedProcedureType, "distributedProcedureType is null");
+            this.procedureArguments = requireNonNull(procedureArguments, "procedureArguments is null");
+            this.procedureAnalysisContext = requireNonNull(procedureAnalysisContext, "procedureAnalysisContext is null");
+        }
+
+        public DistributedProcedure.DistributedProcedureType getDistributedProcedureType()
+        {
+            return distributedProcedureType;
+        }
+
+        public Object[] getProcedureArguments()
+        {
+            return procedureArguments;
+        }
+
+        public Optional<ProcedureAnalysisContext> getProcedureAnalysisContext()
+        {
+            return procedureAnalysisContext;
         }
     }
 

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/procedure/TableDataRewriteAnalysisContext.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/procedure/TableDataRewriteAnalysisContext.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer.procedure;
+
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.procedure.ProcedureAnalysisContext;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.google.errorprone.annotations.Immutable;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class TableDataRewriteAnalysisContext
+        implements ProcedureAnalysisContext
+{
+    private final TableHandle callTarget;
+    private final QuerySpecification targetQuery;
+
+    public TableDataRewriteAnalysisContext(
+            TableHandle callTarget,
+            QuerySpecification targetQuery)
+    {
+        this.callTarget = requireNonNull(callTarget, "callTarget is null");
+        this.targetQuery = requireNonNull(targetQuery, "targetQuery is null");
+    }
+
+    public TableHandle getCallTarget()
+    {
+        return callTarget;
+    }
+
+    public QuerySpecification getTargetQuery()
+    {
+        return targetQuery;
+    }
+}

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/procedure/TableDataRewriteAnalysisContext.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/procedure/TableDataRewriteAnalysisContext.java
@@ -18,6 +18,9 @@ import com.facebook.presto.spi.procedure.ProcedureAnalysisContext;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.google.errorprone.annotations.Immutable;
 
+import java.util.List;
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -26,13 +29,16 @@ public class TableDataRewriteAnalysisContext
 {
     private final TableHandle callTarget;
     private final QuerySpecification targetQuery;
+    private final Optional<List<String>> zOrderColumns;
 
     public TableDataRewriteAnalysisContext(
             TableHandle callTarget,
-            QuerySpecification targetQuery)
+            QuerySpecification targetQuery,
+            Optional<List<String>> zOrderColumns)
     {
         this.callTarget = requireNonNull(callTarget, "callTarget is null");
         this.targetQuery = requireNonNull(targetQuery, "targetQuery is null");
+        this.zOrderColumns = requireNonNull(zOrderColumns, "zOrderColumns is null");
     }
 
     public TableHandle getCallTarget()
@@ -43,5 +49,10 @@ public class TableDataRewriteAnalysisContext
     public QuerySpecification getTargetQuery()
     {
         return targetQuery;
+    }
+
+    public Optional<List<String>> getzOrderColumns()
+    {
+        return zOrderColumns;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
@@ -41,7 +41,9 @@ public enum IcebergMetadataColumn
      */
     UPDATE_ROW_DATA(Integer.MIN_VALUE, "$row_id", RowType.anonymous(ImmutableList.of(UNKNOWN)), STRUCT),
     MERGE_TARGET_ROW_ID_DATA(Integer.MIN_VALUE + 1, "$target_table_row_id", RowType.anonymous(ImmutableList.of(UNKNOWN)), STRUCT),
-    MERGE_PARTITION_DATA(Integer.MIN_VALUE + 2, "partition_data", VARCHAR, PRIMITIVE)
+    MERGE_PARTITION_DATA(Integer.MIN_VALUE + 2, "partition_data", VARCHAR, PRIMITIVE),
+
+    Z_ORDER(Integer.MIN_VALUE + 3, "$z_order", BIGINT, PRIMITIVE)
     /**/;
 
     private static final Set<Integer> COLUMN_IDS = Stream.concat(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -69,11 +69,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static com.facebook.presto.common.type.Decimals.readBigDecimal;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
 import static com.facebook.presto.iceberg.FileContent.DATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.Z_ORDER;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumnsForWrite;
 import static com.facebook.presto.iceberg.PartitionTransforms.getColumnTransform;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -157,7 +159,7 @@ public class IcebergPageSink
         this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
         String tempDirectoryPath = locationProvider.newDataLocation("sort-tmp-files");
         this.tempDirectory = new Path(tempDirectoryPath);
-        this.columnTypes = getColumnsForWrite(outputSchema, partitionSpec, requireNonNull(sortParameters.getTypeManager(), "typeManager is null")).stream()
+        List<Type> types = getColumnsForWrite(outputSchema, partitionSpec, requireNonNull(sortParameters.getTypeManager(), "typeManager is null")).stream()
                 .map(IcebergColumnHandle::getType)
                 .collect(toImmutableList());
         this.sortParameters = sortParameters;
@@ -165,12 +167,22 @@ public class IcebergPageSink
             ImmutableList.Builder<Integer> sortColumnIndexes = ImmutableList.builder();
             ImmutableList.Builder<SortOrder> sortOrders = ImmutableList.builder();
             for (SortField sortField : sortOrder) {
-                Types.NestedField column = outputSchema.findField(sortField.getSourceColumnId());
-                if (column == null) {
-                    throw new PrestoException(ICEBERG_INVALID_METADATA, "Unable to find sort field source column in the table schema: " + sortField);
+                if (sortField.getSourceColumnId() == Z_ORDER.getId()) {
+                    sortColumnIndexes.add(outputSchema.columns().size());
+                    sortOrders.add(sortField.getSortOrder());
+                    types = ImmutableList.<Type>builder()
+                            .addAll(types)
+                            .add(VARBINARY)
+                            .build();
                 }
-                sortColumnIndexes.add(outputSchema.columns().indexOf(column));
-                sortOrders.add(sortField.getSortOrder());
+                else {
+                    Types.NestedField column = outputSchema.findField(sortField.getSourceColumnId());
+                    if (column == null) {
+                        throw new PrestoException(ICEBERG_INVALID_METADATA, "Unable to find sort field source column in the table schema: " + sortField);
+                    }
+                    sortColumnIndexes.add(outputSchema.columns().indexOf(column));
+                    sortOrders.add(sortField.getSortOrder());
+                }
             }
             this.sortColumnIndexes = sortColumnIndexes.build();
             this.sortOrders = sortOrders.build();
@@ -179,6 +191,7 @@ public class IcebergPageSink
             this.sortColumnIndexes = ImmutableList.of();
             this.sortOrders = ImmutableList.of();
         }
+        this.columnTypes = types;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
@@ -13,13 +13,17 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.iceberg.function.IcebergBucketFunction;
+import com.facebook.presto.iceberg.function.IcebergZOrderFunctions;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import javax.management.MBeanServer;
 
 import java.lang.management.ManagementFactory;
+import java.util.Set;
 
 public class IcebergPlugin
         implements Plugin
@@ -40,5 +44,14 @@ public class IcebergPlugin
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
         return ImmutableList.of(new IcebergConnectorFactory(mBeanServer));
+    }
+
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.<Class<?>>builder()
+                .add(IcebergBucketFunction.class)
+                .add(IcebergZOrderFunctions.class)
+                .build();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/IcebergZOrderFunctions.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/IcebergZOrderFunctions.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.function;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.iceberg.util.ZOrderByteUtils;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+/**
+ * Presto scalar functions for Z-Order operations.
+ * These functions convert values to lexicographically ordered byte representations
+ * and interleave bits for Z-Order curve computation.
+ *
+ * Based on Apache Iceberg Spark's Z-Order UDF implementation:
+ * https://github.com/apache/iceberg/blob/main/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+ */
+public final class IcebergZOrderFunctions
+{
+    private IcebergZOrderFunctions() {}
+
+    private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
+
+    @ScalarFunction(value = "zorder_tinyint_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderTinyintBytes(@SqlNullable @SqlType(StandardTypes.TINYINT) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.tinyintToOrderedBytes(value.byteValue());
+    }
+
+    @ScalarFunction(value = "zorder_smallint_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderSmallintBytes(@SqlNullable @SqlType(StandardTypes.SMALLINT) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.shortToOrderedBytes(value.shortValue());
+    }
+
+    @ScalarFunction(value = "zorder_integer_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderIntegerBytes(@SqlNullable @SqlType(StandardTypes.INTEGER) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.intToOrderedBytes(value.intValue());
+    }
+
+    @ScalarFunction(value = "zorder_bigint_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderBigintBytes(@SqlNullable @SqlType(StandardTypes.BIGINT) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.longToOrderedBytes(value);
+    }
+
+    @ScalarFunction(value = "zorder_real_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderRealBytes(@SqlNullable @SqlType(StandardTypes.REAL) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.floatToOrderedBytes(Float.intBitsToFloat(value.intValue()));
+    }
+
+    @ScalarFunction(value = "zorder_double_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderDoubleBytes(@SqlNullable @SqlType(StandardTypes.DOUBLE) Double value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.doubleToOrderedBytes(value);
+    }
+
+    @ScalarFunction(value = "zorder_boolean_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderBooleanBytes(@SqlNullable @SqlType(StandardTypes.BOOLEAN) Boolean value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.booleanToOrderedBytes(value);
+    }
+
+    @ScalarFunction(value = "zorder_varchar_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderVarcharBytes(@SqlNullable @SqlType(StandardTypes.VARCHAR) Slice value, @SqlType(StandardTypes.INTEGER) long length)
+    {
+        // stringToOrderedBytes already handles null by returning zero-filled array
+        return ZOrderByteUtils.stringToOrderedBytes(value, (int) length);
+    }
+
+    @ScalarFunction(value = "zorder_varbinary_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderVarbinaryBytes(@SqlNullable @SqlType(StandardTypes.VARBINARY) Slice value, @SqlType(StandardTypes.INTEGER) long length)
+    {
+        // byteTruncateOrFill already handles null by returning zero-filled array
+        return ZOrderByteUtils.byteTruncateOrFill(value, (int) length);
+    }
+
+    @ScalarFunction(value = "zorder_date_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderDateBytes(@SqlNullable @SqlType(StandardTypes.DATE) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.intToOrderedBytes(value.intValue());
+    }
+
+    @ScalarFunction(value = "zorder_timestamp_bytes", calledOnNullInput = true)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zorderTimestampBytes(@SqlNullable @SqlType(StandardTypes.TIMESTAMP) Long value)
+    {
+        if (value == null) {
+            return Slices.wrappedBuffer(PRIMITIVE_EMPTY);
+        }
+        return ZOrderByteUtils.longToOrderedBytes(value);
+    }
+
+    /**
+     * Interleaves bits from an array of binary values to create a Z-order value.
+     *
+     * @param array Array of binary values (each value is the output of a zorder_*_bytes function)
+     * @param interleavedSize The size of the output in bytes
+     * @return The interleaved binary value
+     */
+    @ScalarFunction("zorder")
+    @SqlType(StandardTypes.VARBINARY)
+    @SqlNullable
+    public static Slice zorder(@SqlType("array(varbinary)") Block array, @SqlType(StandardTypes.INTEGER) long interleavedSize)
+    {
+        if (array == null || array.getPositionCount() == 0) {
+            // Return zero-filled array for empty input
+            byte[] bytes = new byte[(int) interleavedSize];
+            return Slices.wrappedBuffer(bytes);
+        }
+
+        Slice[] columnsBinary = new Slice[array.getPositionCount()];
+        for (int i = 0; i < array.getPositionCount(); i++) {
+            if (array.isNull(i)) {
+                // Return zero-filled array if any column is null
+                byte[] bytes = new byte[(int) interleavedSize];
+                return Slices.wrappedBuffer(bytes);
+            }
+            columnsBinary[i] = array.getSlice(i, 0, array.getSliceLength(i));
+        }
+
+        return ZOrderByteUtils.interleaveBits(columnsBinary, (int) interleavedSize);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -67,6 +68,7 @@ import static com.facebook.presto.common.Utils.checkArgument;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.getSupportedSortFields;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.Z_ORDER;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByFile;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByGroup;
@@ -78,10 +80,11 @@ import static com.facebook.presto.iceberg.IcebergUtil.parseMinInputFiles;
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
 import static com.facebook.presto.iceberg.SortFieldUtils.parseSortFields;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.SCHEMA;
 import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.TABLE_NAME;
+import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.extractSortFieldStrings;
+import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.extractZOrderColumns;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -152,23 +155,14 @@ public class RewriteDataFilesProcedure
             IcebergTableHandle tableHandle = layoutHandle.getTable();
 
             SortOrder sortOrder = icebergTable.sortOrder();
-            List<String> sortFieldStrings = ImmutableList.of();
-            if (sortOrderIndex.isPresent()) {
-                Object value = arguments[sortOrderIndex.getAsInt()];
-                if (value == null) {
-                    sortFieldStrings = ImmutableList.of();
-                }
-                else if (value instanceof List<?>) {
-                    sortFieldStrings = ((List<?>) value).stream()
-                            .map(String.class::cast)
-                            .collect(toImmutableList());
-                }
-                else {
-                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "sorted_by must be an array(varchar)");
-                }
-            }
-            if (sortFieldStrings != null && !sortFieldStrings.isEmpty()) {
-                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), sortFieldStrings);
+            Optional<List<String>> zOrderColumns = Optional.empty();
+            List<String> sortFieldStrings = extractSortFieldStrings(arguments, sortOrderIndex);
+            if (!sortFieldStrings.isEmpty()) {
+                zOrderColumns = extractZOrderColumns(sortFieldStrings);
+                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(),
+                        sortFieldStrings.stream()
+                                .filter(str -> !str.startsWith("zorder"))
+                                .collect(toImmutableList()));
                 if (specifiedSortOrder.satisfies(sortOrder)) {
                     // If the specified sort order satisfies the target table's internal sort order, use the specified sort order
                     sortOrder = specifiedSortOrder;
@@ -179,6 +173,12 @@ public class RewriteDataFilesProcedure
             }
 
             List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);
+            if (zOrderColumns.isPresent()) {
+                sortFields = ImmutableList.<SortField>builder()
+                        .addAll(sortFields)
+                        .add(new SortField(Z_ORDER.getId(), com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST))
+                        .build();
+            }
             return new IcebergDistributedProcedureHandle(
                     tableHandle.getSchemaName(),
                     tableHandle.getIcebergTableName(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/ZOrderByteUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/ZOrderByteUtils.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.util;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * Utility class for Z-Order byte operations.
+ * Converts various types to lexicographically ordered byte representations
+ * and interleaves bits for Z-Order curve computation.
+ *
+ * <p>Based on Apache Iceberg's ZOrderByteUtils implementation:
+ * https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
+ */
+public final class ZOrderByteUtils
+{
+    public static final int PRIMITIVE_BUFFER_SIZE = 8;
+
+    private ZOrderByteUtils() {}
+
+    /**
+     * Converts a byte value to ordered bytes.
+     */
+    public static Slice tinyintToOrderedBytes(byte val)
+    {
+        return wholeNumberOrderedBytes(val);
+    }
+
+    /**
+     * Converts a short value to ordered bytes.
+     */
+    public static Slice shortToOrderedBytes(short val)
+    {
+        return wholeNumberOrderedBytes(val);
+    }
+
+    /**
+     * Converts an int value to ordered bytes.
+     */
+    public static Slice intToOrderedBytes(int val)
+    {
+        return wholeNumberOrderedBytes(val);
+    }
+
+    /**
+     * Converts a long value to ordered bytes.
+     */
+    public static Slice longToOrderedBytes(long val)
+    {
+        return wholeNumberOrderedBytes(val);
+    }
+
+    /**
+     * Signed longs do not have their bytes in magnitude order because of the sign bit.
+     * To fix this, flip the sign bit so that all negatives are ordered before positives.
+     */
+    private static Slice wholeNumberOrderedBytes(long val)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(PRIMITIVE_BUFFER_SIZE);
+        buffer.putLong(val ^ 0x8000000000000000L);
+        return Slices.wrappedBuffer(buffer.array());
+    }
+
+    /**
+     * Converts a float value to ordered bytes.
+     */
+    public static Slice floatToOrderedBytes(float val)
+    {
+        return floatingPointOrderedBytes(val);
+    }
+
+    /**
+     * Converts a double value to ordered bytes.
+     */
+    public static Slice doubleToOrderedBytes(double val)
+    {
+        return floatingPointOrderedBytes(val);
+    }
+
+    /**
+     * IEEE 754: "If two floating-point numbers in the same format are ordered (say, x < y),
+     * they are ordered the same way when their bits are reinterpreted as sign-magnitude integers."
+     *
+     * <p>Which means doubles can be treated as sign magnitude integers which can then be converted
+     * into lexicographically comparable bytes.
+     */
+    private static Slice floatingPointOrderedBytes(double val)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(PRIMITIVE_BUFFER_SIZE);
+        long lval = Double.doubleToLongBits(val);
+        lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
+        buffer.putLong(lval);
+        return Slices.wrappedBuffer(buffer.array());
+    }
+
+    /**
+     * Converts a boolean value to ordered bytes.
+     */
+    public static Slice booleanToOrderedBytes(boolean val)
+    {
+        byte[] bytes = new byte[PRIMITIVE_BUFFER_SIZE];
+        bytes[0] = (byte) (val ? -127 : 0);
+        return Slices.wrappedBuffer(bytes);
+    }
+
+    /**
+     * Strings are lexicographically sortable BUT different byte array lengths will ruin the
+     * Z-Ordering. This implementation uses a set size for all output byte representations,
+     * truncating longer strings and right padding with 0 for shorter strings.
+     */
+    public static Slice stringToOrderedBytes(Slice val, int length)
+    {
+        byte[] bytes = new byte[length];
+        Arrays.fill(bytes, (byte) 0x00);
+
+        if (val != null) {
+            byte[] inputBytes = val.getBytes();
+            int copyLength = Math.min(inputBytes.length, length);
+            System.arraycopy(inputBytes, 0, bytes, 0, copyLength);
+        }
+
+        return Slices.wrappedBuffer(bytes);
+    }
+
+    /**
+     * Return a Slice with the given bytes truncated to length, or filled with 0's to length
+     * depending on whether the given bytes are larger or smaller than the given length.
+     */
+    public static Slice byteTruncateOrFill(Slice val, int length)
+    {
+        byte[] bytes = new byte[length];
+
+        if (val == null) {
+            Arrays.fill(bytes, (byte) 0x00);
+            return Slices.wrappedBuffer(bytes);
+        }
+
+        byte[] inputBytes = val.getBytes();
+        if (inputBytes.length < length) {
+            System.arraycopy(inputBytes, 0, bytes, 0, inputBytes.length);
+            Arrays.fill(bytes, inputBytes.length, length, (byte) 0x00);
+        }
+        else {
+            System.arraycopy(inputBytes, 0, bytes, 0, length);
+        }
+
+        return Slices.wrappedBuffer(bytes);
+    }
+
+    /**
+     * Interleave bits using a naive loop. Variable length inputs are allowed but to get a consistent
+     * ordering it is required that every column contribute the same number of bytes in each invocation.
+     * Bits are interleaved from all columns that have a bit available at that position.
+     * Once a column has no more bits to produce it is skipped in the interleaving.
+     *
+     * @param columnsBinary an array of ordered byte representations of the columns being ZOrdered
+     * @param interleavedSize the number of bytes to use in the output
+     * @return the column bytes interleaved
+     */
+    public static Slice interleaveBits(Slice[] columnsBinary, int interleavedSize)
+    {
+        byte[] interleavedBytes = new byte[interleavedSize];
+        Arrays.fill(interleavedBytes, (byte) 0x00);
+
+        int sourceColumn = 0;
+        int sourceByte = 0;
+        int sourceBit = 7;
+        int interleaveByte = 0;
+        int interleaveBit = 7;
+
+        while (interleaveByte < interleavedSize) {
+            // Get the source column bytes
+            byte[] sourceBytes = columnsBinary[sourceColumn].getBytes();
+
+            // Take the source bit from source byte and move it to the output bit position
+            interleavedBytes[interleaveByte] |=
+                    (sourceBytes[sourceByte] & 1 << sourceBit) >>> sourceBit << interleaveBit;
+            --interleaveBit;
+
+            // Check if an output byte has been completed
+            if (interleaveBit == -1) {
+                // Move to the next output byte
+                interleaveByte++;
+                // Move to the highest order bit of the new output byte
+                interleaveBit = 7;
+            }
+
+            // Check if the last output byte has been completed
+            if (interleaveByte == interleavedSize) {
+                break;
+            }
+
+            // Find the next source bit to interleave
+            do {
+                // Move to next column
+                ++sourceColumn;
+                if (sourceColumn == columnsBinary.length) {
+                    // If the last source column was used, reset to next bit of first column
+                    sourceColumn = 0;
+                    --sourceBit;
+                    if (sourceBit == -1) {
+                        // If the last bit of the source byte was used, reset to the highest bit of the next byte
+                        sourceByte++;
+                        sourceBit = 7;
+                    }
+                }
+            }
+            while (columnsBinary[sourceColumn].length() <= sourceByte);
+        }
+
+        return Slices.wrappedBuffer(interleavedBytes);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -231,6 +231,12 @@ public class TestRewriteDataFilesProcedure
             // do not support rewrite files filtered by non-identity columns
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, TEST_SCHEMA), ".*");
 
+            String tableName1 = "my_table";
+            String schema = "my_schema";
+            System.out.println(getQueryRunner().execute(
+                    format("explain (type distributed) CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''')",
+                            tableName1, schema)
+            ).toString());
             // select 5 files to rewrite
             assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''')", tableName, TEST_SCHEMA), 5);
             table.refresh();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/function/TestIcebergZOrderFunctions.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/function/TestIcebergZOrderFunctions.java
@@ -1,0 +1,428 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.function;
+
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import java.util.OptionalInt;
+
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+
+/**
+ * Tests for Z-Order UDFs.
+ */
+public class TestIcebergZOrderFunctions
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HADOOP)
+                .setFormat(PARQUET)
+                .setNodeCount(OptionalInt.of(1))
+                .setCreateTpchTables(false)
+                .setAddJmxPlugin(false)
+                .build().getQueryRunner();
+    }
+
+    @Test
+    public void testZOrderTinyintBytes()
+    {
+        // Test that tinyint values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_tinyint_bytes(TINYINT '42'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_tinyint_bytes(TINYINT '-42'))", "SELECT 8");
+
+        // Test ordering: negative < positive
+        assertQuery(
+                "SELECT zorder_tinyint_bytes(TINYINT '-1') < zorder_tinyint_bytes(TINYINT '1')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderSmallintBytes()
+    {
+        // Test that smallint values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_smallint_bytes(SMALLINT '1000'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_smallint_bytes(SMALLINT '-1000'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_smallint_bytes(SMALLINT '-100') < zorder_smallint_bytes(SMALLINT '100')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderIntegerBytes()
+    {
+        // Test that integer values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_integer_bytes(INTEGER '100000'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_integer_bytes(INTEGER '-100000'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_integer_bytes(INTEGER '-1000') < zorder_integer_bytes(INTEGER '1000')",
+                "SELECT true");
+        assertQuery(
+                "SELECT zorder_integer_bytes(INTEGER '100') < zorder_integer_bytes(INTEGER '200')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderBigintBytes()
+    {
+        // Test that bigint values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_bigint_bytes(BIGINT '9223372036854775807'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_bigint_bytes(BIGINT '-9223372036854775808'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_bigint_bytes(BIGINT '-1000000') < zorder_bigint_bytes(BIGINT '1000000')",
+                "SELECT true");
+        assertQuery(
+                "SELECT zorder_bigint_bytes(BIGINT '1000') < zorder_bigint_bytes(BIGINT '2000')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderRealBytes()
+    {
+        // Test that real values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_real_bytes(REAL '3.14'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_real_bytes(REAL '-3.14'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_real_bytes(REAL '-1.5') < zorder_real_bytes(REAL '1.5')",
+                "SELECT true");
+        assertQuery(
+                "SELECT zorder_real_bytes(REAL '1.0') < zorder_real_bytes(REAL '2.0')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderDoubleBytes()
+    {
+        // Test that double values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_double_bytes(DOUBLE '3.141592653589793'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_double_bytes(DOUBLE '-3.141592653589793'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_double_bytes(DOUBLE '-1.5') < zorder_double_bytes(DOUBLE '1.5')",
+                "SELECT true");
+        assertQuery(
+                "SELECT zorder_double_bytes(DOUBLE '1.0') < zorder_double_bytes(DOUBLE '2.0')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderBooleanBytes()
+    {
+        // Test that boolean values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_boolean_bytes(true))", "SELECT 8");
+        assertQuery("SELECT length(zorder_boolean_bytes(false))", "SELECT 8");
+
+        // Test ordering: false < true
+        assertQuery(
+                "SELECT zorder_boolean_bytes(false) < zorder_boolean_bytes(true)",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderVarcharBytes()
+    {
+        // Test that varchar values are converted to ordered bytes with specified length
+        assertQuery("SELECT length(zorder_varchar_bytes('hello', 10))", "SELECT 10");
+        assertQuery("SELECT length(zorder_varchar_bytes('world', 20))", "SELECT 20");
+
+        // Test truncation
+        assertQuery("SELECT length(zorder_varchar_bytes('this is a very long string', 10))", "SELECT 10");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_varchar_bytes('apple', 10) < zorder_varchar_bytes('banana', 10)",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderVarbinaryBytes()
+    {
+        // Test that varbinary values are converted to ordered bytes with specified length
+        assertQuery("SELECT length(zorder_varbinary_bytes(X'DEADBEEF', 10))", "SELECT 10");
+        assertQuery("SELECT length(zorder_varbinary_bytes(X'CAFE', 20))", "SELECT 20");
+    }
+
+    @Test
+    public void testZOrderDateBytes()
+    {
+        // Test that date values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_date_bytes(DATE '2024-01-01'))", "SELECT 8");
+        assertQuery("SELECT length(zorder_date_bytes(DATE '1970-01-01'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_date_bytes(DATE '2020-01-01') < zorder_date_bytes(DATE '2024-01-01')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderTimestampBytes()
+    {
+        // Test that timestamp values are converted to ordered bytes
+        assertQuery("SELECT length(zorder_timestamp_bytes(TIMESTAMP '2024-01-01 12:00:00'))", "SELECT 8");
+
+        // Test ordering
+        assertQuery(
+                "SELECT zorder_timestamp_bytes(TIMESTAMP '2020-01-01 00:00:00') < " +
+                "zorder_timestamp_bytes(TIMESTAMP '2024-01-01 00:00:00')",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderInterleave()
+    {
+        // Test interleaving with 2 columns
+        assertQuery(
+                "SELECT length(zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(2)], 16))",
+                "SELECT 16");
+
+        // Test interleaving with 3 columns
+        assertQuery(
+                "SELECT length(zorder(ARRAY[" +
+                "zorder_integer_bytes(1), " +
+                "zorder_integer_bytes(2), " +
+                "zorder_integer_bytes(3)], 24))",
+                "SELECT 24");
+
+        // Test that different input orders produce different outputs
+        assertQuery(
+                "SELECT zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(2)], 16) != " +
+                "zorder(ARRAY[zorder_integer_bytes(2), zorder_integer_bytes(1)], 16)",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderInterleaveTwoColumns()
+    {
+        // Test a complete Z-order computation with 2 integer columns
+        assertQuery(
+                "SELECT length(zorder(ARRAY[" +
+                "zorder_integer_bytes(100), " +
+                "zorder_integer_bytes(200)], 16))",
+                "SELECT 16");
+
+        // Verify that points closer in 2D space have closer Z-order values
+        // Point (1,1) should be closer to (1,2) than to (100,100)
+        assertQuery(
+                "WITH points AS (" +
+                "  SELECT 1 as x, 1 as y, zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(1)], 16) as z " +
+                "  UNION ALL " +
+                "  SELECT 1 as x, 2 as y, zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(2)], 16) as z " +
+                "  UNION ALL " +
+                "  SELECT 100 as x, 100 as y, zorder(ARRAY[zorder_integer_bytes(100), zorder_integer_bytes(100)], 16) as z" +
+                ") " +
+                "SELECT COUNT(*) FROM points",
+                "SELECT 3");
+    }
+
+    @Test
+    public void testZOrderInterleaveThreeColumns()
+    {
+        // Test a complete Z-order computation with 3 columns of different types
+        assertQuery(
+                "SELECT length(zorder(ARRAY[" +
+                "zorder_integer_bytes(100), " +
+                "zorder_double_bytes(3.14), " +
+                "zorder_varchar_bytes('test', 10)], 24))",
+                "SELECT 24");
+    }
+
+    @Test
+    public void testZOrderInterleaveFourColumns()
+    {
+        // Test with 4 columns
+        assertQuery(
+                "SELECT length(zorder(ARRAY[" +
+                "zorder_integer_bytes(1), " +
+                "zorder_integer_bytes(2), " +
+                "zorder_integer_bytes(3), " +
+                "zorder_integer_bytes(4)], 32))",
+                "SELECT 32");
+    }
+
+    @Test
+    public void testZOrderWithNullHandling()
+    {
+        // Test that null inputs return zero-filled byte arrays (not NULL)
+        assertQuery("SELECT zorder_integer_bytes(NULL) IS NOT NULL", "SELECT true");
+        assertQuery("SELECT length(zorder_integer_bytes(NULL))", "SELECT 8");
+        
+        // Test that varchar with null returns zero-filled array
+        assertQuery("SELECT zorder_varchar_bytes(NULL, 10) IS NOT NULL", "SELECT true");
+        assertQuery("SELECT length(zorder_varchar_bytes(NULL, 10))", "SELECT 10");
+
+        // Test that interleave returns zero-filled array if any input is null
+        assertQuery(
+                "SELECT zorder(ARRAY[zorder_integer_bytes(1), NULL], 16) IS NOT NULL",
+                "SELECT true");
+        
+        // Verify the zero-filled array has the correct length
+        assertQuery(
+                "SELECT length(zorder(ARRAY[zorder_integer_bytes(1), NULL], 16))",
+                "SELECT 16");
+    }
+
+    @Test
+    public void testZOrderConsistency()
+    {
+        // Test that the same input always produces the same output
+        assertQuery(
+                "SELECT zorder_integer_bytes(42) = zorder_integer_bytes(42)",
+                "SELECT true");
+
+        assertQuery(
+                "SELECT zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(2)], 16) = " +
+                "zorder(ARRAY[zorder_integer_bytes(1), zorder_integer_bytes(2)], 16)",
+                "SELECT true");
+    }
+
+    @Test
+    public void testZOrderWithTableData()
+    {
+        // Create a table with some data including nulls
+        assertUpdate("CREATE TABLE test_zorder_table (id INT, name VARCHAR, value DOUBLE)");
+        assertUpdate("INSERT INTO test_zorder_table VALUES (1, 'alice', 100.5), (2, 'bob', 200.3), (3, NULL, 150.0), (NULL, 'charlie', NULL)", 4);
+
+        // Test Z-order computation on table data - UDFs always return non-null bytes
+        assertQuery(
+                "SELECT id, name FROM test_zorder_table WHERE id IS NOT NULL ORDER BY id",
+                "VALUES (1, 'alice'), (2, 'bob'), (3, CAST(NULL AS VARCHAR))");
+
+        // Test interleaving multiple columns from table
+        assertQuery(
+                "SELECT id FROM test_zorder_table WHERE id IS NOT NULL AND value IS NOT NULL ORDER BY id",
+                "VALUES 1, 2, 3");
+
+        // Verify that all rows (including NULL id) return byte arrays with correct length
+        assertQuery(
+                "SELECT COUNT(*) FROM test_zorder_table WHERE length(zorder_integer_bytes(id)) = 8",
+                "SELECT 4");
+        
+        // Verify NULL id produces zero-filled bytes (0x0000000000000000)
+        assertQuery(
+                "SELECT length(zorder_integer_bytes(id)) FROM test_zorder_table WHERE id IS NULL",
+                "SELECT 8");
+
+        assertUpdate("DROP TABLE test_zorder_table");
+    }
+
+    @Test
+    public void testZOrderSorting()
+    {
+        /*
+         * Z-Order Curve Visualization (2D Space):
+         *
+         * Y-axis
+         *   2 |  4---5       6---7
+         *     |  |   |       |   |
+         *   1 |  2---3       |   |
+         *     |  |   |       |   |
+         *   0 |  0---1-------+---+
+         *     +-------------------> X-axis
+         *        0   1   2   3
+         *
+         * Z-order traversal follows the curve: 0→1→2→3→4→5→6→7
+         * This creates spatial locality - nearby points in 2D space
+         * are also nearby in the 1D Z-order sequence.
+         *
+         * Our test data points:
+         *   0: (0,0) origin
+         *   1: (1,0) middle-bottom
+         *   2: (0,1) left-middle
+         *   3: (1,1) diagonal1
+         *   4: (2,0) bottom-right
+         *   5: (0,2) top-left
+         *   6: (2,2) diagonal2
+         *
+         * Expected Z-order: (0,0) → (1,0) → (0,1) → (1,1) → (2,0) → (0,2) → (2,2)
+         */
+        
+        // Create a table with 2D spatial data
+        assertUpdate("CREATE TABLE test_zorder_sort (x INT, y INT, name VARCHAR)");
+        assertUpdate("INSERT INTO test_zorder_sort VALUES " +
+                "(0, 0, 'origin'), " +
+                "(1, 1, 'diagonal1'), " +
+                "(2, 2, 'diagonal2'), " +
+                "(0, 2, 'top-left'), " +
+                "(2, 0, 'bottom-right'), " +
+                "(1, 0, 'middle-bottom'), " +
+                "(0, 1, 'left-middle')", 7);
+
+        // Order by Z-order value (interleaved x,y coordinates)
+        // Z-order should cluster spatially close points together
+        assertQuery(
+                "SELECT x, y, name FROM test_zorder_sort " +
+                "ORDER BY zorder(ARRAY[zorder_integer_bytes(x), zorder_integer_bytes(y)], 16)",
+                "VALUES " +
+                "(0, 0, 'origin'), " +
+                "(1, 0, 'middle-bottom'), " +
+                "(0, 1, 'left-middle'), " +
+                "(1, 1, 'diagonal1'), " +
+                "(2, 0, 'bottom-right'), " +
+                "(0, 2, 'top-left'), " +
+                "(2, 2, 'diagonal2')");
+
+        // Verify ordering with 3 columns
+        assertUpdate("CREATE TABLE test_zorder_3d (x INT, y INT, z INT)");
+        assertUpdate("INSERT INTO test_zorder_3d VALUES (1, 2, 3), (0, 0, 0), (2, 1, 0), (1, 1, 1)", 4);
+
+        assertQuery(
+                "SELECT x, y, z FROM test_zorder_3d " +
+                "ORDER BY zorder(ARRAY[zorder_integer_bytes(x), zorder_integer_bytes(y), zorder_integer_bytes(z)], 24)",
+                "VALUES (0, 0, 0), (1, 1, 1), (2, 1, 0), (1, 2, 3)");
+
+
+        // Order by Z-order value (interleaved x,y coordinates)
+        // Z-order should cluster spatially close points together
+        assertUpdate("CREATE TABLE test_zorder (x INT, y INT, name VARCHAR)");
+        System.out.println(getQueryRunner().execute(
+                "EXPLAIN (TYPE DISTRIBUTED) INSERT INTO test_zorder SELECT x, y, name FROM test_zorder_sort " +
+                        "ORDER BY zorder(ARRAY[zorder_integer_bytes(x), zorder_integer_bytes(y)], 16)")
+                .toString());
+        assertUpdate(
+                "INSERT INTO test_zorder SELECT x, y, name FROM test_zorder_sort " +
+                        "ORDER BY zorder(ARRAY[zorder_integer_bytes(x), zorder_integer_bytes(y)], 16)",
+                7);
+        assertQuery(
+                "SELECT x, y, name FROM test_zorder",
+                "VALUES " +
+                        "(0, 0, 'origin'), " +
+                        "(1, 0, 'middle-bottom'), " +
+                        "(0, 1, 'left-middle'), " +
+                        "(1, 1, 'diagonal1'), " +
+                        "(2, 0, 'bottom-right'), " +
+                        "(0, 2, 'top-left'), " +
+                        "(2, 2, 'diagonal2')");
+
+        assertUpdate("DROP TABLE test_zorder_sort");
+        assertUpdate("DROP TABLE test_zorder_3d");
+        assertUpdate("DROP TABLE test_zorder");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/function/TestIcebergZOrderFunctions.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/function/TestIcebergZOrderFunctions.java
@@ -222,8 +222,7 @@ public class TestIcebergZOrderFunctions
     public void testZOrderInterleaveTwoColumns()
     {
         // Test a complete Z-order computation with 2 integer columns
-        assertQuery(
-                "SELECT length(zorder(ARRAY[" +
+        assertQuery("SELECT length(zorder(ARRAY[" +
                 "zorder_integer_bytes(100), " +
                 "zorder_integer_bytes(200)], 16))",
                 "SELECT 16");
@@ -273,16 +272,17 @@ public class TestIcebergZOrderFunctions
         // Test that null inputs return zero-filled byte arrays (not NULL)
         assertQuery("SELECT zorder_integer_bytes(NULL) IS NOT NULL", "SELECT true");
         assertQuery("SELECT length(zorder_integer_bytes(NULL))", "SELECT 8");
-        
+
         // Test that varchar with null returns zero-filled array
-        assertQuery("SELECT zorder_varchar_bytes(NULL, 10) IS NOT NULL", "SELECT true");
+        assertQuery(
+                "SELECT zorder_varchar_bytes(NULL, 10) IS NOT NULL", "SELECT true");
         assertQuery("SELECT length(zorder_varchar_bytes(NULL, 10))", "SELECT 10");
 
         // Test that interleave returns zero-filled array if any input is null
         assertQuery(
                 "SELECT zorder(ARRAY[zorder_integer_bytes(1), NULL], 16) IS NOT NULL",
                 "SELECT true");
-        
+
         // Verify the zero-filled array has the correct length
         assertQuery(
                 "SELECT length(zorder(ARRAY[zorder_integer_bytes(1), NULL], 16))",
@@ -324,7 +324,7 @@ public class TestIcebergZOrderFunctions
         assertQuery(
                 "SELECT COUNT(*) FROM test_zorder_table WHERE length(zorder_integer_bytes(id)) = 8",
                 "SELECT 4");
-        
+
         // Verify NULL id produces zero-filled bytes (0x0000000000000000)
         assertQuery(
                 "SELECT length(zorder_integer_bytes(id)) FROM test_zorder_table WHERE id IS NULL",
@@ -363,7 +363,7 @@ public class TestIcebergZOrderFunctions
          *
          * Expected Z-order: (0,0) → (1,0) → (0,1) → (1,1) → (2,0) → (0,2) → (2,2)
          */
-        
+
         // Create a table with 2D spatial data
         assertUpdate("CREATE TABLE test_zorder_sort (x INT, y INT, name VARCHAR)");
         assertUpdate("INSERT INTO test_zorder_sort VALUES " +
@@ -397,7 +397,6 @@ public class TestIcebergZOrderFunctions
                 "SELECT x, y, z FROM test_zorder_3d " +
                 "ORDER BY zorder(ARRAY[zorder_integer_bytes(x), zorder_integer_bytes(y), zorder_integer_bytes(z)], 24)",
                 "VALUES (0, 0, 0), (1, 1, 1), (2, 1, 0), (1, 2, 3)");
-
 
         // Order by Z-order value (interleaved x,y coordinates)
         // Z-order should cluster spatially close points together

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -276,6 +276,8 @@ import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
 import static com.facebook.presto.spi.function.table.DescriptorArgument.NULL_DESCRIPTOR;
 import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
+import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.extractSortFieldStrings;
+import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.extractZOrderColumns;
 import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
 import static com.facebook.presto.sql.MaterializedViewUtils.buildOwnerSession;
@@ -1457,6 +1459,8 @@ class StatementAnalyzer
                                     session.getAccessControlContext(),
                                     tableName));
 
+                    List<String> sortFieldStrings = extractSortFieldStrings(values, tableDataRewriteDistributedProcedure.getSortOrderIndex());
+                    Optional<List<String>> zOrderColumns = extractZOrderColumns(sortFieldStrings);
                     String filter = tableDataRewriteDistributedProcedure.getFilter(values);
                     Expression filterExpression = sqlParser.createExpression(filter);
                     QuerySpecification querySpecification = new QuerySpecification(
@@ -1472,7 +1476,7 @@ class StatementAnalyzer
 
                     TableHandle tableHandle = metadata.getHandleVersion(session, tableName, Optional.empty())
                             .orElseThrow(() -> (new SemanticException(MISSING_TABLE, call, "Table '%s' does not exist", tableName)));
-                    TableDataRewriteAnalysisContext tableDataRewriteAnalysisContext = new TableDataRewriteAnalysisContext(tableHandle, querySpecification);
+                    TableDataRewriteAnalysisContext tableDataRewriteAnalysisContext = new TableDataRewriteAnalysisContext(tableHandle, querySpecification, zOrderColumns);
                     analysis.setCallDistributedProcedureAnalysis(new Analysis.CallDistributedProcedureAnalysis(procedureType, values, Optional.of(tableDataRewriteAnalysisContext)));
                     break;
                 default:

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -89,6 +89,7 @@ import com.facebook.presto.sql.MaterializedViewUtils;
 import com.facebook.presto.sql.analyzer.Analysis.MergeAnalysis;
 import com.facebook.presto.sql.analyzer.Analysis.TableArgumentAnalysis;
 import com.facebook.presto.sql.analyzer.Analysis.TableFunctionInvocationAnalysis;
+import com.facebook.presto.sql.analyzer.procedure.TableDataRewriteAnalysisContext;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
@@ -1432,9 +1433,8 @@ class StatementAnalyzer
             accessControl.checkCanCallProcedure(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), procedureName);
 
             analysis.setUpdateInfo(call.getUpdateInfo());
-            analysis.setDistributedProcedureType(Optional.of(procedure.getType()));
-            analysis.setProcedureArguments(Optional.of(values));
-            switch (procedure.getType()) {
+            DistributedProcedure.DistributedProcedureType procedureType = procedure.getType();
+            switch (procedureType) {
                 case TABLE_DATA_REWRITE:
                     TableDataRewriteDistributedProcedure tableDataRewriteDistributedProcedure = (TableDataRewriteDistributedProcedure) procedure;
                     QualifiedName qualifiedName = QualifiedName.of(tableDataRewriteDistributedProcedure.getSchema(values), tableDataRewriteDistributedProcedure.getTableName(values));
@@ -1469,11 +1469,11 @@ class StatementAnalyzer
                             Optional.empty(),
                             Optional.empty());
                     analyze(querySpecification, scope);
-                    analysis.setTargetQuery(querySpecification);
 
                     TableHandle tableHandle = metadata.getHandleVersion(session, tableName, Optional.empty())
                             .orElseThrow(() -> (new SemanticException(MISSING_TABLE, call, "Table '%s' does not exist", tableName)));
-                    analysis.setCallTarget(tableHandle);
+                    TableDataRewriteAnalysisContext tableDataRewriteAnalysisContext = new TableDataRewriteAnalysisContext(tableHandle, querySpecification);
+                    analysis.setCallDistributedProcedureAnalysis(new Analysis.CallDistributedProcedureAnalysis(procedureType, values, Optional.of(tableDataRewriteAnalysisContext)));
                     break;
                 default:
                     throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "Unsupported distributed procedure type: " + procedure.getType());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.metadata.TableLayout.TablePartitioning;
@@ -135,6 +136,8 @@ import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateCons
 import static com.facebook.presto.sql.planner.PlannerUtils.newVariable;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.TranslateExpressionsUtil.toRowExpression;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.tree.ExplainFormat.Type.TEXT;
 import static com.google.common.base.Preconditions.checkState;
@@ -315,6 +318,25 @@ public class LogicalPlanner
                 .map(columnToVariableMap::get)
                 .collect(toImmutableSet());
 
+        PlanNode queryRoot = plan.getRoot();
+        Optional<List<String>> zOrderColumns = analysis.getCallDistributedProcedureAnalysis()
+                .flatMap(Analysis.CallDistributedProcedureAnalysis::getProcedureAnalysisContext)
+                .map(TableDataRewriteAnalysisContext.class::cast)
+                .flatMap(TableDataRewriteAnalysisContext::getzOrderColumns);
+        if (zOrderColumns.isPresent() && !zOrderColumns.get().isEmpty()) {
+            // todo: use the column names in `zOrderColumns` to construct a `zorder` function to replace to `to_utf8` function here.
+            VariableReferenceExpression orderCol1 = columnToVariableMap.get(zOrderColumns.get().get(0));
+            CallExpression castToVarchar = call("CAST", metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, orderCol1.getType(), VARCHAR), VARCHAR, orderCol1);
+            CallExpression varbinaryFunction = call("to_utf8", metadata.getFunctionAndTypeManager().lookupFunction("to_utf8", fromTypes(VARCHAR)), VARBINARY, castToVarchar);
+            VariableReferenceExpression output = variableAllocator.newVariable("$z_order", VARBINARY);
+            Assignments assignments = Assignments.builder()
+                    .putAll(identityAssignments(queryRoot.getOutputVariables()))
+                    .put(output, varbinaryFunction)
+                    .build();
+            queryRoot = new ProjectNode(idAllocator.getNextId(), queryRoot, assignments);
+            columnNames = ImmutableList.<String>builder().addAll(columnNames).add("$z_order").build();
+        }
+
         CallDistributedProcedureTarget callDistributedProcedureTarget = new CallDistributedProcedureTarget(
                 procedureName.get(),
                 procedureArguments.get(),
@@ -328,12 +350,12 @@ public class LogicalPlanner
                         Optional.empty(),
                         idAllocator.getNextId(),
                         Optional.empty(),
-                        plan.getRoot(),
+                        queryRoot,
                         Optional.of(callDistributedProcedureTarget),
                         variableAllocator.newVariable("rows", BIGINT),
                         variableAllocator.newVariable("fragment", VARBINARY),
                         variableAllocator.newVariable("commitcontext", VARBINARY),
-                        plan.getRoot().getOutputVariables(),
+                        queryRoot.getOutputVariables(),
                         columnNames,
                         notNullColumnVariables,
                         partitioningScheme),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -51,6 +51,7 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TableWriterNode.CallDistributedProcedureTarget;
 import com.facebook.presto.spi.plan.TableWriterNode.DeleteHandle;
 import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.procedure.DistributedProcedure;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -63,6 +64,7 @@ import com.facebook.presto.sql.analyzer.Field;
 import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
+import com.facebook.presto.sql.analyzer.procedure.TableDataRewriteAnalysisContext;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.StatisticsAggregationPlanner.TableStatisticAggregation;
 import com.facebook.presto.sql.planner.plan.CallDistributedProcedureNode;
@@ -201,12 +203,15 @@ public class LogicalPlanner
             return createAnalyzePlan(analysis, (Analyze) statement);
         }
         else if (statement instanceof Call) {
-            checkState(analysis.getDistributedProcedureType().isPresent(), "Call distributed procedure analysis is missing");
-            switch (analysis.getDistributedProcedureType().get()) {
+            Optional<DistributedProcedure.DistributedProcedureType> procedureType = analysis.getCallDistributedProcedureAnalysis()
+                    .map(Analysis.CallDistributedProcedureAnalysis::getDistributedProcedureType);
+            checkState(procedureType.isPresent(),
+                    "Call distributed procedure analysis is missing");
+            switch (procedureType.get()) {
                 case TABLE_DATA_REWRITE:
                     return createCallDistributedProcedurePlanForTableDataRewrite(analysis, (Call) statement);
                 default:
-                    throw new PrestoException(NOT_SUPPORTED, "Unsupported distributed procedure type: " + analysis.getDistributedProcedureType().get());
+                    throw new PrestoException(NOT_SUPPORTED, "Unsupported distributed procedure type: " + procedureType.get());
             }
         }
         else if (statement instanceof Insert) {
@@ -258,12 +263,19 @@ public class LogicalPlanner
 
     private RelationPlan createCallDistributedProcedurePlanForTableDataRewrite(Analysis analysis, Call statement)
     {
-        TableHandle targetTable = analysis.getCallTarget()
+        TableHandle targetTable = analysis.getCallDistributedProcedureAnalysis()
+                .flatMap(Analysis.CallDistributedProcedureAnalysis::getProcedureAnalysisContext)
+                .map(TableDataRewriteAnalysisContext.class::cast)
+                .map(TableDataRewriteAnalysisContext::getCallTarget)
                 .orElseThrow(() -> new PrestoException(NOT_FOUND, "Target table does not exist"));
         Optional<QualifiedObjectName> procedureName = analysis.getProcedureName();
-        Optional<Object[]> procedureArguments = analysis.getProcedureArguments();
+        Optional<Object[]> procedureArguments = analysis.getCallDistributedProcedureAnalysis()
+                .map(Analysis.CallDistributedProcedureAnalysis::getProcedureArguments);
 
-        QuerySpecification querySpecification = analysis.getTargetQuery()
+        QuerySpecification querySpecification = analysis.getCallDistributedProcedureAnalysis()
+                .flatMap(Analysis.CallDistributedProcedureAnalysis::getProcedureAnalysisContext)
+                .map(TableDataRewriteAnalysisContext.class::cast)
+                .map(TableDataRewriteAnalysisContext::getTargetQuery)
                 .orElseThrow(() -> new PrestoException(NOT_FOUND, "The query for target table does not exist"));
         RelationPlan plan = createRelationPlan(analysis, querySpecification, new SqlPlannerContext(0));
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/ProcedureAnalysisContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/ProcedureAnalysisContext.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.procedure;
+
+/**
+ * This is a context interface that supports each specific subtype of distributed procedure in
+ * implementing and extending its own unique fields during the analyzing phase.
+ * */
+public interface ProcedureAnalysisContext
+{
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
@@ -16,15 +16,23 @@ package com.facebook.presto.spi.procedure;
 import com.facebook.presto.spi.ConnectorDistributedProcedureHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorProcedureContext;
 import io.airlift.slice.Slice;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.procedure.DistributedProcedure.DistributedProcedureType.TABLE_DATA_REWRITE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -32,6 +40,10 @@ import static java.util.Objects.requireNonNull;
 public class TableDataRewriteDistributedProcedure
         extends DistributedProcedure
 {
+    private static final Pattern ZORDER_PATTERN = Pattern.compile(
+            "^zorder\\s*\\(\\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\\s*,\\s*[a-zA-Z_][a-zA-Z0-9_]*)*)?\\s*\\)$",
+            Pattern.CASE_INSENSITIVE);
+
     public static final String SCHEMA = "schema";
     public static final String TABLE_NAME = "table_name";
     public static final String FILTER = "filter";
@@ -129,5 +141,49 @@ public class TableDataRewriteDistributedProcedure
     public interface FinishCallDistributedProcedure
     {
         void finish(ConnectorSession session, ConnectorProcedureContext procedureContext, ConnectorDistributedProcedureHandle procedureHandle, Collection<Slice> fragments);
+    }
+
+    public static List<String> extractSortFieldStrings(Object[] arguments, OptionalInt sortOrderIndex)
+    {
+        List<String> sortFieldStrings = Collections.emptyList();
+        if (sortOrderIndex.isPresent()) {
+            Object value = arguments[sortOrderIndex.getAsInt()];
+            if (value == null) {
+                sortFieldStrings = Collections.emptyList();
+            }
+            else if (value instanceof List<?>) {
+                sortFieldStrings = Collections.unmodifiableList(((List<?>) value).stream()
+                        .map(String.class::cast)
+                        .collect(Collectors.toList()));
+            }
+            else {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "sorted_by must be an array(varchar)");
+            }
+        }
+        return sortFieldStrings;
+    }
+
+    public static Optional<List<String>> extractZOrderColumns(List<String> sortFieldStrings)
+    {
+        return sortFieldStrings.stream()
+                .map(TableDataRewriteDistributedProcedure::parse)
+                .filter(Optional::isPresent).findFirst()
+                .map(Optional::get);
+    }
+
+    private static Optional<List<String>> parse(String input)
+    {
+        Matcher matcher = ZORDER_PATTERN.matcher(input);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        String group = matcher.group(1);
+        if (group == null || group.trim().isEmpty()) {
+            return Optional.of(Collections.emptyList());
+        }
+
+        String[] parts = group.split("\\s*,\\s*");
+        return Optional.of(Arrays.asList(parts));
     }
 }


### PR DESCRIPTION
## Description

[DNM]: this pr try to enable `rewrite_data_files` to sort by values generated by a dummy `zorder` function.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add Z-order based sorting support to the Iceberg rewrite_data_files distributed procedure and centralize distributed procedure call analysis context.

New Features:
- Introduce Iceberg Z-order scalar functions and utilities to generate ordered VARBINARY representations and interleave them for Z-order curve computation.
- Register Iceberg Z-order functions with the Iceberg plugin so they can be used in SQL queries.
- Support specifying Z-order columns via the rewrite_data_files distributed procedure and propagate them through analysis and planning to affect table data rewrite behavior.

Enhancements:
- Refactor distributed procedure call analysis into a dedicated CallDistributedProcedureAnalysis context, enabling procedure-specific analysis data such as rewrite targets and Z-order columns.
- Extend rewrite_data_files planning to append a synthetic Z-order column to the query plan and Iceberg sort order when Z-order columns are requested, including support for an internal $z_order metadata column in Iceberg writes.

Tests:
- Add comprehensive unit and integration tests for Iceberg Z-order functions covering type handling, null semantics, interleaving, spatial ordering behavior, and interaction with table data.