### PR TITLE
docs(security): Add more details in docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -461,10 +461,41 @@ Property Name                                      Description                  
 File Based Authorization
 ------------------------
 
-The config file is specified using JSON and is composed of three sections,
+The configuration file is specified using JSON and is composed of four sections,
 each of which is a list of rules that are matched in the order specified
 in the config file. The user is granted the privileges from the first
-matching rule. All regexes default to ``.*`` if not specified.
+matching rule. If no rule is specified with file based authorization,
+the user does not have permissions to access any of the tables or schemas, to set
+session properties or run any procedures on the catalog.
+
+All regexes default to ``.*`` if not specified provided the required fields from the
+corresponding sections are specified. For example, user ``guest`` is the owner of all the schemas,
+user ``admin`` has SELECT privilege on all the tables in all the schemas, all the users can set
+``force_local_scheduling`` session property, but no user is allowed
+to run any procedures as per the following JSON.
+
+.. code-block:: json
+
+    {
+      "schemas": [
+        {
+          "user": "guest",
+          "owner": true
+        }
+      ],
+      "tables": [
+        {
+          "user": "admin",
+          "privileges": ["SELECT"]
+        }
+      ],
+      "sessionProperties": [
+        {
+          "property": "force_local_scheduling",
+          "allow": true
+        }
+      ]
+    }
 
 Schema Rules
 ^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2982,10 +2982,41 @@ Property Value                                     Description
 File Based Authorization
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The config file is specified using JSON and is composed of three sections,
+The configuration file is specified using JSON and is composed of four sections,
 each of which is a list of rules that are matched in the order specified
 in the config file. The user is granted the privileges from the first
-matching rule. All regexes default to ``.*`` if not specified.
+matching rule. If no rule is specified with file based authorization,
+the user does not have permissions to access any of the tables or schemas, to set
+session properties or run any procedures on the catalog.
+
+All regexes default to ``.*`` if not specified provided the required fields from the
+corresponding sections are specified. For example, user ``guest`` is the owner of all the schemas,
+user ``admin`` has SELECT privilege on all the tables in all the schemas, all the users can set
+``force_local_scheduling`` session property, but no user is allowed
+to run any procedures as per the following JSON.
+
+.. code-block:: json
+
+    {
+      "schemas": [
+        {
+          "user": "guest",
+          "owner": true
+        }
+      ],
+      "tables": [
+        {
+          "user": "admin",
+          "privileges": ["SELECT"]
+        }
+      ],
+      "sessionProperties": [
+        {
+          "property": "force_local_scheduling",
+          "allow": true
+        }
+      ]
+    }
 
 Schema Rules
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Description
File based authorization had a typo for hive and iceberg connectors. Further, more explanation is added around when the regex are supposed to take their default values with an example.

## Motivation and Context
Make docs more self explaining with examples

## Impact
Docs change

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Clarify and expand security configuration documentation for Hive and Iceberg connectors.

Documentation:
- Fix typos in file-based authorization configuration for Hive and Iceberg connectors.
- Document when security-related regular expression properties take their default values, including an illustrative example.