### PR TITLE
fix: Avoid int64 overflow in PlanNodeStatsSummarizer (#27632)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.planner.planPrinter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.facebook.presto.util.MoreMath.saturatingAdd;
+
 public class OperatorInputStats
 {
     private final long totalDrivers;
@@ -63,9 +65,9 @@ public class OperatorInputStats
     public static OperatorInputStats merge(OperatorInputStats first, OperatorInputStats second)
     {
         return new OperatorInputStats(
-                first.totalDrivers + second.totalDrivers,
-                first.inputPositions + second.inputPositions,
-                first.inputDataSizeInBytes + second.inputDataSizeInBytes,
+                saturatingAdd(first.totalDrivers, second.totalDrivers),
+                saturatingAdd(first.inputPositions, second.inputPositions),
+                saturatingAdd(first.inputDataSizeInBytes, second.inputDataSizeInBytes),
                 first.sumSquaredInputPositions + second.sumSquaredInputPositions);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import static com.facebook.airlift.units.DataSize.succinctBytes;
 import static com.facebook.presto.util.MoreMaps.mergeMaps;
+import static com.facebook.presto.util.MoreMath.saturatingAdd;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.max;
 import static java.lang.Math.sqrt;
@@ -279,11 +280,11 @@ public class PlanNodeStats
     {
         checkArgument(planNodeId.equals(other.getPlanNodeId()), "planNodeIds do not match. %s != %s", planNodeId, other.getPlanNodeId());
 
-        long planNodeInputPositions = this.planNodeInputPositions + other.planNodeInputPositions;
+        long planNodeInputPositions = saturatingAdd(this.planNodeInputPositions, other.planNodeInputPositions);
         DataSize planNodeInputDataSize = succinctBytes((long) ((double) this.planNodeInputDataSize.toBytes() + (double) other.planNodeInputDataSize.toBytes()));
-        long planNodeRawInputPositions = this.planNodeRawInputPositions + other.planNodeRawInputPositions;
+        long planNodeRawInputPositions = saturatingAdd(this.planNodeRawInputPositions, other.planNodeRawInputPositions);
         DataSize planNodeRawInputDataSize = succinctBytes((long) ((double) this.planNodeRawInputDataSize.toBytes() + (double) other.planNodeRawInputDataSize.toBytes()));
-        long planNodeOutputPositions = this.planNodeOutputPositions + other.planNodeOutputPositions;
+        long planNodeOutputPositions = saturatingAdd(this.planNodeOutputPositions, other.planNodeOutputPositions);
         DataSize planNodeOutputDataSize = succinctBytes((long) ((double) this.planNodeOutputDataSize.toBytes() + (double) other.planNodeOutputDataSize.toBytes()));
         DataSize planNodePeakMemorySize = succinctBytes(Math.max(this.planNodePeakMemorySize.toBytes(), other.planNodePeakMemorySize.toBytes()));
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -23,6 +23,7 @@ import com.facebook.presto.operator.PipelineStats;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.operator.WindowInfo;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.util.MoreMath;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
@@ -161,11 +162,11 @@ public class PlanNodeStatsSummarizer
                     windowNodeStats.merge(planNodeId, WindowOperatorStats.create(windowInfo), (left, right) -> left.mergeWith(right));
                 }
 
-                planNodeInputPositions.merge(planNodeId, operatorStats.getInputPositions(), Long::sum);
-                planNodeInputBytes.merge(planNodeId, operatorStats.getInputDataSizeInBytes(), Long::sum);
+                planNodeInputPositions.merge(planNodeId, operatorStats.getInputPositions(), MoreMath::saturatingAdd);
+                planNodeInputBytes.merge(planNodeId, operatorStats.getInputDataSizeInBytes(), MoreMath::saturatingAdd);
 
-                planNodeRawInputPositions.merge(planNodeId, operatorStats.getRawInputPositions(), Long::sum);
-                planNodeRawInputBytes.merge(planNodeId, operatorStats.getRawInputDataSizeInBytes(), Long::sum);
+                planNodeRawInputPositions.merge(planNodeId, operatorStats.getRawInputPositions(), MoreMath::saturatingAdd);
+                planNodeRawInputBytes.merge(planNodeId, operatorStats.getRawInputDataSizeInBytes(), MoreMath::saturatingAdd);
 
                 planNodeNullJoinBuildKeyCount.merge(planNodeId, operatorStats.getNullJoinBuildKeyCount(), Long::sum);
                 planNodeJoinBuildKeyCount.merge(planNodeId, operatorStats.getJoinBuildKeyCount(), Long::sum);
@@ -190,8 +191,8 @@ public class PlanNodeStatsSummarizer
                     continue;
                 }
 
-                planNodeOutputPositions.merge(planNodeId, operatorStats.getOutputPositions(), Long::sum);
-                planNodeOutputBytes.merge(planNodeId, operatorStats.getOutputDataSizeInBytes(), Long::sum);
+                planNodeOutputPositions.merge(planNodeId, operatorStats.getOutputPositions(), MoreMath::saturatingAdd);
+                planNodeOutputBytes.merge(planNodeId, operatorStats.getOutputDataSizeInBytes(), MoreMath::saturatingAdd);
                 processedNodes.add(planNodeId);
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/util/MoreMath.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/util/MoreMath.java
@@ -110,4 +110,15 @@ public final class MoreMath
         }
         throw new IllegalArgumentException("All values are NaN");
     }
+
+    public static long saturatingAdd(long a, long b)
+    {
+        long sum = a + b;
+        // Both operands changed sign relative to sum — overflow occurred
+        if (((a ^ sum) & (b ^ sum)) < 0) {
+            return Long.MAX_VALUE;
+        }
+        // Clamp to zero in case either input was already negative (corrupt data)
+        return Math.max(sum, 0);
+    }
 }


### PR DESCRIPTION
Summary:

Some queries have really large numbers reported per operator and these
overflow during summation, which leads to the absence of plan in the query
logging.
To fix that we add functionality to cap the mentrics to still be able to see
more or less reasonable numbers.

```
== NO RELEASE NOTE ==
```

Differential Revision: D101851654


