### PR TITLE
feat(scheduler): Allow configured resource groups to bypass cluster-overload throttling (#27642)

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1589,6 +1589,91 @@ Valid values are ``FAIL`` (throw an error) or ``USE_VIEW_QUERY`` (query base tab
 
 The corresponding session property is :ref:`admin/properties-session:\`\`materialized_view_stale_read_behavior\`\``.
 
+Cluster Overload Properties
+---------------------------
+
+These properties control cluster-overload throttling, which monitors worker CPU and
+memory utilization and throttles query admission when the cluster is under heavy load.
+Cluster-overload throttling is independent of per-resource-group concurrency, memory,
+and CPU limits, which continue to apply regardless of these settings.
+
+``cluster-overload.enable-throttling``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enables cluster-overload throttling. When enabled, the coordinator periodically
+checks worker health and prevents new queries from starting when the cluster is
+overloaded. When disabled, no overload checks are performed and all queries are
+admitted immediately (subject to other admission gates such as resource group limits).
+
+``cluster-overload.overload-policy-type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Allowed values:** ``overload_worker_cnt_based_throttling``, ``overload_worker_pct_based_throttling``
+* **Default value:** ``overload_worker_cnt_based_throttling``
+
+The policy used to determine whether the cluster is overloaded.
+``overload_worker_cnt_based_throttling`` declares the cluster overloaded when the
+number of overloaded workers exceeds ``cluster-overload.allowed-overload-workers-cnt``.
+``overload_worker_pct_based_throttling`` declares it overloaded when the fraction of
+overloaded workers exceeds ``cluster-overload.allowed-overload-workers-pct``.
+
+``cluster-overload.allowed-overload-workers-cnt``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Maximum number of workers that may be in an overloaded state before the cluster is
+considered overloaded. Only used when ``cluster-overload.overload-policy-type`` is set
+to ``overload_worker_cnt_based_throttling``.
+
+``cluster-overload.allowed-overload-workers-pct``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``double``
+* **Default value:** ``0.01``
+
+Maximum fraction of workers (between 0 and 1) that may be in an overloaded state
+before the cluster is considered overloaded. Only used when
+``cluster-overload.overload-policy-type`` is set to
+``overload_worker_pct_based_throttling``.
+
+``cluster.overload-check-cache-ttl-secs``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``5``
+
+How frequently (in seconds) the coordinator re-evaluates the cluster overload state.
+Between checks, the most recently computed state is cached and reused.
+
+``cluster-overload.bypass-resource-groups``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** (empty)
+
+Comma-separated list of fully-qualified resource group ids (dot-separated segments,
+such as ``global.admin, global.etl.priority``) that bypass cluster-overload throttling.
+Listed groups are still subject to all other admission gates — per-group concurrency,
+memory, and CPU limits continue to apply.
+
+A resource group bypasses throttling when it lies on the same root-to-leaf path as any
+configured entry: equal to a listed group, an ancestor of one, or a descendant of one.
+Sibling groups that do not appear in the list remain throttled. Path-based matching is
+required because the admission check runs at every ancestor in the resource group
+hierarchy; without it a non-listed ancestor would veto a listed leaf group.
+
+The bypass set is snapshotted at coordinator startup; changes require a coordinator
+restart. A ``throttlingBypassCount`` JMX counter on ``ClusterResourceChecker`` tracks
+how many times the bypass was applied.
+
+Malformed entries (such as ``global..admin``) cause a startup failure.
+
 Resource Manager Properties
 ---------------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/ClusterOverloadConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/ClusterOverloadConfig.java
@@ -14,16 +14,27 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 public class ClusterOverloadConfig
 {
     public static final String OVERLOAD_POLICY_CNT_BASED = "overload_worker_cnt_based_throttling";
     public static final String OVERLOAD_POLICY_PCT_BASED = "overload_worker_pct_based_throttling";
+    private static final Splitter BYPASS_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private static final Splitter GROUP_ID_SEGMENT_SPLITTER = Splitter.on('.');
+
     private boolean clusterOverloadThrottlingEnabled;
     private double allowedOverloadWorkersPct = 0.01;
     private int allowedOverloadWorkersCnt;
     private String overloadPolicyType = OVERLOAD_POLICY_CNT_BASED;
     private int overloadCheckCacheTtlInSecs = 5;
+    private Set<ResourceGroupId> throttlingBypassResourceGroups = ImmutableSet.of();
 
     /**
      * Gets the time-to-live for the cached cluster overload state.
@@ -107,5 +118,28 @@ public class ClusterOverloadConfig
     public String getOverloadPolicyType()
     {
         return this.overloadPolicyType;
+    }
+
+    public Set<ResourceGroupId> getThrottlingBypassResourceGroups()
+    {
+        return throttlingBypassResourceGroups;
+    }
+
+    @Config("cluster-overload.bypass-resource-groups")
+    @ConfigDescription("Comma-separated list of fully-qualified resource group ids that bypass cluster-overload throttling")
+    public ClusterOverloadConfig setThrottlingBypassResourceGroups(String throttlingBypassResourceGroups)
+    {
+        if (throttlingBypassResourceGroups == null) {
+            this.throttlingBypassResourceGroups = ImmutableSet.of();
+            return this;
+        }
+        // ResourceGroupId rejects empty segments, so a malformed entry like "global..admin" fails fast
+        // at startup. Airlift Bootstrap surfaces the failure with the property name.
+        ImmutableSet.Builder<ResourceGroupId> builder = ImmutableSet.builder();
+        for (String entry : BYPASS_SPLITTER.split(throttlingBypassResourceGroups)) {
+            builder.add(new ResourceGroupId(ImmutableList.copyOf(GROUP_ID_SEGMENT_SPLITTER.split(entry))));
+        }
+        this.throttlingBypassResourceGroups = builder.build();
+        return this;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -1054,8 +1054,9 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
         synchronized (root) {
-            // Check if more queries can be run on the cluster based on cluster overload
-            if (clusterResourceChecker.isClusterCurrentlyOverloaded()) {
+            // Check if more queries can be run on the cluster based on cluster overload.
+            // Resource groups in cluster-overload.bypass-resource-groups skip this check.
+            if (clusterResourceChecker.isClusterCurrentlyOverloaded(id)) {
                 return false;
             }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterResourceChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterResourceChecker.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.stats.CounterStat;
 import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.execution.ClusterOverloadConfig;
 import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.errorprone.annotations.ThreadSafe;
 import com.google.inject.Singleton;
 import jakarta.annotation.PostConstruct;
@@ -26,6 +27,7 @@ import jakarta.inject.Inject;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -48,9 +50,11 @@ public class ClusterResourceChecker
 
     private final ClusterOverloadPolicy clusterOverloadPolicy;
     private final ClusterOverloadConfig config;
+    private final Set<ResourceGroupId> bypassResourceGroupIds;
     private final AtomicBoolean cachedOverloadState = new AtomicBoolean(false);
     private final AtomicLong lastCheckTimeMillis = new AtomicLong(0);
     private final CounterStat overloadDetectionCount = new CounterStat();
+    private final CounterStat throttlingBypassCount = new CounterStat();
     private final TimeStat timeSinceLastCheck = new TimeStat();
     private final AtomicLong overloadStartTimeMillis = new AtomicLong(0);
     private final CopyOnWriteArrayList<ClusterOverloadStateListener> listeners = new CopyOnWriteArrayList<>();
@@ -63,6 +67,7 @@ public class ClusterResourceChecker
     {
         this.clusterOverloadPolicy = requireNonNull(clusterOverloadPolicy, "clusterOverloadPolicy is null");
         this.config = requireNonNull(config, "config is null");
+        this.bypassResourceGroupIds = config.getThrottlingBypassResourceGroups();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.overloadCheckerExecutor = newSingleThreadScheduledExecutor(threadsNamed("cluster-overload-checker-%s"));
     }
@@ -155,16 +160,57 @@ public class ClusterResourceChecker
     }
 
     /**
-     * Returns the current overload state of the cluster.
-     * @return true if cluster is overloaded, false otherwise
+     * Returns the current overload state of the cluster, with the option for the caller's
+     * resource group to bypass throttling when configured via
+     * {@code cluster-overload.bypass-resource-groups}.
+     *
+     * <p>A resource group bypasses cluster-overload throttling when it lies on the same
+     * root-to-leaf path as any configured bypass group — that is, when it is equal to a
+     * configured group, an ancestor of one, or a descendant of one. The path-based predicate
+     * is required because {@code canRunMore()} is invoked at every ancestor in the resource
+     * group hierarchy during query admission, so a single non-bypassed ancestor would
+     * otherwise veto admission for a configured leaf group.
+     *
+     * <p>Per-group concurrency, memory, and CPU limits still apply — only the global
+     * cluster-overload signal is skipped.
+     *
+     * @param resourceGroupId the resource group requesting admission (non-null)
+     * @return true if the cluster is overloaded and the resource group is not on a bypass path,
+     *     false otherwise
      */
-    public boolean isClusterCurrentlyOverloaded()
+    public boolean isClusterCurrentlyOverloaded(ResourceGroupId resourceGroupId)
     {
+        requireNonNull(resourceGroupId, "resourceGroupId is null");
+
         if (!config.isClusterOverloadThrottlingEnabled()) {
             return false;
         }
 
-        return cachedOverloadState.get();
+        if (!cachedOverloadState.get()) {
+            return false;
+        }
+
+        if (isOnBypassPath(resourceGroupId)) {
+            throttlingBypassCount.update(1);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isOnBypassPath(ResourceGroupId resourceGroupId)
+    {
+        if (bypassResourceGroupIds.isEmpty()) {
+            return false;
+        }
+        for (ResourceGroupId bypassed : bypassResourceGroupIds) {
+            if (resourceGroupId.equals(bypassed)
+                    || resourceGroupId.isAncestorOf(bypassed)
+                    || bypassed.isAncestorOf(resourceGroupId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -211,6 +257,19 @@ public class ClusterResourceChecker
     public CounterStat getOverloadDetectionCount()
     {
         return overloadDetectionCount;
+    }
+
+    /**
+     * Returns the number of times throttling has been bypassed because the requesting resource
+     * group is on the {@code cluster-overload.bypass-resource-groups} list.
+     *
+     * @return counter of throttling bypasses
+     */
+    @Managed
+    @Nested
+    public CounterStat getThrottlingBypassCount()
+    {
+        return throttlingBypassCount;
     }
 
     /**

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestClusterOverloadConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestClusterOverloadConfig.java
@@ -14,12 +14,17 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
 import static com.facebook.presto.execution.ClusterOverloadConfig.OVERLOAD_POLICY_CNT_BASED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 public class TestClusterOverloadConfig
 {
@@ -31,7 +36,8 @@ public class TestClusterOverloadConfig
                 .setAllowedOverloadWorkersPct(0.01)
                 .setAllowedOverloadWorkersCnt(0)
                 .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED)
-                .setOverloadCheckCacheTtlInSecs(5));
+                .setOverloadCheckCacheTtlInSecs(5)
+                .setThrottlingBypassResourceGroups(null));
     }
 
     @Test
@@ -43,6 +49,7 @@ public class TestClusterOverloadConfig
                 .put("cluster-overload.allowed-overload-workers-cnt", "5")
                 .put("cluster-overload.overload-policy-type", "overload_worker_pct_based_throttling")
                 .put("cluster.overload-check-cache-ttl-secs", "10")
+                .put("cluster-overload.bypass-resource-groups", "global.admin, global.etl.priority")
                 .build();
 
         ClusterOverloadConfig expected = new ClusterOverloadConfig()
@@ -50,8 +57,40 @@ public class TestClusterOverloadConfig
                 .setAllowedOverloadWorkersPct(0.05)
                 .setAllowedOverloadWorkersCnt(5)
                 .setOverloadPolicyType("overload_worker_pct_based_throttling")
-                .setOverloadCheckCacheTtlInSecs(10);
+                .setOverloadCheckCacheTtlInSecs(10)
+                .setThrottlingBypassResourceGroups("global.admin, global.etl.priority");
 
         ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testThrottlingBypassParsing()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig();
+        assertEquals(config.getThrottlingBypassResourceGroups(), ImmutableSet.of());
+
+        config.setThrottlingBypassResourceGroups("global.admin, global.etl, ,global.adhoc");
+        assertEquals(
+                config.getThrottlingBypassResourceGroups(),
+                ImmutableSet.of(
+                        new ResourceGroupId(ImmutableList.of("global", "admin")),
+                        new ResourceGroupId(ImmutableList.of("global", "etl")),
+                        new ResourceGroupId(ImmutableList.of("global", "adhoc"))));
+
+        config.setThrottlingBypassResourceGroups(null);
+        assertEquals(config.getThrottlingBypassResourceGroups(), ImmutableSet.of());
+
+        config.setThrottlingBypassResourceGroups("");
+        assertEquals(config.getThrottlingBypassResourceGroups(), ImmutableSet.of());
+    }
+
+    @Test
+    public void testThrottlingBypassMalformedEntryFailsFast()
+    {
+        // Empty segments are rejected by ResourceGroupId; airlift Bootstrap surfaces this as a
+        // configuration error tagged with the property name.
+        ClusterOverloadConfig config = new ClusterOverloadConfig();
+        assertThrows(IllegalArgumentException.class,
+                () -> config.setThrottlingBypassResourceGroups("global..admin"));
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestClusterResourceChecker.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestClusterResourceChecker.java
@@ -20,6 +20,8 @@ import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.NodeLoadMetrics;
 import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -38,6 +40,7 @@ public class TestClusterResourceChecker
 {
     private static final int CACHE_TTL_SECS = 1;
     private static final int SLEEP_BUFFER_MILLIS = 200;
+    private static final ResourceGroupId TEST_RESOURCE_GROUP = new ResourceGroupId(ImmutableList.of("test", "group"));
 
     private ClusterOverloadConfig config;
     private TestingClusterOverloadPolicy clusterOverloadPolicy;
@@ -73,19 +76,19 @@ public class TestClusterResourceChecker
 
         // Initially not overloaded
         clusterOverloadPolicy.setOverloaded(false);
-        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
 
         // Wait for periodic check to update state
         clusterOverloadPolicy.setOverloaded(true);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
         assertTrue(clusterResourceChecker.isClusterOverloaded());
         assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 1);
 
         // Set back to not overloaded
         clusterOverloadPolicy.setOverloaded(false);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
         assertFalse(clusterResourceChecker.isClusterOverloaded());
 
         // Stop the periodic task
@@ -101,7 +104,7 @@ public class TestClusterResourceChecker
         // Set to overloaded and wait for periodic check
         clusterOverloadPolicy.setOverloaded(true);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
         assertTrue(clusterResourceChecker.isClusterOverloaded());
 
         // Duration should be greater than 0
@@ -111,7 +114,7 @@ public class TestClusterResourceChecker
         // Set back to not overloaded
         clusterOverloadPolicy.setOverloaded(false);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
 
         // Duration should be 0 again
         assertEquals(clusterResourceChecker.getOverloadDurationMillis(), 0);
@@ -129,18 +132,18 @@ public class TestClusterResourceChecker
         // First transition to overloaded
         clusterOverloadPolicy.setOverloaded(true);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
         assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 1);
 
         // Wait and transition back to not overloaded
         clusterOverloadPolicy.setOverloaded(false);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
 
         // Second transition to overloaded
         clusterOverloadPolicy.setOverloaded(true);
         sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
-        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
         assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 2);
 
         // Stop the periodic task
@@ -164,7 +167,196 @@ public class TestClusterResourceChecker
 
         // Even when cluster is overloaded, isClusterCurrentlyOverloaded should return false if throttling is disabled
         clusterOverloadPolicy.setOverloaded(true);
-        assertFalse(disabledChecker.isClusterCurrentlyOverloaded());
+        assertFalse(disabledChecker.isClusterCurrentlyOverloaded(TEST_RESOURCE_GROUP));
+    }
+
+    @Test
+    public void testBypassResourceGroupsSkipsThrottling()
+    {
+        // Bypass on path semantics: a group bypasses cluster overload when it is equal to,
+        // an ancestor of, or a descendant of any configured bypass entry. Required because
+        // canRunMore() is invoked at every ancestor in the hierarchy during admission.
+        ClusterOverloadConfig bypassConfig = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(true)
+                .setThrottlingBypassResourceGroups("global.admin, global.etl.priority");
+
+        ClusterResourceChecker bypassChecker = new ClusterResourceChecker(clusterOverloadPolicy, bypassConfig, nodeManager);
+        bypassChecker.start();
+
+        try {
+            // Drive the cluster into the overloaded state
+            clusterOverloadPolicy.setOverloaded(true);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertTrue(bypassChecker.isClusterOverloaded());
+
+            ResourceGroupId bypassedExact = new ResourceGroupId(ImmutableList.of("global", "admin"));
+            ResourceGroupId alsoBypassedExact = new ResourceGroupId(ImmutableList.of("global", "etl", "priority"));
+            ResourceGroupId descendantOfBypassed = new ResourceGroupId(ImmutableList.of("global", "admin", "user_x"));
+            ResourceGroupId deepDescendantOfBypassed = new ResourceGroupId(ImmutableList.of("global", "admin", "user_x", "session_1"));
+            ResourceGroupId rootAncestor = new ResourceGroupId(ImmutableList.of("global"));
+            ResourceGroupId etlIntermediateAncestor = new ResourceGroupId(ImmutableList.of("global", "etl"));
+            ResourceGroupId siblingOfBypassed = new ResourceGroupId(ImmutableList.of("global", "adhoc"));
+            ResourceGroupId siblingUnderEtl = new ResourceGroupId(ImmutableList.of("global", "etl", "lowprio"));
+
+            // Exact match bypasses
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassedExact));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(alsoBypassedExact));
+
+            // Descendants of a bypassed group bypass (so the leaf does not veto its own admission)
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(descendantOfBypassed));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(deepDescendantOfBypassed));
+
+            // Ancestors of a bypassed group bypass (so they do not veto a downstream bypassed admission)
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(rootAncestor));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(etlIntermediateAncestor));
+
+            // Unrelated subtrees remain throttled
+            assertTrue(bypassChecker.isClusterCurrentlyOverloaded(siblingOfBypassed));
+            // Sibling under an ancestor of a bypassed group: 'global.etl' is bypassed (ancestor of priority),
+            // but 'global.etl.lowprio' is neither equal to, ancestor of, nor descendant of any bypass entry,
+            // so its leaf-level check still vetoes — which is the correct behavior for queries on that branch.
+            assertTrue(bypassChecker.isClusterCurrentlyOverloaded(siblingUnderEtl));
+
+            // Bypass counter incremented once per matched call above (6 matches)
+            assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 6);
+        }
+        finally {
+            bypassChecker.stop();
+        }
+    }
+
+    @Test
+    public void testBypassNeverReturnsFalseWhenClusterHealthy()
+    {
+        ClusterOverloadConfig bypassConfig = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(true)
+                .setThrottlingBypassResourceGroups("global.admin");
+
+        ClusterResourceChecker bypassChecker = new ClusterResourceChecker(clusterOverloadPolicy, bypassConfig, nodeManager);
+
+        // Cluster healthy — bypass logic must not run / increment counter
+        ResourceGroupId bypassed = new ResourceGroupId(ImmutableList.of("global", "admin"));
+        assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassed));
+        assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 0);
+    }
+
+    @Test
+    public void testBypassedSiblingDoesNotLeakBypassToOtherSibling()
+    {
+        // Bypass scenario: bypass list contains 'global.pipeline.a' only. A query in
+        // 'global.pipeline.b' must remain throttled, even though both share the ancestors
+        // 'global' and 'global.pipeline' (which themselves bypass because they are ancestors
+        // of the configured 'a'). The leaf-level check on 'b' is the veto that keeps 'b'
+        // throttled while 'a' is admitted.
+        ClusterOverloadConfig bypassConfig = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(true)
+                .setThrottlingBypassResourceGroups("global.pipeline.a");
+
+        ClusterResourceChecker bypassChecker = new ClusterResourceChecker(clusterOverloadPolicy, bypassConfig, nodeManager);
+        bypassChecker.start();
+
+        try {
+            clusterOverloadPolicy.setOverloaded(true);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertTrue(bypassChecker.isClusterOverloaded());
+
+            ResourceGroupId pipelineA = new ResourceGroupId(ImmutableList.of("global", "pipeline", "a"));
+            ResourceGroupId pipelineB = new ResourceGroupId(ImmutableList.of("global", "pipeline", "b"));
+            ResourceGroupId sharedParent = new ResourceGroupId(ImmutableList.of("global", "pipeline"));
+            ResourceGroupId sharedRoot = new ResourceGroupId(ImmutableList.of("global"));
+
+            // 'a' is bypassed at every level of its admission path.
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(pipelineA));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(sharedParent));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(sharedRoot));
+
+            // 'b' is throttled at its own leaf, even though it shares ancestors with 'a'.
+            assertTrue(bypassChecker.isClusterCurrentlyOverloaded(pipelineB));
+        }
+        finally {
+            bypassChecker.stop();
+        }
+    }
+
+    @Test
+    public void testBypassBehaviorAcrossOverloadTransitions()
+    {
+        // Verifies bypass behavior across healthy -> overloaded -> healthy -> overloaded transitions:
+        // - Under load, bypassed groups skip throttling while unrelated groups are throttled.
+        // - When the cluster becomes healthy, the early-exit in isClusterCurrentlyOverloaded must
+        //   short-circuit before the bypass path, so the bypass counter must not increment for
+        //   either group while healthy.
+        // - Re-entering overload restores bypass behavior and resumes counter increments.
+        ClusterOverloadConfig bypassConfig = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(true)
+                .setThrottlingBypassResourceGroups("global.admin");
+
+        ClusterResourceChecker bypassChecker = new ClusterResourceChecker(clusterOverloadPolicy, bypassConfig, nodeManager);
+        bypassChecker.start();
+
+        try {
+            ResourceGroupId bypassed = new ResourceGroupId(ImmutableList.of("global", "admin"));
+            ResourceGroupId throttled = new ResourceGroupId(ImmutableList.of("global", "adhoc"));
+
+            // Initial healthy state: nothing is throttled, bypass counter untouched.
+            clusterOverloadPolicy.setOverloaded(false);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertFalse(bypassChecker.isClusterOverloaded());
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassed));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(throttled));
+            assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 0);
+
+            // Transition healthy -> overloaded: bypassed group skips throttling, unrelated group is throttled.
+            clusterOverloadPolicy.setOverloaded(true);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertTrue(bypassChecker.isClusterOverloaded());
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassed));
+            assertTrue(bypassChecker.isClusterCurrentlyOverloaded(throttled));
+            assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 1);
+
+            // Transition overloaded -> healthy: nothing is throttled, bypass counter must NOT increment
+            // (the cluster-healthy short-circuit must run before the bypass path).
+            clusterOverloadPolicy.setOverloaded(false);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertFalse(bypassChecker.isClusterOverloaded());
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassed));
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(throttled));
+            assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 1);
+
+            // Re-enter overload: bypass behavior recovers and counter resumes incrementing.
+            clusterOverloadPolicy.setOverloaded(true);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+            assertTrue(bypassChecker.isClusterOverloaded());
+            assertFalse(bypassChecker.isClusterCurrentlyOverloaded(bypassed));
+            assertTrue(bypassChecker.isClusterCurrentlyOverloaded(throttled));
+            assertEquals(bypassChecker.getThrottlingBypassCount().getTotalCount(), 2);
+        }
+        finally {
+            bypassChecker.stop();
+        }
+    }
+
+    @Test
+    public void testEmptyBypassListBehavesLikeBefore()
+    {
+        // Default bypass list is empty
+        clusterResourceChecker.start();
+
+        try {
+            clusterOverloadPolicy.setOverloaded(true);
+            sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+
+            ResourceGroupId anyGroup = new ResourceGroupId(ImmutableList.of("global", "admin"));
+            assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded(anyGroup));
+            assertEquals(clusterResourceChecker.getThrottlingBypassCount().getTotalCount(), 0);
+        }
+        finally {
+            clusterResourceChecker.stop();
+        }
     }
 
     private void sleep(long millis)


### PR DESCRIPTION
Summary:

## Description

Adds a new coordinator config `cluster-overload.bypass-resource-groups`
(CSV of fully-qualified resource group ids) that lets named groups skip
the cluster-overload admission check while continuing to honor every
other admission gate (per-group concurrency / memory / CPU limits, the
task-count gate, the admission-rate cap, and the periodic kill loop).

A new overload `ClusterResourceChecker.isClusterCurrentlyOverloaded(
ResourceGroupId)` is added; `InternalResourceGroup.canRunMore()` passes
its own id. Configured strings are parsed into `ResourceGroupId` objects
at construction (malformed entries fail fast at startup). A
`throttlingBypassCount` JMX counter is exposed for observability.

A group bypasses throttling iff it lies on the same root-to-leaf path as
any configured bypass entry (equal, ancestor, or descendant). The
path-based predicate is required because `canRunMore()` is invoked at
every ancestor during admission — exact-match-only would let a
non-bypassed ancestor veto a configured leaf.

## Motivation and Context

Today, cluster-overload throttling rejects/queues new queries
indiscriminately whenever workers exceed CPU/memory thresholds. There is
no escape hatch for high-priority groups (admin queries, critical ETL,
small/short queries), so they get throttled together with everything
else during incidents. This change provides a static allowlist for
groups that operators want to keep admitting under cluster pressure.

## Impact

- New config `cluster-overload.bypass-resource-groups`; defaults to
  empty (no behavior change).
- Bypass set is snapshotted at coordinator startup; changes require a
  coordinator restart.
- Only the cluster-overload signal is skipped — per-group limits still
  apply.
- New JMX counter `ClusterResourceChecker.throttlingBypassCount`.

## Release Notes
```
General Changes
* Add ``cluster-overload.bypass-resource-groups`` config property to
  allow named resource groups to bypass cluster-overload throttling
  while continuing to honor per-group concurrency, memory, and CPU
  limits.
```

Reviewed By: prashantgolash

Differential Revision: D101554110


