### PR TITLE
chore(ci): Cleanup permission settings

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -2,9 +2,6 @@ name: arrow flight tests
 
 on: pull_request
 
-permissions:
-  contents: read
-
 env:
   CONTINUOUS_INTEGRATION: true
   MAVEN_OPTS: -Xmx1024M -XX:+ExitOnOutOfMemoryError
@@ -34,6 +31,8 @@ jobs:
   arrowflight-java-tests:
     runs-on: ubuntu-latest
     needs: changes
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +104,7 @@ jobs:
       DEPENDENCY_DIR: "${{ github.workspace }}/adapter-deps/download"
       INSTALL_PREFIX: "${{ github.workspace }}/adapter-deps/install"
     permissions:
+      contents: read
       actions: write
     steps:
       # We cannot use the github action to free disk space from the runner
@@ -219,6 +219,8 @@ jobs:
   arrowflight-native-e2e-tests:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
       volumes:

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,6 +1,5 @@
 name: Maven OWASP Dependency Check
-permissions:
-  contents: read
+
 on:
   pull_request: {}
   workflow_dispatch:
@@ -16,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     # Required permissions
     permissions:
+      contents: read
       pull-requests: read
     # Set job outputs to values from filter step
     outputs:
@@ -34,6 +34,8 @@ jobs:
   dependency-check:
     needs: changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
The reocmmendation is to set permissions at job level and not globally at the workflow level.
The content: read permission is needed for the
github checkout action.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Scope GitHub Actions permissions to individual jobs instead of the entire workflow for arrow flight and OWASP dependency check workflows.

CI:
- Move contents: read permission from workflow-level to job-level in arrow flight tests workflow.
- Set contents: read permission on specific jobs in the OWASP dependency check workflow.