### PR TITLE
feat(native): Add native_min_shuffle_compression_page_size_bytes session property (#27683)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -67,6 +67,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_MAX_PAGE_PARTITIONING_BUFFER_SIZE = "native_max_page_partitioning_buffer_size";
     public static final String NATIVE_PARTITIONED_OUTPUT_EAGER_FLUSH = "native_partitioned_output_eager_flush";
     public static final String NATIVE_MAX_OUTPUT_BUFFER_SIZE = "native_max_output_buffer_size";
+    public static final String NATIVE_MIN_SHUFFLE_COMPRESSION_PAGE_SIZE_BYTES = "native_min_shuffle_compression_page_size_bytes";
     public static final String NATIVE_QUERY_TRACE_ENABLED = "native_query_trace_enabled";
     public static final String NATIVE_QUERY_TRACE_DIR = "native_query_trace_dir";
     public static final String NATIVE_QUERY_TRACE_NODE_ID = "native_query_trace_node_id";
@@ -346,6 +347,11 @@ public class NativeWorkerSessionPropertyProvider
                         "Native Execution only. If true, the PartitionedOutput operator will flush rows eagerly, without " +
                                 "waiting until buffers reach certain size. Default is false.",
                         false,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_MIN_SHUFFLE_COMPRESSION_PAGE_SIZE_BYTES,
+                        "Native Execution only. Minimum serialized page size in bytes to attempt shuffle compression.",
+                        0,
                         !nativeExecution),
                 integerProperty(
                         NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT,

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
@@ -62,7 +62,9 @@ class BroadcastWriteOperator : public Operator {
         getVectorSerdeOptions(
             common::stringToCompressionKind(
                 ctx->queryConfig().shuffleCompressionKind()),
-            "Presto"),
+            "Presto",
+            std::nullopt,
+            ctx->queryConfig().minShuffleCompressionPageSizeBytes()),
         operatorCtx_->pool());
   }
 

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -372,6 +372,15 @@ SessionProperties::SessionProperties() {
       QueryConfig::kPartitionedOutputEagerFlush,
       "false");
 
+  addSessionProperty(
+      kMinShuffleCompressionPageSizeBytes,
+      "Native Execution only. Minimum serialized page size in bytes to attempt "
+      "shuffle compression.",
+      INTEGER(),
+      false,
+      QueryConfig::kMinShuffleCompressionPageSizeBytes,
+      std::to_string(c.minShuffleCompressionPageSizeBytes()));
+
   // If `legacy_timestamp` is true, the coordinator expects timestamp
   // conversions without a timezone to be converted to the user's
   // session_timezone.

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
@@ -266,6 +266,10 @@ class SessionProperties : public SessionPropertiesProvider {
   static constexpr const char* kShuffleCompressionCodec =
       "exchange_compression_codec";
 
+  /// Minimum serialized page size in bytes to attempt shuffle compression.
+  static constexpr const char* kMinShuffleCompressionPageSizeBytes =
+      "native_min_shuffle_compression_page_size_bytes";
+
   /// If set to true, enables scaled processing for table scans.
   static constexpr const char* kTableScanScaledProcessingEnabled =
       "native_table_scan_scaled_processing_enabled";

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -94,6 +94,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
        core::QueryConfig::kMaxPartitionedOutputBufferSize},
       {SessionProperties::kPartitionedOutputEagerFlush,
        core::QueryConfig::kPartitionedOutputEagerFlush},
+      {SessionProperties::kMinShuffleCompressionPageSizeBytes,
+       core::QueryConfig::kMinShuffleCompressionPageSizeBytes},
       {SessionProperties::kLegacyTimestamp,
        core::QueryConfig::kAdjustTimestampToTimezone},
       {SessionProperties::kDriverCpuTimeSliceLimitMs,


### PR DESCRIPTION
Summary:

Wires the new Velox `min_shuffle_compression_page_size_bytes` property through to a Presto-native session property and the BroadcastWrite operator so users can tune the small-page shuffle-compression skip threshold per query.

Adds:
- `native_min_shuffle_compression_page_size_bytes` Java session property in NativeWorkerSessionPropertyProvider, grouped with the other PartitionedOutput / output-buffer properties.
- Matching constant and addSessionProperty() registration in the Prestissimo SessionProperties (placed near kPartitionedOutputEagerFlush, alongside the other shuffle/output-related session properties).
- Mapping entry in SessionPropertiesTest::validateMapping to keep the Java↔Velox name correspondence asserted.
- BroadcastWrite operator: passes the new threshold through to getVectorSerdeOptions so broadcast shuffle pages also honor the skip behavior.

Default value is 0 (disabled), preserving existing behavior unless the user opts in.

Differential Revision: D100420473


