### PR TITLE
fix: Honor channels parameter in RestSqlFunctionExecutor

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/rest/RestSqlFunctionExecutor.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/rest/RestSqlFunctionExecutor.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.Response;
 import com.facebook.airlift.http.client.ResponseHandler;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.function.SqlFunctionResult;
 import com.facebook.presto.common.type.Type;
@@ -75,7 +76,7 @@ public class RestSqlFunctionExecutor
 {
     private BlockEncodingSerde blockEncodingSerde;
     private static PagesSerde pageSerde;
-    private HttpClient httpClient;
+    private final HttpClient httpClient;
     private final RestBasedFunctionNamespaceManagerConfig restBasedFunctionNamespaceManagerConfig;
     public static final String PRESTO_PAGES = "application/X-presto-pages";
 
@@ -97,7 +98,7 @@ public class RestSqlFunctionExecutor
     {
         checkState(this.blockEncodingSerde == null, "blockEncodingSerde already set");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
-        this.pageSerde = new PagesSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), Optional.empty());
+        pageSerde = new PagesSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
@@ -114,8 +115,14 @@ public class RestSqlFunctionExecutor
         RestFunctionHandle restFunctionHandle = (RestFunctionHandle) functionHandle;
         SqlFunctionId functionId = functionHandle.getFunctionId();
         String functionVersion = functionHandle.getVersion();
-        DynamicSliceOutput sliceOutput = new DynamicSliceOutput((int) input.getRetainedSizeInBytes());
-        writeSerializedPage(sliceOutput, pageSerde.serialize(input));
+
+        Block[] blocks = new Block[channels.size()];
+        for (int i = 0; i < channels.size(); i++) {
+            blocks[i] = input.getBlock(channels.get(i));
+        }
+        Page functionInput = new Page(input.getPositionCount(), blocks);
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput((int) functionInput.getRetainedSizeInBytes());
+        writeSerializedPage(sliceOutput, pageSerde.serialize(functionInput));
         try {
             Request request = preparePost()
                     .setUri(getExecutionEndpoint(restFunctionHandle, functionId, functionVersion))

--- a/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
+++ b/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
@@ -122,6 +122,23 @@ public class TestRestRemoteFunctions
     }
 
     @Test
+    public void testCastArgument()
+    {
+        assertQueryWithSameQueryRunner(
+                "SELECT orderkey, totalprice, rest.default.abs(CAST(totalprice AS bigint)) FROM orders",
+                "SELECT orderkey, totalprice, abs(CAST(totalprice AS bigint)) FROM orders");
+        assertQueryWithSameQueryRunner(
+                "SELECT rest.default.abs(shippriority) FROM orders",
+                "SELECT abs(shippriority) FROM orders");
+        assertQueryWithSameQueryRunner(
+                "SELECT rest.default.floor(CAST(totalprice AS real)) FROM orders",
+                "SELECT floor(CAST(totalprice AS real)) FROM orders");
+        assertQueryWithSameQueryRunner(
+                "SELECT rest.default.length(CAST(comment AS VARBINARY)) FROM orders",
+                "SELECT length(CAST(comment AS VARBINARY)) FROM orders");
+    }
+
+    @Test
     public void testRemoteFunctionAppliedToColumn()
     {
         assertQueryWithSameQueryRunner(

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestRestSqlFunctionExecutor.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestRestSqlFunctionExecutor.java
@@ -232,7 +232,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_ABS_INT),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0),
                 types,
                 returnType);
         assertEquals(returnType.getLong(output.get().getResult(), 0), expected);
@@ -253,7 +253,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_POWER_TOWER_DOUBLE_UPDATED),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0),
                 types,
                 returnType);
         assertEquals(returnType.getDouble(output.get().getResult(), 0), expectedValue);
@@ -274,7 +274,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_BOOL_AND),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0),
                 types,
                 returnType);
 
@@ -285,7 +285,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_BOOL_AND),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0, 1),
                 types,
                 returnType);
 
@@ -308,7 +308,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_REV_STRING),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0),
                 types,
                 returnType);
         assertEquals(returnType.getSlice(output.get().getResult(), 0).toStringUtf8(), expected);
@@ -332,7 +332,7 @@ public class TestRestSqlFunctionExecutor
                 "",
                 createRemoteScalarFunctionImplementation(FUNCTION_ARRAY_SUM),
                 createPage(types, arguments),
-                new ArrayList<>(),
+                List.of(0),
                 types,
                 returnType);
         assertEquals(returnType.getLong(output.get().getResult(), 0), expected);


### PR DESCRIPTION
## Description

#### Bug Fixes:
The executor was serializing the full input page and sending it to the remote function server, ignoring the channels parameter entirely. When a function argument is the result of an expression (e.g. a CAST), its column index in the input page is not 0, so the wrong data was being sent. This aligns the REST implementation with how Thrift and gRPC executors handle channel remapping.
- https://github.com/prestodb/presto/issues/27674
#### Summary
- RestSqlFunctionExecutor was ignoring the channels parameter and sending the entire input Page to the remote function server. The channels list maps function argument positions to column indices in the input page — skipping it meant the wrong columns were sent whenever a function argument was a non-trivial expression (e.g. rest.default.abs(CAST(totalprice AS bigint))).
- Fixed by extracting only the argument blocks via channels before serializing, matching the existing pattern in ThriftSqlFunctionExecutor and GrpcSqlFunctionExecutor.
- Updated unit tests in TestRestSqlFunctionExecutor to pass explicit channel indices instead of empty lists, which masked the bug. 
- Added testCastArgument in TestRestRemoteFunctions to cover the case where the function argument is not at column 0 of the input page.

## Motivation and Context
https://github.com/prestodb/presto/issues/27674

## Impact
Bugfix
 
## Test Plan
- TestRestSqlFunctionExecutor — executor unit tests with explicit channel mappings
- TestRestRemoteFunctions#testCastArgument — end-to-end queries with CAST arguments against a real REST function server

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```
## Summary by Sourcery

Honor channel mappings when executing REST remote SQL functions and add coverage for non-trivial argument expressions.

Bug Fixes:
- Ensure RestSqlFunctionExecutor serializes only the argument blocks specified by the channels mapping instead of the full input page, preventing misaligned arguments for non-trivial expressions.
- Make RestSqlFunctionExecutor tests pass explicit channel indices so they no longer mask incorrect handling of function arguments.

Tests:
- Expand TestRestRemoteFunctions with scenarios where REST functions receive casted and non-leading columns to verify parity with built-in functions.
- Update TestRestSqlFunctionExecutor to assert behavior with concrete channel mappings for single- and multi-argument REST functions.

## Summary by Sourcery

Honor channel mappings when serializing input for REST SQL function execution and add coverage for casted and non-zero-index arguments.

Bug Fixes:
- Ensure RestSqlFunctionExecutor serializes only the blocks referenced by the channels list so REST remote functions receive the correct argument columns.

Tests:
- Update RestSqlFunctionExecutor unit tests to pass explicit channel indices instead of empty lists.
- Add REST remote function integration tests covering casted arguments and non-zero-index input columns.