### PR TITLE
feat(plugin-iceberg): Add changes for passing iceberg V3 initialDefaultValue while read

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1544,9 +1544,7 @@ SQL Operation                        Presto Java   Presto C++   Comments
 
 ``ALTER TABLE``                      Yes           Yes
 
-``ALTER TABLE ADD COLUMN DEFAULT``   Yes           Yes          DDL (metadata update) is supported in both. ``initial-default`` read
-                                                                support (returning the default value for historical rows) is only
-                                                                available in Presto C++. Presto Java returns ``NULL`` for historical rows.
+``ALTER TABLE ADD COLUMN DEFAULT``   Yes           Yes
 
 ``ALTER VIEW``                       Yes           Yes
 
@@ -1847,30 +1845,30 @@ To set ``write.metadata.delete-after-commit.enabled`` to true and set ``write.me
 
     ALTER TABLE iceberg.web.page_views_v2 SET PROPERTIES ("write.metadata.delete-after-commit.enabled" = true, "write.metadata.previous-versions-max" = 5);
 
-ADD COLUMN with DEFAULT (Iceberg V3, Presto C++ only)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ADD COLUMN with DEFAULT (Iceberg V3)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
 
-    ``ADD COLUMN DEFAULT`` read support is only available in **Presto C++** (Prestissimo).
-    Presto Java executes the DDL and stores the default in Iceberg metadata, but does **not**
-    inject the ``initial-default`` value during reads — historical rows return ``NULL`` in
-    Presto Java. Write-time handling of ``write-default`` is not yet supported in either engine.
+    ``ADD COLUMN DEFAULT`` read support is available in both **Presto Java** and **Presto C++** (Prestissimo).
+    Both engines execute the DDL, store the default in Iceberg metadata, and inject the ``initial-default``
+    value during reads for historical rows. Write-time handling of ``write-default`` is not supported
+    in either engine.
 
 Iceberg Format Version 3 supports default column values for schema evolution. When a column is
 added with a ``DEFAULT`` clause, Presto sets both the ``initial-default`` and ``write-default``
 fields in the Iceberg schema metadata. This is a metadata-only change — no data files are rewritten.
 
-During reads in Presto C++, rows written before the column was added return the ``initial-default``
-value instead of ``NULL``. This enables correct interoperability with Iceberg V3 tables created or
-evolved by other engines (e.g. Spark).
+During reads, rows written before the column was added return the ``initial-default`` value instead
+of ``NULL``. This enables correct interoperability with Iceberg V3 tables created or evolved by
+other engines, such as Spark.
 
 Example — Add a ``country`` column with a default value of ``'IN'``::
 
      ALTER TABLE iceberg.web.orders ADD COLUMN country VARCHAR DEFAULT 'IN';
 
-After this statement, a ``SELECT`` on the table in Presto C++ returns ``'IN'`` for the ``country``
-column in all rows that were written before the column was added::
+After this statement, a ``SELECT`` on the table returns ``'IN'`` for the ``country`` column in all
+rows that were written before the column was added::
 
      SELECT order_id, country FROM iceberg.web.orders;
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -418,13 +418,6 @@ public abstract class IcebergAbstractMetadata
             schema = metadata.schema();
         }
 
-        // Reject schema default values (initial-default / write-default)
-        for (Types.NestedField field : schema.columns()) {
-            if (field.initialDefault() != null || field.writeDefault() != null) {
-                throw new PrestoException(NOT_SUPPORTED, "Iceberg v3 column default values are not supported");
-            }
-        }
-
         // Reject Iceberg table encryption
         if (!metadata.encryptionKeys().isEmpty() || snapshot.keyId() != null || metadata.properties().containsKey("encryption.key-id")) {
             throw new PrestoException(NOT_SUPPORTED, "Iceberg table encryption is not supported");

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -147,6 +147,12 @@ public class IcebergColumnHandle
         return columnIdentity.getId() == MERGE_TARGET_ROW_ID_DATA.getId();
     }
 
+    @JsonIgnore
+    public boolean hasDefaultValue()
+    {
+        return defaultValue.isPresent();
+    }
+
     @Override
     public ColumnHandle withRequiredSubfields(List<Subfield> subfields)
     {
@@ -252,11 +258,16 @@ public class IcebergColumnHandle
 
     public static IcebergColumnHandle create(Types.NestedField column, TypeManager typeManager, ColumnType columnType)
     {
+        Optional<String> defaultValue = Optional.empty();
+        if (column.initialDefault() != null) {
+            defaultValue = Optional.of(String.valueOf(column.initialDefault()));
+        }
         return new IcebergColumnHandle(
                 createColumnIdentity(column),
                 toPrestoType(column.type(), typeManager),
                 Optional.ofNullable(column.doc()),
-                columnType);
+                columnType,
+                defaultValue);
     }
 
     public static Subfield getPushedDownSubfield(IcebergColumnHandle column)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDefaultValuePageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDefaultValuePageSource.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorPageSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.common.Utils.nativeValueToBlock;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A wrapper page source that replaces NULL values with default values for columns that have them.
+ * This is used to support Iceberg v3 default values feature where columns added with ALTER TABLE
+ * have default values that should be returned for old data files that don't contain the column.
+ */
+public class IcebergDefaultValuePageSource
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource delegate;
+    private final List<IcebergColumnHandle> columns;
+    private final Map<Integer, DefaultValueInfo> defaultValueInfos;
+
+    public IcebergDefaultValuePageSource(
+            ConnectorPageSource delegate,
+            List<IcebergColumnHandle> columns,
+            Map<Integer, Object> defaultValues)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.columns = requireNonNull(columns, "columns is null");
+        requireNonNull(defaultValues, "defaultValues is null");
+        this.defaultValueInfos = columns.stream()
+                .filter(col -> defaultValues.containsKey(col.getId()))
+                .collect(toImmutableMap(
+                        IcebergColumnHandle::getId,
+                        col -> new DefaultValueInfo(col.getType(), defaultValues.get(col.getId()))));
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return delegate.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegate.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page page = delegate.getNextPage();
+        if (page == null || defaultValueInfos.isEmpty()) {
+            return page;
+        }
+        // Process each block and replace NULLs with defaults if needed
+        Block[] blocks = new Block[page.getChannelCount()];
+        for (int channel = 0; channel < page.getChannelCount(); channel++) {
+            Block block = page.getBlock(channel);
+            blocks[channel] = block;
+            // Get the column handle for this channel
+            if (channel < columns.size()) {
+                IcebergColumnHandle column = columns.get(channel);
+                DefaultValueInfo defaultInfo = defaultValueInfos.get(column.getId());
+                if (defaultInfo != null) {
+                    blocks[channel] = replaceNullsWithDefault(block, defaultInfo);
+                }
+            }
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    private Block replaceNullsWithDefault(Block block, DefaultValueInfo defaultInfo)
+    {
+        int positionCount = block.getPositionCount();
+        int nullCount = 0;
+        for (int position = 0; position < positionCount; position++) {
+            if (block.isNull(position)) {
+                nullCount++;
+            }
+        }
+        // All NULL - use pre-computed RLE block (common for old files)
+        if (nullCount == positionCount) {
+            return new RunLengthEncodedBlock(defaultInfo.getBlock(), positionCount);
+        }
+        // No NULLs - return original block unchanged (common for new files)
+        if (nullCount == 0) {
+            return block;
+        }
+        // Mixed case - build new block with selective replacement
+        Type type = defaultInfo.getType();
+        Object defaultValue = defaultInfo.getValue();
+        BlockBuilder builder = type.createBlockBuilder(null, positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            if (block.isNull(position)) {
+                writeNativeValue(type, builder, defaultValue);
+            }
+            else {
+                type.appendTo(block, position, builder);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        long defaultValuesMemory = defaultValueInfos.values().stream()
+                .mapToLong(DefaultValueInfo::getRetainedSizeInBytes)
+                .sum();
+        return delegate.getSystemMemoryUsage() + defaultValuesMemory;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    /**
+     * Encapsulates default value information for a column.
+     */
+    private static class DefaultValueInfo
+    {
+        private final Type type;
+        private final Object value;
+        private Block block;
+
+        public DefaultValueInfo(Type type, Object value)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.value = value;
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public Object getValue()
+        {
+            return value;
+        }
+
+        public synchronized Block getBlock()
+        {
+            if (block == null) {
+                block = nativeValueToBlock(type, value);
+            }
+            return block;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return block == null ? 0 : block.getRetainedSizeInBytes();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -153,6 +153,7 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_COLUM
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_DATA;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.MERGE_PARTITION_DATA;
 import static com.facebook.presto.iceberg.IcebergOrcColumn.ROOT_COLUMN_ID;
+import static com.facebook.presto.iceberg.IcebergUtil.deserializePartitionValue;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getLocationProvider;
 import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTable;
@@ -839,6 +840,7 @@ public class IcebergPageSourceProvider
                         splitContext.isCacheable());
 
         ImmutableMap.Builder<Integer, Object> metadataValues = ImmutableMap.builder();
+        ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
         for (IcebergColumnHandle icebergColumn : icebergColumns) {
             if (icebergColumn.isPathColumn()) {
                 metadataValues.put(icebergColumn.getColumnIdentity().getId(), utf8Slice(split.getPath()));
@@ -858,6 +860,17 @@ public class IcebergPageSourceProvider
                         Optional<String> partitionDataJson = split.getPartitionDataJson();
                         metadataValues.put(subColumn.getId(), partitionDataJson.isPresent() ? utf8Slice(partitionDataJson.get()) : EMPTY_SLICE);
                     }
+                }
+            }
+            else if (icebergColumn.hasDefaultValue()) {
+                Types.NestedField field = tableSchema.findField(icebergColumn.getId());
+                if (field != null && field.initialDefault() != null) {
+                    String defaultValueString = String.valueOf(field.initialDefault());
+                    Object prestoValue = deserializePartitionValue(
+                            icebergColumn.getType(),
+                            defaultValueString,
+                            icebergColumn.getName());
+                    defaultValues.put(icebergColumn.getId(), prestoValue);
                 }
             }
         }
@@ -944,6 +957,10 @@ public class IcebergPageSourceProvider
 
         if (split.getChangelogSplitInfo().isPresent()) {
             dataSource = new ChangelogPageSource(dataSource, split.getChangelogSplitInfo().get(), (List<IcebergColumnHandle>) (List<?>) desiredColumns, icebergColumns);
+        }
+        // Wrap with default value page source if there are columns with defaults
+        if (!defaultValues.build().isEmpty()) {
+            dataSource = new IcebergDefaultValuePageSource(dataSource, icebergColumns, defaultValues.build());
         }
         return dataSource;
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -373,12 +373,27 @@ public abstract class IcebergDistributedTestBase
     private void testAddColumnWithDefault(Session session, FileFormat fileFormat)
     {
         String tableName = "test_add_column_with_default_" + randomTableSuffix();
+        assertUpdate(session, "DROP TABLE IF EXISTS " + tableName);
         // Test varchar default
         assertUpdate(session, "CREATE TABLE " + tableName + "(id int, name varchar) with (\"format-version\" = '3', \"write.format.default\" = '" + fileFormat + "')");
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES(1, 'Alice'), (2, 'Bob')", 2);
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN country varchar DEFAULT 'IN'");
         Table icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("country").initialDefault(), "IN");
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(3, 'Charlie', 'US')", 1);
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN'), (3, 'Charlie', 'US')");
+        assertUpdate(session, "DROP TABLE " + tableName);
+
+        // Test empty string default
+        assertUpdate(session, "CREATE TABLE " + tableName + "(id int, name varchar) with (\"format-version\" = '3', \"write.format.default\" = '" + fileFormat + "')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(1, 'Alice'), (2, 'Bob')", 2);
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN description varchar DEFAULT ''");
+        icebergTable = loadTable(tableName);
+        assertEquals(icebergTable.schema().findField("description").initialDefault(), "");
+        assertQuery(session, "SELECT id, name, description FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', ''), (2, 'Bob', '')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(3, 'Charlie', 'Has description')", 1);
+        assertQuery(session, "SELECT id, name, description FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', ''), (2, 'Bob', ''), (3, 'Charlie', 'Has description')");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test integer default
@@ -387,6 +402,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN priority integer DEFAULT 5");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("priority").initialDefault(), 5);
+        assertQuery(session, "SELECT id, priority FROM " + tableName + " ORDER BY id", "VALUES (1, 5), (2, 5)");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(3, 10)", 1);
+        assertQuery(session, "SELECT id, priority FROM " + tableName + " ORDER BY id", "VALUES (1, 5), (2, 5), (3, 10)");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test double default
@@ -395,6 +413,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN score double DEFAULT 0.0E0");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("score").initialDefault(), 0.0);
+        assertQuery(session, "SELECT id, score FROM " + tableName, "VALUES (1, 0.0)");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, 95.5)", 1);
+        assertQuery(session, "SELECT id, score FROM " + tableName + " ORDER BY id", "VALUES (1, 0.0), (2, 95.5)");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test boolean default
@@ -403,6 +424,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN is_active boolean DEFAULT true");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("is_active").initialDefault(), true);
+        assertQuery(session, "SELECT id, is_active FROM " + tableName, "VALUES (1, true)");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, false)", 1);
+        assertQuery(session, "SELECT id, is_active FROM " + tableName + " ORDER BY id", "VALUES (1, true), (2, false)");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test NOT NULL with default
@@ -411,6 +435,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN status varchar NOT NULL DEFAULT 'ACTIVE'");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("status").initialDefault(), "ACTIVE");
+        assertQuery(session, "SELECT id, status FROM " + tableName, "VALUES (1, 'ACTIVE')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, 'INACTIVE')", 1);
+        assertQuery(session, "SELECT id, status FROM " + tableName + " ORDER BY id", "VALUES (1, 'ACTIVE'), (2, 'INACTIVE')");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test date default
@@ -419,6 +446,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN creation_date date DEFAULT DATE '2023-01-01'");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("creation_date").initialDefault(), 19358);
+        assertQuery(session, "SELECT id, creation_date FROM " + tableName, "VALUES (1, DATE '2023-01-01')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, DATE '2024-06-15')", 1);
+        assertQuery(session, "SELECT id, creation_date FROM " + tableName + " ORDER BY id", "VALUES (1, DATE '2023-01-01'), (2, DATE '2024-06-15')");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test timestamp default
@@ -427,6 +457,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN creation_time timestamp DEFAULT TIMESTAMP '2023-01-01 11:00:00.000000'");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("creation_time").initialDefault(), 1672570800000000L);
+        assertQuery(session, "SELECT id, creation_time FROM " + tableName, "VALUES (1, TIMESTAMP '2023-01-01 11:00:00.000000')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, TIMESTAMP '2024-12-25 15:30:00.000000')", 1);
+        assertQuery(session, "SELECT id, creation_time FROM " + tableName + " ORDER BY id", "VALUES (1, TIMESTAMP '2023-01-01 11:00:00.000000'), (2, TIMESTAMP '2024-12-25 15:30:00.000000')");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test bigint default
@@ -435,6 +468,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN long_val bigint DEFAULT 10000000000");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("long_val").initialDefault(), 10000000000L);
+        assertQuery(session, "SELECT id, long_val FROM " + tableName, "VALUES (1, 10000000000)");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, 99999999999)", 1);
+        assertQuery(session, "SELECT id, long_val FROM " + tableName + " ORDER BY id", "VALUES (1, 10000000000), (2, 99999999999)");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test real default
@@ -443,6 +479,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN real_val real DEFAULT 10.5");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("real_val").initialDefault(), 10.5f);
+        assertQuery(session, "SELECT id, real_val FROM " + tableName, "VALUES (1, CAST(10.5 AS REAL))");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, REAL '25.75')", 1);
+        assertQuery(session, "SELECT id, real_val FROM " + tableName + " ORDER BY id", "VALUES (1, CAST(10.5 AS REAL)), (2, CAST(25.75 AS REAL))");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test decimal default
@@ -451,6 +490,9 @@ public abstract class IcebergDistributedTestBase
         assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN decimal_val decimal(10,2) DEFAULT DECIMAL '10.55'");
         icebergTable = loadTable(tableName);
         assertEquals(icebergTable.schema().findField("decimal_val").initialDefault(), new java.math.BigDecimal("10.55"));
+        assertQuery(session, "SELECT id, decimal_val FROM " + tableName, "VALUES (1, CAST(10.55 AS DECIMAL))");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(2, DECIMAL '99.99')", 1);
+        assertQuery(session, "SELECT id, decimal_val FROM " + tableName + " ORDER BY id", "VALUES (1, CAST(10.55 AS DECIMAL)), (2, CAST(99.99 AS DECIMAL))");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test multiple columns with defaults
@@ -463,6 +505,21 @@ public abstract class IcebergDistributedTestBase
         assertEquals(icebergTable.schema().findField("country").initialDefault(), "US");
         assertEquals(icebergTable.schema().findField("priority").initialDefault(), 10);
         assertEquals(icebergTable.schema().findField("is_enabled").initialDefault(), false);
+        assertQuery(session, "SELECT id, country, priority, is_enabled FROM " + tableName + " ORDER BY id", "VALUES (1, 'US', 10, false), (2, 'US', 10, false)");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(3, 'UK', 20, true)", 1);
+        assertQuery(session, "SELECT id, country, priority, is_enabled FROM " + tableName + " ORDER BY id", "VALUES (1, 'US', 10, false), (2, 'US', 10, false), (3, 'UK', 20, true)");
+        assertUpdate(session, "DROP TABLE " + tableName);
+
+        // Test column aliases with default values
+        assertUpdate(session, "CREATE TABLE " + tableName + "(id int, name varchar) with (\"format-version\" = '3', \"write.format.default\" = '" + fileFormat + "')");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES(1, 'Alice'), (2, 'Bob')", 2);
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN country varchar DEFAULT 'IN'");
+        icebergTable = loadTable(tableName);
+        assertEquals(icebergTable.schema().findField("country").initialDefault(), "IN");
+        // Test with column alias - should still return default value
+        assertQuery(session, "SELECT id, name, country AS region FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        // Test with multiple aliases
+        assertQuery(session, "SELECT id AS user_id, country AS region FROM " + tableName + " ORDER BY user_id", "VALUES (1, 'IN'), (2, 'IN')");
         assertUpdate(session, "DROP TABLE " + tableName);
     }
 


### PR DESCRIPTION
## Description
As a follow-up of https://github.com/prestodb/presto/pull/27353 added support in Presto Java side as well for https://github.com/prestodb/presto/issues/27195

## Motivation and Context
As a follow-up of https://github.com/prestodb/presto/pull/27353 added support in Presto Java side as well for https://github.com/prestodb/presto/issues/27195

## Impact
New feature of iceberg v3

## Test Plan
Added tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add changes for passing iceberg V3 initialDefaultValue while read
```

## Summary by Sourcery

Support reading Iceberg v3 column initial default values and applying them at query time.

New Features:
- Add a page source wrapper that replaces nulls with Iceberg v3 column default values when reading data.
- Propagate Iceberg schema initial default values into column handles so they are available during scan planning.

Enhancements:
- Allow Iceberg tables with v3 column default metadata by removing the previous validation rejection logic.

Tests:
- Extend Iceberg distributed tests to verify that default values are returned for added columns across multiple data types, including empty strings and column aliases.