### PR TITLE
(do not review)test: Add end to end tests for base32 functions

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1052,6 +1052,13 @@ public abstract class AbstractTestNativeGeneralQueries
         // from_base64, to_base64.
         assertQuery("SELECT from_base64(to_base64(cast(comment as varbinary))) FROM orders");
 
+        // from_base32, to_base32.
+        assertQuery("SELECT to_base32(cast(comment as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
+        assertQuery("SELECT from_base32(to_base32(cast(comment as varbinary))) FROM orders");
+        assertQuery("SELECT to_base32(cast('' as varbinary))");
+        assertQuery("SELECT to_base32(cast(null as varbinary))");
+        assertQuery("SELECT from_base32(cast(null as varchar))");
+
         // from_big_endian_32, to_big_endian_32.
         assertQuery("SELECT to_big_endian_32(null)");
         assertQuery("SELECT to_big_endian_32(1)");


### PR DESCRIPTION
## Description
 Add E2E assertions in `testBinaryFunctions` for `to_base32`, the `from_base32 / to_base32` round trip, and empty / null inputs.                                                         
                                                                                                                                                                                              
  ## Motivation and Context
  `from_base32` is already registered on the native worker; `to_base32` lands via https://github.com/facebookincubator/velox/pull/16235. This PR adds the E2E coverage so that once the Velox PR merges both directions are compared Java vs native.                                                                                                                                      
   
  ## Impact                                                                                                                                                                                   
  Tests only. No user-facing or API changes.                      

  ## Test Plan                                                                                                                                                                                
  Ran `testBinaryFunctions` locally. Test will fully pass on the native side once [Velox PR #16235](https://github.com/facebookincubator/velox/pull/16235) merges.
                                                                                                                                                                                              
  ## Release Notes                                                
  == NO RELEASE NOTE ==

## Summary by Sourcery

Tests:
- Extend binary function tests to cover to_base32 results, from_base32/to_base32 round trips, and empty/null input handling for base32.