### PR TITLE
fix: Replace Optional.or with ternary for Java 8 compatibility

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -137,8 +137,9 @@ public class QuerySessionSupplier
         authorizedIdentity = authorizedIdentity.isPresent() ? authorizedIdentity : getAuthorizedIdentity(accessControl, securityConfig, queryId, context);
 
         return authorizedIdentity.map(identity -> {
-            Optional<java.security.Principal> principal = identity.getAuthorizedPrincipal()
-                    .or(() -> context.getIdentity().getPrincipal());
+            Optional<java.security.Principal> principal = identity.getAuthorizedPrincipal().isPresent()
+                    ? identity.getAuthorizedPrincipal()
+                    : context.getIdentity().getPrincipal();
             return new Identity(
                     context.getIdentity().getUser(),
                     principal,


### PR DESCRIPTION
## Description

Replaces the use of `Optional.or(Supplier)` in `QuerySessionSupplier.authenticateIdentity` with an equivalent `isPresent()` ternary expression. `Optional.or` was introduced in Java 9, so any consumer compiling against Java 8 hits `NoSuchMethodError` at runtime.

## Motivation and Context

D97439864 (PR #27639) added gateway principal propagation via `AuthorizedIdentity.getAuthorizedPrincipal()` and used `Optional.or` to fall back to the TLS principal:

```
Optional<Principal> principal = identity.getAuthorizedPrincipal()
        .or(() -> context.getIdentity().getPrincipal());
```

While `presto-main-base` itself targets Java 11+, downstream consumers (e.g. Presto-on-Spark / Sapphire) still compile and run on Java 8 and pull in this class. The `Optional.or` call surfaces only at runtime as:

```
java.lang.NoSuchMethodError: java.util.Optional.or(Ljava/util/function/Supplier;)Ljava/util/Optional;
    at com.facebook.presto.server.QuerySessionSupplier.lambda$authenticateIdentity$1(QuerySessionSupplier.java:141)
```

This breaks `PrestoOnSpark` startup. Switching to a Java 8-safe ternary preserves the original semantics while staying compatible with Java 8 callers.

## Impact

No public API or behavior change. The fallback semantics are identical: when `authorizedPrincipal` is present it is used, otherwise the session falls back to `context.getIdentity().getPrincipal()`.

## Test Plan

Existing unit tests in `TestQuerySessionSupplier` (`testSessionWithAuthorizedPrincipal`, `testSessionWithoutAuthorizedPrincipal`) continue to cover both branches of the fallback.

## Contributor checklist

- [x] Read [CONTRIBUTING.md](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md) and followed the instructions included.
- [x] Read [Review Process](https://github.com/prestodb/presto/wiki/Review-Process).
- [x] CI passes
- [x] Adequate tests were added if applicable.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D103282146

## Summary by Sourcery

Bug Fixes:
- Fix runtime NoSuchMethodError in QuerySessionSupplier caused by use of Optional.or on Java 8 runtimes.