### PR TITLE
feat: Add Oracle i18n character set support

### DIFF
--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -197,6 +197,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>orai18n</artifactId>
+            <version>19.3.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleIntegrationSmokeTest.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleIntegrationSmokeTest.java
@@ -17,12 +17,15 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.plugin.oracle.OracleQueryRunner.createOracleQueryRunner;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestOracleIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
@@ -72,5 +75,33 @@ public class TestOracleIntegrationSmokeTest
                 .build();
         MaterializedResult actualColumns = computeActual("DESCRIBE orders");
         assertEquals(actualColumns, expectedColumns);
+    }
+
+    /**
+     * Test to verify Oracle connector compatibility with non-UTF character sets.
+     * This test ensures the orai18n.jar dependency enables proper handling of
+     * character sets like WE8ISO8859P9.
+     */
+    @Test
+    public void testSpecialCharacterHandling()
+    {
+        assertUpdate("CREATE TABLE test_charset (id bigint, text varchar(100))");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_charset"));
+
+        try {
+            // Insert characters WE8ISO8859P9 specific
+            assertUpdate("INSERT INTO test_charset VALUES (1, 'İstanbul')", 1);
+            assertUpdate("INSERT INTO test_charset VALUES (2, 'Çağrı')", 1);
+            assertUpdate("INSERT INTO test_charset VALUES (3, 'Şehir')", 1);
+
+            // Verify data can be read correctly
+            assertQuery("SELECT COUNT(*) FROM test_charset", "VALUES (3)");
+            assertQuery("SELECT text FROM test_charset WHERE id = 1", "VALUES ('İstanbul')");
+            assertQuery("SELECT COUNT(*) FROM test_charset WHERE text LIKE '%İ%'", "VALUES (1)");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_charset");
+            assertFalse(getQueryRunner().tableExists(getSession(), "test_charset"));
+        }
     }
 }


### PR DESCRIPTION
## Description
Breaking down this PR https://github.com/prestodb/presto/pull/25355 into multiple PRs.

the orai18n.jar dependency enables proper handling of character sets like WE8ISO8859P9

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Add Oracle i18n character set support