### PR TITLE
[WIP] DNR

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1310,7 +1310,7 @@ The ``options`` parameter accepts a map of option names to values. The following
 ========================== ======== =============== ========================================================================
 Option Name                Type     Default         Description
 ========================== ======== =============== ========================================================================
-``min-input-files``        integer  1               Minimum number of files in a partition required for rewriting.
+``min-input-files``        integer  5               Minimum number of files in a partition required for rewriting.
                                                     Partitions with fewer files are skipped. This is a **group filter**
                                                     that operates at the partition level.
 
@@ -1321,6 +1321,10 @@ Option Name                Type     Default         Description
 ``max-file-size-bytes``    long     0 (disabled)    Files larger than this threshold (in bytes) are selected for
                                                     rewriting. This is a **file filter** that operates on individual
                                                     files.
+
+``rewrite-all``            boolean  false           When set to ``true``, bypasses all filtering (both group and file
+                                                    level) and rewrites all data files in the table or selected
+                                                    partitions. Useful for simple, complete table rewrites.
 ========================== ======== =============== ========================================================================
 
 **Filter Behavior:**
@@ -1361,12 +1365,12 @@ Examples
         options => map(array['min-file-size-bytes'], array['104857600'])
     );
 
-* Rewrite only partitions with at least 5 files in table ``db.sample``::
+* Rewrite only partitions with at least 10 files in table ``db.sample``::
 
     CALL iceberg.system.rewrite_data_files(
         schema => 'db',
         table_name => 'sample',
-        options => map(array['min-input-files'], array['5'])
+        options => map(array['min-input-files'], array['10'])
     );
 
 * Rewrite small files (< 50MB) OR large files (> 1GB) in partitions with at least 3 files::
@@ -1378,6 +1382,14 @@ Examples
             array['min-file-size-bytes', 'max-file-size-bytes', 'min-input-files'],
             array['52428800', '1073741824', '3']
         )
+    );
+
+* Rewrite all data files without any filtering::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        options => map(array['rewrite-all'], array['true'])
     );
 
 * Combine options with filter and sorting::

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -240,6 +240,8 @@ public final class IcebergUtil
 
     protected static final String VIEW_OWNER = "view_owner";
 
+    public static final int DEFAULT_MIN_INPUT_FILES = 5;
+
     private IcebergUtil() {}
 
     public static boolean isIcebergTable(com.facebook.presto.hive.metastore.Table table)
@@ -1507,7 +1509,7 @@ public final class IcebergUtil
 
     /**
      * Parses and validates the min-input-files option value.
-     * Returns the parsed integer value, or 1 if the option is not present.
+     * Returns the parsed integer value, or default of {@value #DEFAULT_MIN_INPUT_FILES} if the option is not present.
      *
      * @throws IllegalArgumentException if the value is invalid
      */
@@ -1515,7 +1517,7 @@ public final class IcebergUtil
     {
         String minInputFilesStr = options.get("min-input-files");
         if (minInputFilesStr == null) {
-            return 1;
+            return DEFAULT_MIN_INPUT_FILES;
         }
 
         try {
@@ -1536,6 +1538,8 @@ public final class IcebergUtil
      * Parses and validates the min-file-size-bytes option value.
      * Returns the parsed long value, or 0 if the option is not present.
      *
+     * @param options rewrite options map
+     * @return minimum file size threshold in bytes
      * @throws IllegalArgumentException if the value is invalid
      */
     public static long parseMinFileSize(Map<String, String> options)
@@ -1544,7 +1548,6 @@ public final class IcebergUtil
         if (minFileSizeStr == null) {
             return 0;
         }
-
         try {
             long minFileSize = Long.parseLong(minFileSizeStr);
             if (minFileSize < 0) {
@@ -1571,7 +1574,6 @@ public final class IcebergUtil
         if (maxFileSizeStr == null) {
             return 0;
         }
-
         try {
             long maxFileSize = Long.parseLong(maxFileSizeStr);
             if (maxFileSize < 0) {
@@ -1587,8 +1589,22 @@ public final class IcebergUtil
     }
 
     /**
+     * Parses and validates the rewrite-all option value.
+     * Returns true if the option is set to "true", false otherwise.
+     */
+    public static boolean parseRewriteAll(Map<String, String> options)
+    {
+        String rewriteAllStr = options.get("rewrite-all");
+        if (rewriteAllStr == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(rewriteAllStr.trim());
+    }
+
+    /**
      * Filters files by partition-level criteria.
      * Selects files from partitions that have at least min-input-files files.
+     * If rewrite-all is true, skips filtering and returns all tasks.
      *
      * @param tasks all available tasks
      * @param options rewrite options map
@@ -1596,6 +1612,10 @@ public final class IcebergUtil
      */
     public static CloseableIterable<FileScanTask> filterByGroup(CloseableIterable<FileScanTask> tasks, Map<String, String> options)
     {
+        if (parseRewriteAll(options)) {
+            return tasks;
+        }
+
         int minInputFiles = parseMinInputFiles(options);
         if (minInputFiles <= 1) {
             return tasks;
@@ -1628,6 +1648,7 @@ public final class IcebergUtil
     /**
      * Filters files by individual file criteria using OR logic.
      * Selects files that are too small (< min-file-size-bytes) OR too large (> max-file-size-bytes).
+     * If rewrite-all is true, skips filtering and returns all tasks.
      *
      * @param tasks all available tasks
      * @param options rewrite options map
@@ -1635,6 +1656,10 @@ public final class IcebergUtil
      */
     public static CloseableIterable<FileScanTask> filterByFile(CloseableIterable<FileScanTask> tasks, Map<String, String> options)
     {
+        if (parseRewriteAll(options)) {
+            return tasks;
+        }
+
         long minFileSizeBytes = parseMinFileSize(options);
         long maxFileSizeBytes = parseMaxFileSize(options);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMaxFileSize;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMinFileSize;
 import static com.facebook.presto.iceberg.IcebergUtil.parseMinInputFiles;
+import static com.facebook.presto.iceberg.IcebergUtil.parseRewriteAll;
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
 import static com.facebook.presto.iceberg.SortFieldUtils.parseSortFields;
@@ -140,6 +141,7 @@ public class RewriteDataFilesProcedure
                 parseMinInputFiles(options);
                 parseMinFileSize(options);
                 parseMaxFileSize(options);
+                parseRewriteAll(options);
             }
         }
         return options;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -2093,7 +2093,7 @@ public abstract class IcebergDistributedSmokeTestBase
             assertQueryFails("DELETE FROM " + tableName + " WHERE c > 3", errorMessage);
 
             // Call procedure rewrite_data_files without filter to rewrite all data files
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "')", 5);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', options => map(array['min-input-files'], array['1']))", 5);
 
             // Then we can do metadata delete on column `c`, because all data files are rewritten under new partition spec
             assertUpdate("DELETE FROM " + tableName + " WHERE c > 3", 2);
@@ -2123,7 +2123,7 @@ public abstract class IcebergDistributedSmokeTestBase
             assertQueryFails("DELETE FROM " + tableName + " WHERE c > 3", errorMessage);
 
             // Call procedure rewrite_data_files with filter to rewrite data files under the prior partition spec
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', filter => 'a in (1, 2)')", 2);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', filter => 'a in (1, 2)', options => map(array['min-input-files'], array['1']))", 2);
 
             // Then we can do metadata delete on column `c`, because all data files are now under new partition spec
             assertUpdate("DELETE FROM " + tableName + " WHERE c > 3", 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -2093,7 +2093,7 @@ public abstract class IcebergDistributedSmokeTestBase
             assertQueryFails("DELETE FROM " + tableName + " WHERE c > 3", errorMessage);
 
             // Call procedure rewrite_data_files without filter to rewrite all data files
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', options => map(array['min-input-files'], array['1']))", 5);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', options => map(array['rewrite-all'], array['true']))", 5);
 
             // Then we can do metadata delete on column `c`, because all data files are rewritten under new partition spec
             assertUpdate("DELETE FROM " + tableName + " WHERE c > 3", 2);
@@ -2123,7 +2123,7 @@ public abstract class IcebergDistributedSmokeTestBase
             assertQueryFails("DELETE FROM " + tableName + " WHERE c > 3", errorMessage);
 
             // Call procedure rewrite_data_files with filter to rewrite data files under the prior partition spec
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', filter => 'a in (1, 2)', options => map(array['min-input-files'], array['1']))", 2);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => '" + schemaName + "', filter => 'a in (1, 2)', options => map(array['rewrite-all'], array['true']))", 2);
 
             // Then we can do metadata delete on column `c`, because all data files are now under new partition spec
             assertUpdate("DELETE FROM " + tableName + " WHERE c > 3", 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1817,7 +1817,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1840,7 +1840,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1864,7 +1864,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1887,7 +1887,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1914,7 +1914,7 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "DESC"));
             }
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1972,7 +1972,7 @@ public abstract class IcebergDistributedTestBase
                             "table_name => '%s', " +
                             "filter => 'emp_name = ''AAAAA''', " +
                             "sorted_by => ARRAY['id desc'], " +
-                            "options => map(array['min-input-files'], array['1']))",
+                            "options => map(array['rewrite-all'], array['true']))",
                     schema, tableName), 3);
 
             // Rewrite only rows with `emp_name = 'BBBBB'` and sort the rewritten data files by `id asc`
@@ -1982,7 +1982,7 @@ public abstract class IcebergDistributedTestBase
                             "table_name => '%s', " +
                             "filter => 'emp_name = ''BBBBB''', " +
                             "sorted_by => ARRAY['id asc'], " +
-                            "options => map(array['min-input-files'], array['1']))",
+                            "options => map(array['rewrite-all'], array['true']))",
                     schema, tableName), 4);
 
             // All data is still present
@@ -2415,7 +2415,7 @@ public abstract class IcebergDistributedTestBase
             assertQueryFails("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 3')", ".*");
 
             // Explicitly set min-input-files=1 since we only have 4 files and want to rewrite them
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', options => map(array['min-input-files'], array['1']))", 3);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', options => map(array['rewrite-all'], array['true']))", 3);
             assertQuery("SELECT * FROM " + tableName, "VALUES (2, '1002', NULL), (3, '1003', 3), (5, '1005', 5)");
             icebergTable = loadTable(tableName);
             assertHasDataFiles(icebergTable.currentSnapshot(), 3);
@@ -2429,7 +2429,7 @@ public abstract class IcebergDistributedTestBase
             assertHasDeleteFiles(icebergTable.currentSnapshot(), 0);
 
             // Explicitly set min-input-files=1 since we only have 2 files and want to rewrite them
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 2', options => map(array['min-input-files'], array['1']))", 1);
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 2', options => map(array['rewrite-all'], array['true']))", 1);
             assertQuery("SELECT * FROM " + tableName, "VALUES (2, '1002', NULL), (3, '1003', 3)");
             icebergTable = loadTable(tableName);
             assertHasDataFiles(icebergTable.currentSnapshot(), 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1817,7 +1817,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'])", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1840,7 +1840,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'])", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1864,7 +1864,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'])", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1887,7 +1887,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'])", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1914,7 +1914,7 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "DESC"));
             }
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'])", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['min-input-files'], array['1']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1971,7 +1971,8 @@ public abstract class IcebergDistributedTestBase
                             "schema => '%s', " +
                             "table_name => '%s', " +
                             "filter => 'emp_name = ''AAAAA''', " +
-                            "sorted_by => ARRAY['id desc'])",
+                            "sorted_by => ARRAY['id desc'], " +
+                            "options => map(array['min-input-files'], array['1']))",
                     schema, tableName), 3);
 
             // Rewrite only rows with `emp_name = 'BBBBB'` and sort the rewritten data files by `id asc`
@@ -1980,7 +1981,8 @@ public abstract class IcebergDistributedTestBase
                             "schema => '%s', " +
                             "table_name => '%s', " +
                             "filter => 'emp_name = ''BBBBB''', " +
-                            "sorted_by => ARRAY['id asc'])",
+                            "sorted_by => ARRAY['id asc'], " +
+                            "options => map(array['min-input-files'], array['1']))",
                     schema, tableName), 4);
 
             // All data is still present
@@ -2412,7 +2414,8 @@ public abstract class IcebergDistributedTestBase
             assertQueryFails("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'a > 3')", ".*");
             assertQueryFails("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 3')", ".*");
 
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch')", 3);
+            // Explicitly set min-input-files=1 since we only have 4 files and want to rewrite them
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', options => map(array['min-input-files'], array['1']))", 3);
             assertQuery("SELECT * FROM " + tableName, "VALUES (2, '1002', NULL), (3, '1003', 3), (5, '1005', 5)");
             icebergTable = loadTable(tableName);
             assertHasDataFiles(icebergTable.currentSnapshot(), 3);
@@ -2425,7 +2428,8 @@ public abstract class IcebergDistributedTestBase
             assertHasDataFiles(icebergTable.currentSnapshot(), 2);
             assertHasDeleteFiles(icebergTable.currentSnapshot(), 0);
 
-            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 2')", 1);
+            // Explicitly set min-input-files=1 since we only have 2 files and want to rewrite them
+            assertUpdate("call system.rewrite_data_files(table_name => '" + tableName + "', schema => 'tpch', filter => 'c > 2', options => map(array['min-input-files'], array['1']))", 1);
             assertQuery("SELECT * FROM " + tableName, "VALUES (2, '1002', NULL), (3, '1003', 3)");
             icebergTable = loadTable(tableName);
             assertHasDataFiles(icebergTable.currentSnapshot(), 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileBasedSecurity.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileBasedSecurity.java
@@ -118,7 +118,7 @@ public class TestIcebergFileBasedSecurity
 
             // `icebergAdmin` has permission to execute `iceberg.system.rewrite_data_files` and
             // perform INSERT/DELETE operations on the target table involved in the procedure
-            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", schema, tableName), 2);
+            assertUpdate(icebergAdmin, format("call system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))", schema, tableName), 2);
             // `alice` and `bob` have the permission to execute `iceberg.system.rewrite_data_files`,
             // but they lack the necessary permission to perform INSERT or DELETE on the target table
             assertDenied(() -> assertUpdate(alice, format("call system.rewrite_data_files('%s', '%s')", schema, tableName)),
@@ -152,7 +152,7 @@ public class TestIcebergFileBasedSecurity
 
             // `icebergAdmin` has permission to execute `iceberg.system.rewrite_data_files` and
             // perform INSERT/DELETE operations on the target table involved in the procedure
-            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", schema, tableName), 2);
+            assertUpdate(icebergAdmin, format("call system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))", schema, tableName), 2);
 
             QualifiedObjectName qualifiedTableName = new QualifiedObjectName("iceberg", schema, tableName);
             assertions.executeExclusively(() -> {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileBasedSecurity.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileBasedSecurity.java
@@ -118,7 +118,7 @@ public class TestIcebergFileBasedSecurity
 
             // `icebergAdmin` has permission to execute `iceberg.system.rewrite_data_files` and
             // perform INSERT/DELETE operations on the target table involved in the procedure
-            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s')", schema, tableName), 2);
+            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", schema, tableName), 2);
             // `alice` and `bob` have the permission to execute `iceberg.system.rewrite_data_files`,
             // but they lack the necessary permission to perform INSERT or DELETE on the target table
             assertDenied(() -> assertUpdate(alice, format("call system.rewrite_data_files('%s', '%s')", schema, tableName)),
@@ -152,7 +152,7 @@ public class TestIcebergFileBasedSecurity
 
             // `icebergAdmin` has permission to execute `iceberg.system.rewrite_data_files` and
             // perform INSERT/DELETE operations on the target table involved in the procedure
-            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s')", schema, tableName), 2);
+            assertUpdate(icebergAdmin, format("call system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", schema, tableName), 2);
 
             QualifiedObjectName qualifiedTableName = new QualifiedObjectName("iceberg", schema, tableName);
             assertions.executeExclusively(() -> {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -268,7 +268,7 @@ public class TestIcebergV3
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'A', 100.0), (2, 'B', 200.0), (3, 'A', 150.0), (4, 'C', 300.0)");
 
-            assertQuerySucceeds(format("CALL system.rewrite_data_files('%s', '%s')", TEST_SCHEMA, tableName));
+            assertQuerySucceeds(format("CALL system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", TEST_SCHEMA, tableName));
 
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'A', 100.0), (2, 'B', 200.0), (3, 'A', 150.0), (4, 'C', 300.0)");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -268,7 +268,7 @@ public class TestIcebergV3
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'A', 100.0), (2, 'B', 200.0), (3, 'A', 150.0), (4, 'C', 300.0)");
 
-            assertQuerySucceeds(format("CALL system.rewrite_data_files('%s', '%s', map(array['min-input-files'], array['1']))", TEST_SCHEMA, tableName));
+            assertQuerySucceeds(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))", TEST_SCHEMA, tableName));
 
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'A', 100.0), (2, 'B', 200.0), (3, 'A', 150.0), (4, 'C', 300.0)");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -120,7 +120,7 @@ public class TestRewriteDataFilesProcedure
                             "(5, 'foo'), (6, 'bar'), " +
                             "(9, 'foo')");
 
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s')", tableName, TEST_SCHEMA), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 7);
 
             table.refresh();
             assertHasSize(table.snapshots(), 8);
@@ -181,7 +181,7 @@ public class TestRewriteDataFilesProcedure
                             "(5, 'foo'), (6, 'bar'), " +
                             "(8, 'bar')");
 
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s')", tableName, TEST_SCHEMA), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 7);
 
             table.refresh();
             assertHasSize(table.snapshots(), 8);
@@ -232,7 +232,7 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, TEST_SCHEMA), ".*");
 
             // select 5 files to rewrite
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''')", tableName, TEST_SCHEMA), 5);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 5);
             table.refresh();
             assertHasSize(table.snapshots(), 6);
             //The number of data files is 6，and the number of delete files is 0
@@ -283,7 +283,7 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, TEST_SCHEMA), ".*");
 
             // the filter is `true` means select all files to rewrite
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => '1 = 1')", tableName, TEST_SCHEMA), 10);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => '1 = 1', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 10);
 
             table.refresh();
             assertHasSize(table.snapshots(), 6);
@@ -880,8 +880,7 @@ public class TestRewriteDataFilesProcedure
             // min-file-size-bytes filters files BELOW threshold (too small)
             // Should select the two small files and combine them
             // Set max-file-size-bytes to Long.MAX_VALUE to disable the default maximum filter
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))",
-                    TEST_SCHEMA, tableName, threshold, Long.MAX_VALUE), 2);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))", TEST_SCHEMA, tableName, threshold, Long.MAX_VALUE), 2);
 
             table.refresh();
             // Two small files combined into one, large file unchanged = 2 total files
@@ -929,8 +928,7 @@ public class TestRewriteDataFilesProcedure
             // max-file-size-bytes filters files ABOVE threshold (too large)
             // Should select the two large files and combine them
             // Set min-file-size-bytes=0 to disable the default minimum filter
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '0', '%d']))",
-                    TEST_SCHEMA, tableName, threshold), 10);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '0', '%d']))", TEST_SCHEMA, tableName, threshold), 10);
 
             table.refresh();
             // Two large files combined into one, small file unchanged = 2 total files
@@ -985,8 +983,7 @@ public class TestRewriteDataFilesProcedure
             // min-file-size-bytes selects files < minThreshold (the 2 small files)
             // max-file-size-bytes selects files > maxThreshold (the 1 large file)
             // Medium files should be skipped (not too small, not too large)
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))",
-                    TEST_SCHEMA, tableName, minThreshold, maxThreshold), 17);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))", TEST_SCHEMA, tableName, minThreshold, maxThreshold), 17);
 
             table.refresh();
             // 2 small files + 1 large file -> 1 combined file
@@ -1041,8 +1038,7 @@ public class TestRewriteDataFilesProcedure
             // File size filter selects: small files from A (3) and small files from B (2)
             // Group filter then selects: only files from partitions with >= 3 files (partition A only)
             // Result: Only partition A's 3 small files are rewritten
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['3', '%d']))",
-                    TEST_SCHEMA, tableName, threshold), 3);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['3', '%d']))", TEST_SCHEMA, tableName, threshold), 3);
 
             table.refresh();
             // Partition 'A': 3 small files -> 1 file, large file unchanged
@@ -1187,8 +1183,7 @@ public class TestRewriteDataFilesProcedure
 
             long veryLargeThreshold = 999999999L;
             // Set min-input-files=1 since we only have 3 files
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['1', '%d']))",
-                    TEST_SCHEMA, tableName1, veryLargeThreshold), 3); // All files are smaller than threshold
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['1', '%d']))", TEST_SCHEMA, tableName1, veryLargeThreshold), 3); // All files are smaller than threshold
             table1.refresh();
             assertHasDataFiles(table1.currentSnapshot(), 1);
             assertQuery("SELECT * FROM " + tableName1 + " ORDER BY id", "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
@@ -1206,8 +1201,7 @@ public class TestRewriteDataFilesProcedure
 
             long verySmallThreshold = 1L;
             // Set min-input-files=1 since we only have 3 files
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'max-file-size-bytes'], array['1', '%d']))",
-                    TEST_SCHEMA, tableName2, verySmallThreshold), 3); // All files are larger than threshold
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'max-file-size-bytes'], array['1', '%d']))", TEST_SCHEMA, tableName2, verySmallThreshold), 3); // All files are larger than threshold
             table2.refresh();
             assertHasDataFiles(table2.currentSnapshot(), 1);
             assertQuery("SELECT * FROM " + tableName2 + " ORDER BY id", "VALUES (1, 'a'), (2, 'b'), (3, 'c')");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -386,7 +386,8 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'a > 3')", tableName, TEST_SCHEMA), ".*");
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c > 3')", tableName, TEST_SCHEMA), ".*");
 
-            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s')", tableName, TEST_SCHEMA), 3);
+            // Set min-input-files=1 since we have 4 files across multiple partitions
+            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 3);
             table.refresh();
             assertHasSize(table.snapshots(), 5);
             //The number of data files is 3，and the number of delete files is 0
@@ -404,7 +405,8 @@ public class TestRewriteDataFilesProcedure
             //The number of data files is 3，and the number of delete files is 1
             assertHasDataFiles(table.currentSnapshot(), 3);
             assertHasDeleteFiles(table.currentSnapshot(), 1);
-            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c is null')", tableName, TEST_SCHEMA), 0);
+            // Set min-input-files=1 to allow rewrite with filter
+            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c is null', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 0);
 
             table.refresh();
             assertHasSize(table.snapshots(), 7);
@@ -877,8 +879,9 @@ public class TestRewriteDataFilesProcedure
 
             // min-file-size-bytes filters files BELOW threshold (too small)
             // Should select the two small files and combine them
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-file-size-bytes'], array['%d']))",
-                    TEST_SCHEMA, tableName, threshold), 2);
+            // Set max-file-size-bytes to Long.MAX_VALUE to disable the default maximum filter
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))",
+                    TEST_SCHEMA, tableName, threshold, Long.MAX_VALUE), 2);
 
             table.refresh();
             // Two small files combined into one, large file unchanged = 2 total files
@@ -925,7 +928,8 @@ public class TestRewriteDataFilesProcedure
 
             // max-file-size-bytes filters files ABOVE threshold (too large)
             // Should select the two large files and combine them
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['max-file-size-bytes'], array['%d']))",
+            // Set min-file-size-bytes=0 to disable the default minimum filter
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '0', '%d']))",
                     TEST_SCHEMA, tableName, threshold), 10);
 
             table.refresh();
@@ -981,7 +985,7 @@ public class TestRewriteDataFilesProcedure
             // min-file-size-bytes selects files < minThreshold (the 2 small files)
             // max-file-size-bytes selects files > maxThreshold (the 1 large file)
             // Medium files should be skipped (not too small, not too large)
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-file-size-bytes', 'max-file-size-bytes'], array['%d', '%d']))",
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))",
                     TEST_SCHEMA, tableName, minThreshold, maxThreshold), 17);
 
             table.refresh();
@@ -1117,6 +1121,117 @@ public class TestRewriteDataFilesProcedure
         }
         finally {
             dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteAllOption()
+    {
+        String tableName = "test_rewrite_all_option";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, category varchar, value varchar) WITH (partitioning = ARRAY['category'])");
+
+            // Create files with varying sizes across partitions
+            // Partition A: 3 small files
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'A', 'val1')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'A', 'val2')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'A', 'val3')", 1);
+
+            // Partition B: 2 files
+            assertUpdate("INSERT INTO " + tableName + " VALUES (4, 'B', 'val4')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (5, 'B', 'val5')", 1);
+
+            Table table = loadTable(tableName);
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 5);
+
+            // Without rewrite-all, min-input-files=4 would skip all partitions (A has 3, B has 2)
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files'], array['4']))",
+                    TEST_SCHEMA, tableName), 0);
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 5); // No change
+
+            // With rewrite-all=true, all files should be rewritten regardless of min-input-files
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 5);
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 2); // 1 file per partition
+
+            // Verify data integrity
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'A', 'val1'), (2, 'A', 'val2'), (3, 'A', 'val3'), (4, 'B', 'val4'), (5, 'B', 'val5')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteAllOverridesFileFilters()
+    {
+        String tableName1 = "test_rewrite_all_min_filter";
+        String tableName2 = "test_rewrite_all_max_filter";
+        String tableName3 = "test_rewrite_all_no_filter";
+
+        try {
+            // Test 1: Use only min-file-size-bytes with a very high threshold
+            // This should select files that are SMALLER than the threshold (which is all)
+            assertUpdate("CREATE TABLE " + tableName1 + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName1 + " VALUES (1, 'a')", 1);
+            assertUpdate("INSERT INTO " + tableName1 + " VALUES (2, 'b')", 1);
+            assertUpdate("INSERT INTO " + tableName1 + " VALUES (3, 'c')", 1);
+
+            Table table1 = loadTable(tableName1);
+            table1.refresh();
+            assertHasDataFiles(table1.currentSnapshot(), 3);
+
+            long veryLargeThreshold = 999999999L;
+            // Set min-input-files=1 since we only have 3 files
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['1', '%d']))",
+                    TEST_SCHEMA, tableName1, veryLargeThreshold), 3); // All files are smaller than threshold
+            table1.refresh();
+            assertHasDataFiles(table1.currentSnapshot(), 1);
+            assertQuery("SELECT * FROM " + tableName1 + " ORDER BY id", "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+
+            // Test 2: Use only max-file-size-bytes with a very small threshold
+            // This should select files that are LARGER than the threshold (which is all)
+            assertUpdate("CREATE TABLE " + tableName2 + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName2 + " VALUES (1, 'a')", 1);
+            assertUpdate("INSERT INTO " + tableName2 + " VALUES (2, 'b')", 1);
+            assertUpdate("INSERT INTO " + tableName2 + " VALUES (3, 'c')", 1);
+
+            Table table2 = loadTable(tableName2);
+            table2.refresh();
+            assertHasDataFiles(table2.currentSnapshot(), 3);
+
+            long verySmallThreshold = 1L;
+            // Set min-input-files=1 since we only have 3 files
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'max-file-size-bytes'], array['1', '%d']))",
+                    TEST_SCHEMA, tableName2, verySmallThreshold), 3); // All files are larger than threshold
+            table2.refresh();
+            assertHasDataFiles(table2.currentSnapshot(), 1);
+            assertQuery("SELECT * FROM " + tableName2 + " ORDER BY id", "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+
+            // Test 3: With rewrite-all=true, ignore the filters entirely
+            assertUpdate("CREATE TABLE " + tableName3 + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName3 + " VALUES (1, 'a')", 1);
+            assertUpdate("INSERT INTO " + tableName3 + " VALUES (2, 'b')", 1);
+            assertUpdate("INSERT INTO " + tableName3 + " VALUES (3, 'c')", 1);
+
+            Table table3 = loadTable(tableName3);
+            table3.refresh();
+            assertHasDataFiles(table3.currentSnapshot(), 3);
+
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName3), 3);
+            table3.refresh();
+            assertHasDataFiles(table3.currentSnapshot(), 1);
+            assertQuery("SELECT * FROM " + tableName3 + " ORDER BY id", "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+        }
+        finally {
+            dropTable(tableName1);
+            dropTable(tableName2);
+            dropTable(tableName3);
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -120,7 +120,7 @@ public class TestRewriteDataFilesProcedure
                             "(5, 'foo'), (6, 'bar'), " +
                             "(9, 'foo')");
 
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 7);
 
             table.refresh();
             assertHasSize(table.snapshots(), 8);
@@ -181,7 +181,7 @@ public class TestRewriteDataFilesProcedure
                             "(5, 'foo'), (6, 'bar'), " +
                             "(8, 'bar')");
 
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 7);
 
             table.refresh();
             assertHasSize(table.snapshots(), 8);
@@ -232,7 +232,7 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, TEST_SCHEMA), ".*");
 
             // select 5 files to rewrite
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 5);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 5);
             table.refresh();
             assertHasSize(table.snapshots(), 6);
             //The number of data files is 6，and the number of delete files is 0
@@ -283,7 +283,7 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, TEST_SCHEMA), ".*");
 
             // the filter is `true` means select all files to rewrite
-            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => '1 = 1', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 10);
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => '1 = 1', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 10);
 
             table.refresh();
             assertHasSize(table.snapshots(), 6);
@@ -386,8 +386,7 @@ public class TestRewriteDataFilesProcedure
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'a > 3')", tableName, TEST_SCHEMA), ".*");
             assertQueryFails(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c > 3')", tableName, TEST_SCHEMA), ".*");
 
-            // Set min-input-files=1 since we have 4 files across multiple partitions
-            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 3);
+            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 3);
             table.refresh();
             assertHasSize(table.snapshots(), 5);
             //The number of data files is 3，and the number of delete files is 0
@@ -405,8 +404,7 @@ public class TestRewriteDataFilesProcedure
             //The number of data files is 3，and the number of delete files is 1
             assertHasDataFiles(table.currentSnapshot(), 3);
             assertHasDeleteFiles(table.currentSnapshot(), 1);
-            // Set min-input-files=1 to allow rewrite with filter
-            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c is null', options => map(array['min-input-files'], array['1']))", tableName, TEST_SCHEMA), 0);
+            assertUpdate(format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c is null', options => map(array['rewrite-all'], array['true']))", tableName, TEST_SCHEMA), 0);
 
             table.refresh();
             assertHasSize(table.snapshots(), 7);
@@ -879,8 +877,7 @@ public class TestRewriteDataFilesProcedure
 
             // min-file-size-bytes filters files BELOW threshold (too small)
             // Should select the two small files and combine them
-            // Set max-file-size-bytes to Long.MAX_VALUE to disable the default maximum filter
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '%d', '%d']))", TEST_SCHEMA, tableName, threshold, Long.MAX_VALUE), 2);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes'], array['1', '%d']))", TEST_SCHEMA, tableName, threshold), 2);
 
             table.refresh();
             // Two small files combined into one, large file unchanged = 2 total files
@@ -927,8 +924,7 @@ public class TestRewriteDataFilesProcedure
 
             // max-file-size-bytes filters files ABOVE threshold (too large)
             // Should select the two large files and combine them
-            // Set min-file-size-bytes=0 to disable the default minimum filter
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'min-file-size-bytes', 'max-file-size-bytes'], array['1', '0', '%d']))", TEST_SCHEMA, tableName, threshold), 10);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['min-input-files', 'max-file-size-bytes'], array['1', '%d']))", TEST_SCHEMA, tableName, threshold), 10);
 
             table.refresh();
             // Two large files combined into one, small file unchanged = 2 total files


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adjust Iceberg rewrite_data_files behavior to use a higher default grouping threshold and support a rewrite-all override, updating tests accordingly.

Enhancements:
- Introduce a configurable DEFAULT_MIN_INPUT_FILES constant and use it when parsing the min-input-files option for rewrite_data_files.
- Add a rewrite-all option that bypasses partition and file-level filtering when rewriting data files, and validate it during option extraction for the procedure.
- Clarify and slightly refine parsing utilities for size-based rewrite options to better document their behavior.

Tests:
- Update existing Iceberg rewrite_data_files tests to pass explicit min-input-files and size options to match the new default behavior.
- Add new tests verifying that rewrite-all rewrites all partitions regardless of min-input-files, and that it overrides file-size filters.
- Adjust distributed, security, and smoke tests to explicitly specify min-input-files so they remain valid under the new default threshold.