### PR TITLE
refactor: Decouple Presto session properties from QueryConfig::selectiveNimbleReaderEnabled (#27637)

### DIFF
--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -297,8 +297,8 @@ SessionProperties::SessionProperties() {
       "reader is fully rolled out.",
       BOOLEAN(),
       false,
-      QueryConfig::kSelectiveNimbleReaderEnabled,
-      util::boolToLowerCaseString(c.selectiveNimbleReaderEnabled()));
+      "selective_nimble_reader_enabled",
+      "true");
 
   addSessionProperty(
       kQueryTraceEnabled,

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -78,7 +78,7 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kDebugMemoryPoolWarnThresholdBytes,
        core::QueryConfig::kDebugMemoryPoolWarnThresholdBytes},
       {SessionProperties::kSelectiveNimbleReaderEnabled,
-       core::QueryConfig::kSelectiveNimbleReaderEnabled},
+       "selective_nimble_reader_enabled"},
       {SessionProperties::kQueryTraceEnabled,
        core::QueryConfig::kQueryTraceEnabled},
       {SessionProperties::kQueryTraceDir, core::QueryConfig::kQueryTraceDir},

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -79,7 +79,8 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableCommonSubExpressions());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithMemoization());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
-  EXPECT_TRUE(queryCtx->queryConfig().selectiveNimbleReaderEnabled());
+  EXPECT_TRUE(queryCtx->queryConfig().get<bool>(
+      "selective_nimble_reader_enabled", true));
   EXPECT_EQ(
       queryCtx->queryConfig().rowSizeTrackingMode(),
       facebook::velox::core::QueryConfig::RowSizeTrackingMode::ENABLED_FOR_ALL);


### PR DESCRIPTION
Summary:

This config is being moved from QueryConfig to the Hive connector FileConfig. This diff updates Presto references to use string literals instead of the QueryConfig accessor, so they work with both the old and new Velox APIs.

Changes:
- SessionProperties.cpp: replaced QueryConfig accessor and constant with string literals.
- SessionPropertiesTest.cpp: replaced QueryConfig constant with string literal.
- QueryContextManagerTest.cpp: replaced QueryConfig accessor with get<bool>() using string literal.

Differential Revision: D101924983

== NO RELEASE NOTE ==
