### PR TITLE
fix(server): Fix FutureStateChange listener leak in HttpRemoteTaskWithEventLoop.whenSplitQueueHasSpace()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
@@ -129,6 +129,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.Math.addExact;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
@@ -802,7 +803,13 @@ public final class HttpRemoteTaskWithEventLoop
                 future.set(null);
             }
             else {
-                whenSplitQueueHasSpace.createNewListener().addListener(() -> future.set(null), taskEventLoop);
+                ListenableFuture<?> innerListener = whenSplitQueueHasSpace.createNewListener();
+                innerListener.addListener(() -> future.set(null), taskEventLoop);
+                future.addListener(() -> {
+                    if (future.isCancelled()) {
+                        innerListener.cancel(false);
+                    }
+                }, directExecutor());
             }
         }, "whenSplitQueueHasSpace");
         return future;


### PR DESCRIPTION
### Description
Meta internal Differential Revision: D102477187
## Problem

Coordinator OOM on mwg1_4 (150 GB heap dump, Apr 24 2026). Heap analysis revealed 927 million orphaned AbstractFuture$Listener and SettableFuture instances — 49% of the entire heap — accumulated across 47,846 HttpRemoteTaskWithEventLoop instances (~19,380 leaked listeners per task).

## Root Cause

whenSplitQueueHasSpace() creates a two-layer future structure:

1. An **inner SettableFuture** created by FutureStateChange.createNewListener(), stored in the FutureStateChange.listeners set
2. An **outer SettableFuture** returned to the scheduler
3. A **bridging lambda** () -> future.set(null) connecting the two

The scheduler calls whenSplitQueueHasSpace() on every scheduling cycle for all blocked nodes, then passes the returned futures to whenAnyCompleteCancelOthers(). When one task unblocks, all other outer futures are cancelled. However, cancellation of the outer future does **not** propagate to the inner FutureStateChange listener. The inner listener remains in FutureStateChange.listeners indefinitely.

For tasks whose split queue stays full across scheduling cycles, this creates 4 orphaned objects per cycle per task: 1 inner SettableFuture, 1 outer SettableFuture (held via bridge lambda capture), 1 FutureStateChange self-removal lambda, and 1 HttpRemoteTaskWithEventLoop bridge lambda. Over thousands of scheduling cycles across tens of thousands of tasks, this accumulated to 927M listeners and ~100 GB of leaked memory.

The existing cleanup paths do not help:
- FutureStateChange.fireStateChange() only runs when splitQueueHasSpace() is true (never for always-full tasks)
- The self-removal lambda on the inner future only fires on complete/cancel (inner future is never completed or cancelled)
- cleanUpTask() only runs when the task reaches a terminal state

## Fix

Add a cancellation listener on the outer SettableFuture that propagates cancellation to the inner FutureStateChange listener. When the inner SettableFuture is cancelled, its existing self-removal lambda (FutureStateChange.java:44) fires and removes it from the FutureStateChange.listeners set, preventing accumulation.

The cancellation listener uses directExecutor() since it performs only a lightweight isCancelled() check and cancel() call with no blocking.

## Changes:

Track the internal futures for closing.

## Impact
Internal futures are now closed and heap memory looks significantly better. I have not seen a long running heap spike since we deployed a test build to our clusters, and the heap utilization of our normal operations seems to be mildly lower than before.

## Test Plan
Tested in Meta internal systems with a test build utilizing this change.
Before test build (build was deployed at 16:00)
<img width="3400" height="856" alt="image" src="https://github.com/user-attachments/assets/cf33d2d2-b02f-40c3-9b99-0d1ac0219e8d" />
after test build (build was deployed at 16:00)
<img width="3398" height="942" alt="image" src="https://github.com/user-attachments/assets/c89d51fb-c4d6-40f9-8383-5ca897336882" />


## Contributor checklist
 Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
 PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
 Documented new properties (with its default value), SQL syntax, functions, or other functionality.
 If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
 Adequate tests were added if applicable.
 CI passed.

## Summary by Sourcery

Bug Fixes:
- Ensure cancellation of scheduler futures for split-queue capacity also cancels the associated FutureStateChange listener to avoid orphaned listeners and memory leaks.


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fixed bug wtih http remote task with event loop opening futures that are never closed every cycle when the split queue is full

