### PR TITLE
feat(plugin-oracle): Upgrade presto oracle version and enable inbuilt connection pool.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
         <dep.okhttp.version>4.12.0</dep.okhttp.version>
         <dep.jdbi3.version>3.49.0</dep.jdbi3.version>
-        <dep.oracle.version>19.3.0.0</dep.oracle.version>
+        <dep.oracle.version>23.26.1.0.0</dep.oracle.version>
         <dep.drift.version>${dep.airlift.version}</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
@@ -251,6 +251,14 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
                 <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc11-production</artifactId>
+                <version>${dep.oracle.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -20,11 +20,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>${dep.oracle.version}</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ucp</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-base-jdbc</artifactId>

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -87,6 +87,7 @@ public class OracleClient
 
     private final boolean synonymsEnabled;
     private final int numberDefaultScale;
+    private final Optional<Integer> fetchSize;
 
     @Inject
     public OracleClient(
@@ -100,6 +101,7 @@ public class OracleClient
         requireNonNull(oracleConfig, "oracle config is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
         this.numberDefaultScale = oracleConfig.getNumberDefaultScale();
+        this.fetchSize = oracleConfig.getFetchSize();
     }
 
     private String[] getTableTypes()
@@ -121,15 +123,6 @@ public class OracleClient
                 escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
                 escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
                 getTableTypes());
-    }
-
-    @Override
-    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
-            throws SQLException
-    {
-        PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(FETCH_SIZE);
-        return statement;
     }
 
     @Override
@@ -225,6 +218,15 @@ public class OracleClient
         catch (SQLException | RuntimeException e) {
             throw new PrestoException(JDBC_ERROR, "Failed fetching statistics for table: " + handle, e);
         }
+    }
+
+    @Override
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
+            throws SQLException
+    {
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize.orElse(FETCH_SIZE));
+        return statement;
     }
 
     private String getColumnStaticsSql(JdbcTableHandle handle)

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -22,6 +22,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import jakarta.validation.constraints.NotNull;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleDriver;
 
@@ -45,17 +46,21 @@ public class OracleClientModule
 
     @Provides
     @Singleton
-    public static ConnectionFactory connectionFactory(BaseJdbcConfig config, OracleConfig oracleConfig)
+    public static ConnectionFactory connectionFactory(BaseJdbcConfig config, @NotNull OracleConfig oracleConfig)
             throws SQLException
     {
         Properties connectionProperties = new Properties();
         connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
-
-        return new DriverConnectionFactory(
-                new OracleDriver(),
-                config.getConnectionUrl(),
-                Optional.empty(),
-                Optional.empty(),
-                connectionProperties);
+        if (oracleConfig.isConnectionPoolEnabled()) {
+            return new OraclePoolConnectionFactory(new OracleDriver(), config, oracleConfig, connectionProperties);
+        }
+        else {
+            return new DriverConnectionFactory(
+                    new OracleDriver(),
+                    config.getConnectionUrl(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    connectionProperties);
+        }
     }
 }

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
@@ -14,19 +14,32 @@
 package com.facebook.presto.plugin.oracle;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.units.Duration;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.RoundingMode;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class OracleConfig
 {
     private boolean synonymsEnabled;
+    private boolean connectionPoolEnabled;
     private int varcharMaxSize = 4000;
     private int timestampDefaultPrecision = 6;
     private int numberDefaultScale = 10;
     private RoundingMode numberRoundingMode = RoundingMode.HALF_UP;
+    private int connectionPoolMinSize = 1;
+    private int connectionPoolMaxSize = 30;
+    private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
+    private Duration connectionPoolWaitDuration = new Duration(3, SECONDS);
+    private Integer fetchSize = 1000;
 
     @NotNull
     public boolean isSynonymsEnabled()
@@ -93,5 +106,90 @@ public class OracleConfig
     {
         this.timestampDefaultPrecision = timestampDefaultPrecision;
         return this;
+    }
+
+    @NotNull
+    public boolean isConnectionPoolEnabled()
+    {
+        return connectionPoolEnabled;
+    }
+
+    @Config("oracle.connection-pool.enabled")
+    public OracleConfig setConnectionPoolEnabled(boolean enabled)
+    {
+        this.connectionPoolEnabled = enabled;
+        return this;
+    }
+
+    @Min(0)
+    public int getConnectionPoolMinSize()
+    {
+        return connectionPoolMinSize;
+    }
+
+    @Config("oracle.connection-pool.min-size")
+    public OracleConfig setConnectionPoolMinSize(int connectionPoolMinSize)
+    {
+        this.connectionPoolMinSize = connectionPoolMinSize;
+        return this;
+    }
+
+    @Min(1)
+    public int getConnectionPoolMaxSize()
+    {
+        return connectionPoolMaxSize;
+    }
+
+    @Config("oracle.connection-pool.max-size")
+    public OracleConfig setConnectionPoolMaxSize(int connectionPoolMaxSize)
+    {
+        this.connectionPoolMaxSize = connectionPoolMaxSize;
+        return this;
+    }
+
+    @NotNull
+    public Duration getInactiveConnectionTimeout()
+    {
+        return inactiveConnectionTimeout;
+    }
+
+    @Config("oracle.connection-pool.inactive-timeout")
+    @ConfigDescription("How long a connection in the pool can remain idle before it is closed")
+    public OracleConfig setInactiveConnectionTimeout(Duration inactiveConnectionTimeout)
+    {
+        this.inactiveConnectionTimeout = inactiveConnectionTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getConnectionPoolWaitDuration()
+    {
+        return connectionPoolWaitDuration;
+    }
+
+    @Config("oracle.connection-pool.wait-duration")
+    @ConfigDescription("Maximum amount of time a request will wait to obtain an available connection from the pool if all connections are currently in use")
+    public OracleConfig setConnectionPoolWaitDuration(Duration connectionPoolWaitDuration)
+    {
+        this.connectionPoolWaitDuration = connectionPoolWaitDuration;
+        return this;
+    }
+
+    public Optional<@Min(0) Integer> getFetchSize()
+    {
+        return Optional.ofNullable(fetchSize);
+    }
+
+    @Config("oracle.fetch-size")
+    public OracleConfig setFetchSize(Integer fetchSize)
+    {
+        this.fetchSize = fetchSize;
+        return this;
+    }
+
+    @AssertTrue(message = "Pool min size cannot be larger than max size")
+    public boolean isPoolSizedProperly()
+    {
+        return getConnectionPoolMaxSize() >= getConnectionPoolMinSize();
     }
 }

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OraclePoolConnectionFactory.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OraclePoolConnectionFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.plugin.oracle;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
+import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import oracle.jdbc.pool.OracleDataSource;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class OraclePoolConnectionFactory
+        extends DriverConnectionFactory
+{
+    private final DataSource dataSource;
+
+    public OraclePoolConnectionFactory(Driver driver, BaseJdbcConfig config, OracleConfig oracleConfig, Properties connectionProperties)
+            throws SQLException
+    {
+        super(driver, config);
+        PoolDataSource dataSource = PoolDataSourceFactory.getPoolDataSource();
+
+        //Setting connection properties of the data source
+        dataSource.setConnectionFactoryClassName(OracleDataSource.class.getName());
+        dataSource.setURL(config.getConnectionUrl());
+
+        //Setting pool properties
+        dataSource.setInitialPoolSize(oracleConfig.getConnectionPoolMinSize());
+        dataSource.setMinPoolSize(oracleConfig.getConnectionPoolMinSize());
+        dataSource.setMaxPoolSize(oracleConfig.getConnectionPoolMaxSize());
+        dataSource.setValidateConnectionOnBorrow(true);
+        dataSource.setConnectionProperties(connectionProperties);
+        dataSource.setInactiveConnectionTimeout(toIntExact(oracleConfig.getInactiveConnectionTimeout().roundTo(SECONDS)));
+        dataSource.setConnectionWaitTimeout(toIntExact(oracleConfig.getConnectionPoolWaitDuration().roundTo(SECONDS)));
+
+        if (config.getConnectionUser() != null) {
+            dataSource.setUser(config.getConnectionUser());
+        }
+        if (config.getConnectionPassword() != null) {
+            dataSource.setPassword(config.getConnectionPassword());
+        }
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection openConnection(JdbcIdentity identity)
+            throws SQLException
+    {
+        Connection connection = dataSource.getConnection();
+        // Oracle's pool doesn't reset autocommit state of connections when reusing them so we explicitly enable
+        // autocommit by default to match the JDBC specification.
+        connection.setAutoCommit(true);
+        return connection;
+    }
+}


### PR DESCRIPTION
## Description
Oracle ojdbc11 driver has builtin connection pool - this PR just enables that and discusses performance benchmark and comparison with or without this feature. 

## Motivation and Context
Yesterday, out of curiosity I tried the above code against a trino cluster and results were impressive. So, started exploring what all optimization they have done. And porter a connection pool from trino's oracle connector to Presto's oracle connector.

Oracle table under test has 10000 records and is running in docker container with default resources (i.e. no extra mem/cpu specified).

Latest version of OSS Presto( + my changes) and OSS Trino was used for the bench-marking.

### Trino' performance (with default setup):
1. Benchmarking presto oracle connector for select query performance with filter pushdown. 
✓ 1000 select statements executed in 14790 ms
  Average time per query: 14 ms n-percentiles 25=13.0,50=14.0,95=19.0
2. Benchmarking presto oracle connector for select query performance without filter pushdown. 
✓ 1000 select statements executed in 31378 ms
  Average time per query: 31 ms n-percentiles 25=30.0,50=31.0,95=35.0
3. Benchmarking oracle for select query performance. 
✓ 100 select statements executed in 220 ms
  Average time per query: 2 ms n-percentiles 25=2.0,50=2.0,95=3.0

### Presto's performance (Post adding a connection pool + metadata caching.)

1. Benchmarking presto oracle connector for select query performance with filter pushdown. 
✓ 1000 select statements executed in 24785 ms
  Average time per query: 24 ms n-percentiles 25=23.0,50=24.0,95=25.0
2. Benchmarking presto oracle connector for select query performance without filter pushdown. 
✓ 1000 select statements executed in 26960 ms
  Average time per query: 26 ms n-percentiles 25=25.0,50=26.0,95=31.0
3. Benchmarking oracle for select query performance. 
✓ 100 select statements executed in 247 ms
  Average time per query: 2 ms n-percentiles 25=2.0,50=2.0,95=3.0

### Presto's performance (Without enabling a connection pool, but enabled metadata caching.)

1. Benchmarking presto oracle connector for select query performance with filter pushdown. 
✓ 1000 select statements executed in 34043 ms
  Average time per query: 34 ms n-percentiles 25=31.0,50=32.0,95=42.0
2. Benchmarking presto oracle connector for select query performance without filter pushdown. 
✓ 1000 select statements executed in 46456 ms
  Average time per query: 46 ms n-percentiles 25=45.0,50=46.0,95=50.0
3. Benchmarking oracle for select query performance. 
✓ 100 select statements executed in 266 ms
  Average time per query: 2 ms n-percentiles 25=2.0,50=3.0,95=3.0

### Presto's performance (Without enabling a connection pool, without enabling metadata caching.)

1. Benchmarking presto oracle connector for select query performance with filter pushdown. 
✓ 10 select statements executed in 1685 ms
  Average time per query: 168 ms n-percentiles 25=147.5,50=151.0,95=253.7
2. Benchmarking presto oracle connector for select query performance without filter pushdown. 
✓ 10 select statements executed in 1717 ms
  Average time per query: 171 ms n-percentiles 25=163.25,50=165.5,95=194.45
3. Benchmarking oracle for select query performance. 
✓ 100 select statements executed in 221 ms
  Average time per query: 2 ms n-percentiles 25=2.0,50=2.0,95=3.0
  
  The reason for performing only 10 trials is, oracle connector fails (ORA-12516: Cannot connect to database. Listener at host localhost port 1521 does not have a protocol handler for TCP ready or registered for service FREEPDB1. (CONNECTION_ID=K+QCNtQVQS2Gav7L9l8OQQ==) if the number of trials are greater than 15.
  
  
  ### Conclusion:
  
  1. Presto's oracle connector sees performance improvement when we add connection pooling + metadata caching.
  2. Trino is still faster than presto for both queries which can have filter predicate be pushed down and queries which cannot be pushed down.
  

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade the Oracle JDBC driver and add optional inbuilt connection pooling support for the Oracle connector, including configurable pool sizing, timeouts, and fetch size.

New Features:
- Introduce an optional Oracle connection pool backed by Oracle UCP, configurable via new oracle.connection-pool.* properties.
- Allow configuring Oracle JDBC fetch size via the oracle.fetch-size property.

Enhancements:
- Upgrade the Oracle JDBC dependency from ojdbc8 to ojdbc11 and wire the Oracle connector to use the new pooled connection factory when enabled.
- Add validation to ensure Oracle connection pool minimum size does not exceed the maximum size.

Build:
- Switch Maven dependencies to the newer Oracle JDBC artifacts (ojdbc11 and ojdbc11-production BOM) and add the UCP dependency for pooling support.