### PR TITLE
feat: Add configurable JDBC fetch size support for SQL server

### DIFF
--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -28,7 +28,11 @@ import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import jakarta.inject.Inject;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.lang.String.format;
@@ -38,11 +42,37 @@ public class SqlServerClient
         extends BaseJdbcClient
 {
     private static final Joiner DOT_JOINER = Joiner.on(".");
+    private final int fetchSize;
 
     @Inject
     public SqlServerClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
     {
         super(connectorId, config, "\"", new DriverConnectionFactory(new SQLServerDriver(), config));
+        this.fetchSize = config.getFetchSize();
+    }
+
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        String escape = metadata.getSearchStringEscape();
+        ResultSet resultSet = metadata.getTables(
+                connection.getCatalog(),
+                escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
+                escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
+                new String[] {"TABLE", "VIEW"});
+        resultSet.setFetchSize(fetchSize);
+        return resultSet;
+    }
+
+    @Override
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
+            throws SQLException
+    {
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
     }
 
     @Override


### PR DESCRIPTION
## Description

Add configurable JDBC fetch size support for SQL server

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add configurable JDBC fetch size support for SQL server