### PR TITLE
fix: Fix failure when inserting into Iceberg tables partitioned by day(timestamp with time zone)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.common.type.Decimals.encodeShortScaledValue;
@@ -43,6 +44,7 @@ import static com.facebook.presto.common.type.Decimals.readBigDecimal;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -89,6 +91,12 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP, block, transformYear),
                             ValueTransform.from(TIMESTAMP, transformYear));
                 }
+                if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+                    LongUnaryOperator transformYear = value -> epochYear(unpackMillisUtc(value));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformYear),
+                            ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformYear));
+                }
                 throw new UnsupportedOperationException("Unsupported type for 'year': " + field);
             case "month":
                 if (type.equals(DATE)) {
@@ -102,6 +110,12 @@ public final class PartitionTransforms
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP, block, transformMonth),
                             ValueTransform.from(TIMESTAMP, transformMonth));
+                }
+                if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+                    LongUnaryOperator transformMonth = value -> epochMonth(unpackMillisUtc(value));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformMonth),
+                            ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformMonth));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'month': " + field);
             case "day":
@@ -117,6 +131,12 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP, block, transformDay),
                             ValueTransform.from(TIMESTAMP, transformDay));
                 }
+                if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+                    LongUnaryOperator transformDay = value -> epochDay(unpackMillisUtc(value));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformDay),
+                            ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformDay));
+                }
                 throw new UnsupportedOperationException("Unsupported type for 'day': " + field);
             case "hour":
                 if (type.equals(TIMESTAMP)) {
@@ -124,6 +144,12 @@ public final class PartitionTransforms
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP, block, transformHour),
                             ValueTransform.from(TIMESTAMP, transformHour));
+                }
+                if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+                    LongUnaryOperator transformHour = value -> epochHour(unpackMillisUtc(value));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformHour),
+                            ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformHour));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'hour': " + field);
         }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1691,36 +1691,40 @@ public abstract class IcebergDistributedSmokeTestBase
                 "Unsupported type for 'bucket': 1000: col_timestamp_tz_bucket: bucket\\[2\\]\\(1\\)");
         assertUpdate("drop table if exists test_bucket_transform_timestamp_tz");
 
-        //TODO: Not yet support year transform for timestamp with time zone, which was supported by Iceberg
+        // Test year transform for timestamp with time zone
         assertUpdate("create table test_year_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
                 "with (partitioning = ARRAY['year(col_timestamp_tz)'])");
-        assertQueryFails("insert into test_year_transform_timestamp_tz " +
-                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
-                "Unsupported type for 'year': 1000: col_timestamp_tz_year: year\\(1\\)");
+        assertUpdate("insert into test_year_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))", 1);
+        assertQuery("select * from test_year_transform_timestamp_tz",
+                "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))");
         assertUpdate("drop table if exists test_year_transform_timestamp_tz");
 
-        //TODO: Not yet support month transform for timestamp with time zone, which was supported by Iceberg
+        // Test month transform for timestamp with time zone
         assertUpdate("create table test_month_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
                 "with (partitioning = ARRAY['month(col_timestamp_tz)'])");
-        assertQueryFails("insert into test_month_transform_timestamp_tz " +
-                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
-                "Unsupported type for 'month': 1000: col_timestamp_tz_month: month\\(1\\)");
+        assertUpdate("insert into test_month_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))", 1);
+        assertQuery("select * from test_month_transform_timestamp_tz",
+                "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))");
         assertUpdate("drop table if exists test_month_transform_timestamp_tz");
 
-        //TODO: Not yet support day transform for timestamp with time zone, which was supported by Iceberg
+        // Test day transform for timestamp with time zone
         assertUpdate("create table test_day_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
                 "with (partitioning = ARRAY['day(col_timestamp_tz)'])");
-        assertQueryFails("insert into test_day_transform_timestamp_tz " +
-                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
-                "Unsupported type for 'day': 1000: col_timestamp_tz_day: day\\(1\\)");
+        assertUpdate("insert into test_day_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))", 1);
+        assertQuery("select * from test_day_transform_timestamp_tz",
+                "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))");
         assertUpdate("drop table if exists test_day_transform_timestamp_tz");
 
-        //TODO: Not yet support hour transform for timestamp with time zone, which was supported by Iceberg
+        // Test hour transform for timestamp with time zone
         assertUpdate("create table test_hour_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
                 "with (partitioning = ARRAY['hour(col_timestamp_tz)'])");
-        assertQueryFails("insert into test_hour_transform_timestamp_tz " +
-                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
-                "Unsupported type for 'hour': 1000: col_timestamp_tz_hour: hour\\(1\\)");
+        assertUpdate("insert into test_hour_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))", 1);
+        assertQuery("select * from test_hour_transform_timestamp_tz",
+                "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))");
         assertUpdate("drop table if exists test_hour_transform_timestamp_tz");
     }
 


### PR DESCRIPTION
## Description

Presto currently throws an UnsupportedOperationException when inserting into Iceberg tables partitioned using day(column) if the column type is timestamp with time zone. The failure occurs during partition transform evaluation in the Iceberg connector.

This change updates the partition transform handling to support timestamp with time zone inputs for day(), aligning behaviour with Iceberg expectations and Spark compatibility.

With this fix:
- INSERT operations succeed for tables partitioned by day(timestamp with time zone)
- Existing behavior for timestamp (without time zone) remains unchanged

This resolves a limitation in Presto's Iceberg connector when working with timezone-aware timestamps. Git issue https://github.com/prestodb/presto/issues/27644

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Test cases added, Along with that tested the change through Presto CLI
<img width="968" height="32" alt="Screenshot 2026-04-23 at 2 39 02 PM" src="https://github.com/user-attachments/assets/eea585a8-08df-477c-8bb1-b9035fa5ca61" />
<img width="545" height="134" alt="Screenshot 2026-04-23 at 2 36 24 PM" src="https://github.com/user-attachments/assets/4d4d226a-1ae1-4741-a2c1-e9ba9e671b0d" />



## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix failure during INSERT into Iceberg tables partitioned by day() when using timestamp with time zone columns.
```

## Summary by Sourcery

Support Iceberg partition transforms on timestamp with time zone columns and update tests accordingly.

New Features:
- Enable year, month, day, and hour partition transforms for timestamp with time zone columns in the Iceberg connector.

Tests:
- Expand Iceberg distributed smoke tests to verify successful inserts and reads for year, month, day, and hour transforms on timestamp with time zone columns.

## Summary by Sourcery

Support Iceberg partition transforms for timestamp with time zone columns and verify them with integration tests.

New Features:
- Enable year, month, day, and hour partition transforms for timestamp with time zone columns in the Iceberg connector.

Bug Fixes:
- Fix failures when inserting into Iceberg tables partitioned by day(), year(), month(), or hour() on timestamp with time zone columns.

Tests:
- Update Iceberg distributed smoke tests to cover successful inserts and reads using year, month, day, and hour transforms on timestamp with time zone columns.