### PR TITLE
fix: Update downstream consumers of selective Nimble reader config

### DIFF
--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -297,8 +297,8 @@ SessionProperties::SessionProperties() {
       "reader is fully rolled out.",
       BOOLEAN(),
       false,
-      QueryConfig::kSelectiveNimbleReaderEnabled,
-      util::boolToLowerCaseString(c.selectiveNimbleReaderEnabled()));
+      "selective_nimble_reader_enabled",
+      "true");
 
   addSessionProperty(
       kQueryTraceEnabled,

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -78,7 +78,7 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kDebugMemoryPoolWarnThresholdBytes,
        core::QueryConfig::kDebugMemoryPoolWarnThresholdBytes},
       {SessionProperties::kSelectiveNimbleReaderEnabled,
-       core::QueryConfig::kSelectiveNimbleReaderEnabled},
+       "selective_nimble_reader_enabled"},
       {SessionProperties::kQueryTraceEnabled,
        core::QueryConfig::kQueryTraceEnabled},
       {SessionProperties::kQueryTraceDir, core::QueryConfig::kQueryTraceDir},


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17293

Updates all downstream references to `QueryConfig::kSelectiveNimbleReaderEnabled` to use the new location in `FileConfig` or string literals, and removes the deprecated backward-compat constant from `QueryConfig.h`.

Changes:
- Presto SessionProperties: replaced QueryConfig references with string literals.
- FbTableScanTest: converted query config settings to connector session properties via `connectorSessionProperty()` or `setConnectorSessionOverridesUnsafe()`.
- PrismConnector tests: converted `.config()` calls to `.connectorSessionProperty()`.
- MetalakeFileJoiner: replaced QueryConfig constant with string literal.
- QueryConfig.h: removed the deprecated `kSelectiveNimbleReaderEnabled` constant.

Differential Revision: D101893417

## Summary by Sourcery

Update downstream usage of the selective Nimble reader configuration to use the new session property key and remove reliance on the deprecated QueryConfig constant.

Bug Fixes:
- Align selective Nimble reader session property wiring with the new configuration source to keep it functional after QueryConfig changes.

Enhancements:
- Switch Presto session properties and related tests to reference the selective Nimble reader flag via the connector/session property key rather than QueryConfig.
- Remove the deprecated kSelectiveNimbleReaderEnabled constant from QueryConfig to complete the config migration.