### PR TITLE
docs(security): Improve authentication docs

### DIFF
--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -41,7 +41,7 @@ the following example `keytool` command to import the certificate
 
     $ keytool -import -keystore <JAVA_HOME>/jre/lib/security/cacerts -trustcacerts -alias ldap_server -file ldap_server.crt
 
-In addition to this, access to the Presto coordinator should be
+In addition to this, access to the Presto coordinator from any Presto client should be
 through HTTPS. You can do it by creating a :ref:`server_java_keystore` on
 the coordinator.
 
@@ -63,7 +63,7 @@ to configure LDAP as the password authenticator plugin.
 Server Config Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following is an example of the required properties that need to be added
+The following is an example of the properties that must be added
 to the coordinator's ``config.properties`` file:
 
 .. code-block:: none
@@ -222,6 +222,8 @@ property may be set as follows:
 Presto CLI
 ----------
 
+See :doc:`/clients/presto-cli` for instructions to set up Presto CLI.
+
 Environment Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -233,9 +235,9 @@ authentication. The Presto CLI can use either a :ref:`Java Keystore
 <server_java_keystore>` file or :ref:`Java Truststore <cli_java_truststore>`
 for its TLS configuration.
 
-If you are using keystore file, it can be copied to the client machine and used
+If you are using a keystore file, it can be copied to the client machine and used
 for its TLS configuration. If you are using truststore, you can either use
-default java truststores or create a custom truststore on the CLI. We do not
+the default Java truststore, or create a custom truststore on the client machine. We do not
 recommend using self-signed certificates in production.
 
 Presto CLI Execution
@@ -248,6 +250,8 @@ options. You can either use ``--keystore-*`` or ``--truststore-*`` properties
 to secure TLS connection. The simplest way to invoke the CLI is with a
 wrapper script.
 
+Invoke CLI with ``--keystore-*`` properties:
+
 .. code-block:: none
 
     #!/bin/bash
@@ -256,6 +260,20 @@ wrapper script.
     --server https://presto-coordinator.example.com:8443 \
     --keystore-path /tmp/presto.jks \
     --keystore-password password \
+    --catalog <catalog> \
+    --schema <schema> \
+    --user <LDAP user> \
+    --password
+
+
+Invoke CLI with ``--truststore-*`` properties:
+
+.. code-block:: none
+
+    #!/bin/bash
+
+    ./presto \
+    --server https://presto-coordinator.example.com:8443 \
     --truststore-path /tmp/presto_truststore.jks \
     --truststore-password password \
     --catalog <catalog> \
@@ -295,6 +313,8 @@ Java Keystore File Verification
 Verify the password for a keystore file and view its contents using
 :ref:`troubleshooting_keystore`.
 
+.. _ssl_debugging_for_cli:
+
 SSL Debugging for Presto CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -317,11 +337,11 @@ java.security.cert.CertificateException: No subject alternative names present
 
 This error is seen when the Presto coordinator’s certificate is invalid and does not have the IP you provide
 in the ``--server`` argument of the CLI. You will have to regenerate the coordinator's SSL certificate
-with the appropriate :abbr:`SAN (Subject Alternative Name)` added.
+with the appropriate SAN (Subject Alternative Name) added.
 
 Adding a SAN to this certificate is required in cases where ``https://`` uses IP address in the URL rather
 than the domain contained in the coordinator's certificate, and the certificate does not contain the
-:abbr:`SAN (Subject Alternative Name)` parameter with the matching IP address as an alternative attribute.
+SAN parameter with the matching IP address as an alternative attribute.
 
 No console from which to read password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/security/password-file.rst
+++ b/presto-docs/src/main/sphinx/security/password-file.rst
@@ -5,16 +5,84 @@ Password File Authentication
 ============================
 
 Presto can be configured to enable frontend password authentication over
-HTTPS for clients, such as the CLI, or the JDBC and ODBC drivers. The
+HTTPS for clients, such as the :ref:`cli`, or the JDBC and ODBC drivers. The
 username and password are validated against usernames and passwords stored
-in a file.
+in a file. Once password-file-based authentication is set up, no user is able
+to connect to the Presto coordinator without authenticating themselves.
 
-Password file authentication is very similar to :doc:`ldap`. Please see
-the LDAP documentation for generic instructions on configuring the server
-and clients to use TLS and authenticate with a username and password.
+To enable password-file-based authentication for Presto, configuration changes are made on
+the Presto coordinator. No changes are required to the worker configuration;
+only the communication from the clients to the coordinator is authenticated.
+To secure the communication between Presto nodes with SSL/TLS, see :doc:`/security/internal-communication`.
+
+Presto Server Configuration
+---------------------------
+
+TLS Configuration on Presto Coordinator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using password-file-based authentication, access to the Presto coordinator
+should be through HTTPS. With the HTTPS protocol, the Presto coordinator needs to present its
+certificate to the client for successfully completing SSL handshake. You can do it by
+creating a :ref:`server_java_keystore` on the coordinator.
+
+Presto Coordinator Node Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You must make the following changes to the environment prior to configuring the
+Presto coordinator to use password-file-based authentication and HTTPS.
+
+* :ref:`server_java_keystore`
+
+You also need to make changes to the Presto configuration files.
+Password-file-based authentication is configured on the coordinator in two parts.
+The first part is to enable HTTPS support and password authentication
+in the coordinator's ``config.properties`` file. The second part is
+to configure the password file as the password authenticator.
+
+Server Config Properties
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following is an example of the properties that must be added
+to the coordinator's ``config.properties`` file:
+
+.. code-block:: none
+
+    http-server.authentication.type=PASSWORD
+
+    http-server.https.enabled=true
+    http-server.https.port=8443
+
+    http-server.https.keystore.path=/etc/presto_keystore.jks
+    http-server.https.keystore.key=keystore_password
+
+.. note::
+
+    If :doc:`/security/internal-communication` is not configured, you need to keep
+    both ``http-server.http.port`` and ``http-server.https.port`` in your ``config.properties``.
+    Further, no changes are needed in the value for ``discovery.uri``.
+
+
+======================================================= ======================================================
+Property                                                Description
+======================================================= ======================================================
+``http-server.authentication.type``                     Enable password authentication for the Presto
+                                                        coordinator. Must be set to ``PASSWORD``.
+``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
+                                                        Should be set to ``true``. Default value is
+                                                        ``false``.
+``http-server.https.port``                              HTTPS server port.
+``http-server.https.keystore.path``                     The location of the Java Keystore file that will be
+                                                        used to secure TLS.
+``http-server.https.keystore.key``                      The password for the keystore. This must match the
+                                                        password you specified when creating the keystore.
+``http-server.authentication.allow-forwarded-https``    Enable treating forwarded HTTPS requests over HTTP as secure.
+                                                        Requires the ``X-Forwarded-Proto`` header to be set to ``https`` on forwarded requests.
+                                                        Default value is ``false``.
+======================================================= ======================================================
 
 Password Authenticator Configuration
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enable password file authentication by creating an
 ``etc/password-authenticator.properties`` file on the coordinator:
@@ -117,3 +185,146 @@ Add or update the password for the user ``test``:
 
     htpasswd -B -C 10 password.db test
 
+.. _cli:
+
+Presto CLI
+----------
+
+See :doc:`/clients/presto-cli` for instructions to set up Presto CLI.
+
+Environment Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TLS Configuration
+~~~~~~~~~~~~~~~~~
+
+Access to the Presto coordinator should be through HTTPS when using
+password-file-based authentication. The Presto CLI must verify the certificate presented by the
+coordinator using its truststore to complete SSL handshake. You can either use the
+default truststore which comes with your Java installation on the client machine, or
+you can define a custom truststore. See :ref:`cli_java_truststore` for instructions
+to import the server's certificate into the CLI's truststore. We do not recommend using self-signed
+certificates in production.
+
+.. _cli_execution:
+
+Presto CLI Execution
+^^^^^^^^^^^^^^^^^^^^
+
+In addition to the options that are required when connecting to a Presto
+coordinator that does not require authentication, invoking the CLI
+for secure Presto cluster requires a number of additional command line
+options. You must include ``--truststore-*`` properties to secure the
+connection.
+
+.. code-block:: none
+
+    #!/bin/bash
+
+    ./presto \
+    --server https://presto-coordinator.example.com:8443 \
+    --truststore-path /tmp/presto_truststore.jks \
+    --truststore-password <password> \
+    --user <user> \
+    --password
+
+=============================== =========================================================================
+Option                          Description
+=============================== =========================================================================
+``--server``                    The address and port of the Presto coordinator.  The port must
+                                be set to the port the Presto coordinator is listening for HTTPS
+                                connections on. Presto CLI does not support using ``http`` scheme for
+                                the url when using password-file-based authentication.
+``--truststore-path``           The location of the Java Truststore file on the client machine that will be used
+                                to secure TLS.
+``--truststore-password``       The password for the truststore. This must match the
+                                password you specified when creating the truststore.
+``--user``                      The username of the user trying to connect to the server.
+``--password``                  Prompts for a password for the ``user``.
+=============================== =========================================================================
+
+.. note::
+
+    Run ``./presto --help`` for getting the list of available command line options with their descriptions.
+
+
+Troubleshooting
+---------------
+
+Java Keystore File Verification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Verify the password for a keystore file and view its contents using
+:ref:`troubleshooting_keystore`.
+
+SSL Debugging for Presto CLI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Debug SSL related errors when running Presto CLI using :ref:`ssl_debugging_for_cli`.
+
+NullPointerException while locating HttpServerProvider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: none
+
+    [Guice/ErrorInCustomProvider]: NullPointerException
+      while locating HttpServerProvider
+      at HttpServerModule.configure(HttpServerModule.java:54)
+      while locating HttpServer
+
+Include below configurations in ``config.properties`` file
+
+.. code-block:: none
+
+    http-server.https.keystore.path=<path_to_keystore>
+    http-server.https.keystore.key=<keystore_password>
+
+
+Password authenticator file is not registered
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Check if ``presto-password-authenticators`` plugin is included with Presto installation.
+For local installations, include below line in ``plugin.bundles`` in ``config.properties`` file:
+
+.. code-block:: none
+
+    ../presto-password-authenticators/pom.xml
+
+
+Authentication using username/password requires HTTPS to be enabled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: none
+
+    Exception in thread "main" java.lang.IllegalArgumentException: Authentication using username/password requires HTTPS to be enabled
+            at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
+            at com.facebook.presto.cli.QueryRunner.setupBasicAuth(QueryRunner.java:166)
+            at com.facebook.presto.cli.QueryRunner.<init>(QueryRunner.java:95)
+            at com.facebook.presto.cli.Console.run(Console.java:143)
+            at com.facebook.presto.cli.Presto.main(Presto.java:31)
+
+Include ``--server`` command line option with HTTPS endpoint when running Presto CLI.
+
+PKIX path building failed
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: none
+
+    Error running command: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+
+Import the Presto coordinator's certificate into client's truststore. See :ref:`cli_java_truststore` for instructions to import the certificate.
+Also make sure to include ``--truststore-*`` properties when running Presto CLI as suggested in :ref:`cli_execution`.
+
+javax.net.ssl.SSLPeerUnverifiedException: Hostname <some_host_name> not verified
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error implies the Common Name in the imported coordinator's certificate in the client's truststore does not match the hostname
+provided with ``--server`` flag. Modify the ``--server`` option to use the same hostname that is mentioned as the Common Name
+in the certificate, or create a new certificate for the server with <some_host_name> as the Common Name. See :ref:`server_java_keystore`
+for instructions to create a new certificate for the server using :command:`keytool`.
+
+Common SSL Errors
+^^^^^^^^^^^^^^^^^
+
+See `SSL Handshake Failures <https://www.baeldung.com/java-ssl-handshake-failures>`_ for detailed
+explanation around common SSL errors and their fixes.

--- a/presto-docs/src/main/sphinx/security/tls.rst
+++ b/presto-docs/src/main/sphinx/security/tls.rst
@@ -7,23 +7,23 @@ Java Keystores and Truststores
 Java Keystore File for TLS
 --------------------------
 
-Access to the Presto coordinator must be through HTTPS when using Kerberos
-and LDAP authentication. The Presto coordinator uses a :ref:`Java Keystore
+Access to the Presto coordinator must be through HTTPS when using Kerberos, LDAP,
+and password-file-based authentication. The Presto coordinator uses a :ref:`Java Keystore
 <server_java_keystore>` file for its TLS configuration. These keys are
 generated using :command:`keytool` and stored in a Java Keystore file for the
 Presto coordinator.
 
 The alias in the :command:`keytool` command line should match the principal that the
-Presto coordinator will use.
+Presto coordinator will use in the case of :doc:`/security/server`.
 
-You'll be prompted for the first and last name. Use the Common Name that will
+When using the :command:`keytool` command, you'll be prompted for the first and last name. Use the Common Name that will
 be used in the certificate. In this case, it should be the unqualified hostname
 of the Presto coordinator. In the following example, you can see this in the prompt
 that confirms the information is correct:
 
 .. code-block:: none
 
-    keytool -genkeypair -alias presto -keyalg RSA -keystore keystore.jks
+    keytool -genkeypair -alias presto -keyalg RSA -keystore presto_keystore.jks
     Enter keystore password:
     Re-enter new password:
     What is your first and last name?
@@ -44,6 +44,19 @@ that confirms the information is correct:
     Enter key password for <presto>
             (RETURN if same as keystore password):
 
+.. note::
+
+    Use ``localhost`` as the Common Name if you are generating a self-signed certificate
+    for setting up secure client to coordinator communication on your local machine.
+
+The keystore file generated with the above command must be configured in ``config.properties``
+file on the coordinator.
+
+.. code-block:: none
+
+    http-server.https.keystore.path=/etc/presto_keystore.jks
+    http-server.https.keystore.key=keystore_password
+
 .. _cli_java_truststore:
 
 Java Truststore File for TLS
@@ -55,9 +68,14 @@ to the Presto coordinator through HTTPS the clients can configure truststores.
 For the Presto CLI to trust the Presto coordinator, the coordinator's certificate
 must be imported to the CLI's truststore.
 
-You can either import the certificate to the default Java truststore, or to a
-custom truststore. You should be careful if you choose to use the default
-one, since you may need to remove the certificates of CAs you do not deem trustworthy.
+If the coordinator's certificate is issued by well-known CAs, it is possible that
+this certificate is already present in your default Java truststore located at
+``<JAVA_HOME>/jre/lib/security/cacerts`` and there is no need to import it again
+to the truststore or to create a custom truststore. If the certificate is issued by a private
+CA or you are using a self-signed certificate for testing purposes, you can either import the
+certificate to the default Java truststore, or to a custom truststore. You should be
+careful if you choose to use the default one, since you may need to remove the certificates
+of CAs you do not deem trustworthy.
 
 You can use :command:`keytool` to import the certificate to the truststore.
 In the example, we are going to import ``presto_certificate.cer`` to a custom


### PR DESCRIPTION
## Description
Add more details in Authentication related documentation. This PR improves below pages - 
 - Password-file based authentication
 - LDAP authentication
 - Java Keystore and Truststore

## Motivation and Context
The docs around setting up authentication lacked a lot of critical and useful information which made it difficult for users to follow them smoothly. This PR attempts to bridge this gap to some extent.

## Impact
Documentation update

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update and expand security authentication documentation for Presto.

Documentation:
- Enhance password file authentication documentation with additional setup and usage details.
- Improve LDAP authentication documentation with clearer configuration guidance and examples.
- Expand TLS and Java keystore/truststore documentation to better explain configuration and usage.