### PR TITLE
feat(optimizer): Add TopN late materialization using $row_id

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -384,6 +384,8 @@ public final class SystemSessionProperties
     public static final String REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM = "remote_function_names_for_fixed_parallelism";
     public static final String REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT = "remote_function_fixed_parallelism_task_count";
     public static final String RPC_FUNCTION_PARALLELISM = "rpc_function_parallelism";
+    public static final String OPTIMIZE_TOP_N_USING_ROW_ID = "optimize_top_n_using_row_id";
+    public static final String OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS = "optimize_top_n_using_row_id_min_column_savings";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -2258,6 +2260,16 @@ public final class SystemSessionProperties
                         ALWAYS_ANALYZE_CREATE_TABLE_QUERY_ENABLED,
                         "When enabled, analyze inner query on CTAS IF NOT EXISTS to populate view definitions for access control checks",
                         featuresConfig.isAlwaysAnalyzeCreateTableQueryEnabled(),
+                        false),
+                booleanProperty(
+                        OPTIMIZE_TOP_N_USING_ROW_ID,
+                        "Use $row_id late materialization for TopN over wide tables: first sort narrow keys, then semi-join to fetch full rows",
+                        false,
+                        false),
+                integerProperty(
+                        OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS,
+                        "Minimum number of non-sort-key columns required before TopN row_id optimization triggers",
+                        10,
                         false));
     }
 
@@ -3671,6 +3683,16 @@ public final class SystemSessionProperties
     public static boolean isJoinPrefilterEnabled(Session session)
     {
         return session.getSystemProperty(JOIN_PREFILTER_BUILD_SIDE, Boolean.class);
+    }
+
+    public static boolean isOptimizeTopNUsingRowIdEnabled(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, Boolean.class);
+    }
+
+    public static int getOptimizeTopNUsingRowIdMinColumnSavings(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, Integer.class);
     }
 
     public static boolean isPrintEstimatedStatsFromCacheEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -196,6 +196,7 @@ import com.facebook.presto.sql.planner.optimizations.MergePartialAggregationsWit
 import com.facebook.presto.sql.planner.optimizations.MetadataDeleteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MetadataQueryOptimizer;
 import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggregations;
+import com.facebook.presto.sql.planner.optimizations.OptimizeTopNUsingRowId;
 import com.facebook.presto.sql.planner.optimizations.PayloadJoinOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PhysicalCteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
@@ -845,6 +846,8 @@ public class PlanOptimizers
                                 .build()));
 
         builder.add(new JoinPrefilter(metadata));
+
+        builder.add(new OptimizeTopNUsingRowId(metadata));
 
         builder.add(
                 new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -669,4 +669,85 @@ public class PlannerUtils
         }
         return hashExpression;
     }
+
+    /**
+     * Walk through Filter/Project chain to find the underlying TableScanNode.
+     */
+    public static Optional<TableScanNode> findTableScanNode(PlanNode node)
+    {
+        if (node instanceof TableScanNode) {
+            return Optional.of((TableScanNode) node);
+        }
+        if (node instanceof FilterNode) {
+            return findTableScanNode(((FilterNode) node).getSource());
+        }
+        if (node instanceof ProjectNode) {
+            return findTableScanNode(((ProjectNode) node).getSource());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Create a new TableScanNode with one additional column added to outputVariables and assignments.
+     */
+    public static TableScanNode addColumnToTableScan(
+            TableScanNode scanNode,
+            ColumnHandle columnHandle,
+            VariableReferenceExpression variable,
+            PlanNodeIdAllocator idAllocator)
+    {
+        List<VariableReferenceExpression> newOutputVariables = ImmutableList.<VariableReferenceExpression>builder()
+                .addAll(scanNode.getOutputVariables())
+                .add(variable)
+                .build();
+
+        Map<VariableReferenceExpression, ColumnHandle> newAssignments = ImmutableMap.<VariableReferenceExpression, ColumnHandle>builder()
+                .putAll(scanNode.getAssignments())
+                .put(variable, columnHandle)
+                .build();
+
+        return new TableScanNode(
+                scanNode.getSourceLocation(),
+                idAllocator.getNextId(),
+                scanNode.getTable(),
+                newOutputVariables,
+                newAssignments,
+                scanNode.getTableConstraints(),
+                scanNode.getCurrentConstraint(),
+                scanNode.getEnforcedConstraint(),
+                scanNode.getCteMaterializationInfo());
+    }
+
+    /**
+     * Recursively propagate a new variable through a Project/Filter chain by adding
+     * identity assignments in ProjectNodes and rebuilding FilterNodes.
+     * Returns Optional.empty() if an unsupported node type is encountered.
+     */
+    public static Optional<PlanNode> addPassThroughVariable(
+            PlanNode node,
+            VariableReferenceExpression variable,
+            PlanNodeIdAllocator idAllocator)
+    {
+        if (node instanceof TableScanNode) {
+            // TableScanNode should already have the variable added via addColumnToTableScan
+            return Optional.of(node);
+        }
+        if (node instanceof FilterNode) {
+            FilterNode filterNode = (FilterNode) node;
+            return addPassThroughVariable(filterNode.getSource(), variable, idAllocator)
+                    .map(newSource -> new FilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate()));
+        }
+        if (node instanceof ProjectNode) {
+            ProjectNode projectNode = (ProjectNode) node;
+            return addPassThroughVariable(projectNode.getSource(), variable, idAllocator)
+                    .map(newSource -> {
+                        Assignments newAssignments = Assignments.builder()
+                                .putAll(projectNode.getAssignments())
+                                .put(variable, variable)
+                                .build();
+                        return new ProjectNode(idAllocator.getNextId(), newSource, newAssignments);
+                    });
+        }
+        return Optional.empty();
+    }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayout;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.plan.TopNNode.Step;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.getOptimizeTopNUsingRowIdMinColumnSavings;
+import static com.facebook.presto.SystemSessionProperties.isOptimizeTopNUsingRowIdEnabled;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.planner.PlannerUtils.addColumnToTableScan;
+import static com.facebook.presto.sql.planner.PlannerUtils.addPassThroughVariable;
+import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
+import static com.facebook.presto.sql.planner.PlannerUtils.findTableScanNode;
+import static com.facebook.presto.sql.planner.PlannerUtils.isDeterministicScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.restrictOutput;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Late materialization for TopN over wide tables using $row_id.
+ *
+ * Rewrites:
+ *   TopN(N, orderBy=[a, b])
+ *     └─ Source(a, b, c, d, e, ...)
+ *
+ * Into:
+ *   TopN(N, orderBy=[a, b])
+ *     └─ Project(remove $row_id, semi_mark)
+ *       └─ Filter(semi_mark = true)
+ *         └─ SemiJoin(source=$row_id, filtering=$row_id_clone, output=semi_mark)
+ *           ├─ Source_with_row_id(a, b, c, d, e, ..., $row_id)
+ *           └─ TopN(N, orderBy=[a_clone, b_clone])
+ *               └─ ClonedSource(a_clone, b_clone, $row_id_clone)
+ *
+ * The inner TopN sorts only the narrow clone (sort keys + $row_id).
+ * The SemiJoin filters the full scan to only the N matching rows.
+ * The outer TopN re-sorts only N rows (cheap).
+ */
+public class OptimizeTopNUsingRowId
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+    private boolean isEnabledForTesting;
+
+    public OptimizeTopNUsingRowId(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || isOptimizeTopNUsingRowIdEnabled(session);
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isEnabled(session)) {
+            Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator, metadata.getFunctionAndTypeManager());
+            PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
+            return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());
+        }
+        return PlanOptimizerResult.optimizerResult(plan, false);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final PlanNodeIdAllocator idAllocator;
+        private final VariableAllocator variableAllocator;
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final int minColumnSavings;
+        private boolean planChanged;
+
+        private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.minColumnSavings = getOptimizeTopNUsingRowIdMinColumnSavings(session);
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+
+        @Override
+        public PlanNode visitTopN(TopNNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getSource());
+
+            // Guard: only SINGLE step (before distribution)
+            if (node.getStep() != Step.SINGLE) {
+                return replaceSource(node, source);
+            }
+
+            // Guard: source must be a scan-filter-project chain
+            if (!isScanFilterProject(source)) {
+                return replaceSource(node, source);
+            }
+
+            // Guard: source must be deterministic
+            if (!isDeterministicScanFilterProject(source, functionAndTypeManager)) {
+                return replaceSource(node, source);
+            }
+
+            // Find the underlying TableScanNode
+            Optional<TableScanNode> tableScanOpt = findTableScanNode(source);
+            if (!tableScanOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            TableScanNode tableScan = tableScanOpt.get();
+
+            // Check unique column from table layout
+            TableLayout layout = metadata.getLayout(session, tableScan.getTable());
+            Optional<ColumnHandle> uniqueColumnOpt = layout.getUniqueColumn();
+            if (!uniqueColumnOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            ColumnHandle uniqueColumnHandle = uniqueColumnOpt.get();
+
+            // Check heuristic: enough non-sort-key columns to justify the rewrite
+            Set<VariableReferenceExpression> sortKeySet = new HashSet<>(node.getOrderingScheme().getOrderByVariables());
+            int totalColumns = source.getOutputVariables().size();
+            int columnSavings = totalColumns - sortKeySet.size();
+            if (columnSavings < minColumnSavings) {
+                return replaceSource(node, source);
+            }
+
+            // === Build the rewritten plan ===
+
+            // 1. Add $row_id to the original source
+            VariableReferenceExpression rowIdVar = variableAllocator.newVariable("$row_id",
+                    metadata.getColumnMetadata(session, tableScan.getTable(), uniqueColumnHandle).getType());
+            TableScanNode augmentedTableScan = addColumnToTableScan(tableScan, uniqueColumnHandle, rowIdVar, idAllocator);
+            Optional<PlanNode> augmentedSourceOpt = addPassThroughVariable(source, rowIdVar, idAllocator);
+            if (!augmentedSourceOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            // Replace the original tableScan with the augmented one at the bottom
+            augmentedSourceOpt = replaceTableScan(augmentedSourceOpt.get(), augmentedTableScan, idAllocator);
+            if (!augmentedSourceOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            PlanNode augmentedSource = augmentedSourceOpt.get();
+
+            // 2. Clone narrow source: sort keys only + $row_id
+            List<VariableReferenceExpression> sortKeys = node.getOrderingScheme().getOrderByVariables();
+            Map<VariableReferenceExpression, VariableReferenceExpression> varMap = new HashMap<>();
+            PlanNode narrowClone = clonePlanNode(source, session, metadata, idAllocator, sortKeys, varMap);
+
+            // Add $row_id to the cloned narrow source too
+            Optional<TableScanNode> clonedTableScanOpt = findTableScanNode(narrowClone);
+            if (!clonedTableScanOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            VariableReferenceExpression clonedRowIdVar = variableAllocator.newVariable("$row_id_clone",
+                    metadata.getColumnMetadata(session, tableScan.getTable(), uniqueColumnHandle).getType());
+            TableScanNode clonedAugmentedTableScan = addColumnToTableScan(clonedTableScanOpt.get(), uniqueColumnHandle, clonedRowIdVar, idAllocator);
+            Optional<PlanNode> narrowCloneOpt = addPassThroughVariable(narrowClone, clonedRowIdVar, idAllocator);
+            if (!narrowCloneOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            narrowCloneOpt = replaceTableScan(narrowCloneOpt.get(), clonedAugmentedTableScan, idAllocator);
+            if (!narrowCloneOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            narrowClone = narrowCloneOpt.get();
+
+            // Restrict narrow clone to only sort keys (mapped) + cloned $row_id
+            List<VariableReferenceExpression> narrowOutputs = ImmutableList.<VariableReferenceExpression>builder()
+                    .addAll(sortKeys.stream().map(v -> varMap.getOrDefault(v, v)).collect(toImmutableList()))
+                    .add(clonedRowIdVar)
+                    .build();
+            narrowClone = restrictOutput(narrowClone, idAllocator, narrowOutputs);
+
+            // 3. Build inner TopN over narrow clone with mapped ordering scheme
+            List<Ordering> clonedOrderings = node.getOrderingScheme().getOrderBy().stream()
+                    .map(o -> new Ordering(varMap.getOrDefault(o.getVariable(), o.getVariable()), o.getSortOrder()))
+                    .collect(toImmutableList());
+            OrderingScheme clonedOrderingScheme = new OrderingScheme(clonedOrderings);
+            TopNNode innerTopN = new TopNNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    narrowClone,
+                    node.getCount(),
+                    clonedOrderingScheme,
+                    Step.SINGLE);
+
+            // 4. Build SemiJoinNode: source=$row_id from augmented original, filtering=$row_id_clone from inner TopN
+            //    For small N (<= 100K), broadcast the TopN result to all workers to avoid a full repartition.
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            Optional<SemiJoinNode.DistributionType> semiJoinDistribution = node.getCount() <= 100_000
+                    ? Optional.of(SemiJoinNode.DistributionType.REPLICATED)
+                    : Optional.empty();
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    augmentedSource,
+                    innerTopN,
+                    rowIdVar,
+                    clonedRowIdVar,
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    semiJoinDistribution,
+                    ImmutableMap.of());
+
+            // 5. Filter on semi_mark = true
+            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+
+            // 6. Build outer TopN with original ordering scheme over the filtered result.
+            // Don't project away $row_id and semiJoinOutput here — PruneUnreferencedOutputs will handle it.
+            // Projecting them away here would break StreamPropertyDerivations' unique column consistency check.
+            TopNNode outerTopN = new TopNNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    filtered,
+                    node.getCount(),
+                    node.getOrderingScheme(),
+                    Step.SINGLE);
+
+            planChanged = true;
+            return outerTopN;
+        }
+
+        private static TopNNode replaceSource(TopNNode topNNode, PlanNode newSource)
+        {
+            if (topNNode.getSource() == newSource) {
+                return topNNode;
+            }
+            return new TopNNode(
+                    topNNode.getSourceLocation(),
+                    topNNode.getId(),
+                    topNNode.getStatsEquivalentPlanNode(),
+                    newSource,
+                    topNNode.getCount(),
+                    topNNode.getOrderingScheme(),
+                    topNNode.getStep());
+        }
+
+        /**
+         * Replace the TableScanNode at the bottom of a Filter/Project chain with a new one.
+         * Returns Optional.empty() if an unsupported node type is encountered.
+         */
+        private static Optional<PlanNode> replaceTableScan(PlanNode node, TableScanNode newTableScan, PlanNodeIdAllocator idAllocator)
+        {
+            if (node instanceof TableScanNode) {
+                return Optional.of(newTableScan);
+            }
+            if (node instanceof FilterNode) {
+                FilterNode filterNode = (FilterNode) node;
+                return replaceTableScan(filterNode.getSource(), newTableScan, idAllocator)
+                        .map(newSource -> new FilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate()));
+            }
+            if (node instanceof ProjectNode) {
+                ProjectNode projectNode = (ProjectNode) node;
+                return replaceTableScan(projectNode.getSource(), newTableScan, idAllocator)
+                        .map(newSource -> new ProjectNode(idAllocator.getNextId(), newSource, projectNode.getAssignments()));
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.ColumnNaming;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.tpch.TpchMetadata;
+import com.facebook.presto.tpch.TpchRecordSetProvider;
+import com.facebook.presto.tpch.TpchSplitManager;
+import com.facebook.presto.tpch.TpchTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestOptimizeTopNUsingRowId
+        extends BasePlanTest
+{
+    public TestOptimizeTopNUsingRowId()
+    {
+        super(TestOptimizeTopNUsingRowId::createQueryRunner);
+    }
+
+    private static LocalQueryRunner createQueryRunner()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .setSystemProperty("task_concurrency", "1")
+                .build();
+
+        LocalQueryRunner queryRunner = new LocalQueryRunner(
+                session,
+                new FeaturesConfig(),
+                new FunctionsConfig(),
+                new NodeSpillConfig(),
+                false,
+                false,
+                createObjectMapper(),
+                new TaskManagerConfig().setTaskConcurrency(1));
+
+        queryRunner.createCatalog("local", new UniqueColumnMockConnectorFactory(), ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @Test
+    public void testBasicRewrite()
+    {
+        // lineitem has 16 columns, sorting by 1 gives savings of 15 >= 10 threshold.
+        // With unique column available, the optimization should produce SemiJoin plan.
+        assertPlanWithSession(
+                "SELECT * FROM lineitem ORDER BY orderkey LIMIT 10",
+                enabledSession(),
+                true,
+                output(
+                        topN(10, ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST)),
+                                anyTree(
+                                        node(FilterNode.class,
+                                                anyTree(
+                                                        semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
+                                                                anyTree(
+                                                                        tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey", "ROW_ID", "$row_id"))),
+                                                                anyTree(
+                                                                        tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))))));
+    }
+
+    @Test
+    public void testNoRewriteWhenDisabled()
+    {
+        // With optimization disabled, should produce a regular TopN plan.
+        assertPlanWithSession(
+                "SELECT * FROM lineitem ORDER BY orderkey LIMIT 10",
+                disabledSession(),
+                true,
+                output(
+                        topN(10, ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST)),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey"))))));
+    }
+
+    @Test
+    public void testNoRewriteNarrowTable()
+    {
+        // nation has only 4 columns. With savings of 3 (4 - 1 sort key), below the default threshold of 10.
+        assertPlanWithSession(
+                "SELECT * FROM nation ORDER BY name LIMIT 5",
+                enabledSession(),
+                true,
+                output(
+                        topN(5, ImmutableList.of(sort("NAME", ASCENDING, LAST)),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("NAME", "name"))))));
+    }
+
+    @Test
+    public void testNoRewriteAllSortKeys()
+    {
+        // When all columns are sort keys, there's no savings.
+        assertPlanWithSession(
+                "SELECT regionkey FROM nation ORDER BY regionkey LIMIT 5",
+                enabledSession(),
+                true,
+                output(
+                        topN(5, ImmutableList.of(sort("REGIONKEY", ASCENDING, LAST)),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("REGIONKEY", "regionkey"))))));
+    }
+
+    @Test
+    public void testRewriteWithLowThreshold()
+    {
+        // Even for nation (4 columns), with min_column_savings = 2 and sorting by 1, savings = 3 >= 2.
+        Session lowThreshold = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, "2")
+                .build();
+
+        assertPlanWithSession(
+                "SELECT * FROM nation ORDER BY name LIMIT 5",
+                lowThreshold,
+                true,
+                output(
+                        topN(5, ImmutableList.of(sort("NAME", ASCENDING, LAST)),
+                                anyTree(
+                                        node(FilterNode.class,
+                                                anyTree(
+                                                        semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
+                                                                anyTree(
+                                                                        tableScan("nation", ImmutableMap.of("NAME", "name", "ROW_ID", "$row_id"))),
+                                                                anyTree(
+                                                                        tableScan("nation", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))))));
+    }
+
+    private Session enabledSession()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
+                .build();
+    }
+
+    private Session disabledSession()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "false")
+                .build();
+    }
+
+    /**
+     * Mock TpchConnectorFactory that provides a unique column ($row_id) on all tables.
+     */
+    private static class UniqueColumnMockConnectorFactory
+            extends TpchConnectorFactory
+    {
+        UniqueColumnMockConnectorFactory()
+        {
+            super(1);
+        }
+
+        @Override
+        public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
+        {
+            int splitsPerNode = getSplitsPerNode(properties);
+            ColumnNaming columnNaming = ColumnNaming.valueOf(
+                    properties.getOrDefault(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()).toUpperCase());
+            NodeManager nodeManager = context.getNodeManager();
+
+            return new Connector()
+            {
+                @Override
+                public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+                {
+                    return TpchTransactionHandle.INSTANCE;
+                }
+
+                @Override
+                public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+                {
+                    return new UniqueColumnMockMetadata(catalogName, columnNaming, isPredicatePushdownEnabled(), isPartitioningEnabled(properties));
+                }
+
+                @Override
+                public ConnectorSplitManager getSplitManager()
+                {
+                    return new TpchSplitManager(nodeManager, splitsPerNode);
+                }
+
+                @Override
+                public ConnectorRecordSetProvider getRecordSetProvider()
+                {
+                    return new TpchRecordSetProvider();
+                }
+            };
+        }
+    }
+
+    /**
+     * Mock metadata that adds a unique column ($row_id) to the table layout of all tables.
+     */
+    private static class UniqueColumnMockMetadata
+            extends TpchMetadata
+    {
+        // Synthetic $row_id column handle for testing
+        private static final TpchColumnHandle ROW_ID_COLUMN = new TpchColumnHandle("$row_id", VARBINARY);
+
+        UniqueColumnMockMetadata(String connectorId, ColumnNaming columnNaming, boolean predicatePushdownEnabled, boolean partitioningEnabled)
+        {
+            super(connectorId, columnNaming, predicatePushdownEnabled, partitioningEnabled);
+        }
+
+        @Override
+        public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+        {
+            ConnectorTableLayout baseLayout = super.getTableLayout(session, handle);
+            // Add the unique column to make the optimizer applicable
+            return new ConnectorTableLayout(
+                    baseLayout.getHandle(),
+                    baseLayout.getColumns(),
+                    baseLayout.getPredicate(),
+                    baseLayout.getTablePartitioning(),
+                    baseLayout.getStreamPartitioningColumns(),
+                    baseLayout.getDiscretePredicates(),
+                    baseLayout.getLocalProperties(),
+                    Optional.empty(),
+                    Optional.of(ROW_ID_COLUMN));
+        }
+
+        @Override
+        public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+        {
+            Map<String, ColumnHandle> base = super.getColumnHandles(session, tableHandle);
+            return ImmutableMap.<String, ColumnHandle>builder()
+                    .putAll(base)
+                    .put("$row_id", ROW_ID_COLUMN)
+                    .build();
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            TpchColumnHandle tpchColumn = (TpchColumnHandle) columnHandle;
+            if (tpchColumn.getColumnName().equals("$row_id")) {
+                return ColumnMetadata.builder().setName("$row_id").setType(VARBINARY).setHidden(true).build();
+            }
+            return super.getColumnMetadata(session, tableHandle, columnHandle);
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -35,6 +35,8 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS;
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.common.predicate.Marker.Bound.EXACTLY;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -206,5 +208,29 @@ public class TestLocalQueries
         // TopN with downstream join where ordering matters
         assertQuery("SELECT t.nationkey, r.name FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 10) t " +
                 "JOIN region r ON t.regionkey = r.regionkey");
+    }
+
+    @Test
+    public void testOptimizeTopNUsingRowId()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, "1")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "false")
+                .build();
+
+        // Basic wide-table TopN (lineitem has 16 columns, well above threshold)
+        assertQuery(enabled, "SELECT * FROM lineitem ORDER BY orderkey LIMIT 10",
+                disabled, "SELECT * FROM lineitem ORDER BY orderkey LIMIT 10");
+
+        // Another wide table with DESC ordering
+        assertQuery(enabled, "SELECT * FROM orders ORDER BY orderkey DESC LIMIT 5",
+                disabled, "SELECT * FROM orders ORDER BY orderkey DESC LIMIT 5");
+
+        // TopN with filter
+        assertQuery(enabled, "SELECT * FROM lineitem WHERE shipdate > DATE '1995-01-01' ORDER BY orderkey LIMIT 10",
+                disabled, "SELECT * FROM lineitem WHERE shipdate > DATE '1995-01-01' ORDER BY orderkey LIMIT 10");
     }
 }


### PR DESCRIPTION
## Summary

For `ORDER BY ... LIMIT N` over wide tables with a unique `$row_id` column, this optimization avoids sorting all columns by first sorting only the narrow sort keys + `$row_id`, then using a SemiJoin to fetch the full rows for the top-N results.

### Rewrite

```
Before:  TopN(SINGLE) → ScanFilterProject (all columns)

After:   TopN → Filter(semi_mark) → SemiJoin
           source:    augmented original scan (with $row_id added)
           filtering: TopN → narrow clone (sort keys + $row_id_clone only)
```

### Guards
- Session property `optimize_top_n_using_row_id` (default `false`)
- TopN must be `Step.SINGLE` over a scan-filter-project subtree
- Table layout must expose a unique column via `getUniqueColumn()`
- Column savings must exceed `optimize_top_n_using_row_id_min_column_savings` (default `10`)

### Bug fix
Also fixes a latent bug in `StreamPropertyDerivations.visitTopN` where SINGLE/FINAL TopN dropped `streamPropertiesFromUniqueColumn`, causing an `IllegalStateException` when a unique column was explicitly present in a table scan's assignments under TopN. The PARTIAL step already preserved this correctly.

## Files Changed

| File | Change |
|------|--------|
| `SystemSessionProperties.java` | Added 2 session properties + accessors |
| `PlannerUtils.java` | Added `findTableScanNode`, `addColumnToTableScan`, `addPassThroughVariable` helpers |
| `OptimizeTopNUsingRowId.java` | **New** — The optimizer (300 lines) |
| `PlanOptimizers.java` | Registered optimizer after JoinPrefilter |
| `StreamPropertyDerivations.java` | Bug fix: propagate `streamPropertiesFromUniqueColumn` through TopN |
| `TestOptimizeTopNUsingRowId.java` | **New** — 5 unit tests with mock connector |

## Test Plan
- 5 new unit tests (all pass):
  - `testBasicRewrite` — lineitem (16 cols), verifies SemiJoin plan
  - `testNoRewriteWhenDisabled` — optimization disabled via session property
  - `testNoRewriteNarrowTable` — nation (4 cols), below threshold
  - `testNoRewriteAllSortKeys` — all columns are sort keys, no savings
  - `testRewriteWithLowThreshold` — nation with threshold=1, verifies rewrite
- 92 existing TopN tests pass (no regressions)
- 9 existing JoinPrefilter tests pass (no regressions)

## Summary by Sourcery

Introduce new planner optimizations for TopN late materialization and OFFSET over ORDER BY, extend join prefiltering to more complex plans, and wire them via session/config properties with accompanying tests and a planner bug fix.

New Features:
- Add OptimizeTopNUsingRowId optimizer to perform late materialization for TopN over wide tables using a unique $row_id column.
- Add EliminateOffsetOverTopN optimizer to rewrite ORDER BY + OFFSET + LIMIT into a triple-TopN pattern instead of RowNumber-based offset implementation.

Bug Fixes:
- Preserve streamPropertiesFromUniqueColumn through non-PARTIAL TopN nodes in StreamPropertyDerivations to avoid illegal state when unique columns are present under TopN.

Enhancements:
- Extend JoinPrefilter to handle more complex left-side probe shapes (UNION ALL, cross joins, unnest, aggregations) and support pushing the prefilter below certain right-side aggregations.
- Enhance PlannerUtils to clone UnionNode subtrees, treat Union-based scan/filter/project chains as deterministic, and provide helpers for locating and augmenting table scans and threading new variables through projection/filter chains.

Tests:
- Add unit tests for OptimizeTopNUsingRowId using a mock connector that exposes a unique $row_id column and various threshold/shape cases.
- Add targeted plan tests for the extended JoinPrefilter behavior, including complex probe-side patterns and aggregation pushdown conditions.
- Add planner and integration tests validating EliminateOffsetOverTopN behavior and correctness for ASC/DESC cases and interaction with OFFSET clause enabling.
- Extend existing query tests to cover OFFSET over TopN plans and join prefilter scenarios with new session properties.