### PR TITLE
fix(planner): Propagate streamPropertiesFromUniqueColumn through TopN

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -667,7 +667,8 @@ public final class StreamPropertyDerivations
             if (node.getStep().equals(TopNNode.Step.PARTIAL)) {
                 return Iterables.getOnlyElement(inputProperties);
             }
-            return StreamProperties.ordered();
+            StreamProperties input = Iterables.getOnlyElement(inputProperties);
+            return StreamProperties.ordered().withStreamPropertiesFromUniqueColumn(input.getStreamPropertiesFromUniqueColumn());
         }
 
         @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -189,4 +189,22 @@ public class TestLocalQueries
 
         assertQuery(enabled, sql, disabled, sql);
     }
+
+    @Test
+    public void testTopNStreamPropertyDerivation()
+    {
+        // Regression test for propagating streamPropertiesFromUniqueColumn through TopN.
+        // Without the fix, stream properties were lost after TopN, which could cause
+        // incorrect plans when downstream operators depend on stream ordering properties.
+
+        // TopN with downstream filter
+        assertQuery("SELECT * FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 10) t WHERE regionkey = 1");
+
+        // TopN with downstream aggregation depending on stream properties
+        assertQuery("SELECT regionkey, count(*) FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 20) t GROUP BY regionkey");
+
+        // TopN with downstream join where ordering matters
+        assertQuery("SELECT t.nationkey, r.name FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 10) t " +
+                "JOIN region r ON t.regionkey = r.regionkey");
+    }
 }


### PR DESCRIPTION
## Summary
- `visitTopN` in `StreamPropertyDerivations` was returning `StreamProperties.ordered()` without preserving the `streamPropertiesFromUniqueColumn` from its input
- This causes `AddExchanges` to fail with an `IllegalStateException` when a downstream node depends on unique column properties originating from the source table's scan
- Fix: propagate the input's `streamPropertiesFromUniqueColumn` through the ordered result

## Test plan
- [x] Compile passes (`mvn compile -pl presto-main-base -q`)
- [ ] CI checks pass
- Prerequisite for #27641 (TopN late materialization)

## Summary by Sourcery

Bug Fixes:
- Ensure StreamPropertyDerivations.visitTopN propagates streamPropertiesFromUniqueColumn from its input instead of discarding it for non-partial TopN steps.