### PR TITLE
docs: Fix phrasing in connector/lance.rst

### DIFF
--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -6,7 +6,7 @@ Overview
 --------
 
 The Lance connector allows querying and writing data stored in
-`Lance <https://lance.org/>`_ format from Presto. Lance is a modern columnar
+`Lance <https://lance.org/>`_ format from Presto. Lance is a columnar
 data format optimized for machine learning workloads and fast random access.
 
 The connector uses the Lance Java SDK to read and write Lance datasets.


### PR DESCRIPTION
## Description
Fix [an overlooked doc change](https://github.com/prestodb/presto/pull/27185#pullrequestreview-3848410342) in a previous PR. 

<img width="814" height="319" alt="Screenshot 2026-04-22 at 3 19 57 PM" src="https://github.com/user-attachments/assets/95a1b42e-41d7-4872-9d9d-447bab400285" />

## Motivation and Context
Followup on what was a nit of phrasing. 

## Impact
Documentation. 

## Test Plan
Local doc builds before and after. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

