### PR TITLE
feat: Add configurable JDBC fetch size support

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -25,6 +25,7 @@ import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Set;
@@ -54,6 +55,8 @@ public class BaseJdbcConfig
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private Set<String> listSchemasIgnoredSchemas = ImmutableSet.of("information_schema");
     private boolean caseSensitiveNameMatchingEnabled;
+    @Min(1)
+    private int fetchSize = 20000;
 
     @NotNull
     public String getConnectionUrl()
@@ -190,5 +193,18 @@ public class BaseJdbcConfig
         if (connectionUrl == null) {
             throw new ConfigurationException(ImmutableList.of(new Message("connection-url is required but was not provided")));
         }
+    }
+
+    public int getFetchSize()
+    {
+        return fetchSize;
+    }
+
+    @Config("jdbc-fetch-size")
+    @ConfigDescription("Number of rows to fetch from the database at a time")
+    public BaseJdbcConfig setFetchSize(int fetchSize)
+    {
+        this.fetchSize = fetchSize;
+        return this;
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
@@ -40,7 +40,8 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setlistSchemasIgnoredSchemas("information_schema")
-                .setCaseSensitiveNameMatching(false));
+                .setCaseSensitiveNameMatching(false)
+                .setFetchSize(20000));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestBaseJdbcConfig
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .put("list-schemas-ignored-schemas", "test,test2")
                 .put("case-sensitive-name-matching", "true")
+                .put("jdbc-fetch-size", "5000")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
@@ -67,7 +69,8 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(true)
                 .setlistSchemasIgnoredSchemas("test,test2")
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
-                .setCaseSensitiveNameMatching(true);
+                .setCaseSensitiveNameMatching(true)
+                .setFetchSize(5000);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -74,6 +74,10 @@ Property Name                                      Description                  
 ``case-sensitive-name-matching``                   Enable case sensitive identifier support for schema and table        ``false``
                                                    names for the connector. When disabled, names are matched
                                                    case-insensitively using lowercase normalization.
+
+``jdbc-fetch-size``                                Number of rows to fetch from the database at a time. Higher          ``20000``
+                                                   values can improve performance for large result sets but may
+                                                   increase memory usage.
 ================================================== ==================================================================== ===========
 
 Querying Oracle

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -83,7 +83,7 @@ public class OracleClient
         extends BaseJdbcClient
 {
     private static final Logger LOG = Logger.get(OracleClient.class);
-    private static final int FETCH_SIZE = 1000;
+    private final int fetchSize;
 
     private final boolean synonymsEnabled;
     private final int numberDefaultScale;
@@ -100,6 +100,7 @@ public class OracleClient
         requireNonNull(oracleConfig, "oracle config is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
         this.numberDefaultScale = oracleConfig.getNumberDefaultScale();
+        this.fetchSize = config.getFetchSize();
     }
 
     private String[] getTableTypes()
@@ -116,11 +117,13 @@ public class OracleClient
     {
         DatabaseMetaData metadata = connection.getMetaData();
         String escape = metadata.getSearchStringEscape();
-        return metadata.getTables(
+        ResultSet resultSet = metadata.getTables(
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
                 escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
                 getTableTypes());
+        resultSet.setFetchSize(fetchSize);
+        return resultSet;
     }
 
     @Override
@@ -128,7 +131,7 @@ public class OracleClient
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(FETCH_SIZE);
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 


### PR DESCRIPTION
## Description

Breaking down this PR https://github.com/prestodb/presto/pull/25355 into multiple PRs.

Add jdbc-fetch-size configuration property to BaseJdbcConfig with a default value of 20000 rows. This allows tuning of database fetch performance based on workload characteristics.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Add fetch size to both PreparedStatement and ResultSet operations
* Add documentation for jdbc-fetch-size property in docs