### PR TITLE
fix(plugin-pinot): Normalize mixed-case Pinot table/column name handl…

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
@@ -33,6 +33,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNSUPPORTED_COLUMN_TYPE;
@@ -52,15 +53,20 @@ public class PinotColumnUtils
 
     public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType)
     {
-        return getPinotColumnsForPinotSchema(pinotTableSchema, inferDateType, inferTimestampType, false);
+        return getPinotColumnsForPinotSchema(pinotTableSchema, inferDateType, inferTimestampType, false, false);
     }
 
-    public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType, boolean nullHandlingEnabled)
+    public static List<PinotColumn> getPinotColumnsForPinotSchema(
+            Schema pinotTableSchema,
+            boolean inferDateType,
+            boolean inferTimestampType,
+            boolean nullHandlingEnabled,
+            boolean isCaseSensitiveNameMatchingEnabled)
     {
         return pinotTableSchema.getColumnNames().stream()
                 .filter(columnName -> !columnName.startsWith("$")) // Hidden columns starts with "$", ignore them as we can't use them in SQL
                 .map(columnName -> new PinotColumn(
-                        columnName,
+                        isCaseSensitiveNameMatchingEnabled ? columnName : columnName.toLowerCase(Locale.ROOT),
                         getPrestoTypeFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), inferDateType, inferTimestampType),
                         isNullableColumnFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), nullHandlingEnabled),
                         getCommentFromPinotType(pinotTableSchema.getFieldSpecFor(columnName))))

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
@@ -64,7 +64,10 @@ public class PinotConnection
                                     throws Exception
                             {
                                 Schema tablePinotSchema = pinotClusterInfoFetcher.getTableSchema(tableName);
-                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema(), nullHandlingEnabled);
+                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(),
+                                        pinotConfig.isInferTimestampTypeInSchema(),
+                                        nullHandlingEnabled,
+                                        pinotConfig.isCaseSensitiveNameMatchingEnabled());
                             }
                         }, executor));
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
@@ -67,11 +67,13 @@ public class PinotMetadata
         return ImmutableList.of(SCHEMA_NAME);
     }
 
-    private String getPinotTableNameFromPrestoTableName(String prestoTableName)
+    private String getPinotTableNameFromPrestoTableName(ConnectorSession session, String prestoTableName)
     {
         List<String> allTables = pinotPrestoConnection.getTableNames();
+        String normalizedPrestoTableName = normalizeIdentifier(session, prestoTableName);
         for (String pinotTableName : allTables) {
-            if (prestoTableName.equals(pinotTableName)) {
+            String normalizedPinotTableName = normalizeIdentifier(session, pinotTableName);
+            if (normalizedPrestoTableName.equals(normalizedPinotTableName)) {
                 return pinotTableName;
             }
         }
@@ -84,7 +86,7 @@ public class PinotMetadata
         if (!SCHEMA_NAME.equals(normalizeIdentifier(session, tableName.getSchemaName()))) {
             throw new PrestoException(NOT_FOUND, format("Schema %s does not exist", tableName.getSchemaName()));
         }
-        String pinotTableName = getPinotTableNameFromPrestoTableName(tableName.getTableName());
+        String pinotTableName = getPinotTableNameFromPrestoTableName(session, tableName.getTableName());
         return new PinotTableHandle(connectorId, tableName.getSchemaName(), pinotTableName);
     }
 
@@ -114,7 +116,7 @@ public class PinotMetadata
         checkArgument(pinotTableHandle.getConnectorId().equals(connectorId), "tableHandle is not for this connector");
         SchemaTableName tableName = new SchemaTableName(pinotTableHandle.getSchemaName(), pinotTableHandle.getTableName());
 
-        return getTableMetadata(tableName);
+        return getTableMetadata(session, tableName);
     }
 
     @Override
@@ -136,7 +138,7 @@ public class PinotMetadata
         PinotTableHandle pinotTableHandle = (PinotTableHandle) tableHandle;
         checkArgument(pinotTableHandle.getConnectorId().equals(connectorId), "tableHandle is not for this connector");
 
-        String pinotTableName = getPinotTableNameFromPrestoTableName(pinotTableHandle.getTableName());
+        String pinotTableName = getPinotTableNameFromPrestoTableName(session, pinotTableHandle.getTableName());
         PinotTable table = pinotPrestoConnection.getTable(pinotTableName);
         if (table == null) {
             throw new TableNotFoundException(pinotTableHandle.toSchemaTableName());
@@ -155,7 +157,7 @@ public class PinotMetadata
         requireNonNull(prefix, "prefix is null");
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         for (SchemaTableName tableName : listTables(session, prefix)) {
-            ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
+            ConnectorTableMetadata tableMetadata = getTableMetadata(session, tableName);
             // table can disappear during listing operation
             if (tableMetadata != null) {
                 columns.put(tableName, tableMetadata.getColumns());
@@ -164,9 +166,9 @@ public class PinotMetadata
         return columns.build();
     }
 
-    private ConnectorTableMetadata getTableMetadata(SchemaTableName tableName)
+    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName tableName)
     {
-        String pinotTableName = getPinotTableNameFromPrestoTableName(tableName.getTableName());
+        String pinotTableName = getPinotTableNameFromPrestoTableName(session, tableName.getTableName());
         PinotTable table = pinotPrestoConnection.getTable(pinotTableName);
         if (table == null) {
             return null;

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotColumnMetadata.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotColumnMetadata.java
@@ -72,57 +72,56 @@ public class TestPinotColumnMetadata
                 .build();
 
         Map<String, Type> expectedTypeMap = new ImmutableMap.Builder<String, Type>()
-                .put("singleValueIntDimension", INTEGER)
-                .put("singleValueLongDimension", BIGINT)
-                .put("singleValueFloatDimension", DOUBLE)
-                .put("singleValueDoubleDimension", DOUBLE)
-                .put("singleValueBytesDimension", VARBINARY)
-                .put("singleValueBooleanDimension", BOOLEAN)
-                .put("singleValueStringDimension", VARCHAR)
-                .put("multiValueIntDimension", new ArrayType(INTEGER))
-                .put("multiValueLongDimension", new ArrayType(BIGINT))
-                .put("multiValueFloatDimension", new ArrayType(DOUBLE))
-                .put("multiValueDoubleDimension", new ArrayType(DOUBLE))
-                .put("multiValueBytesDimension", new ArrayType(VARBINARY))
-                .put("multiValueBooleanDimension", new ArrayType(BOOLEAN))
-                .put("multiValueStringDimension", new ArrayType(VARCHAR))
-                .put("intMetric", INTEGER)
-                .put("longMetric", BIGINT)
-                .put("floatMetric", DOUBLE)
-                .put("doubleMetric", DOUBLE)
-                .put("bytesMetric", VARBINARY)
-                .put("daysSinceEpoch", DateType.DATE)
-                .put("epochDayDateTime", DateType.DATE)
-                .put("epochMillisDateTime", TimestampType.TIMESTAMP)
-                .put("epochTenDayDateTime", INTEGER)
-                .put("epochSecondsDateTime", BIGINT)
+                .put("singlevalueintdimension", INTEGER)
+                .put("singlevaluelongdimension", BIGINT)
+                .put("singlevaluefloatdimension", DOUBLE)
+                .put("singlevaluedoubledimension", DOUBLE)
+                .put("singlevaluebytesdimension", VARBINARY)
+                .put("singlevaluebooleandimension", BOOLEAN)
+                .put("singlevaluestringdimension", VARCHAR)
+                .put("multivalueintdimension", new ArrayType(INTEGER))
+                .put("multivaluelongdimension", new ArrayType(BIGINT))
+                .put("multivaluefloatdimension", new ArrayType(DOUBLE))
+                .put("multivaluedoubledimension", new ArrayType(DOUBLE))
+                .put("multivaluebytesdimension", new ArrayType(VARBINARY))
+                .put("multivaluebooleandimension", new ArrayType(BOOLEAN))
+                .put("multivaluestringdimension", new ArrayType(VARCHAR))
+                .put("intmetric", INTEGER)
+                .put("longmetric", BIGINT)
+                .put("floatmetric", DOUBLE)
+                .put("doublemetric", DOUBLE)
+                .put("bytesmetric", VARBINARY)
+                .put("dayssinceepoch", DateType.DATE)
+                .put("epochdaydatetime", DateType.DATE)
+                .put("epochmillisdatetime", TimestampType.TIMESTAMP)
+                .put("epochtendaydatetime", INTEGER)
+                .put("epochsecondsdatetime", BIGINT)
                 .build();
         Map<String, String> expectedComment = new ImmutableMap.Builder<String, String>()
-                .put("sd1", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueIntDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueLongDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueFloatDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueDoubleDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueBytesDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueBooleanDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("singleValueStringDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueIntDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueLongDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueFloatDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueDoubleDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueBytesDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueBooleanDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("multiValueStringDimension", FieldSpec.FieldType.DIMENSION.name())
-                .put("intMetric", FieldSpec.FieldType.METRIC.name())
-                .put("longMetric", FieldSpec.FieldType.METRIC.name())
-                .put("floatMetric", FieldSpec.FieldType.METRIC.name())
-                .put("doubleMetric", FieldSpec.FieldType.METRIC.name())
-                .put("bytesMetric", FieldSpec.FieldType.METRIC.name())
-                .put("daysSinceEpoch", FieldSpec.FieldType.TIME.name())
-                .put("epochDayDateTime", FieldSpec.FieldType.DATE_TIME.name())
-                .put("epochMillisDateTime", FieldSpec.FieldType.DATE_TIME.name())
-                .put("epochTenDayDateTime", FieldSpec.FieldType.DATE_TIME.name())
-                .put("epochSecondsDateTime", FieldSpec.FieldType.DATE_TIME.name())
+                .put("singlevalueintdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluelongdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluefloatdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluedoubledimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluebytesdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluebooleandimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("singlevaluestringdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivalueintdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluelongdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluefloatdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluedoubledimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluebytesdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluebooleandimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("multivaluestringdimension", FieldSpec.FieldType.DIMENSION.name())
+                .put("intmetric", FieldSpec.FieldType.METRIC.name())
+                .put("longmetric", FieldSpec.FieldType.METRIC.name())
+                .put("floatmetric", FieldSpec.FieldType.METRIC.name())
+                .put("doublemetric", FieldSpec.FieldType.METRIC.name())
+                .put("bytesmetric", FieldSpec.FieldType.METRIC.name())
+                .put("dayssinceepoch", FieldSpec.FieldType.TIME.name())
+                .put("epochdaydatetime", FieldSpec.FieldType.DATE_TIME.name())
+                .put("epochmillisdatetime", FieldSpec.FieldType.DATE_TIME.name())
+                .put("epochtendaydatetime", FieldSpec.FieldType.DATE_TIME.name())
+                .put("epochsecondsdatetime", FieldSpec.FieldType.DATE_TIME.name())
                 .build();
 
         List<PinotColumn> pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testPinotSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
@@ -146,7 +145,7 @@ public class TestPinotColumnMetadata
                 .build();
         List<PinotColumn> pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         PinotColumn column = pinotColumns.get(0);
-        assertEquals(column.getName(), "daysSinceEpoch");
+        assertEquals(column.getName(), "dayssinceepoch");
         assertEquals(column.getType(), DateType.DATE);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -156,7 +155,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "daysSinceEpoch");
+        assertEquals(column.getName(), "dayssinceepoch");
         assertEquals(column.getType(), DateType.DATE);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -166,7 +165,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "millisSinceEpoch");
+        assertEquals(column.getName(), "millissinceepoch");
         assertEquals(column.getType(), TimestampType.TIMESTAMP);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -176,7 +175,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "millisSinceEpoch");
+        assertEquals(column.getName(), "millissinceepoch");
         assertEquals(column.getType(), TimestampType.TIMESTAMP);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -186,7 +185,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -196,7 +195,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -206,7 +205,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
     }
@@ -224,7 +223,7 @@ public class TestPinotColumnMetadata
                 .build();
         List<PinotColumn> pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         PinotColumn column = pinotColumns.get(0);
-        assertEquals(column.getName(), "daysSinceEpoch");
+        assertEquals(column.getName(), "dayssinceepoch");
         assertEquals(column.getType(), INTEGER);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -234,7 +233,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "daysSinceEpoch");
+        assertEquals(column.getName(), "dayssinceepoch");
         assertEquals(column.getType(), INTEGER);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -244,7 +243,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "millisSinceEpoch");
+        assertEquals(column.getName(), "millissinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -254,7 +253,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "millisSinceEpoch");
+        assertEquals(column.getName(), "millissinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -264,7 +263,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -274,7 +273,7 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
 
@@ -284,8 +283,45 @@ public class TestPinotColumnMetadata
                 .build();
         pinotColumns = PinotColumnUtils.getPinotColumnsForPinotSchema(testSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema());
         column = pinotColumns.get(0);
-        assertEquals(column.getName(), "secondsSinceEpoch");
+        assertEquals(column.getName(), "secondssinceepoch");
         assertEquals(column.getType(), BIGINT);
         assertEquals(column.getComment(), FieldSpec.FieldType.TIME.name());
+    }
+
+    @Test
+    public void testCaseSensitivityNameMatching()
+    {
+        PinotConfig pinotConfig = new PinotConfig();
+        pinotConfig.setInferDateTypeInSchema(true);
+        pinotConfig.setInferTimestampTypeInSchema(true);
+
+        Schema testSchema = new Schema.SchemaBuilder()
+                .addSingleValueDimension("singleValueIntDimension", FieldSpec.DataType.INT)
+                .build();
+        assertEquals(getColumns(testSchema, pinotConfig, true).get(0).getName(), "singleValueIntDimension");
+        assertEquals(getColumns(testSchema, pinotConfig, false).get(0).getName(), "singlevalueintdimension");
+
+        testSchema = new Schema.SchemaBuilder()
+                .addMetric("intMetric", FieldSpec.DataType.INT)
+                .build();
+        assertEquals(getColumns(testSchema, pinotConfig, true).get(0).getName(), "intMetric");
+        assertEquals(getColumns(testSchema, pinotConfig, false).get(0).getName(), "intmetric");
+
+        testSchema = new Schema.SchemaBuilder()
+                .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"))
+                .build();
+        assertEquals(getColumns(testSchema, pinotConfig, true).get(0).getName(), "daysSinceEpoch");
+        assertEquals(getColumns(testSchema, pinotConfig, false).get(0).getName(), "dayssinceepoch");
+
+        testSchema = new Schema.SchemaBuilder()
+                .addDateTime("epochMillisDateTime", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:SECONDS")
+                .build();
+        assertEquals(getColumns(testSchema, pinotConfig, true).get(0).getName(), "epochMillisDateTime");
+        assertEquals(getColumns(testSchema, pinotConfig, false).get(0).getName(), "epochmillisdatetime");
+    }
+
+    private List<PinotColumn> getColumns(Schema schema, PinotConfig pinotConfig, boolean caseSensitive)
+    {
+        return PinotColumnUtils.getPinotColumnsForPinotSchema(schema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema(), false, caseSensitive);
     }
 }


### PR DESCRIPTION
Original PR: [https://github.com/prestodb/presto/pull/26663](https://github.com/prestodb/presto/pull/26663)

## Description
<!---Describe your changes in detail-->

This bug fix normalizes identifiers for tables and columns when the case-sensitive flag is **disabled**. As a result, mixed case table/column names no longer cause query failures when using the Pinot connector in Presto.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
to fix failing queries when the flag is disabled 

## Test Plan
<!---Please fill in how you tested your change-->

Tested using a Pinot connector instance from IBM QA. Also tested with the flag enabled to ensure behavior remains unchanged.

Flag disabled;

<img width="1023" height="76" alt="Screenshot 2025-11-20 at 2 06 20 PM" src="https://github.com/user-attachments/assets/ce244686-ffd4-4c98-ba6c-d0cfa79dc5d3" />
<img width="1023" height="106" alt="Screenshot 2025-11-20 at 2 07 08 PM" src="https://github.com/user-attachments/assets/9f4ff94d-0bb8-4b2f-b60a-46274ac1d678" />

Flag enabled; 
<img width="1023" height="163" alt="Screenshot 2025-11-20 at 2 19 45 PM" src="https://github.com/user-attachments/assets/1ff4372e-ce1f-4898-869a-b2c8253f738e" />

<img width="1023" height="403" alt="Screenshot 2025-11-20 at 2 19 19 PM" src="https://github.com/user-attachments/assets/abf3f87b-f37d-4e49-9a61-36aac30fbd8c" />

(Tested again on latest version)

<img width="3408" height="660" alt="image" src="https://github.com/user-attachments/assets/ebdd81e3-e75c-4ae5-9fdc-3c8c7ada5db5" />

<img width="3408" height="660" alt="image" src="https://github.com/user-attachments/assets/f7260978-2982-4607-90ca-f82566c36309" />

<img width="3408" height="660" alt="image" src="https://github.com/user-attachments/assets/ce9fff8b-813d-4a11-a3da-73fe15e63984" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Normalize Pinot table and column name handling in the Presto Pinot connector when case-sensitive name matching is disabled.

Bug Fixes:
- Fix Pinot table resolution to correctly match Presto table names to Pinot tables using normalized identifiers instead of strict case-sensitive equality.

Enhancements:
- Propagate connector session into Pinot metadata lookups so identifier normalization is consistently applied.
- Derive Pinot column names in a case-insensitive manner by lowercasing them when case-sensitive name matching is disabled, honoring the connector configuration flag.

## Summary by Sourcery

Normalize Pinot table and column name handling in the Presto Pinot connector when case-sensitive name matching is disabled.

Bug Fixes:
- Resolve Pinot table lookup by matching normalized Pinot and Presto table identifiers instead of relying on case-sensitive equality.

Enhancements:
- Derive Pinot column names in a case-insensitive manner by lowercasing schema column identifiers when case-sensitive name matching is disabled.
- Thread connector session and case-sensitivity configuration through Pinot metadata and schema-to-column conversion utilities to ensure consistent identifier normalization.

Tests:
- Update Pinot column metadata tests to assert lowercased column names when case-insensitive name matching is used.