### PR TITLE
refactor: Move selective Nimble reader config from QueryConfig to FileConfig

### DIFF
--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/main/common/Utils.h"
+#include "velox/connectors/hive/FileConfig.h"
 #include "velox/core/QueryConfig.h"
 
 using namespace facebook::velox;
@@ -297,8 +298,8 @@ SessionProperties::SessionProperties() {
       "reader is fully rolled out.",
       BOOLEAN(),
       false,
-      QueryConfig::kSelectiveNimbleReaderEnabled,
-      util::boolToLowerCaseString(c.selectiveNimbleReaderEnabled()));
+      "selective_nimble_reader_enabled",
+      "true");
 
   addSessionProperty(
       kQueryTraceEnabled,

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include "presto_cpp/main/properties/session/SessionProperties.h"
+#include "velox/connectors/hive/FileConfig.h"
 #include "velox/core/QueryConfig.h"
 
 using namespace facebook::presto;
@@ -78,7 +79,7 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kDebugMemoryPoolWarnThresholdBytes,
        core::QueryConfig::kDebugMemoryPoolWarnThresholdBytes},
       {SessionProperties::kSelectiveNimbleReaderEnabled,
-       core::QueryConfig::kSelectiveNimbleReaderEnabled},
+       connector::hive::FileConfig::kSelectiveNimbleReaderEnabledSession},
       {SessionProperties::kQueryTraceEnabled,
        core::QueryConfig::kQueryTraceEnabled},
       {SessionProperties::kQueryTraceDir, core::QueryConfig::kQueryTraceDir},

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include "presto_cpp/main/TaskManager.h"
 #include "presto_cpp/main/common/Configs.h"
+#include "velox/connectors/hive/FileConfig.h"
 #include "velox/core/QueryConfig.h"
 
 namespace facebook::presto {
@@ -79,7 +80,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableCommonSubExpressions());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithMemoization());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
-  EXPECT_TRUE(queryCtx->queryConfig().selectiveNimbleReaderEnabled());
+  EXPECT_TRUE(queryCtx->queryConfig().get<bool>(velox::connector::hive::FileConfig::kSelectiveNimbleReaderEnabledSession, true));
   EXPECT_EQ(
       queryCtx->queryConfig().rowSizeTrackingMode(),
       facebook::velox::core::QueryConfig::RowSizeTrackingMode::ENABLED_FOR_ALL);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17292

QueryConfig should be agnostic of connectors and file formats. The `kSelectiveNimbleReaderEnabled` config is Nimble-specific and was threaded through QueryConfig -> Operator.cpp -> ConnectorQueryCtx -> FileConnectorUtil, which unnecessarily coupled the core query layer to a connector-specific detail.

This moves the config to FileConfig (the Hive connector config base class), where other format-specific reader settings already live (e.g., Nimble footer speculative IO size, ORC/Parquet column name settings).

Changes:
- Added `kSelectiveNimbleReaderEnabledSession` to FileConfig using the `VELOX_HIVE_CONFIG` macro, with the same session key (`selective_nimble_reader_enabled`) and default (`true`) for backward compatibility.
- Registered the property in `FileConfig::registeredProperties()`.
- Updated `FileConnectorUtil::configureReaderOptions()` to read from `FileConfig` + session properties instead of `ConnectorQueryCtx`.
- Removed the accessor and registration from `QueryConfig.h` / `QueryConfig.cpp`, keeping only a deprecated `static constexpr` string constant for downstream compatibility.
- Removed the getter, setter, and member variable from `ConnectorQueryCtx` in `Connector.h`.
- Removed the threading line from `Operator.cpp`.

Differential Revision: D101893418

## Summary by Sourcery

Decouple the selective Nimble reader configuration from QueryConfig by mapping the session property directly to the Hive FileConfig-based setting and updating tests accordingly.

Enhancements:
- Map the selective Nimble reader session property to the Hive FileConfig session key instead of the QueryConfig constant, aligning it with connector-specific configuration.

Tests:
- Adjust session property and query context tests to validate the new FileConfig-based selective Nimble reader configuration path rather than the removed QueryConfig accessor.