### PR TITLE
feat: Add authorizedPrincipal to AuthorizedIdentity for gateway identity propagation (#27639)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -136,14 +136,18 @@ public class QuerySessionSupplier
         Optional<AuthorizedIdentity> authorizedIdentity = context.getAuthorizedIdentity();
         authorizedIdentity = authorizedIdentity.isPresent() ? authorizedIdentity : getAuthorizedIdentity(accessControl, securityConfig, queryId, context);
 
-        return authorizedIdentity.map(identity -> new Identity(
-                context.getIdentity().getUser(),
-                context.getIdentity().getPrincipal(),
-                context.getIdentity().getRoles(),
-                context.getIdentity().getExtraCredentials(),
-                context.getIdentity().getExtraAuthenticators(),
-                Optional.of(identity.getUserName()),
-                identity.getReasonForSelect(),
-                context.getCertificates())).orElseGet(context::getIdentity);
+        return authorizedIdentity.map(identity -> {
+            Optional<java.security.Principal> principal = identity.getAuthorizedPrincipal()
+                    .or(() -> context.getIdentity().getPrincipal());
+            return new Identity(
+                    context.getIdentity().getUser(),
+                    principal,
+                    context.getIdentity().getRoles(),
+                    context.getIdentity().getExtraCredentials(),
+                    context.getIdentity().getExtraAuthenticators(),
+                    Optional.of(identity.getUserName()),
+                    identity.getReasonForSelect(),
+                    context.getCertificates());
+        }).orElseGet(context::getIdentity);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -32,7 +32,9 @@ import com.google.common.collect.ImmutableSet;
 import jakarta.servlet.http.HttpServletRequest;
 import org.testng.annotations.Test;
 
+import java.security.Principal;
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
@@ -58,6 +60,7 @@ import static com.facebook.presto.server.security.ServletSecurityUtils.AUTHORIZE
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestQuerySessionSupplier
 {
@@ -150,6 +153,72 @@ public class TestQuerySessionSupplier
                 ImmutableMap.of());
         HttpRequestSessionContext context2 = new HttpRequestSessionContext(request2, new SqlParserOptions());
         assertEquals(context2.getClientTags(), ImmutableSet.of());
+    }
+
+    @Test
+    public void testSessionWithAuthorizedPrincipal()
+    {
+        Principal clientPrincipal = new javax.security.auth.x500.X500Principal("CN=user:testclient");
+        AuthorizedIdentity authorizedIdentity = new AuthorizedIdentity("userName", "reasonForSelect", false, clientPrincipal);
+
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .build(),
+                "testRemote",
+                ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, authorizedIdentity));
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
+                createTestTransactionManager(),
+                new AllowAllAccessControl(),
+                createTestingSessionPropertyManager(),
+                new SqlEnvironmentConfig(),
+                new SecurityConfig());
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        Session session = sessionSupplier.createSessionBuilder(new QueryId("test_query_id"), context, warningCollectorFactory).build();
+
+        assertTrue(session.getIdentity().getPrincipal().isPresent());
+        assertEquals(session.getIdentity().getPrincipal().get(), clientPrincipal);
+        assertEquals(session.getIdentity().getSelectedUser().get(), "userName");
+    }
+
+    @Test
+    public void testSessionWithoutAuthorizedPrincipal()
+    {
+        AuthorizedIdentity authorizedIdentity = new AuthorizedIdentity("userName", "reasonForSelect", false);
+
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .build(),
+                "testRemote",
+                ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, authorizedIdentity));
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
+                createTestTransactionManager(),
+                new AllowAllAccessControl(),
+                createTestingSessionPropertyManager(),
+                new SqlEnvironmentConfig(),
+                new SecurityConfig());
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        Session session = sessionSupplier.createSessionBuilder(new QueryId("test_query_id"), context, warningCollectorFactory).build();
+
+        assertEquals(session.getIdentity().getPrincipal(), Optional.empty());
+        assertEquals(session.getIdentity().getSelectedUser().get(), "userName");
     }
 
     @Test(expectedExceptions = TimeZoneNotSupportedException.class)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AuthorizedIdentity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AuthorizedIdentity.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.spi.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.security.Principal;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -26,6 +28,7 @@ public class AuthorizedIdentity
     private final String userName;
     private final Optional<String> reasonForSelect;
     private final Optional<Boolean> delegationCheckResult;
+    private final Optional<Principal> authorizedPrincipal;
 
     @JsonCreator
     public AuthorizedIdentity(
@@ -33,9 +36,19 @@ public class AuthorizedIdentity
             @JsonProperty("reasonForSelect") String reasonForSelect,
             @JsonProperty("delegationCheckResult") Boolean delegationCheckResult)
     {
+        this(userName, reasonForSelect, delegationCheckResult, (Principal) null);
+    }
+
+    public AuthorizedIdentity(
+            String userName,
+            String reasonForSelect,
+            Boolean delegationCheckResult,
+            Principal authorizedPrincipal)
+    {
         this.userName = requireNonNull(userName, "userName is null");
         this.reasonForSelect = Optional.ofNullable(reasonForSelect);
         this.delegationCheckResult = Optional.ofNullable(delegationCheckResult);
+        this.authorizedPrincipal = Optional.ofNullable(authorizedPrincipal);
     }
 
     @JsonProperty("userName")
@@ -64,6 +77,12 @@ public class AuthorizedIdentity
     public Boolean getDelegationCheckResultValue()
     {
         return delegationCheckResult.orElse(null);
+    }
+
+    @JsonIgnore
+    public Optional<Principal> getAuthorizedPrincipal()
+    {
+        return authorizedPrincipal;
     }
 
     @Override


### PR DESCRIPTION
Summary:

When a gateway proxies requests to a Presto coordinator, the TLS principal
on the connection belongs to the gateway, not the original client. This adds
an optional authorizedPrincipal field to AuthorizedIdentity so that the
access control layer can override the session principal with the original
client's principal.

QuerySessionSupplier uses the authorizedPrincipal (if present) to construct
an X500Principal for the session Identity, falling back to the TLS principal
when absent. This is backward compatible — existing code that doesn't set
authorizedPrincipal continues to use the TLS principal.

The authorizedPrincipal field is intentionally excluded from equals/hashCode
and JSON serialization since it is a transport-layer detail set programmatically
by the gateway, not part of the identity's logical key.

Differential Revision: D97439864

```
== RELEASE NOTES ==

Security Changes
* Add optional authorizedPrincipal to AuthorizedIdentity to support gateway identity propagation, allowing the session principal to reflect the original client instead of the gateway
```


