### PR TITLE
fix: Change error tagging from internal error to user error

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/DataTypeMismatchException.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/DataTypeMismatchException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+/**
+ * Thrown when two operands have incompatible types, in modules (such as
+ * {@code presto-common}) that cannot depend on {@code presto-spi}. {@link
+ * com.facebook.presto.util.Failures#toErrorCode} translates this to
+ * {@link com.facebook.presto.spi.StandardErrorCode#DATATYPE_MISMATCH}.
+ */
+public class DataTypeMismatchException
+        extends RuntimeException
+{
+    public DataTypeMismatchException(String message)
+    {
+        super(message);
+    }
+
+    public DataTypeMismatchException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -170,7 +171,7 @@ public class AllOrNoneValueSet
     private AllOrNoneValueSet checkCompatibility(ValueSet other)
     {
         if (!getType().equals(other.getType())) {
-            throw new IllegalArgumentException(String.format("Mismatched types: %s vs %s", getType(), other.getType()));
+            throw new DataTypeMismatchException(String.format("Mismatched types: %s vs %s", getType(), other.getType()));
         }
         if (!(other instanceof AllOrNoneValueSet)) {
             throw new IllegalArgumentException(String.format("ValueSet is not a AllOrNoneValueSet: %s", other.getClass()));

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -226,10 +227,10 @@ public final class Domain
     private void checkCompatibility(Domain domain)
     {
         if (!getType().equals(domain.getType())) {
-            throw new IllegalArgumentException(String.format("Mismatched Domain types: %s vs %s", getType(), domain.getType()));
+            throw new DataTypeMismatchException(String.format("Mismatched Domain types: %s vs %s", getType(), domain.getType()));
         }
         if (values.getClass() != domain.values.getClass()) {
-            throw new IllegalArgumentException(String.format("Mismatched Domain value set classes: %s vs %s", values.getClass(), domain.values.getClass()));
+            throw new DataTypeMismatchException(String.format("Mismatched Domain value set classes: %s vs %s", values.getClass(), domain.values.getClass()));
         }
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/EquatableValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/EquatableValueSet.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.Utils;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
@@ -289,7 +290,7 @@ public class EquatableValueSet
     private EquatableValueSet checkCompatibility(ValueSet other)
     {
         if (!getType().equals(other.getType())) {
-            throw new IllegalStateException(String.format("Mismatched types: %s vs %s", getType(), other.getType()));
+            throw new DataTypeMismatchException(String.format("Mismatched types: %s vs %s", getType(), other.getType()));
         }
         if (!(other instanceof EquatableValueSet)) {
             throw new IllegalStateException(String.format("ValueSet is not a EquatableValueSet: %s", other.getClass()));

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -353,7 +354,7 @@ public final class SortedRangeSet
     private SortedRangeSet checkCompatibility(ValueSet other)
     {
         if (!getType().equals(other.getType())) {
-            throw new IllegalStateException(format("Mismatched types: %s vs %s", getType(), other.getType()));
+            throw new DataTypeMismatchException(format("Mismatched types: %s vs %s", getType(), other.getType()));
         }
         if (!(other instanceof SortedRangeSet)) {
             throw new IllegalStateException(format("ValueSet is not a SortedRangeSet: %s", other.getClass()));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2517,9 +2517,11 @@ public class HiveMetadata
                         .orElseThrow(() -> new TableNotFoundException(baseTableName)))
                 .collect(toImmutableList());
 
-        baseTables.forEach(table -> checkState(
-                table.getTableType().equals(MANAGED_TABLE),
-                format("base table %s is not a managed table", table.getTableName())));
+        baseTables.forEach(table -> {
+            if (!table.getTableType().equals(MANAGED_TABLE)) {
+                throw new PrestoException(NOT_SUPPORTED, format("base table %s is not a managed table", table.getTableName()));
+            }
+        });
 
         Table materializedViewTable = metastore.getTable(metastoreContext, materializedViewName.getSchemaName(), materializedViewName.getTableName())
                 .orElseThrow(() -> new MaterializedViewNotFoundException(materializedViewName));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeWithName;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -44,9 +45,9 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -172,8 +173,12 @@ public final class ExpressionTreeUtils
 
     public static FieldId checkAndGetColumnReferenceField(Expression expression, Multimap<NodeRef<Expression>, FieldId> columnReferences)
     {
-        checkState(columnReferences.containsKey(NodeRef.of(expression)), "Missing field reference for expression");
-        checkState(columnReferences.get(NodeRef.of(expression)).size() == 1, "Multiple field references for expression");
+        if (!columnReferences.containsKey(NodeRef.of(expression))) {
+            throw new PrestoException(INVALID_ARGUMENTS, "Missing field reference for expression");
+        }
+        if (columnReferences.get(NodeRef.of(expression)).size() != 1) {
+            throw new PrestoException(INVALID_ARGUMENTS, "Multiple field references for expression");
+        }
 
         return columnReferences.get(NodeRef.of(expression)).iterator().next();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -252,6 +252,7 @@ import static com.facebook.presto.execution.CallTask.extractParameterValuesInOrd
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.MetadataUtil.getConnectorIdOrThrow;
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
+import static com.facebook.presto.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.DATATYPE_MISMATCH;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_COLUMN_MASK;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_ROW_FILTER;
@@ -2258,7 +2259,9 @@ class StatementAnalyzer
                         false);
                 fields.add(field);
                 ColumnHandle columnHandle = columnHandles.get(column.getName());
-                checkArgument(columnHandle != null, "Unknown field %s", field);
+                if (columnHandle == null) {
+                    throw new PrestoException(COLUMN_NOT_FOUND, format("Unknown field %s", field));
+                }
                 analysis.setColumn(field, columnHandle);
                 analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, column.getName())));
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -1129,7 +1129,7 @@ public class ExpressionInterpreter
             Object value = process(node.getExpression(), context);
             Type targetType = metadata.getType(parseTypeSignature(node.getType()));
             if (targetType == null) {
-                throw new IllegalArgumentException("Unsupported type: " + node.getType());
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported type: " + node.getType());
             }
 
             if (value == null) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -28,6 +28,7 @@ import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
@@ -103,6 +104,7 @@ import static com.facebook.presto.common.Subfield.structureOnly;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
@@ -379,7 +381,9 @@ public class PushdownSubfields
 
                 List<Subfield> subfields = context.get().findSubfields(variable.getName());
 
-                verify(!subfields.isEmpty(), "Missing variable: " + variable);
+                if (subfields.isEmpty()) {
+                    throw new PrestoException(INVALID_ARGUMENTS, "Missing variable: " + variable);
+                }
 
                 String columnName = getColumnName(session, metadata, node.getTable(), entry.getValue());
 
@@ -433,7 +437,9 @@ public class PushdownSubfields
 
                 List<Subfield> subfields = context.get().findSubfields(variable.getName());
 
-                verify(!subfields.isEmpty(), "Missing variable: " + variable);
+                if (subfields.isEmpty()) {
+                    throw new PrestoException(INVALID_ARGUMENTS, "Missing variable: " + variable);
+                }
 
                 String columnName = getColumnName(session, metadata, node.getTableHandle(), entry.getValue());
 
@@ -1083,7 +1089,9 @@ public class PushdownSubfields
                 }
 
                 List<Subfield> matchingSubfields = findSubfields(variable.getName());
-                verify(!matchingSubfields.isEmpty(), "Missing variable: " + variable);
+                if (matchingSubfields.isEmpty()) {
+                    throw new PrestoException(INVALID_ARGUMENTS, "Missing variable: " + variable);
+                }
 
                 matchingSubfields.stream()
                         .map(Subfield::getPath)
@@ -1099,7 +1107,9 @@ public class PushdownSubfields
                 }
 
                 List<Subfield> matchingSubfields = findSubfields(variable.getName());
-                verify(!matchingSubfields.isEmpty(), "Missing variable: " + variable);
+                if (matchingSubfields.isEmpty()) {
+                    throw new PrestoException(INVALID_ARGUMENTS, "Missing variable: " + variable);
+                }
 
                 matchingSubfields.stream()
                         .map(Subfield::getPath)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -29,6 +29,7 @@ import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.UnknownType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -129,6 +130,7 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.metadata.CastType.CAST;
 import static com.facebook.presto.metadata.CastType.TRY_CAST;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.BIND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
@@ -393,7 +395,7 @@ public final class SqlToRowExpressionTranslator
                 type = functionAndTypeResolver.getType(parseTypeSignature(node.getType()));
             }
             catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Unsupported type: " + node.getType());
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported type: " + node.getType());
             }
 
             return constant(node.getValue(), type);
@@ -407,7 +409,7 @@ public final class SqlToRowExpressionTranslator
                 type = functionAndTypeResolver.getType(parseTypeSignature(node.getType()));
             }
             catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Unsupported type: " + node.getType());
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported type: " + node.getType());
             }
 
             try {

--- a/presto-main-base/src/main/java/com/facebook/presto/util/Failures.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/util/Failures.java
@@ -15,6 +15,7 @@ package com.facebook.presto.util;
 
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.client.ErrorLocation;
+import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.common.InvalidTypeDefinitionException;
 import com.facebook.presto.execution.ExecutionFailureInfo;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.spi.ErrorCause.UNKNOWN;
+import static com.facebook.presto.spi.StandardErrorCode.DATATYPE_MISMATCH;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TYPE_DEFINITION;
 import static com.facebook.presto.spi.StandardErrorCode.SLICE_TOO_LARGE;
@@ -174,6 +176,10 @@ public final class Failures
 
         if (throwable instanceof InvalidTypeDefinitionException) {
             return INVALID_TYPE_DEFINITION.toErrorCode();
+        }
+
+        if (throwable instanceof DataTypeMismatchException) {
+            return DATATYPE_MISMATCH.toErrorCode();
         }
 
         if (throwable instanceof PrestoException) {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

```
  ┌─────┬────-──────────────────────┬───────────────────────────────────┬───────────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐                   
  │  #  │     Message pattern       │               File                │                      Before                       │                           After                            │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                   
  │ 07  │ Mismatched Domain types   │ Domain.java                       │ IllegalArgumentException → GENERIC_INTERNAL_ERROR │ DataTypeMismatchException → DATATYPE_MISMATCH (USER_ERROR) │                   
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                   
  │ 07  │ Mismatched types          │ SortedRangeSet.java               │ IllegalStateException → GENERIC_INTERNAL_ERROR    │ DataTypeMismatchException → DATATYPE_MISMATCH (USER_ERROR) │                 
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 07  │ Mismatched types          │ EquatableValueSet.java            │ IllegalStateException → GENERIC_INTERNAL_ERROR    │ DataTypeMismatchException → DATATYPE_MISMATCH (USER_ERROR) │                 
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 07  │ Mismatched types          │ AllOrNoneValueSet.java            │ IllegalArgumentException → GENERIC_INTERNAL_ERROR │ DataTypeMismatchException → DATATYPE_MISMATCH (USER_ERROR) │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 15  │ Unsupported type          │ ExpressionInterpreter.java        │ IllegalArgumentException → GENERIC_INTERNAL_ERROR │ PrestoException → NOT_SUPPORTED (USER_ERROR)               │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 15  │ Unsupported type (x2)     │ SqlToRowExpressionTranslator.java │ IllegalArgumentException → GENERIC_INTERNAL_ERROR │ PrestoException → NOT_SUPPORTED (USER_ERROR)               │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 16  │ is not a managed table    │ HiveMetadata.java                 │ IllegalStateException → GENERIC_INTERNAL_ERROR    │ PrestoException → NOT_SUPPORTED (USER_ERROR)               │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 35  │ Unknown field             │ StatementAnalyzer.java            │ IllegalArgumentException → GENERIC_INTERNAL_ERROR │ PrestoException → COLUMN_NOT_FOUND (USER_ERROR)            │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 38  │ Missing variable (x4)     │ PushdownSubfields.java            │ VerifyException → GENERIC_INTERNAL_ERROR          │ PrestoException → INVALID_ARGUMENTS (USER_ERROR)           │
  ├─────┼───────────────────────────┼───────────────────────────────────┼───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤                 
  │ 40  │ Multiple field references │ ExpressionTreeUtils.java          │ IllegalStateException → GENERIC_INTERNAL_ERROR    │ PrestoException → INVALID_ARGUMENTS (USER_ERROR)           │
  └─────┴───────────────────────────┴───────────────────────────────────┴───────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘  
  ```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
as above

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

error code correction

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adjust error classification to map specific user input issues to appropriate user-facing error codes instead of generic internal errors.

Bug Fixes:
- Report data type mismatches in predicate and domain/value set operations using a dedicated DataTypeMismatchException mapped to the DATATYPE_MISMATCH user error code.
- Return NOT_SUPPORTED user errors for unsupported types in expression interpretation and SQL-to-row-expression translation, and for non-managed base tables in Hive materialized views.
- Return COLUMN_NOT_FOUND user errors when a referenced field is missing during statement analysis instead of treating it as an internal error.
- Return INVALID_ARGUMENTS user errors for missing variables in subfield pushdown and for multiple field references in expression analysis instead of internal verification failures.

Enhancements:
- Introduce a reusable DataTypeMismatchException in presto-common and wire it into centralized failure handling to translate it to the DATATYPE_MISMATCH error code.