### PR TITLE
[DNR]feat(plugin-clickhouse) : Enable jdbc-fetch-size 

### DIFF
--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseClient.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseClient.java
@@ -98,6 +98,7 @@ public class ClickHouseClient
     protected final Cache<ClickHouseIdentity, Map<String, String>> remoteSchemaNames;
     protected final Cache<RemoteTableNameCacheKey, Map<String, String>> remoteTableNames;
     protected final boolean caseSensitiveNameMatchingEnabled;
+    private final int fetchSize;
 
     private final boolean mapStringAsVarchar;
 
@@ -110,6 +111,7 @@ public class ClickHouseClient
         this.commitBatchSize = config.getCommitBatchSize();
         this.mapStringAsVarchar = config.isMapStringAsVarchar();
         this.caseSensitiveEnabled = config.isCaseInsensitiveNameMatching();
+        this.fetchSize = config.getFetchSize();
         CacheBuilder<Object, Object> remoteNamesCacheBuilder = CacheBuilder.newBuilder()
                 .expireAfterWrite(config.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS);
         this.remoteSchemaNames = remoteNamesCacheBuilder.build();
@@ -223,7 +225,9 @@ public class ClickHouseClient
     public PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException
     {
-        return connection.prepareStatement(sql);
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
     }
 
     public PreparedStatement buildSql(ConnectorSession session, Connection connection, ClickHouseSplit split, List<ClickHouseColumnHandle> columnHandles)
@@ -330,11 +334,13 @@ public class ClickHouseClient
     {
         DatabaseMetaData metadata = connection.getMetaData();
         Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
-        return metadata.getTables(
+        ResultSet resultSet = metadata.getTables(
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, escape).orElse(null),
                 escapeNamePattern(tableName, escape).orElse(null),
                 new String[] {"TABLE", "VIEW"});
+        resultSet.setFetchSize(fetchSize);
+        return resultSet;
     }
 
     private static ResultSet getColumns(ClickHouseTableHandle tableHandle, DatabaseMetaData metadata)

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseConfig.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseConfig.java
@@ -19,6 +19,7 @@ import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import com.facebook.airlift.units.Duration;
 import com.facebook.airlift.units.MinDuration;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -36,6 +37,8 @@ public class ClickHouseConfig
     private boolean allowDropTable;
     private int commitBatchSize;
     private boolean caseSensitiveNameMatchingEnabled;
+    @Min(1)
+    private int fetchSize = 20000;
 
     @NotNull
     public String getConnectionUrl()
@@ -186,6 +189,19 @@ public class ClickHouseConfig
     public ClickHouseConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatchingEnabled)
     {
         this.caseSensitiveNameMatchingEnabled = caseSensitiveNameMatchingEnabled;
+        return this;
+    }
+
+    public int getFetchSize()
+    {
+        return fetchSize;
+    }
+
+    @Config("jdbc-fetch-size")
+    @ConfigDescription("Number of rows to fetch from the database at a time")
+    public ClickHouseConfig setFetchSize(int fetchSize)
+    {
+        this.fetchSize = fetchSize;
         return this;
     }
 }

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseConfig.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseConfig.java
@@ -36,6 +36,7 @@ public class TestClickHouseConfig
     private static final String allowDropTable = "clickhouse.allow-drop-table";
     private static final String commitBatchSize = "clickhouse.commitBatchSize";
     private static final String caseSensitiveNameMatching = "case-sensitive-name-matching";
+    private static final String jdbcFetchSize = "jdbc-fetch-size";
 
     @Test
     public void testDefaults()
@@ -51,7 +52,8 @@ public class TestClickHouseConfig
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setMapStringAsVarchar(false)
                 .setCommitBatchSize(0)
-                .setCaseSensitiveNameMatching(false));
+                .setCaseSensitiveNameMatching(false)
+                .setFetchSize(20000));
     }
 
     @Test
@@ -69,6 +71,7 @@ public class TestClickHouseConfig
                 .put(allowDropTable, "true")
                 .put(commitBatchSize, "1000")
                 .put(caseSensitiveNameMatching, "true")
+                .put(jdbcFetchSize, "5000")
                 .build();
 
         ClickHouseConfig expected = new ClickHouseConfig()
@@ -82,7 +85,8 @@ public class TestClickHouseConfig
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
                 .setMapStringAsVarchar(true)
                 .setCaseSensitiveNameMatching(true)
-                .setCommitBatchSize(1000);
+                .setCommitBatchSize(1000)
+                .setFetchSize(5000);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add configurable JDBC fetch size support to the ClickHouse connector and apply it to query and metadata retrieval.

New Features:
- Introduce a jdbc-fetch-size configuration option for the ClickHouse connector with a default value of 20000 rows, used when fetching query and metadata results.

Tests:
- Extend ClickHouse configuration tests to cover the new jdbc-fetch-size property defaults and explicit mappings.