### PR TITLE
[presto-native-execution] Expose spill_io_stats_key_prefix as a session property (#27694)

### DIFF
--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -128,6 +128,20 @@ SessionProperties::SessionProperties() {
       c.spillFileCreateConfig());
 
   addSessionProperty(
+      kSpillIoStatsKeySuffix,
+      "Native Execution only. Suffix appended to filesystem IoStats keys "
+      "harvested from the spill FileSystem when folded into operator "
+      "runtimeStats. Empty by default. Set to a non-empty value (e.g. "
+      "\".spill\") in deployments where the spill backend and a connector "
+      "backend share a FileSystem implementation that emits IoStats under "
+      "a globally-shared key namespace, to disambiguate spill IoStats from "
+      "connector IoStats on the same operator's runtimeStats.",
+      VARCHAR(),
+      false,
+      QueryConfig::kSpillIoStatsKeySuffix,
+      c.spillIoStatsKeySuffix());
+
+  addSessionProperty(
       kAggregationSpillFileCreateConfig,
       "Native Execution only. Config used to create aggregation spill files. "
       "This config is provided to underlying file system and the config is "

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
@@ -81,6 +81,15 @@ class SessionProperties : public SessionPropertiesProvider {
   static constexpr const char* kSpillFileCreateConfig =
       "native_spill_file_create_config";
 
+  /// Suffix appended to filesystem IoStats keys harvested from the spill
+  /// FileSystem when folded into operator runtimeStats. Empty by default.
+  /// Set to a non-empty value (e.g. ".spill") in deployments where the
+  /// spill backend and a connector backend share a FileSystem implementation
+  /// that emits IoStats under a globally-shared key namespace, to prevent
+  /// silent collisions on TableScan/TableWriter operators.
+  static constexpr const char* kSpillIoStatsKeySuffix =
+      "native_spill_io_stats_key_suffix";
+
   /// Config used to create aggregation spill files. This config is provided to
   /// underlying file system and the config is free form.
   static constexpr const char* kAggregationSpillFileCreateConfig =


### PR DESCRIPTION
Summary:

Adds Presto session property in order to set the Spill IO stats suffix introduced in https://github.com/facebookincubator/velox/pull/17390

Differential Revision: D103308964


