### PR TITLE
feat(analyzer): Allow HAVING in materialized view query rewrite

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -1336,6 +1336,167 @@ public class TestHiveMaterializedViewLogicalPlanner
     }
 
     @Test
+    public void testBaseToViewConversionWithHavingOnGroupingKey()
+    {
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "lineitem_partitioned_having_groupkey";
+        String view = "lineitem_partitioned_view_having_groupkey";
+        try {
+            queryRunner.execute(format(
+                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                            "UNION ALL " +
+                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                    table));
+            assertUpdate(format(
+                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
+                    view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+
+            String baseQuery = format(
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
+                            "GROUP BY ds, shipmode HAVING shipmode = 'AIR' ORDER BY ds, shipmode",
+                    table);
+
+            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
+            MaterializedResult baseQueryResult = computeActual(baseQuery);
+            assertEquals(optimizedQueryResult, baseQueryResult);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testBaseToViewConversionWithHavingOnAggregate()
+    {
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "lineitem_partitioned_having_aggregate";
+        String view = "lineitem_partitioned_view_having_aggregate";
+        try {
+            queryRunner.execute(format(
+                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                            "UNION ALL " +
+                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                    table));
+            assertUpdate(format(
+                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
+                    view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+
+            String baseQuery = format(
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
+                            "GROUP BY ds, shipmode HAVING SUM(discount * extendedprice) > 1000 ORDER BY ds, shipmode",
+                    table);
+
+            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
+            MaterializedResult baseQueryResult = computeActual(baseQuery);
+            assertEquals(optimizedQueryResult, baseQueryResult);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testBaseToViewConversionWithHavingMixedWithWhere()
+    {
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "lineitem_partitioned_having_where";
+        String view = "lineitem_partitioned_view_having_where";
+        try {
+            queryRunner.execute(format(
+                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                            "UNION ALL " +
+                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                    table));
+            assertUpdate(format(
+                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
+                    view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+
+            String baseQuery = format(
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
+                            "WHERE ds = '2020-01-02' GROUP BY ds, shipmode " +
+                            "HAVING SUM(discount * extendedprice) > 100 ORDER BY ds, shipmode",
+                    table);
+
+            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
+            MaterializedResult baseQueryResult = computeActual(baseQuery);
+            assertEquals(optimizedQueryResult, baseQueryResult);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testBaseToViewConversionWithHavingCount()
+    {
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "lineitem_partitioned_having_count";
+        String view = "lineitem_partitioned_view_having_count";
+        try {
+            queryRunner.execute(format(
+                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                            "UNION ALL " +
+                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                    table));
+            assertUpdate(format(
+                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT COUNT(extendedprice) as _count_extprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
+                    view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+
+            String baseQuery = format(
+                    "SELECT COUNT(extendedprice) as _count_extprice_, ds, shipmode FROM %s " +
+                            "GROUP BY ds, shipmode HAVING COUNT(extendedprice) > 5 ORDER BY ds, shipmode",
+                    table);
+
+            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
+            MaterializedResult baseQueryResult = computeActual(baseQuery);
+            assertEquals(optimizedQueryResult, baseQueryResult);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
     public void testBaseToViewConversionCountOptimizationWithStitching()
     {
         Session queryOptimizationWithMaterializedView = Session.builder(getSession())

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -1338,107 +1338,57 @@ public class TestHiveMaterializedViewLogicalPlanner
     @Test
     public void testBaseToViewConversionWithHavingOnGroupingKey()
     {
-        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
-                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
-                .build();
-        QueryRunner queryRunner = getQueryRunner();
         String table = "lineitem_partitioned_having_groupkey";
         String view = "lineitem_partitioned_view_having_groupkey";
+        Session session = sessionWithMaterializedViewRewrite();
         try {
-            queryRunner.execute(format(
-                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
-                            "UNION ALL " +
-                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
-                    table));
-            assertUpdate(format(
-                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
-                    view, table));
-            assertTrue(getQueryRunner().tableExists(getSession(), view));
-            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+            createPartitionedHavingFixture(table, view,
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode");
 
             String baseQuery = format(
                     "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
                             "GROUP BY ds, shipmode HAVING shipmode = 'AIR' ORDER BY ds, shipmode",
                     table);
 
-            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
-            MaterializedResult baseQueryResult = computeActual(baseQuery);
-            assertEquals(optimizedQueryResult, baseQueryResult);
+            assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
         }
         finally {
-            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            dropHavingFixture(table, view);
         }
     }
 
     @Test
     public void testBaseToViewConversionWithHavingOnAggregate()
     {
-        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
-                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
-                .build();
-        QueryRunner queryRunner = getQueryRunner();
         String table = "lineitem_partitioned_having_aggregate";
         String view = "lineitem_partitioned_view_having_aggregate";
+        Session session = sessionWithMaterializedViewRewrite();
         try {
-            queryRunner.execute(format(
-                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
-                            "UNION ALL " +
-                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
-                    table));
-            assertUpdate(format(
-                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
-                    view, table));
-            assertTrue(getQueryRunner().tableExists(getSession(), view));
-            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+            createPartitionedHavingFixture(table, view,
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode");
 
             String baseQuery = format(
                     "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
                             "GROUP BY ds, shipmode HAVING SUM(discount * extendedprice) > 1000 ORDER BY ds, shipmode",
                     table);
 
-            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
-            MaterializedResult baseQueryResult = computeActual(baseQuery);
-            assertEquals(optimizedQueryResult, baseQueryResult);
+            assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
+            assertPlan(session, baseQuery, anyTree(constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
-            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            dropHavingFixture(table, view);
         }
     }
 
     @Test
     public void testBaseToViewConversionWithHavingMixedWithWhere()
     {
-        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
-                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
-                .build();
-        QueryRunner queryRunner = getQueryRunner();
         String table = "lineitem_partitioned_having_where";
         String view = "lineitem_partitioned_view_having_where";
+        Session session = sessionWithMaterializedViewRewrite();
         try {
-            queryRunner.execute(format(
-                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
-                            "UNION ALL " +
-                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
-                    table));
-            assertUpdate(format(
-                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
-                    view, table));
-            assertTrue(getQueryRunner().tableExists(getSession(), view));
-            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+            createPartitionedHavingFixture(table, view,
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s GROUP BY ds, shipmode");
 
             String baseQuery = format(
                     "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, ds, shipmode FROM %s " +
@@ -1446,53 +1396,32 @@ public class TestHiveMaterializedViewLogicalPlanner
                             "HAVING SUM(discount * extendedprice) > 100 ORDER BY ds, shipmode",
                     table);
 
-            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
-            MaterializedResult baseQueryResult = computeActual(baseQuery);
-            assertEquals(optimizedQueryResult, baseQueryResult);
+            assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
         }
         finally {
-            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            dropHavingFixture(table, view);
         }
     }
 
     @Test
     public void testBaseToViewConversionWithHavingCount()
     {
-        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
-                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
-                .build();
-        QueryRunner queryRunner = getQueryRunner();
         String table = "lineitem_partitioned_having_count";
         String view = "lineitem_partitioned_view_having_count";
+        Session session = sessionWithMaterializedViewRewrite();
         try {
-            queryRunner.execute(format(
-                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
-                            "UNION ALL " +
-                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
-                    table));
-            assertUpdate(format(
-                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
-                            "SELECT COUNT(extendedprice) as _count_extprice_, ds, shipmode FROM %s GROUP BY ds, shipmode",
-                    view, table));
-            assertTrue(getQueryRunner().tableExists(getSession(), view));
-            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
-            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+            createPartitionedHavingFixture(table, view,
+                    "SELECT COUNT(extendedprice) as _count_extprice_, ds, shipmode FROM %s GROUP BY ds, shipmode");
 
             String baseQuery = format(
                     "SELECT COUNT(extendedprice) as _count_extprice_, ds, shipmode FROM %s " +
                             "GROUP BY ds, shipmode HAVING COUNT(extendedprice) > 5 ORDER BY ds, shipmode",
                     table);
 
-            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
-            MaterializedResult baseQueryResult = computeActual(baseQuery);
-            assertEquals(optimizedQueryResult, baseQueryResult);
+            assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
         }
         finally {
-            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            dropHavingFixture(table, view);
         }
     }
 
@@ -3764,5 +3693,36 @@ public class TestHiveMaterializedViewLogicalPlanner
             metastore.dropTable(metastoreContext, originalTable.getDatabaseName(), originalTable.getTableName(), false);
             metastore.createTable(metastoreContext, alteredTable, new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()), emptyList());
         }
+    }
+
+    private Session sessionWithMaterializedViewRewrite()
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+    }
+
+    private void createPartitionedHavingFixture(String table, String view, String mvSelectFormat)
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        queryRunner.execute(format(
+                "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                        "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                        "UNION ALL " +
+                        "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                table));
+        assertUpdate(format(
+                "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " + mvSelectFormat,
+                view, table));
+        assertTrue(getQueryRunner().tableExists(getSession(), view));
+        setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+        assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 7);
+        assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-02'", view), 7);
+    }
+
+    private void dropHavingFixture(String table, String view)
+    {
+        getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+        getQueryRunner().execute("DROP TABLE IF EXISTS " + table);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -1351,6 +1351,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     table);
 
             assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
+            assertPlan(session, baseQuery, anyTree(constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             dropHavingFixture(table, view);
@@ -1397,6 +1398,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     table);
 
             assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
+            assertPlan(session, baseQuery, anyTree(constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             dropHavingFixture(table, view);
@@ -1419,6 +1421,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     table);
 
             assertEquals(computeActual(session, baseQuery), computeActual(baseQuery));
+            assertPlan(session, baseQuery, anyTree(constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             dropHavingFixture(table, view);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -535,10 +535,7 @@ public class MaterializedViewQueryOptimizer
                 }
                 expressionsInGroupBy = Optional.of(expressionsInGroupByBuilder.build());
             }
-            // TODO: Add HAVING validation to the validator https://github.com/prestodb/presto/issues/16406
-            if (node.getHaving().isPresent()) {
-                throw new SemanticException(NOT_SUPPORTED, node, "Having clause is not supported in query optimizer");
-            }
+
             if (materializedViewInfo.getWhereClause().isPresent()) {
                 if (!node.getWhere().isPresent()) {
                     throw new IllegalStateException("Query with no where clause is not rewritable by materialized view with where clause");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
@@ -48,10 +48,7 @@ public final class MaterializedViewRewriteQueryShapeValidator
 
         public Optional<String> validateMaterializedViewOptimizationQueryShape(QuerySpecification querySpecification)
         {
-            if (querySpecification.getHaving().isPresent()) {
-                errorMessage = Optional.of("Query shape invalid: HAVING is not supported for materialized view optimizations");
-            }
-            else if (!querySpecification.getFrom().isPresent()) {
+            if (!querySpecification.getFrom().isPresent()) {
                 errorMessage = Optional.of("Query shape invalid: QuerySpecification without from clause is not supported for materialized view optimization");
             }
             else {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -230,6 +230,16 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testHavingOnAggregateRemapped()
+    {
+        String originalViewSql = format("SELECT a as mv_a, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a) FROM %s GROUP BY c HAVING SUM(a) > 10", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(mv_a) FROM %s GROUP BY c HAVING SUM(mv_a) > 10", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testMismatchingColumnTypes()
     {
         // d is registered as bigint- expect optimization to fail

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -210,6 +210,26 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testHavingPreservedThroughRewrite()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a), c FROM %s GROUP BY c HAVING c > 'X'", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(a), c FROM %s GROUP BY c HAVING c > 'X'", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testHavingWithRenamedColumnRemapped()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a), c FROM %s WHERE b < 10 GROUP BY c HAVING c > 'X'", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(mv_a), mv_c as c FROM %s WHERE b < 10 GROUP BY mv_c HAVING mv_c > 'X'", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testMismatchingColumnTypes()
     {
         // d is registered as bigint- expect optimization to fail

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
@@ -42,11 +42,11 @@ public class TestMaterializedViewRewriteQueryShapeValidator
     }
 
     @Test
-    public void havingClause()
+    public void havingClauseAllowed()
     {
-        assertFails(
-                "SELECT SUM(x) AS sum_x, y FROM tbl GROUP BY y HAVING COUNT(x) < 10",
-                "Query shape invalid: HAVING is not supported for materialized view optimizations");
+        assertSucceeds("SELECT SUM(x) AS sum_x, y FROM tbl GROUP BY y HAVING y > 'a'");
+        assertSucceeds("SELECT SUM(x) AS sum_x, y FROM tbl GROUP BY y HAVING COUNT(x) < 10");
+        assertSucceeds("SELECT SUM(x) AS sum_x, y, z FROM tbl GROUP BY y, z HAVING y > 'a' AND SUM(x) > 10");
     }
 
     private static void assertFails(String baseQuerySql, String expectedErrorMessage)


### PR DESCRIPTION
## Description
Allow HAVING in user queries when transparently rewriting onto a materialized view. Drop the rejection in `MaterializedViewRewriteQueryShapeValidator` and `MaterializedViewQueryOptimizer.visitQuerySpecification`.

## Motivation and Context
The rewriter's visit methods already remap columns and aggregates inside HAVING the same way they do for WHERE/SELECT, and plan-level `PredicatePushDown` handles HAVING-to-WHERE pushdown post-planning. The original rejection conflated two distinct problems: HAVING in user queries (always safe) and HAVING in MV definitions (needs filter containment, separately tracked in #16406).

## Impact
Queries with HAVING that previously fell back to scanning the base table can now be rewritten onto a compatible materialized view. No SPI or syntax changes. MV-definition HAVING continues to be rejected.

## Test Plan
Unit and integration tests have been added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Allow HAVING in queries that are transparently rewritten onto a materialized view. 
```

## Summary by Sourcery

Allow queries with HAVING clauses to be eligible for materialized view-based optimization and ensure they are correctly rewritten and validated.

New Features:
- Support materialized view query rewrites for base queries that include HAVING clauses on grouping keys and aggregates.

Enhancements:
- Remove restrictions in the materialized view query optimizer and shape validator that previously rejected HAVING clauses in eligible queries.

Tests:
- Add planner and analyzer tests covering HAVING on grouping keys, aggregates, combinations with WHERE, and COUNT-based predicates to verify correctness of materialized view rewrites.