### PR TITLE
fix: Fix target table inconsistency for Iceberg's rewrite_data_files

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -518,6 +518,37 @@ public final class Session
                 queryType);
     }
 
+    public Session useSpecifiedCatalogAsSession(String catalog)
+    {
+        return new Session(
+                queryId,
+                transactionId,
+                clientTransactionSupport,
+                identity,
+                source,
+                Optional.ofNullable(catalog),
+                schema,
+                traceToken,
+                timeZoneKey,
+                locale,
+                remoteUserAddress,
+                userAgent,
+                clientInfo,
+                clientTags,
+                resourceEstimates,
+                startTime,
+                systemProperties,
+                connectorProperties,
+                unprocessedCatalogProperties,
+                sessionPropertyManager,
+                preparedStatements,
+                sessionFunctions,
+                tracer,
+                warningCollector,
+                runtimeStats,
+                queryType);
+    }
+
     public ConnectorSession toConnectorSession()
     {
         return new FullConnectorSession(this, identity.toConnectorIdentity());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1542,11 +1542,8 @@ class StatementAnalyzer
             }
             DistributedProcedure procedure = metadata.getProcedureRegistry().resolveDistributed(connectorId, toSchemaTableName(procedureName));
             Session sessionForProcedure = session;
-            if (procedure.useProcedureInnerScopeSession()) {
-                Session.SessionBuilder sessionBuilder = Session.builder(session.clearTransaction(metadata.getFunctionAndTypeManager().getTransactionManager(), accessControl))
-                        .setCatalog(procedureName.getCatalogName());
-                session.getTransactionId().ifPresent(sessionBuilder::setTransactionId);
-                sessionForProcedure = sessionBuilder.build();
+            if (procedure.usesProcedureCatalogAsSession()) {
+                sessionForProcedure = session.useSpecifiedCatalogAsSession(procedureName.getCatalogName());
             }
             Object[] values = extractParameterValuesInOrder(call, procedure, metadata, sessionForProcedure, analysis.getParameters());
             accessControl.checkCanCallProcedure(sessionForProcedure.getRequiredTransactionId(), sessionForProcedure.getIdentity(), sessionForProcedure.getAccessControlContext(), procedureName);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -444,6 +444,11 @@ class StatementAnalyzer
 
     public Scope analyze(Node node, Optional<Scope> outerQueryScope)
     {
+        return analyze(node, outerQueryScope, session);
+    }
+
+    public Scope analyze(Node node, Optional<Scope> outerQueryScope, Session session)
+    {
         return new Visitor(metadata, session, outerQueryScope, warningCollector).process(node, Optional.empty());
     }
 
@@ -1454,8 +1459,15 @@ class StatementAnalyzer
                 throw new SemanticException(PROCEDURE_NOT_FOUND, "Distributed procedure not registered: " + procedureName);
             }
             DistributedProcedure procedure = metadata.getProcedureRegistry().resolveDistributed(connectorId, toSchemaTableName(procedureName));
-            Object[] values = extractParameterValuesInOrder(call, procedure, metadata, session, analysis.getParameters());
-            accessControl.checkCanCallProcedure(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), procedureName);
+            Session sessionForProcedure = session;
+            if (procedure.useProcedureInnerScopeSession()) {
+                Session.SessionBuilder sessionBuilder = Session.builder(session.clearTransaction(metadata.getFunctionAndTypeManager().getTransactionManager(), accessControl))
+                        .setCatalog(procedureName.getCatalogName());
+                session.getTransactionId().ifPresent(sessionBuilder::setTransactionId);
+                sessionForProcedure = sessionBuilder.build();
+            }
+            Object[] values = extractParameterValuesInOrder(call, procedure, metadata, sessionForProcedure, analysis.getParameters());
+            accessControl.checkCanCallProcedure(sessionForProcedure.getRequiredTransactionId(), sessionForProcedure.getIdentity(), sessionForProcedure.getAccessControlContext(), procedureName);
 
             analysis.setUpdateInfo(call.getUpdateInfo());
             DistributedProcedure.DistributedProcedureType procedureType = procedure.getType();
@@ -1463,23 +1475,23 @@ class StatementAnalyzer
                 case TABLE_DATA_REWRITE:
                     TableDataRewriteDistributedProcedure tableDataRewriteDistributedProcedure = (TableDataRewriteDistributedProcedure) procedure;
                     QualifiedName qualifiedName = QualifiedName.of(tableDataRewriteDistributedProcedure.getSchema(values), tableDataRewriteDistributedProcedure.getTableName(values));
-                    QualifiedObjectName tableName = createQualifiedObjectName(session, call, qualifiedName, metadata);
+                    QualifiedObjectName tableName = createQualifiedObjectName(sessionForProcedure, call, qualifiedName, metadata);
 
                     analysis.addAccessControlCheckForTable(
                             TABLE_INSERT,
                             new AccessControlInfoForTable(
                                     accessControl,
-                                    session.getIdentity(),
-                                    session.getTransactionId(),
-                                    session.getAccessControlContext(),
+                                    sessionForProcedure.getIdentity(),
+                                    sessionForProcedure.getTransactionId(),
+                                    sessionForProcedure.getAccessControlContext(),
                                     tableName));
                     analysis.addAccessControlCheckForTable(
                             TABLE_DELETE,
                             new AccessControlInfoForTable(
                                     accessControl,
-                                    session.getIdentity(),
-                                    session.getTransactionId(),
-                                    session.getAccessControlContext(),
+                                    sessionForProcedure.getIdentity(),
+                                    sessionForProcedure.getTransactionId(),
+                                    sessionForProcedure.getAccessControlContext(),
                                     tableName));
 
                     List<String> sortFieldStrings = extractSortFieldStrings(values, tableDataRewriteDistributedProcedure.getSortOrderIndex());
@@ -1495,9 +1507,9 @@ class StatementAnalyzer
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty());
-                    analyze(querySpecification, scope);
+                    analyze(querySpecification, scope, sessionForProcedure);
 
-                    TableHandle tableHandle = metadata.getHandleVersion(session, tableName, Optional.empty())
+                    TableHandle tableHandle = metadata.getHandleVersion(sessionForProcedure, tableName, Optional.empty())
                             .orElseThrow(() -> (new SemanticException(MISSING_TABLE, call, "Table '%s' does not exist", tableName)));
                     TableDataRewriteAnalysisContext tableDataRewriteAnalysisContext = new TableDataRewriteAnalysisContext(tableHandle, querySpecification, zOrderColumns);
                     analysis.setCallDistributedProcedureAnalysis(new Analysis.CallDistributedProcedureAnalysis(procedureType, values, Optional.of(tableDataRewriteAnalysisContext)));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1460,11 +1460,8 @@ class StatementAnalyzer
             }
             DistributedProcedure procedure = metadata.getProcedureRegistry().resolveDistributed(connectorId, toSchemaTableName(procedureName));
             Session sessionForProcedure = session;
-            if (procedure.useProcedureInnerScopeSession()) {
-                Session.SessionBuilder sessionBuilder = Session.builder(session.clearTransaction(metadata.getFunctionAndTypeManager().getTransactionManager(), accessControl))
-                        .setCatalog(procedureName.getCatalogName());
-                session.getTransactionId().ifPresent(sessionBuilder::setTransactionId);
-                sessionForProcedure = sessionBuilder.build();
+            if (procedure.usesProcedureCatalogAsSession()) {
+                sessionForProcedure = session.useSpecifiedCatalogAsSession(procedureName.getCatalogName());
             }
             Object[] values = extractParameterValuesInOrder(call, procedure, metadata, sessionForProcedure, analysis.getParameters());
             accessControl.checkCanCallProcedure(sessionForProcedure.getRequiredTransactionId(), sessionForProcedure.getIdentity(), sessionForProcedure.getAccessControlContext(), procedureName);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -461,6 +461,11 @@ class StatementAnalyzer
 
     public Scope analyze(Node node, Optional<Scope> outerQueryScope)
     {
+        return analyze(node, outerQueryScope, session);
+    }
+
+    public Scope analyze(Node node, Optional<Scope> outerQueryScope, Session session)
+    {
         return new Visitor(metadata, session, outerQueryScope, warningCollector).process(node, Optional.empty());
     }
 
@@ -1536,8 +1541,15 @@ class StatementAnalyzer
                 throw new SemanticException(PROCEDURE_NOT_FOUND, "Distributed procedure not registered: " + procedureName);
             }
             DistributedProcedure procedure = metadata.getProcedureRegistry().resolveDistributed(connectorId, toSchemaTableName(procedureName));
-            Object[] values = extractParameterValuesInOrder(call, procedure, metadata, session, analysis.getParameters());
-            accessControl.checkCanCallProcedure(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), procedureName);
+            Session sessionForProcedure = session;
+            if (procedure.useProcedureInnerScopeSession()) {
+                Session.SessionBuilder sessionBuilder = Session.builder(session.clearTransaction(metadata.getFunctionAndTypeManager().getTransactionManager(), accessControl))
+                        .setCatalog(procedureName.getCatalogName());
+                session.getTransactionId().ifPresent(sessionBuilder::setTransactionId);
+                sessionForProcedure = sessionBuilder.build();
+            }
+            Object[] values = extractParameterValuesInOrder(call, procedure, metadata, sessionForProcedure, analysis.getParameters());
+            accessControl.checkCanCallProcedure(sessionForProcedure.getRequiredTransactionId(), sessionForProcedure.getIdentity(), sessionForProcedure.getAccessControlContext(), procedureName);
 
             analysis.setUpdateInfo(call.getUpdateInfo());
             DistributedProcedure.DistributedProcedureType procedureType = procedure.getType();
@@ -1545,23 +1557,23 @@ class StatementAnalyzer
                 case TABLE_DATA_REWRITE:
                     TableDataRewriteDistributedProcedure tableDataRewriteDistributedProcedure = (TableDataRewriteDistributedProcedure) procedure;
                     QualifiedName qualifiedName = QualifiedName.of(tableDataRewriteDistributedProcedure.getSchema(values), tableDataRewriteDistributedProcedure.getTableName(values));
-                    QualifiedObjectName tableName = createQualifiedObjectName(session, call, qualifiedName, metadata);
+                    QualifiedObjectName tableName = createQualifiedObjectName(sessionForProcedure, call, qualifiedName, metadata);
 
                     analysis.addAccessControlCheckForTable(
                             TABLE_INSERT,
                             new AccessControlInfoForTable(
                                     accessControl,
-                                    session.getIdentity(),
-                                    session.getTransactionId(),
-                                    session.getAccessControlContext(),
+                                    sessionForProcedure.getIdentity(),
+                                    sessionForProcedure.getTransactionId(),
+                                    sessionForProcedure.getAccessControlContext(),
                                     tableName));
                     analysis.addAccessControlCheckForTable(
                             TABLE_DELETE,
                             new AccessControlInfoForTable(
                                     accessControl,
-                                    session.getIdentity(),
-                                    session.getTransactionId(),
-                                    session.getAccessControlContext(),
+                                    sessionForProcedure.getIdentity(),
+                                    sessionForProcedure.getTransactionId(),
+                                    sessionForProcedure.getAccessControlContext(),
                                     tableName));
 
                     List<String> sortFieldStrings = extractSortFieldStrings(values, tableDataRewriteDistributedProcedure.getSortOrderIndex());
@@ -1577,9 +1589,9 @@ class StatementAnalyzer
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty());
-                    analyze(querySpecification, scope);
+                    analyze(querySpecification, scope, sessionForProcedure);
 
-                    TableHandle tableHandle = metadata.getHandleVersion(session, tableName, Optional.empty())
+                    TableHandle tableHandle = metadata.getHandleVersion(sessionForProcedure, tableName, Optional.empty())
                             .orElseThrow(() -> (new SemanticException(MISSING_TABLE, call, "Table '%s' does not exist", tableName)));
                     TableDataRewriteAnalysisContext tableDataRewriteAnalysisContext = new TableDataRewriteAnalysisContext(tableHandle, querySpecification, zOrderColumns);
                     analysis.setCallDistributedProcedureAnalysis(new Analysis.CallDistributedProcedureAnalysis(procedureType, values, Optional.of(tableDataRewriteAnalysisContext)));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -218,7 +218,14 @@ public class TestLogicalPlanner
                                 arguments,
                                 (session, transactionContext, procedureHandle, fragments, sortOrderIndex) -> null,
                                 (session, transactionContext, procedureHandle, fragments) -> {},
-                                ignored -> new TestProcedureRegistry.TestProcedureContext()));
+                                ignored -> new TestProcedureRegistry.TestProcedureContext())
+                        {
+                            @Override
+                            public boolean useProcedureInnerScopeSession()
+                            {
+                                return false;
+                            }
+                        });
 
                         return new Connector()
                         {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -221,7 +221,7 @@ public class TestLogicalPlanner
                                 ignored -> new TestProcedureRegistry.TestProcedureContext())
                         {
                             @Override
-                            public boolean useProcedureInnerScopeSession()
+                            public boolean usesProcedureCatalogAsSession()
                             {
                                 return false;
                             }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/DistributedProcedure.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/DistributedProcedure.java
@@ -44,6 +44,11 @@ public abstract class DistributedProcedure
         return type;
     }
 
+    public boolean useProcedureInnerScopeSession()
+    {
+        return false;
+    }
+
     /**
      * Performs the preparatory work required when starting the execution of this distributed procedure.
      * */

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/DistributedProcedure.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/DistributedProcedure.java
@@ -44,7 +44,25 @@ public abstract class DistributedProcedure
         return type;
     }
 
-    public boolean useProcedureInnerScopeSession()
+    /**
+     *Indicates whether this distributed procedure should execute using the procedure's own catalog
+     * as the effective catalog for internal execution.
+     *
+     * When this method returns (@code true), the procedure will override the catalog from the caller's
+     * session and execute using the procedure's associated catalog as the default catalog. This ensures
+     * that table resolution and metadata access are scoped to the procedure's catalog, rather than the
+     * catalog of the initiating session. This behavior is typically required for catalog-specific
+     * procedures (e.g., Iceberg maintenance procedure such as `rewrite_data_files`).
+     *
+     * When this method returns {@code false}, the procedure does not override the session catalog and
+     * instead executes in a catalog-agnostic manner. Table resolution follows the caller's session context
+     * or fully qualified identifiers, enabling cross-catalog access and federation. This mode is intended
+     * for generalized distributed procedures.
+     *
+     * @return true if the procedure must execute with its own catalog as the effective execution catalog;
+     *         false if it should respect the caller's session catalog and support cross-catalog execution
+     * */
+    public boolean usesProcedureCatalogAsSession()
     {
         return false;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
@@ -90,7 +90,7 @@ public class TableDataRewriteDistributedProcedure
     }
 
     @Override
-    public boolean useProcedureInnerScopeSession()
+    public boolean usesProcedureCatalogAsSession()
     {
         return true;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/procedure/TableDataRewriteDistributedProcedure.java
@@ -90,6 +90,12 @@ public class TableDataRewriteDistributedProcedure
     }
 
     @Override
+    public boolean useProcedureInnerScopeSession()
+    {
+        return true;
+    }
+
+    @Override
     public ConnectorDistributedProcedureHandle begin(ConnectorSession session, ConnectorProcedureContext procedureContext, ConnectorTableLayoutHandle tableLayoutHandle, Object[] arguments)
     {
         return this.beginCallDistributedProcedure.begin(session, procedureContext, tableLayoutHandle, arguments, getSortOrderIndex());


### PR DESCRIPTION
## Description

This change fixes the issue of target table inconsistency caused by calling Iceberg's rewrite_data_files in other catalogs.

This change allows different subtypes of `DistributedProcedure` to define for themselves whether the default catalog used internally during execution is the current session's catalog or the procedure's own catalog.

For certain connector-specific procedures, the target table must belong to the catalog where the procedure resides, for example, `iceberg.system.rewrite_data_files(...)` as mentioned in this issue.

Meanwhile, for other subtypes of distributed procedures that are implemented by certain specific connectors but are designed to provide some kind of generalized capabilities, the target table shouldn't be bound to the catalog where the procedure resides. For example, in future the Lance connector has the potential to provide a series of generalized vector indexing capabilities and other AI workflow capabilities for tables from all connectors (serves as the actual storage for vectors/vector indexes, as well as temporary storage for datasets used in model training):

```
-- use distributed procedure provided by lance to handle target table in Iceberg
use iceberg.default;
call lance.system.create_vector_index(schema => 'default', table_name => 'iceberg_table', options => ....);

-- use distributed procedure provided by lance to handle target table in hive
call lance.system.create_vector_index(catalog => 'hive', schema => 'default', table_name => 'hive_table', options => ...);

call lance.system.refresh_vector_index(...);
......
```


## Motivation and Context

Fix issue: https://github.com/prestodb/presto/issues/27646

## Impact

N/A

## Test Plan

 - Make sure this change do not affect existing CI tests.
 - Manually tested the related scenario from the issue.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Fix incorrect target table resolution and access control when invoking Iceberg rewrite_data_files via distributed procedures in non-default catalogs.

## Summary by Sourcery

Ensure distributed procedures resolve and access target tables using the appropriate catalog context.

Bug Fixes:
- Fix target table resolution and access control for catalog-specific distributed procedures such as Iceberg's rewrite_data_files when invoked from another catalog.

Enhancements:
- Allow distributed procedure subtypes to choose whether execution uses the procedure's catalog or the caller's session catalog, supporting both connector-specific and cross-catalog procedures.

Tests:
- Update distributed procedure planner coverage to verify procedures can opt out of using their own catalog.