### PR TITLE
test (do not review): Add end to end tests for array_least_frequent function

### DIFF
--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -90,7 +90,7 @@ public class TestNativeSidecarPlugin
     private static final String REGEX_FUNCTION_NAMESPACE = "native.default.*";
     private static final String REGEX_SESSION_NAMESPACE = "Native Execution only.*";
     private static final long SIDECAR_HTTP_CLIENT_MAX_CONTENT_SIZE_MB = 128;
-    private static final int INLINED_SQL_FUNCTIONS_COUNT = 5;
+    private static final int INLINED_SQL_FUNCTIONS_COUNT = 3;
 
     @Override
     protected void createTables()
@@ -637,19 +637,14 @@ public class TestNativeSidecarPlugin
     @Test
     public void testNonOverriddenInlinedSqlInvokedFunctionsWhenConfigDisabled()
     {
-        // When inline_sql_functions is set to false, the below queries should fail as the implementations don't exist on the native worker
         Session session = Session.builder(getSession())
                 .setSystemProperty(KEY_BASED_SAMPLING_ENABLED, "true")
                 .setSystemProperty(INLINE_SQL_FUNCTIONS, "false")
                 .build();
 
         // Array functions
-        assertQueryFails(session,
-                "SELECT array_least_frequent(quantities) from orders_ex",
-                ".*Scalar function name not registered: native.default.array_least_frequent.*");
-        assertQueryFails(session,
-                "SELECT array_least_frequent(split(comment, ''), 2) from nation",
-                ".*Scalar function name not registered: native.default.array_least_frequent.*");
+        assertQuery(session, "SELECT array_least_frequent(quantities) from orders_ex");
+        assertQuery(session, "SELECT array_least_frequent(split(comment, ''), 2) from nation");
 
         // Map functions
         assertQueryFails(session,

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
@@ -99,6 +99,65 @@ public class TestPrestoNativeArrayFunctionQueries
     }
 
     @Test
+    public void testArrayLeastFrequent()
+    {
+        // Single least frequent element.
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (ARRAY[1, 2, 2, 3, 3, 3])) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (CAST(ARRAY['a', 'b', 'b', 'c', 'c', 'c'] AS ARRAY(VARCHAR)))) AS t(a)");
+
+        // Unsorted input exercises ascending-order output.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[3, 1, 2, 3, 2, 3], 2)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (CAST(ARRAY['c', 'a', 'b', 'c', 'b', 'c'] AS ARRAY(VARCHAR)), 2)) AS t(a, b)");
+
+        // Tie-break: returns the smallest element among those with the lowest frequency.
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (ARRAY[1, 1, 2, 2, 3, 3])) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (CAST(ARRAY['abc', 'bc', 'aaa'] AS ARRAY(VARCHAR)))) AS t(a)");
+
+        // Single-element and all-equal arrays.
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (ARRAY[42])) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (ARRAY[42, 42])) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[42], 1)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[42, 42], 1)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[42, 42], 2)) AS t(a, b)");
+
+        // Null handling.
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (CAST(NULL AS ARRAY(INTEGER)))) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (CAST(ARRAY[] AS ARRAY(INTEGER)))) AS t(a)");
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (CAST(ARRAY[NULL, NULL, NULL] AS ARRAY(INTEGER)))) AS t(a)");
+
+        // Nulls in array are ignored.
+        assertQuery("SELECT array_least_frequent(a) FROM (VALUES (ARRAY[1, 2, 2, NULL])) AS t(a)");
+
+        // Nulls are also ignored for the N-argument variant.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, NULL], 1)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, NULL], 2)) AS t(a, b)");
+
+        // N least frequent elements returned in ascending order.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, 3, 3, 3], 2)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (CAST(ARRAY['a', 'b', 'b', 'c', 'c', 'c'] AS ARRAY(VARCHAR)), 3)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 1, 2, 2, 3, 3], 1)) AS t(a, b)");
+
+        // N equal to number of distinct non-null elements: returns all.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, 3, 3, 3], 3)) AS t(a, b)");
+
+        // N greater than number of distinct non-null elements: returns all.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, 3, 3, 3, -1], 5)) AS t(a, b)");
+
+        // N = 0 returns empty array (not null) when array has non-null elements.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (ARRAY[1, 2, 2, NULL], 0)) AS t(a, b)");
+
+        // Null/empty input returns null regardless of n.
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (CAST(NULL AS ARRAY(INTEGER)), 3)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (CAST(ARRAY[] AS ARRAY(INTEGER)), 2)) AS t(a, b)");
+        assertQuery("SELECT array_least_frequent(a, b) FROM (VALUES (CAST(ARRAY[NULL, NULL, NULL] AS ARRAY(INTEGER)), 1)) AS t(a, b)");
+
+        // Negative n fails.
+        assertQueryFails(
+                "SELECT array_least_frequent(a, b) FROM (VALUES (CAST(ARRAY['a', 'b', 'b', 'c', 'c', 'c'] AS ARRAY(VARCHAR)), -1)) AS t(a, b)",
+                ".*n must be greater than or equal to 0.*");
+    }
+
+    @Test
     public void testArrayTopN()
     {
         assertQuery("SELECT array_top_n(a, b) FROM (VALUES(ARRAY[1, 5, 3, 9, 2],3)) as t(a,b)");

--- a/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeArraySqlFunctions.java
+++ b/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeArraySqlFunctions.java
@@ -24,26 +24,6 @@ public class NativeArraySqlFunctions
 {
     private NativeArraySqlFunctions() {}
 
-    @SqlInvokedScalarFunction(value = "array_least_frequent", deterministic = true, calledOnNullInput = true)
-    @Description("Determines the least frequent element in the array. If there are multiple elements, the function returns the smallest element")
-    @TypeParameter("T")
-    @SqlParameter(name = "input", type = "array(T)")
-    @SqlType("array<T>")
-    public static String arrayLeastFrequent()
-    {
-        return "RETURN IF(COALESCE(CARDINALITY(REMOVE_NULLS(input)), 0) = 0, NULL, TRANSFORM(SLICE(ARRAY_SORT(TRANSFORM(MAP_ENTRIES(ARRAY_FREQUENCY(REMOVE_NULLS(input))), x -> ROW(x[2], x[1]))), 1, 1), x -> x[2]))";
-    }
-
-    @SqlInvokedScalarFunction(value = "array_least_frequent", deterministic = true, calledOnNullInput = true)
-    @Description("Determines the n least frequent element in the array in the ascending order of the elements.")
-    @TypeParameter("T")
-    @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "n", type = "bigint")})
-    @SqlType("array<T>")
-    public static String arrayNLeastFrequent()
-    {
-        return "RETURN IF(n < 0, fail('n must be greater than or equal to 0'), IF(COALESCE(CARDINALITY(REMOVE_NULLS(input)), 0) = 0, NULL, TRANSFORM(SLICE(ARRAY_SORT(TRANSFORM(MAP_ENTRIES(ARRAY_FREQUENCY(REMOVE_NULLS(input))), x -> ROW(x[2], x[1]))), 1, n), x -> x[2])))";
-    }
-
     @SqlInvokedScalarFunction(value = "array_top_n", deterministic = true, calledOnNullInput = true)
     @Description("Returns the top N values of the given map sorted using the provided lambda comparator.")
     @TypeParameter("T")


### PR DESCRIPTION
Add E2E tests for array_least_frequent function

## Description
 Add end-to-end tests for `array_least_frequent` covering the single-element form and the n-element form

## Motivation and Context
Companion to https://github.com/facebookincubator/velox/pull/16487, which adds array_least_frequent in Velox

## Impact
Tests only. No user-facing or API changes.  

## Test Plan
Run new tests once array_least_frequent is moved in with  https://github.com/facebookincubator/velox/pull/16487

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Add E2E native tests for array_least_frequent covering basic behavior, tie-breaking, null and empty inputs, N-argument variants, and invalid N handling.