### PR TITLE
refactor(native): Clean up the saturate cast of count metric

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -18,6 +18,7 @@
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/time/Timer.h"
 
 using namespace facebook::velox;
@@ -998,17 +999,13 @@ folly::dynamic PrestoTask::toJson() const {
 protocol::RuntimeMetric toRuntimeMetric(
     const std::string& name,
     const RuntimeMetric& metric) {
-  // Presto's RuntimeMetric uses int64_t for count, but Velox's RuntimeMetric
-  // uses uint64_t. To avoid overflow, we cap the count at int64_t's max value.
-  static const uint64_t maxCount =
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
-  const auto count = static_cast<int64_t>(
-      std::min(static_cast<uint64_t>(metric.count), maxCount));
+  // Use Velox provided saturate cast to safely convert uint64_t to int64_t
+  // without overflow.
   return protocol::RuntimeMetric{
       name,
       toPrestoRuntimeUnit(metric.unit),
       metric.sum,
-      count,
+      saturateCast(metric.count),
       metric.max,
       metric.min};
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

After the Velox version is updated, we can use the newly added `saturateCast` to handle potential overflow of the count metric.

Follow-up for: https://github.com/prestodb/presto/commit/7f97f8d533fb7f92e0a9a10cc5ec0a1db732b178.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Code cleanup after the Velox version being updated.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refine native runtime metric conversion to use Velox’s built-in saturating cast for count values when mapping to Presto runtime metrics.

Enhancements:
- Use Velox’s saturating cast helper for converting unsigned count metrics to signed counts to avoid overflow.
- Update native task implementation includes to pull in the Velox runtime metrics utilities.