### PR TITLE
fix: Take 'finishingTime' and 'planningTime' out of 'executionTime' (#27691)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateTimer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateTimer.java
@@ -41,23 +41,23 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 //    Dispatching                                                                                   -----------
 //        |                                                                                         | dispatchingTime
 //        V                                                                                         V
-//     Planning                                                                                     ----------------------------------
-//        |                                                                                         | executionTime     | planningTime
-//        |      Analysis Start                                                                     |                   |        -----------
-//        |         |                                                                               |                   |        | analysisTime
-//        |         V                                                                               |                   |        V
-//        |      Analysis End                                                                       |                   |        -----------
-//        V                                                                                         |                   V
-//     Starting                                                                                     |                   -----------
+//     Planning                                                                                     -----------
+//        |                                                                                         | planningTime
+//        |      Analysis Start                                                                     |        -----------
+//        |         |                                                                               |        | analysisTime
+//        |         V                                                                               |        V
+//        |      Analysis End                                                                       |        -----------
+//        V                                                                                         V
+//     Starting                                                                                     -----------
+//        |
+//        V                                                                                         -----------
+//     Running                                                                                      | executionTime
 //        |                                                                                         |
-//        V                                                                                         |
-//     Running                                                                                      |
-//        |                                                                                         |
-//        V                                                                                         |
-//    Finishing                                                                                     |                   -----------
-//        |                                                                                         |                   | finishingTime
-//        V                                                                                         V                   V
-//       End                                                                                        ----------------------------------
+//        V                                                                                         V
+//    Finishing                                                                                      -----------
+//        |                                                                                         | finishingTime
+//        V                                                                                         V
+//       End                                                                                        -----------
 public class QueryStateTimer
 {
     private final Ticker ticker;
@@ -71,6 +71,7 @@ public class QueryStateTimer
     private final AtomicReference<Long> beginColumnAccessPermissionCheckingNanos = new AtomicReference<>();
     private final AtomicReference<Long> beginDispatchingNanos = new AtomicReference<>();
     private final AtomicReference<Long> beginPlanningNanos = new AtomicReference<>();
+    private final AtomicReference<Long> beginRunningNanos = new AtomicReference<>();
     private final AtomicReference<Long> beginFinishingNanos = new AtomicReference<>();
     private final AtomicReference<Long> endNanos = new AtomicReference<>();
 
@@ -199,6 +200,7 @@ public class QueryStateTimer
     private void beginRunning(long now)
     {
         beginStarting(now);
+        beginRunningNanos.compareAndSet(null, now);
     }
 
     public void beginFinishing()
@@ -210,6 +212,7 @@ public class QueryStateTimer
     {
         beginRunning(now);
         beginFinishingNanos.compareAndSet(null, now);
+        executionTime.compareAndSet(null, nanosSince(beginRunningNanos, now));
     }
 
     public void endQuery()
@@ -221,7 +224,6 @@ public class QueryStateTimer
     {
         beginFinishing(now);
         finishingTime.compareAndSet(null, nanosSince(beginFinishingNanos, now));
-        executionTime.compareAndSet(null, nanosSince(beginPlanningNanos, now));
         endNanos.compareAndSet(null, now);
     }
 
@@ -255,7 +257,7 @@ public class QueryStateTimer
 
     public long getExecutionStartTimeInMillis()
     {
-        return toMillis(beginPlanningNanos);
+        return toMillis(beginRunningNanos);
     }
 
     public Duration getElapsedTime()
@@ -314,7 +316,7 @@ public class QueryStateTimer
 
     public Duration getExecutionTime()
     {
-        return getDuration(executionTime, beginPlanningNanos);
+        return getDuration(executionTime, beginRunningNanos);
     }
 
     public long getEndTimeInMillis()

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -396,8 +396,8 @@ public class TestQueryStateMachine
         assertEquals(queryStats.getTotalPlanningTime().toMillis(), 200);
         // there is no way to induce finishing time without a transaction and connector
         assertEquals(queryStats.getFinishingTime().toMillis(), 0);
-        // query execution time is starts when query transitions to planning
-        assertEquals(queryStats.getExecutionTime().toMillis(), 900);
+        // query execution time starts when query transitions to running
+        assertEquals(queryStats.getExecutionTime().toMillis(), 400);
     }
 
     @Test
@@ -575,7 +575,7 @@ public class TestQueryStateMachine
         assertNotNull(queryStats.getFinishingTime());
 
         assertTrue(queryStats.getCreateTimeInMillis() > 0);
-        if (queryInfo.getState() == WAITING_FOR_PREREQUISITES || queryInfo.getState() == QUEUED || queryInfo.getState() == WAITING_FOR_RESOURCES || queryInfo.getState() == DISPATCHING) {
+        if (queryInfo.getState() == WAITING_FOR_PREREQUISITES || queryInfo.getState() == QUEUED || queryInfo.getState() == WAITING_FOR_RESOURCES || queryInfo.getState() == DISPATCHING || queryInfo.getState() == PLANNING || queryInfo.getState() == STARTING) {
             assertEquals(queryStats.getExecutionStartTimeInMillis(), 0L);
         }
         else {


### PR DESCRIPTION
Summary:

The 'finishingTime' and 'planningTime' are the parts of the 'executionTime' at the moment, which can be confusing for some queries that write thousands of partitions, where execution time can be 1 min and the finishing time 10 mins.
This small change ensures that 'executionTime' covers the execution stage only.
Note that we report 'finishingTime' and 'planningTime' separately.

Reviewed By: shelton408

Differential Revision: D103259171

  ```                                                                                                                                     
  == RELEASE NOTES ==                        
                                                                                                                                          
  General Changes                            
  * Fix 'planningTime' and 'finishingTime' are no longer added to the 'executionTime'. 'executionTime' is now a true execution time - how long
   it took the query to run the compute. It can be used to measure the efficiency of the workers w/o added planning time or the time spent
   on final steps, like partition registration.
  ```   



