### PR TITLE
fix(plugin-hive): Write table statistics inline during CREATE TABLE with NOT NULL constraints

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1416,14 +1416,16 @@ public class SemiTransactionalHiveMetastore
                     }
                 }
             }
-            addTableOperations.add(new CreateTableOperation(metastoreContext, table, tableAndMore.getPrincipalPrivileges(), tableAndMore.isIgnoreExisting(), tableAndMore.getConstraints()));
-            if (!isPrestoView(table)) {
-                updateStatisticsOperations.add(new UpdateStatisticsOperation(metastoreContext,
-                        table.getSchemaTableName(),
-                        Optional.empty(),
-                        tableAndMore.getStatisticsUpdate(),
-                        false));
-            }
+            // Statistics are written inline by CreateTableOperation to avoid a race with constraint registration.
+            // HMS constraint additions trigger an internal alter_table call that can invalidate the thrift
+            // connection before a deferred UpdateStatisticsOperation runs.
+            addTableOperations.add(new CreateTableOperation(
+                    metastoreContext,
+                    table,
+                    tableAndMore.getPrincipalPrivileges(),
+                    tableAndMore.isIgnoreExisting(),
+                    tableAndMore.getConstraints(),
+                    tableAndMore.getStatisticsUpdate()));
         }
 
         private void prepareInsertExistingTable(MetastoreContext metastoreContext, HdfsContext context, TableAndMore tableAndMore)
@@ -1669,6 +1671,11 @@ public class SemiTransactionalHiveMetastore
         {
             for (CreateTableOperation addTableOperation : addTableOperations) {
                 addTableOperation.run(delegate);
+                // Write statistics inline in the same execution phase as table creation,
+                // before executeUpdateStatisticsOperations() runs for existing tables.
+                // This avoids a race condition where HMS constraint registration invalidates
+                // the thrift connection before deferred statistics writes can complete.
+                addTableOperation.writeStatistics(delegate);
             }
         }
 
@@ -2782,8 +2789,15 @@ public class SemiTransactionalHiveMetastore
         private final String queryId;
         private final MetastoreContext metastoreContext;
         private Optional<MetastoreOperationResult> operationResult;
+        private final PartitionStatistics statisticsUpdate;
 
-        public CreateTableOperation(MetastoreContext metastoreContext, Table newTable, PrincipalPrivileges privileges, boolean ignoreExisting, List<TableConstraint<String>> constraints)
+        public CreateTableOperation(
+                MetastoreContext metastoreContext,
+                Table newTable,
+                PrincipalPrivileges privileges,
+                boolean ignoreExisting,
+                List<TableConstraint<String>> constraints,
+                PartitionStatistics statisticsUpdate)
         {
             requireNonNull(newTable, "newTable is null");
             this.metastoreContext = requireNonNull(metastoreContext, "identity is null");
@@ -2793,6 +2807,7 @@ public class SemiTransactionalHiveMetastore
             this.constraints = requireNonNull(constraints, "constraints is null");
             this.queryId = getPrestoQueryId(newTable).orElseThrow(() -> new IllegalArgumentException("Query id is not present"));
             this.operationResult = Optional.empty();
+            this.statisticsUpdate = requireNonNull(statisticsUpdate, "statisticsUpdate is null");
         }
 
         public String getDescription()
@@ -2815,7 +2830,6 @@ public class SemiTransactionalHiveMetastore
             boolean done = false;
             try {
                 operationResult = Optional.of(metastore.createTable(metastoreContext, newTable, privileges, constraints));
-                done = true;
             }
             catch (RuntimeException e) {
                 try {
@@ -2853,6 +2867,22 @@ public class SemiTransactionalHiveMetastore
                 }
             }
             tableCreated = true;
+        }
+
+        public void writeStatistics(ExtendedHiveMetastore metastore)
+        {
+            if (!tableCreated || isPrestoView(newTable)) {
+                return;
+            }
+            // Write statistics on the same connection immediately after table creation.
+            // Deferring this to UpdateStatisticsOperation is unsafe when constraints are present:
+            // HMS registers NOT NULL constraints via an internal alter_table, which invalidates the thrift
+            // connection state and causes the deferred write to fail with TableNotFoundException.
+            metastore.updateTableStatistics(
+                    metastoreContext,
+                    newTable.getDatabaseName(),
+                    newTable.getTableName(),
+                    ignored -> statisticsUpdate);
         }
 
         private boolean hasTheSameSchema(Table newTable, Table existingTable)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2979,6 +2979,48 @@ public abstract class AbstractTestHiveClient
     }
 
     @Test
+    public void testCreateTableWithNotNullConstraintInitializesStatistics()
+            throws Exception
+    {
+        SchemaTableName tableName = temporaryTable("create_not_null_stats");
+        try {
+            // Create table with NOT NULL constraint
+            List<ColumnMetadata> columns = ImmutableList.of(
+                    ColumnMetadata.builder().setName("c_custkey").setType(BIGINT).setNullable(false).build());
+
+            ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(
+                    tableName,
+                    columns,
+                    createTableProperties(TEXTFILE));
+
+            try (Transaction transaction = newTransaction()) {
+                ConnectorSession session = newSession();
+                ConnectorMetadata metadata = transaction.getMetadata();
+                metadata.createTable(session, tableMetadata, false);
+                transaction.commit();
+            }
+
+            // Verify statistics are initialized immediately after table creation.
+            // Regression test: metastore constraint registration can invalidate
+            // the connection before statistics are written.
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
+            PartitionStatistics stats = metastoreClient.getTableStatistics(
+                    METASTORE_CONTEXT,
+                    tableName.getSchemaName(),
+                    tableName.getTableName());
+
+            // Table was just created with no data — row count should be 0, not unknown
+            assertTrue(stats.getBasicStatistics().getRowCount().isPresent(),
+                    "Row count should be present after CREATE TABLE with NOT NULL constraints");
+            assertEquals(stats.getBasicStatistics().getRowCount().getAsLong(), 0L,
+                    "Row count should be 0 for newly created empty table");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testTableCreationIgnoreExisting()
     {
         List<Column> columns = ImmutableList.of(new Column("dummy", HiveType.valueOf("uniontype<smallint,tinyint>"), Optional.empty(), Optional.empty()));


### PR DESCRIPTION
## Description

CREATE TABLE` with `NOT NULL` constraints fails with `TableNotFoundException` on the Hive connector.

**Root cause:** In WXD Hive Metastore implementation, NOT NULL constraints are processed via a separate internal `alter_table` call on the HMS server side after the initial table creation. The deferred `UpdateStatisticsOperation` runs after `executeAddTableOperations()` completes but during the window when HMS is still executing this internal `alter_table`. A fresh `get_table` call issued by `UpdateStatisticsOperation` during this
window returns `TableNotFoundException`, causing the entire transaction to roll back.

**Fix:** Write table statistics inline within `CreateTableOperation`, immediately after `createTable()` returns, before any constraint-driven HMS `alter_table` can open this timing window. Statistics are written in the same `executeAddTableOperations()` loop via a separate `writeStatistics()` method, keeping `CreateTableOperation` single-purpose and independently testable.

Tables without constraints are unaffected, the statistics write is semantically equivalent to the previous deferred write for newly created empty tables.

## Impact
Users can now create Hive tables with `NOT NULL` constraints without encountering `TableNotFoundException` errors.

## Test Plan
Tested via Presto-CLI

**Before fix:**
```sql
presto> CREATE TABLE hive_data.test_hive.tab1 (
    ->     c_custkey bigint NOT NULL
    -> );
Query 20260410_074001_00323_brxgg failed: Table 'test_hive.tab1' not found
```

**After fix:**
```sql
presto> CREATE TABLE hive_data.test_hive.tab1 (
    ->     c_custkey bigint NOT NULL
    -> );
CREATE TABLE
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix `CREATE TABLE` failure when using `NOT NULL` constraints. Statistics are now written inline during table creation to prevent race conditions with HMS constraint registration.
```

## Summary by Sourcery

Handle Hive table statistics initialization inline during table creation to avoid failures when NOT NULL constraints are present.

Bug Fixes:
- Prevent TableNotFoundException when creating Hive tables with NOT NULL constraints by writing table statistics on the same metastore connection immediately after table creation.

Enhancements:
- Refine CreateTableOperation to accept and apply initial table statistics directly instead of relying on a deferred UpdateStatisticsOperation.