### PR TITLE
feat: Add TLS/SSL configuration support for Oracle connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -76,6 +76,35 @@ Property Name                                      Description                  
                                                    case-insensitively using lowercase normalization.
 ================================================== ==================================================================== ===========
 
+Oracle-Specific Configuration Properties
+----------------------------------------
+
+================================================== ==================================================================== ===========
+Property Name                                      Description                                                          Default
+================================================== ==================================================================== ===========
+``oracle.tls.enabled``                             Enable TLS/SSL for secure connections to Oracle database.            ``false``
+
+``oracle.tls.truststore-path``                     Path to the Java truststore file containing the Oracle server's
+                                                   SSL certificate. Required when ``oracle.tls.enabled`` is ``true``.
+
+``oracle.tls.truststore-password``                 Password for the truststore file. Required when
+                                                   ``oracle.tls.enabled`` is ``true``.
+================================================== ==================================================================== ===========
+
+TLS/SSL Configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+To enable secure connections to Oracle using TLS/SSL, configure the following properties:
+
+.. code-block:: none
+
+    oracle.tls.enabled=true
+    oracle.tls.truststore-path=/path/to/truststore.jks
+    oracle.tls.truststore-password=changeit
+
+The truststore file must contain the Oracle server's SSL certificate or the certificate
+authority (CA) certificate that signed the Oracle server's certificate.
+
 Querying Oracle
 ---------------
 

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -22,7 +22,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleDriver;
 
 import java.sql.SQLException;
@@ -30,6 +29,8 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+import static oracle.jdbc.OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS;
 
 public class OracleClientModule
         implements Module
@@ -49,7 +50,22 @@ public class OracleClientModule
             throws SQLException
     {
         Properties connectionProperties = new Properties();
-        connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
+
+        requireNonNull(oracleConfig, "oracle config is null");
+        requireNonNull(config, "BaseJdbc config is null");
+
+        if (config.getConnectionUser() != null && config.getConnectionPassword() != null) {
+            connectionProperties.setProperty("user", config.getConnectionUser());
+            connectionProperties.setProperty("password", config.getConnectionPassword());
+        }
+
+        if (oracleConfig.isTlsEnabled()) {
+            requireNonNull(oracleConfig.getTrustStorePath(), "oracle.tls.truststore-path is null");
+            connectionProperties.setProperty("javax.net.ssl.trustStore", oracleConfig.getTrustStorePath());
+            connectionProperties.setProperty("javax.net.ssl.trustStorePassword", oracleConfig.getTruststorePassword());
+        }
+
+        connectionProperties.setProperty(CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
 
         return new DriverConnectionFactory(
                 new OracleDriver(),

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.oracle;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -27,6 +28,9 @@ public class OracleConfig
     private int timestampDefaultPrecision = 6;
     private int numberDefaultScale = 10;
     private RoundingMode numberRoundingMode = RoundingMode.HALF_UP;
+    private boolean tlsEnabled;
+    private String trustStorePath;
+    private String truststorePassword;
 
     @NotNull
     public boolean isSynonymsEnabled()
@@ -92,6 +96,43 @@ public class OracleConfig
     public OracleConfig setTimestampDefaultPrecision(int timestampDefaultPrecision)
     {
         this.timestampDefaultPrecision = timestampDefaultPrecision;
+        return this;
+    }
+
+    public boolean isTlsEnabled()
+    {
+        return tlsEnabled;
+    }
+
+    @Config("oracle.tls.enabled")
+    public OracleConfig setTlsEnabled(boolean tlsEnabled)
+    {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public String getTrustStorePath()
+    {
+        return trustStorePath;
+    }
+
+    @Config("oracle.tls.truststore-path")
+    public OracleConfig setTrustStorePath(String trustStorePath)
+    {
+        this.trustStorePath = trustStorePath;
+        return this;
+    }
+
+    public String getTruststorePassword()
+    {
+        return truststorePassword;
+    }
+
+    @Config("oracle.tls.truststore-password")
+    @ConfigSecuritySensitive
+    public OracleConfig setTruststorePassword(String truststorePassword)
+    {
+        this.truststorePassword = truststorePassword;
         return this;
     }
 }

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleConfig.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleConfig.java
@@ -33,7 +33,10 @@ public class TestOracleConfig
                 .setVarcharMaxSize(4000)
                 .setTimestampDefaultPrecision(6)
                 .setNumberDefaultScale(10)
-                .setNumberRoundingMode(RoundingMode.HALF_UP));
+                .setNumberRoundingMode(RoundingMode.HALF_UP)
+                .setTlsEnabled(false)
+                .setTrustStorePath(null)
+                .setTruststorePassword(null));
     }
 
     @Test
@@ -45,6 +48,9 @@ public class TestOracleConfig
                 .put("oracle.timestamp.precision", "3")
                 .put("oracle.number.default-scale", "2")
                 .put("oracle.number.rounding-mode", "CEILING")
+                .put("oracle.tls.enabled", "true")
+                .put("oracle.tls.truststore-path", "/path/to/truststore.jks")
+                .put("oracle.tls.truststore-password", "changeit")
                 .build();
 
         OracleConfig expected = new OracleConfig()
@@ -52,7 +58,10 @@ public class TestOracleConfig
                 .setVarcharMaxSize(10000)
                 .setTimestampDefaultPrecision(3)
                 .setNumberDefaultScale(2)
-                .setNumberRoundingMode(RoundingMode.CEILING);
+                .setNumberRoundingMode(RoundingMode.CEILING)
+                .setTlsEnabled(true)
+                .setTrustStorePath("/path/to/truststore.jks")
+                .setTruststorePassword("changeit");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Breaking down this PR https://github.com/prestodb/presto/pull/25355 into multiple PRs.

This PR enables secure connections to Oracle databases using TLS/SSL by configuring
truststore path and password for certificate validation

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Add TLS/SSL configuration support for Oracle connector

## Summary by Sourcery

Add TLS/SSL configuration options to the Oracle connector to support secure connections using a truststore.

New Features:
- Introduce Oracle connector configuration properties to enable TLS and specify truststore path and password for certificate validation.

Enhancements:
- Extend Oracle JDBC connection factory to populate user/password and optional TLS truststore properties when establishing connections.

Tests:
- Update OracleConfig tests to cover default values and explicit mappings for the new TLS-related configuration properties.