### PR TITLE
feat: Add support for forwarded host/port in statement result URIs behind trusted reverse proxies

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.spi.NodePoolType;
 import jakarta.validation.constraints.NotNull;
@@ -44,6 +45,7 @@ public class ServerConfig
     private Duration clusterResourceGroupStateInfoExpirationDuration = new Duration(0, MILLISECONDS);
     private String clusterTag;
     private boolean webUIEnabled = true;
+    private boolean queryResultsUseForwardedHeadersInUris;
 
     public boolean isResourceManager()
     {
@@ -264,6 +266,19 @@ public class ServerConfig
     public ServerConfig setClusterTag(String clusterTag)
     {
         this.clusterTag = clusterTag;
+        return this;
+    }
+
+    public boolean isQueryResultsUseForwardedHeadersInUris()
+    {
+        return queryResultsUseForwardedHeadersInUris;
+    }
+
+    @Config("query-results.use-forwarded-headers-in-uris")
+    @ConfigDescription("Trust X-Forwarded-Host and X-Forwarded-Port when building statement response URIs. Enable only behind a trusted reverse proxy.")
+    public ServerConfig setQueryResultsUseForwardedHeadersInUris(boolean queryResultsUseForwardedHeadersInUris)
+    {
+        this.queryResultsUseForwardedHeadersInUris = queryResultsUseForwardedHeadersInUris;
         return this;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -275,7 +275,7 @@ public class ServerConfig
     }
 
     @Config("query-results.use-forwarded-headers-in-uris")
-    @ConfigDescription("Trust X-Forwarded-Host and X-Forwarded-Port when building statement response URIs. Enable only behind a trusted reverse proxy.")
+    @ConfigDescription("Trust X-Forwarded-Host and X-Forwarded-Port when building statement response URIs. X-Forwarded-Proto continues to determine the external scheme. Enable only behind a trusted reverse proxy.")
     public ServerConfig setQueryResultsUseForwardedHeadersInUris(boolean queryResultsUseForwardedHeadersInUris)
     {
         this.queryResultsUseForwardedHeadersInUris = queryResultsUseForwardedHeadersInUris;

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -51,7 +51,8 @@ public class TestServerConfig
                 .setClusterStatsExpirationDuration(new Duration(0, MILLISECONDS))
                 .setNestedDataSerializationEnabled(true)
                 .setClusterResourceGroupStateInfoExpirationDuration(new Duration(0, MILLISECONDS))
-                .setClusterTag(null));
+                .setClusterTag(null)
+                .setQueryResultsUseForwardedHeadersInUris(false));
     }
 
     @Test
@@ -76,6 +77,7 @@ public class TestServerConfig
                 .put("nested-data-serialization-enabled", "false")
                 .put("cluster-resource-group-state-info-expiration-duration", "10s")
                 .put("cluster-tag", "test-cluster")
+                .put("query-results.use-forwarded-headers-in-uris", "true")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -96,7 +98,8 @@ public class TestServerConfig
                 .setClusterStatsExpirationDuration(new Duration(10, SECONDS))
                 .setNestedDataSerializationEnabled(false)
                 .setClusterResourceGroupStateInfoExpirationDuration(new Duration(10, SECONDS))
-                .setClusterTag("test-cluster");
+                .setClusterTag("test-cluster")
+                .setQueryResultsUseForwardedHeadersInUris(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Optional;
@@ -27,6 +28,8 @@ import java.util.Optional;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.oauth2.OAuth2Utils.getLastURLParameter;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 
 @Path("/")
@@ -38,20 +41,25 @@ public class WebUiResource
     @GET
     public Response redirectIndexHtml(
             @HeaderParam(X_FORWARDED_PROTO) String proto,
+            @HeaderParam(X_FORWARDED_HOST) String host,
+            @HeaderParam(X_FORWARDED_PORT) String port,
             @Context UriInfo uriInfo)
     {
-        if (isNullOrEmpty(proto)) {
-            proto = uriInfo.getRequestUri().getScheme();
-        }
         Optional<String> lastURL = getLastURLParameter(uriInfo.getQueryParameters());
+
         if (lastURL.isPresent()) {
             return Response
-                    .seeOther(uriInfo.getRequestUriBuilder().scheme(proto).uri(lastURL.get()).build())
+                    .seeOther(buildUri(uriInfo.getRequestUriBuilder(), proto, host, port, uriInfo)
+                            .uri(lastURL.get())
+                            .build())
                     .build();
         }
 
         return Response
-                .temporaryRedirect(uriInfo.getRequestUriBuilder().scheme(proto).path("/ui/").replaceQuery("").build())
+                .temporaryRedirect(buildUri(uriInfo.getRequestUriBuilder(), proto, host, port, uriInfo)
+                        .path("/ui/")
+                        .replaceQuery("")
+                        .build())
                 .build();
     }
 
@@ -59,14 +67,53 @@ public class WebUiResource
     @Path("/logout")
     public Response logout(
             @HeaderParam(X_FORWARDED_PROTO) String proto,
+            @HeaderParam(X_FORWARDED_HOST) String host,
+            @HeaderParam(X_FORWARDED_PORT) String port,
             @Context UriInfo uriInfo)
     {
+        return Response
+                .temporaryRedirect(buildUri(uriInfo.getBaseUriBuilder(), proto, host, port, uriInfo)
+                        .path("/ui/logout.html")
+                        .build())
+                .cookie(OAuthWebUiCookie.delete())
+                .build();
+    }
+
+    private static UriBuilder buildUri(
+            UriBuilder uriBuilder,
+            String proto,
+            String host,
+            String port,
+            UriInfo uriInfo)
+    {
+        // Fallbacks if headers are missing
         if (isNullOrEmpty(proto)) {
             proto = uriInfo.getRequestUri().getScheme();
         }
-        return Response
-                .temporaryRedirect(uriInfo.getBaseUriBuilder().scheme(proto).path("/ui/logout.html").build())
-                .cookie(OAuthWebUiCookie.delete())
-                .build();
+
+        if (isNullOrEmpty(host)) {
+            host = uriInfo.getRequestUri().getHost();
+        }
+
+        int resolvedPort = uriInfo.getRequestUri().getPort();
+        if (!isNullOrEmpty(port)) {
+            try {
+                resolvedPort = Integer.parseInt(port);
+            }
+            catch (NumberFormatException e) {
+                // Fallback to request URI port if X-Forwarded-Port is invalid
+            }
+        }
+
+        // Normalize default ports (avoid :80 or :443 in URLs)
+        if ((proto.equalsIgnoreCase("http") && resolvedPort == 80) ||
+                (proto.equalsIgnoreCase("https") && resolvedPort == 443)) {
+            resolvedPort = -1;
+        }
+
+        return uriBuilder
+                .scheme(proto)
+                .host(host)
+                .port(resolvedPort);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server.protocol;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.dispatcher.DispatchInfo;
+import com.facebook.presto.server.protocol.QueryResourceUtil.ExternalUriInfo;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.ws.rs.core.Response;
@@ -41,8 +42,8 @@ public interface ExecutingQueryResponseProvider
      * @param slug nonce to protect the query
      * @param dispatchInfo information about state of the query
      * @param uriInfo endpoint URI
+     * @param externalUriInfo externally visible request URI components
      * @param xPrestoPrefixUrl prefix URL, that is useful if a proxy is being used
-     * @param scheme HTTP scheme
      * @param maxWait duration to wait for query results
      * @param targetResultSize target result size of first response
      * @param compressionEnabled enable compression
@@ -58,8 +59,8 @@ public interface ExecutingQueryResponseProvider
             String slug,
             DispatchInfo dispatchInfo,
             UriInfo uriInfo,
+            ExternalUriInfo externalUriInfo,
             String xPrestoPrefixUrl,
-            String scheme,
             Duration maxWait,
             DataSize targetResultSize,
             boolean compressionEnabled,

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
@@ -21,6 +21,7 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.server.ForStatementResource;
 import com.facebook.presto.server.ServerConfig;
+import com.facebook.presto.server.protocol.QueryResourceUtil.ExternalUriInfo;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -46,10 +47,12 @@ import org.weakref.jmx.Nested;
 import static com.facebook.airlift.http.server.AsyncResponseHandler.bindAsyncResponse;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREFIX_URL;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_HOST;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_PORT;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.abortIfPrefixUrlInvalid;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.createExternalUriInfo;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.toResponse;
 import static com.facebook.presto.server.security.RoleType.USER;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.Futures.transformAsync;
@@ -71,6 +74,7 @@ public class ExecutingStatementResource
     private final QueryManager queryManager;
     private final boolean compressionEnabled;
     private final boolean nestedDataSerializationEnabled;
+    private final boolean queryResultsUseForwardedHeaders;
     private final QueryBlockingRateLimiter queryRateLimiter;
 
     @Inject
@@ -84,8 +88,10 @@ public class ExecutingStatementResource
         this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
         this.queryProvider = requireNonNull(queryProvider, "queryProvider is null");
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
-        this.compressionEnabled = requireNonNull(serverConfig, "serverConfig is null").isQueryResultsCompressionEnabled();
-        this.nestedDataSerializationEnabled = requireNonNull(serverConfig, "serverConfig is null").isNestedDataSerializationEnabled();
+        ServerConfig actualServerConfig = requireNonNull(serverConfig, "serverConfig is null");
+        this.compressionEnabled = actualServerConfig.isQueryResultsCompressionEnabled();
+        this.nestedDataSerializationEnabled = actualServerConfig.isNestedDataSerializationEnabled();
+        this.queryResultsUseForwardedHeaders = actualServerConfig.isQueryResultsUseForwardedHeadersInUris();
         this.queryRateLimiter = requireNonNull(queryRateLimiter, "queryRateLimiter is null");
     }
 
@@ -107,6 +113,8 @@ public class ExecutingStatementResource
             @QueryParam("targetResultSize") DataSize targetResultSize,
             @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String proto,
+            @HeaderParam(X_FORWARDED_HOST) String xForwardedHost,
+            @HeaderParam(X_FORWARDED_PORT) String xForwardedPort,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo,
             @Suspended AsyncResponse asyncResponse)
@@ -118,21 +126,17 @@ public class ExecutingStatementResource
         else {
             targetResultSize = Ordering.natural().min(targetResultSize, MAX_TARGET_RESULT_SIZE);
         }
-        if (isNullOrEmpty(proto)) {
-            proto = uriInfo.getRequestUri().getScheme();
-        }
-
         abortIfPrefixUrlInvalid(xPrestoPrefixUrl);
 
         Query query = queryProvider.getQuery(queryId, slug);
+        ExternalUriInfo externalUriInfo = createExternalUriInfo(uriInfo, proto, xForwardedHost, xForwardedPort, queryResultsUseForwardedHeaders);
         ListenableFuture<Double> acquirePermitAsync = queryRateLimiter.acquire(queryId);
-        String effectiveFinalProto = proto;
         DataSize effectiveFinalTargetResultSize = targetResultSize;
         ListenableFuture<QueryResults> waitForResultsAsync = transformAsync(
                 acquirePermitAsync,
                 acquirePermitTimeSeconds -> {
                     queryRateLimiter.addRateLimiterBlockTime(new Duration(acquirePermitTimeSeconds, SECONDS));
-                    return query.waitForResults(token, uriInfo, effectiveFinalProto, wait, effectiveFinalTargetResultSize, binaryResults);
+                    return query.waitForResults(token, uriInfo, externalUriInfo, wait, effectiveFinalTargetResultSize, binaryResults);
                 },
                 responseExecutor);
         long durationUntilExpirationMs = queryManager.getDurationUntilExpirationInMillis(queryId);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server.protocol;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.dispatcher.DispatchInfo;
+import com.facebook.presto.server.protocol.QueryResourceUtil.ExternalUriInfo;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.inject.Inject;
@@ -49,8 +50,8 @@ public class LocalExecutingQueryResponseProvider
             String slug,
             DispatchInfo dispatchInfo,
             UriInfo uriInfo,
+            ExternalUriInfo externalUriInfo,
             String xPrestoPrefixUrl,
-            String scheme,
             Duration maxWait,
             DataSize targetResultSize,
             boolean compressionEnabled,
@@ -69,7 +70,7 @@ public class LocalExecutingQueryResponseProvider
             return Optional.empty();
         }
         return Optional.of(transform(
-                query.waitForResults(0, uriInfo, scheme, maxWait, targetResultSize, binaryResults),
+                query.waitForResults(0, uriInfo, externalUriInfo, maxWait, targetResultSize, binaryResults),
                 results -> toResponse(query, results, xPrestoPrefixUrl, compressionEnabled, nestedDataSerializationEnabled, durationUntilExpirationMs),
                 directExecutor()));
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -37,6 +37,7 @@ import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.operator.ExchangeClient;
 import com.facebook.presto.server.RetryConfig;
+import com.facebook.presto.server.protocol.QueryResourceUtil.ExternalUriInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -86,6 +87,7 @@ import static com.facebook.presto.SystemSessionProperties.trackHistoryBasedPlanS
 import static com.facebook.presto.SystemSessionProperties.useHistoryBasedPlanStatisticsEnabled;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.WAITING_FOR_PREREQUISITES;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.getExternalUriBuilder;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.page.PagesSerdeUtil.writeSerializedPage;
 import static com.facebook.presto.util.Failures.toFailure;
@@ -352,7 +354,7 @@ class Query
         return removedSessionFunctions;
     }
 
-    public synchronized ListenableFuture<QueryResults> waitForResults(long token, UriInfo uriInfo, String scheme, Duration wait, DataSize targetResultSize, boolean binaryResults)
+    public synchronized ListenableFuture<QueryResults> waitForResults(long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, Duration wait, DataSize targetResultSize, boolean binaryResults)
     {
         // before waiting, check if this request has already been processed and cached
         Optional<QueryResults> cachedResult = getCachedResult(token);
@@ -368,7 +370,7 @@ class Query
                 timeoutExecutor);
 
         // when state changes, fetch the next result
-        return Futures.transform(futureStateChange, ignored -> getNextResultWithRetry(token, uriInfo, scheme, targetResultSize, binaryResults), resultsProcessorExecutor);
+        return Futures.transform(futureStateChange, ignored -> getNextResultWithRetry(token, uriInfo, externalUriInfo, targetResultSize, binaryResults), resultsProcessorExecutor);
     }
 
     private synchronized ListenableFuture<?> getFutureStateChange()
@@ -421,9 +423,9 @@ class Query
         return Optional.empty();
     }
 
-    private synchronized QueryResults getNextResultWithRetry(long token, UriInfo uriInfo, String scheme, DataSize targetResultSize, boolean binaryResults)
+    private synchronized QueryResults getNextResultWithRetry(long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, DataSize targetResultSize, boolean binaryResults)
     {
-        QueryResults queryResults = getNextResult(token, uriInfo, scheme, targetResultSize, binaryResults);
+        QueryResults queryResults = getNextResult(token, uriInfo, externalUriInfo, targetResultSize, binaryResults);
 
         if (queryResults.getError() == null) {
             return queryResults;
@@ -461,7 +463,7 @@ class Query
 
         // build a new query with next uri
         // we expect failed nodes have been removed from discovery server upon query failure
-        URI nextUri = createRetryUri(scheme, uriInfo);
+        URI nextUri = createRetryUri(externalUriInfo, uriInfo);
 
         return new QueryResults(
                 queryId.toString(),
@@ -481,7 +483,7 @@ class Query
                 queryResults.getUpdateCount());
     }
 
-    private synchronized QueryResults getNextResult(long token, UriInfo uriInfo, String scheme, DataSize targetResultSize, boolean binaryResults)
+    private synchronized QueryResults getNextResult(long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, DataSize targetResultSize, boolean binaryResults)
     {
         // check if the result for the token have already been created
         Optional<QueryResults> cachedResult = getCachedResult(token);
@@ -491,8 +493,7 @@ class Query
 
         verify(nextToken.isPresent(), "Can not generate next result when next token is not present");
         verify(token == nextToken.getAsLong(), "Expected token to equal next token");
-        URI queryHtmlUri = uriInfo.getRequestUriBuilder()
-                .scheme(scheme)
+        URI queryHtmlUri = getExternalUriBuilder(uriInfo, externalUriInfo)
                 .replacePath("ui/query.html")
                 .replaceQuery(queryId.toString())
                 .build();
@@ -596,7 +597,7 @@ class Query
 
         URI nextResultsUri = null;
         if (nextToken.isPresent()) {
-            nextResultsUri = createNextResultsUri(scheme, uriInfo, nextToken.getAsLong(), binaryResults);
+            nextResultsUri = createNextResultsUri(externalUriInfo, uriInfo, nextToken.getAsLong(), binaryResults);
         }
 
         // update catalog, schema, and path
@@ -626,7 +627,7 @@ class Query
         QueryResults queryResults = new QueryResults(
                 queryId.toString(),
                 queryHtmlUri,
-                findCancelableLeafStage(queryInfo),
+                createPartialCancelUri(queryInfo, uriInfo, externalUriInfo),
                 nextResultsUri,
                 columns,
                 data,
@@ -685,10 +686,9 @@ class Query
         return Futures.transformAsync(queryManager.getStateChange(queryId, currentState), this::queryDoneFuture, directExecutor());
     }
 
-    private synchronized URI createNextResultsUri(String scheme, UriInfo uriInfo, long nextToken, boolean binaryResults)
+    private synchronized URI createNextResultsUri(ExternalUriInfo externalUriInfo, UriInfo uriInfo, long nextToken, boolean binaryResults)
     {
-        UriBuilder uri = uriInfo.getBaseUriBuilder()
-                .scheme(scheme)
+        UriBuilder uri = getExternalUriBuilder(uriInfo, externalUriInfo)
                 .replacePath("/v1/statement/executing")
                 .path(queryId.toString())
                 .path(String.valueOf(nextToken))
@@ -704,7 +704,7 @@ class Query
         return uri.build();
     }
 
-    private synchronized URI createRetryUri(String scheme, UriInfo uriInfo)
+    private synchronized URI createRetryUri(ExternalUriInfo externalUriInfo, UriInfo uriInfo)
     {
         // Check if we have external retry URL information
         if (retryUrl.isPresent()) {
@@ -720,8 +720,7 @@ class Query
         }
 
         // Use the default retry mechanism
-        UriBuilder uri = uriInfo.getBaseUriBuilder()
-                .scheme(scheme)
+        UriBuilder uri = getExternalUriBuilder(uriInfo, externalUriInfo)
                 .replacePath("/v1/statement/queued/retry")
                 .path(queryId.toString())
                 .replaceQuery("");
@@ -732,13 +731,21 @@ class Query
         return uri.build();
     }
 
-    private static URI findCancelableLeafStage(QueryInfo queryInfo)
+    private static URI createPartialCancelUri(QueryInfo queryInfo, UriInfo uriInfo, ExternalUriInfo externalUriInfo)
     {
-        // if query is running, find the leaf-most running stage
-        return queryInfo.getOutputStage().map(Query::findCancelableLeafStage).orElse(null);
+        StageInfo cancelableStage = queryInfo.getOutputStage().map(Query::findCancelableLeafStage).orElse(null);
+        if (cancelableStage == null) {
+            return null;
+        }
+
+        return getExternalUriBuilder(uriInfo, externalUriInfo)
+                .replacePath("/v1/stage")
+                .path(cancelableStage.getStageId().toString())
+                .replaceQuery("")
+                .build();
     }
 
-    private static URI findCancelableLeafStage(StageInfo stage)
+    private static StageInfo findCancelableLeafStage(StageInfo stage)
     {
         // if this stage is already done, we can't cancel it
         if (stage.getLatestAttemptExecutionInfo().getState().isDone()) {
@@ -748,14 +755,14 @@ class Query
         // attempt to find a cancelable sub stage
         // check in reverse order since build side of a join will be later in the list
         for (StageInfo subStage : Lists.reverse(stage.getSubStages())) {
-            URI leafStage = findCancelableLeafStage(subStage);
+            StageInfo leafStage = findCancelableLeafStage(subStage);
             if (leafStage != null) {
                 return leafStage;
             }
         }
 
         // no matching sub stage, so return this stage
-        return stage.getSelf();
+        return stage;
     }
 
     private boolean retryConditionsMet(QueryResults queryResults)

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -287,7 +287,11 @@ public final class QueryResourceUtil
 
     private static String getFirstForwardedHeaderValue(String headerValue)
     {
-        return FORWARDED_HEADER_SPLITTER.splitToList(headerValue).get(0);
+        List<String> values = FORWARDED_HEADER_SPLITTER.splitToList(headerValue);
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("Forwarded header value is empty");
+        }
+        return values.get(0);
     }
 
     private static String urlEncode(String value)

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -28,7 +28,9 @@ import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.core.Context;
@@ -47,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
@@ -83,6 +86,9 @@ import static java.util.stream.Collectors.toList;
 public final class QueryResourceUtil
 {
     private static final Logger log = Logger.get(QueryResourceUtil.class);
+    public static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+    public static final String X_FORWARDED_PORT = "X-Forwarded-Port";
+    private static final Splitter FORWARDED_HEADER_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
     private static final JsonCodec<SqlFunctionId> SQL_FUNCTION_ID_JSON_CODEC = jsonCodec(SqlFunctionId.class);
     private static final JsonCodec<SqlInvokedFunction> SQL_INVOKED_FUNCTION_JSON_CODEC = jsonCodec(SqlInvokedFunction.class);
     private static final JsonCodec<List<Object>> LIST_JSON_CODEC = listJsonCodec(Object.class);
@@ -220,6 +226,70 @@ public final class QueryResourceUtil
         return backendUri;
     }
 
+    public static ExternalUriInfo createExternalUriInfo(UriInfo uriInfo, String xForwardedProto, String xForwardedHost, String xForwardedPort, boolean useForwardedHeaders)
+    {
+        String scheme = getScheme(xForwardedProto, uriInfo);
+        if (!useForwardedHeaders || isNullOrEmpty(xForwardedHost)) {
+            return new ExternalUriInfo(scheme, Optional.empty(), OptionalInt.empty());
+        }
+
+        try {
+            HostAndPort forwardedHost = HostAndPort.fromString(getFirstForwardedHeaderValue(xForwardedHost));
+            OptionalInt forwardedPort = parseForwardedPort(forwardedHost, xForwardedPort);
+            return new ExternalUriInfo(scheme, Optional.of(forwardedHost.getHost()), forwardedPort);
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Ignoring invalid forwarded host or port headers while building statement response URIs");
+            return new ExternalUriInfo(scheme, Optional.empty(), OptionalInt.empty());
+        }
+    }
+
+    public static UriBuilder getExternalUriBuilder(UriInfo uriInfo, ExternalUriInfo externalUriInfo)
+    {
+        UriBuilder uriBuilder = uriInfo.getBaseUriBuilder()
+                .scheme(externalUriInfo.getScheme());
+
+        if (externalUriInfo.getHost().isPresent()) {
+            uriBuilder.host(externalUriInfo.getHost().get());
+            if (externalUriInfo.getPort().isPresent()) {
+                uriBuilder.port(externalUriInfo.getPort().getAsInt());
+            }
+            else {
+                uriBuilder.port(-1);
+            }
+        }
+
+        return uriBuilder;
+    }
+
+    public static String getRequestHost(UriInfo uriInfo, ExternalUriInfo externalUriInfo)
+    {
+        return externalUriInfo.getHost().orElseGet(() -> uriInfo.getBaseUri().getHost());
+    }
+
+    private static OptionalInt parseForwardedPort(HostAndPort forwardedHost, String xForwardedPort)
+    {
+        if (forwardedHost.hasPort()) {
+            return OptionalInt.of(forwardedHost.getPort());
+        }
+
+        if (isNullOrEmpty(xForwardedPort)) {
+            return OptionalInt.empty();
+        }
+
+        try {
+            return OptionalInt.of(Integer.parseInt(getFirstForwardedHeaderValue(xForwardedPort)));
+        }
+        catch (RuntimeException e) {
+            throw new IllegalArgumentException("Invalid X-Forwarded-Port header", e);
+        }
+    }
+
+    private static String getFirstForwardedHeaderValue(String headerValue)
+    {
+        return FORWARDED_HEADER_SPLITTER.splitToList(headerValue).get(0);
+    }
+
     private static String urlEncode(String value)
     {
         try {
@@ -301,20 +371,18 @@ public final class QueryResourceUtil
         return value;
     }
 
-    private static URI getQueryHtmlUri(QueryId queryId, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl)
+    private static URI getQueryHtmlUri(QueryId queryId, UriInfo uriInfo, ExternalUriInfo externalUriInfo, String xPrestoPrefixUrl)
     {
-        URI uri = uriInfo.getRequestUriBuilder()
-                .scheme(getScheme(xForwardedProto, uriInfo))
+        URI uri = getExternalUriBuilder(uriInfo, externalUriInfo)
                 .replacePath("ui/query.html")
                 .replaceQuery(queryId.toString())
                 .build();
         return prependUri(uri, xPrestoPrefixUrl);
     }
 
-    public static URI getQueuedUri(QueryId queryId, String slug, long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, boolean binaryResults)
+    public static URI getQueuedUri(QueryId queryId, String slug, long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, String xPrestoPrefixUrl, boolean binaryResults)
     {
-        UriBuilder uriBuilder = uriInfo.getBaseUriBuilder()
-                .scheme(getScheme(xForwardedProto, uriInfo))
+        UriBuilder uriBuilder = getExternalUriBuilder(uriInfo, externalUriInfo)
                 .replacePath("/v1/statement/queued")
                 .path(queryId.toString())
                 .path(String.valueOf(token))
@@ -337,7 +405,7 @@ public final class QueryResourceUtil
             URI nextUri,
             Optional<QueryError> queryError,
             UriInfo uriInfo,
-            String xForwardedProto,
+            ExternalUriInfo externalUriInfo,
             String xPrestoPrefixUrl,
             Duration elapsedTime,
             Optional<Duration> queuedTime,
@@ -347,7 +415,7 @@ public final class QueryResourceUtil
                 .orElseGet(() -> queuedTime.isPresent() ? QUEUED : WAITING_FOR_PREREQUISITES);
         return new QueryResults(
                 queryId.toString(),
-                getQueryHtmlUri(queryId, uriInfo, xForwardedProto, xPrestoPrefixUrl),
+                getQueryHtmlUri(queryId, uriInfo, externalUriInfo, xPrestoPrefixUrl),
                 null,
                 nextUri,
                 null,
@@ -364,5 +432,34 @@ public final class QueryResourceUtil
                 ImmutableList.of(),
                 null,
                 null);
+    }
+
+    public static final class ExternalUriInfo
+    {
+        private final String scheme;
+        private final Optional<String> host;
+        private final OptionalInt port;
+
+        private ExternalUriInfo(String scheme, Optional<String> host, OptionalInt port)
+        {
+            this.scheme = requireNonNull(scheme, "scheme is null");
+            this.host = requireNonNull(host, "host is null");
+            this.port = requireNonNull(port, "port is null");
+        }
+
+        public String getScheme()
+        {
+            return scheme;
+        }
+
+        public Optional<String> getHost()
+        {
+            return host;
+        }
+
+        public OptionalInt getPort()
+        {
+            return port;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -29,6 +29,7 @@ import com.facebook.presto.server.HttpRequestSessionContext;
 import com.facebook.presto.server.RetryUrlValidator;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.server.SessionContext;
+import com.facebook.presto.server.protocol.QueryResourceUtil.ExternalUriInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -81,11 +82,14 @@ import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREFIX_URL;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_RETRY_QUERY;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.NO_DURATION;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_HOST;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_PORT;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.abortIfPrefixUrlInvalid;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.createExternalUriInfo;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.createQueuedQueryResults;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.getCacheControlMaxAge;
 import static com.facebook.presto.server.protocol.QueryResourceUtil.getQueuedUri;
-import static com.facebook.presto.server.protocol.QueryResourceUtil.getScheme;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.getRequestHost;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.RETRY_QUERY_NOT_FOUND;
@@ -133,6 +137,7 @@ public class QueuedStatementResource
     private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("dispatch-query-purger"));
     private final boolean compressionEnabled;
     private final boolean nestedDataSerializationEnabled;
+    private final boolean queryResultsUseForwardedHeaders;
 
     private final SqlParserOptions sqlParserOptions;
     private final TracerProviderManager tracerProviderManager;
@@ -156,8 +161,10 @@ public class QueuedStatementResource
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.executingQueryResponseProvider = requireNonNull(executingQueryResponseProvider, "executingQueryResponseProvider is null");
         this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
-        this.compressionEnabled = requireNonNull(serverConfig, "serverConfig is null").isQueryResultsCompressionEnabled();
-        this.nestedDataSerializationEnabled = requireNonNull(serverConfig, "serverConfig is null").isNestedDataSerializationEnabled();
+        ServerConfig actualServerConfig = requireNonNull(serverConfig, "serverConfig is null");
+        this.compressionEnabled = actualServerConfig.isQueryResultsCompressionEnabled();
+        this.nestedDataSerializationEnabled = actualServerConfig.isNestedDataSerializationEnabled();
+        this.queryResultsUseForwardedHeaders = actualServerConfig.isQueryResultsUseForwardedHeadersInUris();
 
         this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
         this.timeoutExecutor = requireNonNull(executor, "timeoutExecutor is null").getScheduledExecutor();
@@ -217,6 +224,8 @@ public class QueuedStatementResource
             @QueryParam("retryExpirationInSeconds") Long retryExpirationInSeconds,
             @HeaderParam(PRESTO_RETRY_QUERY) String isRetryQueryHeader,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @HeaderParam(X_FORWARDED_HOST) String xForwardedHost,
+            @HeaderParam(X_FORWARDED_PORT) String xForwardedPort,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context HttpServletRequest servletRequest,
             @Context UriInfo uriInfo)
@@ -229,6 +238,7 @@ public class QueuedStatementResource
 
         // Parse retry query header
         boolean isRetryQuery = parseBoolean(isRetryQueryHeader);
+        ExternalUriInfo externalUriInfo = createExternalUriInfo(uriInfo, xForwardedProto, xForwardedHost, xForwardedPort, queryResultsUseForwardedHeaders);
 
         // Validate retry URL if provided
         Optional<URI> retryUrl = Optional.empty();
@@ -239,7 +249,7 @@ public class QueuedStatementResource
             }
             retryUrl = Optional.of(getRetryUrl(retryUrlString));
             retryExpirationEpochTime = OptionalLong.of(currentTimeMillis() + SECONDS.toMillis(retryExpirationInSeconds));
-            String currentHost = uriInfo.getBaseUri().getHost();
+            String currentHost = getRequestHost(uriInfo, externalUriInfo);
             if (!retryUrlValidator.isValidRetryUrl(retryUrl.get(), currentHost)) {
                 throw badRequest(BAD_REQUEST, "Invalid retry URL");
             }
@@ -268,7 +278,7 @@ public class QueuedStatementResource
 
         queries.put(query.getQueryId(), query);
 
-        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
+        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, externalUriInfo, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
                 .cacheControl(query.getDefaultCacheControl())
                 .build();
     }
@@ -309,6 +319,8 @@ public class QueuedStatementResource
             @QueryParam("slug") String slug,
             @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @HeaderParam(X_FORWARDED_HOST) String xForwardedHost,
+            @HeaderParam(X_FORWARDED_PORT) String xForwardedPort,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context HttpServletRequest servletRequest,
             @Context UriInfo uriInfo)
@@ -334,7 +346,9 @@ public class QueuedStatementResource
             throw badRequest(CONFLICT, "Query already exists");
         }
 
-        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
+        ExternalUriInfo externalUriInfo = createExternalUriInfo(uriInfo, xForwardedProto, xForwardedHost, xForwardedPort, queryResultsUseForwardedHeaders);
+
+        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, externalUriInfo, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
                 .cacheControl(query.getDefaultCacheControl())
                 .build();
     }
@@ -353,6 +367,8 @@ public class QueuedStatementResource
             @PathParam("queryId") QueryId queryId,
             @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @HeaderParam(X_FORWARDED_HOST) String xForwardedHost,
+            @HeaderParam(X_FORWARDED_PORT) String xForwardedPort,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo)
     {
@@ -396,7 +412,9 @@ public class QueuedStatementResource
             }
         }
 
-        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
+        ExternalUriInfo externalUriInfo = createExternalUriInfo(uriInfo, xForwardedProto, xForwardedHost, xForwardedPort, queryResultsUseForwardedHeaders);
+
+        return withCompressionConfiguration(Response.ok(query.getInitialQueryResults(uriInfo, externalUriInfo, xPrestoPrefixUrl, binaryResults)), compressionEnabled)
                 .cacheControl(query.getDefaultCacheControl())
                 .build();
     }
@@ -421,6 +439,8 @@ public class QueuedStatementResource
             @QueryParam("maxWait") Duration maxWait,
             @DefaultValue("false") @QueryParam("binaryResults") boolean binaryResults,
             @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @HeaderParam(X_FORWARDED_HOST) String xForwardedHost,
+            @HeaderParam(X_FORWARDED_PORT) String xForwardedPort,
             @HeaderParam(PRESTO_PREFIX_URL) String xPrestoPrefixUrl,
             @Context UriInfo uriInfo,
             @Suspended AsyncResponse asyncResponse)
@@ -428,6 +448,7 @@ public class QueuedStatementResource
         abortIfPrefixUrlInvalid(xPrestoPrefixUrl);
 
         Query query = getQuery(queryId, slug);
+        ExternalUriInfo externalUriInfo = createExternalUriInfo(uriInfo, xForwardedProto, xForwardedHost, xForwardedPort, queryResultsUseForwardedHeaders);
 
         if (query.isRetryQuery()) {
             throw badRequest(
@@ -453,7 +474,7 @@ public class QueuedStatementResource
         // when state changes, fetch the next result
         ListenableFuture<Response> queryResultsFuture = transformAsync(
                 futureStateChange,
-                ignored -> query.toResponse(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait), compressionEnabled, nestedDataSerializationEnabled, binaryResults),
+                ignored -> query.toResponse(token, uriInfo, externalUriInfo, xPrestoPrefixUrl, WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait), compressionEnabled, nestedDataSerializationEnabled, binaryResults),
                 responseExecutor);
         bindAsyncResponse(asyncResponse, queryResultsFuture, responseExecutor);
     }
@@ -680,14 +701,14 @@ public class QueuedStatementResource
          * @param xForwardedProto Forwarded protocol (http or https)
          * @return {@link com.facebook.presto.client.QueryResults}
          */
-        public synchronized QueryResults getInitialQueryResults(UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, boolean binaryResults)
+        public synchronized QueryResults getInitialQueryResults(UriInfo uriInfo, ExternalUriInfo externalUriInfo, String xPrestoPrefixUrl, boolean binaryResults)
         {
             verify(lastToken.get() == 0);
             verify(querySubmissionFuture == null);
             return createQueryResults(
                     1,
                     uriInfo,
-                    xForwardedProto,
+                    externalUriInfo,
                     xPrestoPrefixUrl,
                     DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION),
                     binaryResults);
@@ -696,7 +717,7 @@ public class QueuedStatementResource
         public ListenableFuture<Response> toResponse(
                 long token,
                 UriInfo uriInfo,
-                String xForwardedProto,
+                ExternalUriInfo externalUriInfo,
                 String xPrestoPrefixUrl,
                 Duration maxWait,
                 boolean compressionEnabled,
@@ -717,7 +738,7 @@ public class QueuedStatementResource
                     QueryResults queryResults = createQueryResults(
                             token + 1,
                             uriInfo,
-                            xForwardedProto,
+                            externalUriInfo,
                             xPrestoPrefixUrl,
                             DispatchInfo.waitingForPrerequisites(NO_DURATION, NO_DURATION),
                             binaryResults);
@@ -743,8 +764,8 @@ public class QueuedStatementResource
                         slug,
                         dispatchInfo.get(),
                         uriInfo,
+                        externalUriInfo,
                         xPrestoPrefixUrl,
-                        getScheme(xForwardedProto, uriInfo),
                         maxWait,
                         TARGET_RESULT_SIZE,
                         compressionEnabled,
@@ -761,7 +782,7 @@ public class QueuedStatementResource
             }
 
             return immediateFuture(withCompressionConfiguration(Response.ok(
-                    createQueryResults(token + 1, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo.get(), binaryResults)), compressionEnabled)
+                    createQueryResults(token + 1, uriInfo, externalUriInfo, xPrestoPrefixUrl, dispatchInfo.get(), binaryResults)), compressionEnabled)
                     .cacheControl(getCacheControlMaxAge(durationUntilExpirationMs))
                     .build());
         }
@@ -771,9 +792,9 @@ public class QueuedStatementResource
             querySubmissionFuture.addListener(() -> dispatchManager.cancelQuery(queryId), directExecutor());
         }
 
-        private QueryResults createQueryResults(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
+        private QueryResults createQueryResults(long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
         {
-            URI nextUri = getNextUri(token, uriInfo, xForwardedProto, xPrestoPrefixUrl, dispatchInfo, binaryResults);
+            URI nextUri = getNextUri(token, uriInfo, externalUriInfo, xPrestoPrefixUrl, dispatchInfo, binaryResults);
 
             Optional<QueryError> queryError = dispatchInfo.getFailureInfo()
                     .map(this::toQueryError);
@@ -783,7 +804,7 @@ public class QueuedStatementResource
                     nextUri,
                     queryError,
                     uriInfo,
-                    xForwardedProto,
+                    externalUriInfo,
                     xPrestoPrefixUrl,
                     dispatchInfo.getElapsedTime(),
                     dispatchInfo.getQueuedTime(),
@@ -795,13 +816,13 @@ public class QueuedStatementResource
             return "x" + randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
         }
 
-        private URI getNextUri(long token, UriInfo uriInfo, String xForwardedProto, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
+        private URI getNextUri(long token, UriInfo uriInfo, ExternalUriInfo externalUriInfo, String xPrestoPrefixUrl, DispatchInfo dispatchInfo, boolean binaryResults)
         {
             // if failed, query is complete
             if (dispatchInfo.getFailureInfo().isPresent()) {
                 return null;
             }
-            return getQueuedUri(queryId, slug, token, uriInfo, xForwardedProto, xPrestoPrefixUrl, binaryResults);
+            return getQueuedUri(queryId, slug, token, uriInfo, externalUriInfo, xPrestoPrefixUrl, binaryResults);
         }
 
         private QueryError toQueryError(ExecutionFailureInfo executionFailureInfo)

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.page.SerializedPage;
+import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.BasicSliceInput;
@@ -186,6 +187,37 @@ public class TestServer
     }
 
     @Test
+    public void testPartialCancelUriUsesForwardedHostWhenEnabled()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog("tpch", "tpch");
+
+        Request request = forwardedRequest(preparePost(), "engine.example.com", null)
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("SELECT * FROM tpch.sf100.lineitem", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        while (queryResults.getPartialCancelUri() == null && queryResults.getNextUri() != null) {
+            queryResults = client.execute(
+                    forwardedRequest(prepareGet(), "engine.example.com", null)
+                            .setUri(toServerUri(queryResults.getNextUri()))
+                            .build(),
+                    createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        }
+
+        assertNotNull(queryResults.getPartialCancelUri(), "expected a running query to expose partialCancelUri");
+        assertEquals(queryResults.getPartialCancelUri().getScheme(), "https");
+        assertEquals(queryResults.getPartialCancelUri().getHost(), "engine.example.com");
+        assertEquals(queryResults.getPartialCancelUri().getPort(), -1);
+    }
+
+    @Test
     public void testStatementUrisUseForwardedPortWhenEnabled()
             throws Exception
     {
@@ -220,6 +252,29 @@ public class TestServer
                 .setHeader(X_FORWARDED_PROTO, "https")
                 .setHeader(X_FORWARDED_HOST, "engine.example.com")
                 .setHeader(X_FORWARDED_PORT, "not-a-port")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        assertEquals(queryResults.getInfoUri().getScheme(), "https");
+        assertEquals(queryResults.getNextUri().getScheme(), "https");
+        assertEquals(queryResults.getInfoUri().getHost(), server.getBaseUrl().getHost());
+        assertEquals(queryResults.getNextUri().getHost(), server.getBaseUrl().getHost());
+    }
+
+    @Test
+    public void testStatementUrisFallBackToInternalHostWhenForwardedHostIsEffectivelyEmpty()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+
+        Request request = preparePost()
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(X_FORWARDED_PROTO, "https")
+                .setHeader(X_FORWARDED_HOST, " ,  , ")
                 .build();
 
         QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -48,6 +48,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
@@ -78,9 +79,12 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.server.TestHttpRequestSessionContext.createFunctionAdd;
 import static com.facebook.presto.server.TestHttpRequestSessionContext.createSqlFunctionIdAdd;
 import static com.facebook.presto.server.TestHttpRequestSessionContext.urlEncode;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_HOST;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.X_FORWARDED_PORT;
 import static com.facebook.presto.spi.StandardErrorCode.INCOMPATIBLE_CLIENT;
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static com.facebook.presto.spi.page.PagesSerdeUtil.readSerializedPage;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static jakarta.ws.rs.core.HttpHeaders.CACHE_CONTROL;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -121,6 +125,130 @@ public class TestServer
     {
         Closeables.closeQuietly(server);
         Closeables.closeQuietly(client);
+    }
+
+    @Test
+    public void testStatementUrisIgnoreForwardedHostByDefault()
+    {
+        Request request = forwardedRequest(preparePost(), "engine.example.com", null)
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        assertEquals(queryResults.getInfoUri().getScheme(), "https");
+        assertEquals(queryResults.getNextUri().getScheme(), "https");
+        assertEquals(queryResults.getInfoUri().getHost(), server.getBaseUrl().getHost());
+        assertEquals(queryResults.getNextUri().getHost(), server.getBaseUrl().getHost());
+    }
+
+    @Test
+    public void testStatementUrisUseForwardedHostWhenEnabled()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+
+        Request request = forwardedRequest(preparePost(), "engine.example.com", null)
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        assertEquals(queryResults.getInfoUri().getScheme(), "https");
+        assertEquals(queryResults.getInfoUri().getHost(), "engine.example.com");
+        assertEquals(queryResults.getInfoUri().getPort(), -1);
+        assertEquals(queryResults.getNextUri().getHost(), "engine.example.com");
+        assertEquals(queryResults.getNextUri().getPort(), -1);
+
+        while (queryResults.getNextUri() != null) {
+            queryResults = client.execute(
+                    forwardedRequest(prepareGet(), "engine.example.com", null)
+                            .setUri(toServerUri(queryResults.getNextUri()))
+                            .build(),
+                    createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+            assertEquals(queryResults.getInfoUri().getHost(), "engine.example.com");
+            if (queryResults.getNextUri() != null) {
+                assertEquals(queryResults.getNextUri().getHost(), "engine.example.com");
+            }
+            if (queryResults.getPartialCancelUri() != null) {
+                assertEquals(queryResults.getPartialCancelUri().getHost(), "engine.example.com");
+            }
+        }
+
+        assertNull(queryResults.getError());
+    }
+
+    @Test
+    public void testStatementUrisUseForwardedPortWhenEnabled()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+
+        Request request = forwardedRequest(preparePost(), "engine.example.com", "8443")
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        assertEquals(queryResults.getInfoUri().getHost(), "engine.example.com");
+        assertEquals(queryResults.getInfoUri().getPort(), 8443);
+        assertEquals(queryResults.getNextUri().getHost(), "engine.example.com");
+        assertEquals(queryResults.getNextUri().getPort(), 8443);
+    }
+
+    @Test
+    public void testStatementUrisFallBackToInternalHostWhenForwardedHeadersAreInvalid()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+
+        Request request = preparePost()
+                .setUri(uriFor("/v1/statement"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(X_FORWARDED_PROTO, "https")
+                .setHeader(X_FORWARDED_HOST, "engine.example.com")
+                .setHeader(X_FORWARDED_PORT, "not-a-port")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        assertEquals(queryResults.getInfoUri().getScheme(), "https");
+        assertEquals(queryResults.getNextUri().getScheme(), "https");
+        assertEquals(queryResults.getInfoUri().getHost(), server.getBaseUrl().getHost());
+        assertEquals(queryResults.getNextUri().getHost(), server.getBaseUrl().getHost());
+    }
+
+    @Test
+    public void testRetryUrlValidationUsesForwardedHostWhenEnabled()
+            throws Exception
+    {
+        restartServer(ImmutableMap.of("query-results.use-forwarded-headers-in-uris", "true"));
+
+        URI uri = buildStatementUri("https://engine.example.com/v1/statement/queued/retry/abc123", 3600, false);
+        Request request = forwardedRequest(preparePost(), "engine.example.com", null)
+                .setUri(uri)
+                .setBodyGenerator(createStaticBodyGenerator("SELECT 123", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .build();
+
+        JsonResponse<QueryResults> response = client.execute(request, createFullJsonResponseHandler(QUERY_RESULTS_CODEC));
+        assertEquals(response.getStatusCode(), OK.getStatusCode());
+        assertEquals(response.getValue().getNextUri().getHost(), "engine.example.com");
     }
 
     @Test
@@ -760,6 +888,29 @@ public class TestServer
             Closeables.closeQuietly(backupClient);
             Closeables.closeQuietly(backupServer);
         }
+    }
+
+    private void restartServer(Map<String, String> properties)
+            throws Exception
+    {
+        Closeables.closeQuietly(server);
+        server = new TestingPrestoServer(properties);
+    }
+
+    private static Request.Builder forwardedRequest(Request.Builder request, String forwardedHost, String forwardedPort)
+    {
+        request.addHeader(X_FORWARDED_PROTO, "https");
+        request.addHeader(X_FORWARDED_HOST, forwardedHost);
+        if (forwardedPort != null) {
+            request.addHeader(X_FORWARDED_PORT, forwardedPort);
+        }
+        return request;
+    }
+
+    private URI toServerUri(URI externalUri)
+    {
+        String query = externalUri.getRawQuery();
+        return URI.create(server.getBaseUrl().getScheme() + "://" + server.getBaseUrl().getAuthority() + externalUri.getRawPath() + (query == null ? "" : "?" + query));
     }
 
     public URI uriFor(String path)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

This PR adds an opt-in server setting that makes Presto build client-visible statement/result URIs from forwarded request headers when running behind a trusted reverse proxy.

New server property:

`query-results.use-forwarded-headers-in-uris=true`

When enabled, the statement API will use:

- X-Forwarded-Proto
- X-Forwarded-Host
- X-Forwarded-Port (optional)

to construct externally visible:

- infoUri
- nextUri
- retry URI
- partialCancelUri

Default behavior remains unchanged unless the property is explicitly enabled.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add optional support for building statement and web UI URIs from X-Forwarded-* headers when enabled via a new server property, while preserving existing behavior by default.

New Features:
- Introduce a server configuration flag to allow query result and statement URIs to use forwarded host and port headers behind trusted reverse proxies.
- Support constructing external query and UI URIs (info, next, retry, partial cancel, and web UI redirects) from X-Forwarded-Proto/Host/Port when configured.

Enhancements:
- Centralize external URI construction logic via an ExternalUriInfo helper to consistently apply forwarded header semantics and fallbacks.
- Update retry URL validation to use the externally visible host when the forwarded headers feature is enabled.

Tests:
- Add server configuration mapping tests for the new forwarded-headers property.
- Extend server integration tests to cover forwarded host/port handling, fallbacks on invalid headers, and use of forwarded hosts in retry validation.