### PR TITLE
feat(native-pos): Driver-side metadata sidecar to register native-only functions

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1786,3 +1786,67 @@ or HTTP/S. HTTPS are supported using the same internal communication HTTPS
 configs.
 
 To enable SSL/TLS, see :doc:`/security/internal-communication`.
+
+Driver-side Metadata Sidecar Properties
+---------------------------------------
+
+When :doc:`Presto on Spark </admin/spark>` runs on a native (Velox) execution engine,
+the driver can optionally launch a short-lived ``presto_server`` sidecar at bootstrap
+to register native-only functions into ``FunctionAndTypeManager`` before planning
+(analogous to :doc:`/plugin/native-sidecar-plugin` on the coordinator). The
+sidecar is shut down before query execution and is **disabled by default**.
+
+``built-in-sidecar-functions-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enables the bootstrap step that fetches native function metadata and registers it
+into ``FunctionAndTypeManager``. Must be paired with ``metadata-sidecar.enabled``.
+
+``metadata-sidecar.enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enables the driver-side sidecar lifecycle.
+
+``metadata-sidecar.executable-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** (unset)
+
+Absolute path to the ``presto_server`` binary on the driver host. Required when
+``metadata-sidecar.enabled=true`` unless a custom ``SidecarBinaryLocator`` binding
+is provided.
+
+``metadata-sidecar.program-arguments``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** (empty)
+
+Extra whitespace-separated arguments for the sidecar binary. ``--etc_dir`` is always
+added automatically.
+
+``metadata-sidecar.startup-timeout``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``duration``
+* **Default value:** ``2m``
+
+Maximum wait for the sidecar to become reachable on its HTTP port before bootstrap
+fails.
+
+``metadata-sidecar.storage-oncall-name``, ``metadata-sidecar.storage-user-name``, ``metadata-sidecar.storage-service-name``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** (empty)
+
+Optional values written into the sidecar's ``config.properties`` to satisfy
+required-property checks in deployment-specific native worker initialization paths.
+Leave unset if not required by your deployment.

--- a/presto-docs/src/main/sphinx/admin/spark.rst
+++ b/presto-docs/src/main/sphinx/admin/spark.rst
@@ -59,3 +59,11 @@ in Spark). These are also equal to the number of cores (4 in the example) and ar
 same as some of the ``config.properties`` settings discussed above. This is to ensure that
 a single Presto on Spark task is run in a single Spark executor (This limitation may be
 temporary and is introduced to avoid duplicating broadcasted hash tables for every task).
+
+Driver-side Metadata Sidecar
+----------------------------
+
+When the executors run on a native (Velox) execution engine, the driver can launch a
+short-lived ``presto_server`` sidecar at bootstrap to register native-only functions
+into the planner. See :ref:`Driver-side Metadata Sidecar Properties
+<admin/properties:Driver-side Metadata Sidecar Properties>` for the configuration.

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -56,6 +56,16 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-built-in-worker-function-tools</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-client</artifactId>
             <exclusions>
                 <exclusion>
@@ -344,11 +354,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-function-namespace-managers-common</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarFunctionRegistryTool.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarFunctionRegistryTool.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.builtin.tools.WorkerFunctionRegistryTool;
+import com.facebook.presto.builtin.tools.WorkerFunctionUtil;
+import com.facebook.presto.functionNamespace.JsonBasedUdfFunctionMetadata;
+import com.facebook.presto.functionNamespace.UdfFunctionSignatureMap;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Presto-on-Spark driver-side equivalent of
+ * {@code com.facebook.presto.builtin.tools.NativeSidecarFunctionRegistryTool}, but pointed at
+ * a driver-local {@link MetadataSidecarProcess} instead of a NodeManager-discovered worker.
+ *
+ * <p>HTTP-fetches {@code GET /v1/functions} from the driver-local sidecar URL and converts each
+ * entry into a {@code SqlInvokedFunction} via
+ * {@link WorkerFunctionUtil#createSqlInvokedFunction} with catalog {@code "presto"} so the
+ * resulting handles register as built-ins (Path B from the design doc).
+ */
+public class DriverSidecarFunctionRegistryTool
+        implements WorkerFunctionRegistryTool
+{
+    private static final Logger log = Logger.get(DriverSidecarFunctionRegistryTool.class);
+    private static final String FUNCTION_SIGNATURES_ENDPOINT = "/v1/functions";
+    private static final String CATALOG = "presto";
+
+    private final OkHttpClient httpClient;
+    private final JsonCodec<Map<String, List<JsonBasedUdfFunctionMetadata>>> functionSignatureMapJsonCodec;
+    private final MetadataSidecarProcessFactory sidecarProcessFactory;
+
+    private volatile UdfFunctionSignatureMap cachedSignatureMap;
+
+    @Inject
+    public DriverSidecarFunctionRegistryTool(
+            @ForMetadataSidecar OkHttpClient httpClient,
+            JsonCodec<Map<String, List<JsonBasedUdfFunctionMetadata>>> functionSignatureMapJsonCodec,
+            MetadataSidecarProcessFactory sidecarProcessFactory)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.functionSignatureMapJsonCodec = requireNonNull(functionSignatureMapJsonCodec, "functionSignatureMapJsonCodec is null");
+        this.sidecarProcessFactory = requireNonNull(sidecarProcessFactory, "sidecarProcessFactory is null");
+    }
+
+    @Override
+    public List<? extends SqlFunction> getWorkerFunctions()
+    {
+        return getCachedSignatureMap().getUDFSignatureMap().entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(metaInfo -> WorkerFunctionUtil.createSqlInvokedFunction(entry.getKey(), metaInfo, CATALOG)))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public Set<String> getRpcFunctionNames()
+    {
+        return getCachedSignatureMap().getUDFSignatureMap().entrySet().stream()
+                .filter(entry -> entry.getValue().stream().anyMatch(JsonBasedUdfFunctionMetadata::getIsRpcFunction))
+                .map(Map.Entry::getKey)
+                .map(name -> name.toLowerCase(Locale.ENGLISH))
+                .collect(toImmutableSet());
+    }
+
+    private synchronized UdfFunctionSignatureMap getCachedSignatureMap()
+    {
+        if (cachedSignatureMap == null) {
+            cachedSignatureMap = fetchFromSidecar();
+        }
+        return cachedSignatureMap;
+    }
+
+    private UdfFunctionSignatureMap fetchFromSidecar()
+    {
+        URI sidecarUri = sidecarProcessFactory.getOrStart();
+        try {
+            URI endpoint = sidecarUri.resolve(FUNCTION_SIGNATURES_ENDPOINT);
+            Request request = new Request.Builder().url(endpoint.toString()).get().build();
+            log.info("Fetching native function metadata from %s", endpoint);
+
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    throw new PrestoException(
+                            GENERIC_INTERNAL_ERROR,
+                            String.format("Metadata sidecar returned HTTP %d for %s", response.code(), endpoint));
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    throw new PrestoException(
+                            GENERIC_INTERNAL_ERROR,
+                            String.format("Metadata sidecar returned an empty body for %s", endpoint));
+                }
+                String responseJson = body.string();
+                Map<String, List<JsonBasedUdfFunctionMetadata>> map =
+                        functionSignatureMapJsonCodec.fromJson(responseJson);
+                log.info("Fetched %d native function names from metadata sidecar", map.size());
+                return new UdfFunctionSignatureMap(ImmutableMap.copyOf(map));
+            }
+            catch (IOException e) {
+                throw new PrestoException(
+                        GENERIC_INTERNAL_ERROR,
+                        String.format("Failed to fetch functions from metadata sidecar at %s", endpoint),
+                        e);
+            }
+        }
+        finally {
+            // Sidecar is only needed to fetch the function metadata once; shut it down
+            // deterministically here rather than relying on @PreDestroy, which is not
+            // always invoked on the Spark driver during executor shutdown.
+            sidecarProcessFactory.close();
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarModule.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.builtin.tools.WorkerFunctionRegistryTool;
+import com.facebook.presto.functionNamespace.JsonBasedUdfFunctionMetadata;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import okhttp3.OkHttpClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+
+/**
+ * Guice module that wires the driver-side metadata sidecar.
+ *
+ * <p>Install only on the Presto-on-Spark driver (gated by {@code SparkProcessType == DRIVER} at the
+ * call site, typically inside {@code PrestoFacebookSparkServiceFactory.getAdditionalModules}).
+ * No-ops on executors.
+ *
+ * <p>Bindings:
+ * <ul>
+ *   <li>{@link MetadataSidecarConfig} — Airlift @Config
+ *   <li>{@link MetadataSidecarProcessFactory} — singleton owning the sidecar lifecycle
+ *   <li>{@link WorkerFunctionRegistryTool} → {@link DriverSidecarFunctionRegistryTool}
+ *   <li>{@link OkHttpClient} / {@link ScheduledExecutorService} / {@link ExecutorService}
+ *       all annotated {@link ForMetadataSidecar}, plus the JSON codecs the registry tool needs
+ * </ul>
+ *
+ * <p>Callers may also supply their own binding for
+ * {@link MetadataSidecarProcessFactory.SidecarBinaryLocator} to resolve the native worker
+ * binary on disk when {@code metadata-sidecar.executable-path} is not set in config. This
+ * module installs a default binding that returns {@code Optional.empty()} so the OSS build
+ * does not depend on any deployment-specific launcher; deployments that want automatic
+ * binary discovery should override the binding from their own module.
+ */
+public class DriverSidecarModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(MetadataSidecarConfig.class);
+        binder.bind(MetadataSidecarProcessFactory.class).in(Scopes.SINGLETON);
+        binder.bind(WorkerFunctionRegistryTool.class)
+                .to(DriverSidecarFunctionRegistryTool.class)
+                .in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    @ForMetadataSidecar
+    public OkHttpClient provideOkHttpClient()
+    {
+        return new OkHttpClient.Builder()
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @Provides
+    @Singleton
+    @ForMetadataSidecar
+    public ScheduledExecutorService provideScheduledExecutor()
+    {
+        return Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "metadata-sidecar-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Provides
+    @Singleton
+    @ForMetadataSidecar
+    public ExecutorService provideExecutor()
+    {
+        return Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "metadata-sidecar-executor");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Provides
+    @Singleton
+    public JsonCodec<Map<String, List<JsonBasedUdfFunctionMetadata>>> provideFunctionSignatureMapJsonCodec()
+    {
+        return mapJsonCodec(String.class, listJsonCodec(JsonBasedUdfFunctionMetadata.class));
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/ForMetadataSidecar.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/ForMetadataSidecar.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+/**
+ * Qualifier for Guice bindings used by the driver-side metadata sidecar — keeps them isolated
+ * from any unqualified bindings installed by {@code NativeExecutionModule} on the same JVM.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForMetadataSidecar
+{
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarConfig.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.units.Duration;
+import com.facebook.airlift.units.MinDuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for the driver-side metadata-only Velox sidecar process used by Presto-on-Spark
+ * to register native-only Velox functions into FunctionAndTypeManager before query planning.
+ */
+public class MetadataSidecarConfig
+{
+    private boolean enabled;
+    private String executablePath;
+    private String programArguments = "";
+    private Duration startupTimeout = new Duration(2, TimeUnit.MINUTES);
+    private String storageOncallName = "presto_oncall";
+    private String storageUserName = "presto";
+    private String storageServiceName = "warm_storage_service";
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("metadata-sidecar.enabled")
+    @ConfigDescription("Enables the driver-side metadata-only Velox sidecar process")
+    public MetadataSidecarConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public String getExecutablePath()
+    {
+        return executablePath;
+    }
+
+    @Config("metadata-sidecar.executable-path")
+    @ConfigDescription("Absolute path to the native worker (presto_server) binary; if unset, the SidecarBinaryLocator binding is consulted to discover one")
+    public MetadataSidecarConfig setExecutablePath(String executablePath)
+    {
+        this.executablePath = executablePath;
+        return this;
+    }
+
+    public String getProgramArguments()
+    {
+        return programArguments;
+    }
+
+    @Config("metadata-sidecar.program-arguments")
+    @ConfigDescription("Extra command-line arguments passed to the metadata sidecar binary")
+    public MetadataSidecarConfig setProgramArguments(String programArguments)
+    {
+        this.programArguments = programArguments;
+        return this;
+    }
+
+    @MinDuration("1s")
+    public Duration getStartupTimeout()
+    {
+        return startupTimeout;
+    }
+
+    @Config("metadata-sidecar.startup-timeout")
+    @ConfigDescription("Maximum total time to wait for the metadata sidecar's /v1/info endpoint to become reachable")
+    public MetadataSidecarConfig setStartupTimeout(Duration startupTimeout)
+    {
+        this.startupTimeout = startupTimeout;
+        return this;
+    }
+
+    public String getStorageOncallName()
+    {
+        return storageOncallName;
+    }
+
+    @Config("metadata-sidecar.storage-oncall-name")
+    @ConfigDescription("Value for storage_oncall_name; required by FacebookPrestoBase but unused in metadata-only mode")
+    public MetadataSidecarConfig setStorageOncallName(String storageOncallName)
+    {
+        this.storageOncallName = storageOncallName;
+        return this;
+    }
+
+    public String getStorageUserName()
+    {
+        return storageUserName;
+    }
+
+    @Config("metadata-sidecar.storage-user-name")
+    @ConfigDescription("Value for storage_user_name; required by FacebookPrestoBase but unused in metadata-only mode")
+    public MetadataSidecarConfig setStorageUserName(String storageUserName)
+    {
+        this.storageUserName = storageUserName;
+        return this;
+    }
+
+    public String getStorageServiceName()
+    {
+        return storageServiceName;
+    }
+
+    @Config("metadata-sidecar.storage-service-name")
+    @ConfigDescription("Value for storage_service_name; required by FacebookPrestoBase but unused in metadata-only mode")
+    public MetadataSidecarConfig setStorageServiceName(String storageServiceName)
+    {
+        this.storageServiceName = storageServiceName;
+        return this;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcess.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spi.PrestoException;
+import okhttp3.OkHttpClient;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.String.format;
+
+/**
+ * A driver-side {@code AbstractNativeProcess} that runs Velox in metadata-only sidecar mode
+ * ({@code native-sidecar=true}). It exposes the standard Prestissimo HTTP endpoints
+ * ({@code /v1/functions}, {@code /v1/expressions}, {@code /v1/velox/plan}, etc.) so that
+ * the Presto-on-Spark driver can register native-only Velox functions into FunctionAndTypeManager
+ * before query planning begins.
+ *
+ * <p>Differences from {@link NativeExecutionProcess}:
+ * <ul>
+ *   <li>No {@code Session}, {@code WorkerProperty}, {@code SparkConf}, or {@code SparkFiles}.
+ *   <li>Resolves the binary as an absolute path (no {@code SparkFiles.getRootDirectory()}).
+ *   <li>Writes a small fixed {@code config.properties}/{@code node.properties} pair with the
+ *       FB-specific properties that {@code FacebookPrestoBase::registerFileSinks} requires
+ *       even when sidecar mode is enabled (the WS storage triple and a spill-path
+ *       short-circuit). No catalogs.
+ *   <li>Failure to start throws a regular {@link PrestoException} rather than the
+ *       {@code PrestoSparkFatalException} used by executor-side processes &mdash; this is the
+ *       Spark driver, not an executor, so we want to fail the application instead of
+ *       triggering executor failover.
+ * </ul>
+ */
+public class MetadataSidecarProcess
+        extends AbstractNativeProcess
+{
+    private static final Logger log = Logger.get(MetadataSidecarProcess.class);
+
+    static final String SIDECAR_NODE_INTERNAL_ADDRESS = "127.0.0.1";
+
+    private final String storageOncallName;
+    private final String storageUserName;
+    private final String storageServiceName;
+
+    // Captured during populateConfigurationFiles so close() can clean up the etc tree the
+    // sidecar process wrote at startup. Volatile because start() runs on the caller's
+    // thread but close() may be invoked from a shutdown hook on a different thread.
+    private volatile Path configBasePath;
+
+    public MetadataSidecarProcess(
+            String executablePath,
+            String programArguments,
+            OkHttpClient httpClient,
+            Executor executor,
+            ScheduledExecutorService scheduledExecutorService,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            Duration maxErrorDuration,
+            String storageOncallName,
+            String storageUserName,
+            String storageServiceName)
+    {
+        super(executablePath,
+                programArguments,
+                SIDECAR_NODE_INTERNAL_ADDRESS,
+                httpClient,
+                executor,
+                scheduledExecutorService,
+                serverInfoCodec,
+                maxErrorDuration);
+        this.storageOncallName = storageOncallName;
+        this.storageUserName = storageUserName;
+        this.storageServiceName = storageServiceName;
+    }
+
+    @Override
+    protected String resolveProcessWorkingPath(String path)
+    {
+        // Drop the etc-dir under the system tmpdir rather than the JVM's working directory.
+        // The binary path itself is always absolute (config) so we don't need to resolve it.
+        return new java.io.File(System.getProperty("java.io.tmpdir"), path).getAbsolutePath();
+    }
+
+    @Override
+    protected void populateConfigurationFiles(Path configBasePath)
+            throws IOException
+    {
+        Files.createDirectories(configBasePath);
+        Files.write(workerConfigFile(configBasePath), buildSystemConfigLines());
+        Files.write(workerNodeConfigFile(configBasePath), buildNodeConfigLines());
+        // The catalog directory is intentionally empty (no connectors) but must exist —
+        // PrestoServer iterates it during startup and aborts if it's missing.
+        Files.createDirectories(workerCatalogDir(configBasePath));
+        // Remember where we wrote so close() can clean it up; the parent abstract class
+        // computes this path internally and never exposes it to the subclass otherwise.
+        this.configBasePath = configBasePath;
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            super.close();
+        }
+        finally {
+            // Etc-dir written by populateConfigurationFiles (may be null if start() never ran),
+            // and the spill dir referenced from config.properties (may or may not exist
+            // depending on whether the native process actually spilled).
+            deleteQuietly(configBasePath);
+            deleteQuietly(Paths.get(sidecarSpillDirectory(getPort())));
+        }
+    }
+
+    private static void deleteQuietly(Path dir)
+    {
+        if (dir == null || !Files.exists(dir)) {
+            return;
+        }
+        try {
+            deleteRecursively(dir, ALLOW_INSECURE);
+        }
+        catch (IOException e) {
+            log.warn(e, "Failed to delete sidecar temp dir: %s", dir);
+        }
+    }
+
+    private Iterable<String> buildSystemConfigLines()
+    {
+        // The native-sidecar=true flag turns on /v1/functions and friends.
+        // The storage-* triple satisfies FacebookPrestoBase::registerFileSinks, which calls
+        // requiredProperty() for these even though we never use WarmStorage in metadata-only
+        // mode. The experimental.spiller-spill-path setting short-circuits the FB datacenter
+        // detection in FacebookPrestoBase::getBaseSpillDirectory.
+        return Arrays.asList(
+                "discovery.uri=http://" + SIDECAR_NODE_INTERNAL_ADDRESS + ":" + getPort(),
+                "presto.version=metadata-sidecar",
+                "http-server.http.port=" + getPort(),
+                "shutdown-onset-sec=1",
+                "native-sidecar=true",
+                "storage_oncall_name=" + storageOncallName,
+                "storage_user_name=" + storageUserName,
+                "storage_service_name=" + storageServiceName,
+                "experimental.spiller-spill-path=" + sidecarSpillDirectory(getPort()));
+    }
+
+    private static String sidecarSpillDirectory(int port)
+    {
+        return System.getProperty("java.io.tmpdir") + "/presto-spark-metadata-sidecar-spill-" + port;
+    }
+
+    private Iterable<String> buildNodeConfigLines()
+    {
+        return Arrays.asList(
+                "node.environment=presto-spark-driver-sidecar",
+                "node.internal-address=" + SIDECAR_NODE_INTERNAL_ADDRESS,
+                "node.location=presto-spark-driver-sidecar",
+                "node.id=" + UUID.randomUUID());
+    }
+
+    @Override
+    protected RuntimeException propagateStartFailure(Throwable t)
+    {
+        // Driver-side: fail the Spark application, don't trigger executor failover.
+        throw new PrestoException(
+                NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                format("Failed to start metadata sidecar at %s", getLocation()),
+                t);
+    }
+
+    /**
+     * Writes config.properties / node.properties into the given directory using the same
+     * content {@link #populateConfigurationFiles} writes. Exposed for unit tests that want
+     * to verify the file layout without spawning a process.
+     */
+    void writeConfigsForTest(Path configBasePath)
+            throws IOException
+    {
+        populateConfigurationFiles(configBasePath);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcessFactory.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spi.PrestoException;
+import com.google.inject.Inject;
+import okhttp3.OkHttpClient;
+
+import javax.annotation.PreDestroy;
+
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Singleton factory for the driver-side {@link MetadataSidecarProcess}. Owns the lifecycle of
+ * a single sidecar process per Spark driver JVM. The process is started lazily on the first
+ * call to {@link #getOrStart()} and reused thereafter; {@link #close()} (also called via
+ * {@code @PreDestroy}) tears it down.
+ */
+public class MetadataSidecarProcessFactory
+{
+    private static final Logger log = Logger.get(MetadataSidecarProcessFactory.class);
+
+    private final OkHttpClient httpClient;
+    private final ExecutorService executor;
+    private final ScheduledExecutorService scheduledExecutor;
+    private final JsonCodec<ServerInfo> serverInfoCodec;
+    private final MetadataSidecarConfig config;
+    private final SidecarBinaryLocator binaryLocator;
+
+    private volatile MetadataSidecarProcess process;
+
+    @Inject
+    public MetadataSidecarProcessFactory(
+            @ForMetadataSidecar OkHttpClient httpClient,
+            @ForMetadataSidecar ExecutorService executor,
+            @ForMetadataSidecar ScheduledExecutorService scheduledExecutor,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            MetadataSidecarConfig config,
+            SidecarBinaryLocator binaryLocator)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.scheduledExecutor = requireNonNull(scheduledExecutor, "scheduledExecutor is null");
+        this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.config = requireNonNull(config, "config is null");
+        this.binaryLocator = requireNonNull(binaryLocator, "binaryLocator is null");
+    }
+
+    /**
+     * Returns the running sidecar's local URI ({@code http://127.0.0.1:<port>}), starting it
+     * if it has not been started yet.
+     */
+    public synchronized URI getOrStart()
+    {
+        if (process != null && process.isAlive()) {
+            return process.getLocation();
+        }
+        if (process != null) {
+            log.warn("Existing metadata sidecar process is not alive — replacing it");
+            try {
+                process.close();
+            }
+            catch (Exception e) {
+                log.warn(e, "Error closing previous metadata sidecar process");
+            }
+        }
+        process = new MetadataSidecarProcess(
+                resolveExecutablePath(),
+                config.getProgramArguments(),
+                httpClient,
+                executor,
+                scheduledExecutor,
+                serverInfoCodec,
+                config.getStartupTimeout(),
+                config.getStorageOncallName(),
+                config.getStorageUserName(),
+                config.getStorageServiceName());
+        try {
+            process.start();
+        }
+        catch (ExecutionException | InterruptedException | java.io.IOException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            try {
+                process.close();
+            }
+            catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw new PrestoException(
+                    NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                    "Failed to start metadata sidecar",
+                    e);
+        }
+        log.info("Metadata sidecar started at %s", process.getLocation());
+        return process.getLocation();
+    }
+
+    @PreDestroy
+    public synchronized void close()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+        if (process != null) {
+            try {
+                log.info("Stopping metadata sidecar at %s", process.getLocation());
+                process.close();
+            }
+            finally {
+                process = null;
+            }
+        }
+    }
+
+    private String resolveExecutablePath()
+    {
+        if (config.getExecutablePath() != null && !config.getExecutablePath().isEmpty()) {
+            return config.getExecutablePath();
+        }
+        return binaryLocator.locateNativeWorkerBinary()
+                .orElseThrow(() -> new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        "metadata-sidecar.executable-path is unset and the SidecarBinaryLocator " +
+                                "binding did not return a native worker binary"));
+    }
+
+    /**
+     * Provides the absolute path to the native worker binary. The default binding returns
+     * {@code Optional.empty()}; deployments that want automatic binary discovery should bind
+     * a concrete implementation (e.g. one backed by an fbpkg lookup at the Presto-on-Spark
+     * launcher layer). Kept as an interface here so {@code presto-spark-base} doesn't need to
+     * depend on any deployment-specific launcher.
+     */
+    public interface SidecarBinaryLocator
+    {
+        java.util.Optional<String> locateNativeWorkerBinary();
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestDriverSidecarFunctionRegistryTool.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestDriverSidecarFunctionRegistryTool.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.functionNamespace.JsonBasedUdfFunctionMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import okhttp3.OkHttpClient;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestDriverSidecarFunctionRegistryTool
+{
+    private static final JsonCodec<Map<String, List<JsonBasedUdfFunctionMetadata>>> CODEC =
+            mapJsonCodec(String.class, listJsonCodec(JsonBasedUdfFunctionMetadata.class));
+
+    private HttpServer server;
+    private URI baseUri;
+    private AtomicInteger fetchCount;
+
+    @BeforeMethod
+    public void setUp()
+            throws IOException
+    {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        fetchCount = new AtomicInteger();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFetchAndConvert()
+    {
+        String body = "{" +
+                "\"my_scalar\": [{" +
+                "  \"docString\":\"presto.default.my_scalar\"," +
+                "  \"functionKind\":\"SCALAR\"," +
+                "  \"outputType\":\"bigint\"," +
+                "  \"paramTypes\":[\"bigint\"]," +
+                "  \"schema\":\"default\"," +
+                "  \"variableArity\":false," +
+                "  \"longVariableConstraints\":[]," +
+                "  \"typeVariableConstraints\":[]," +
+                "  \"routineCharacteristics\":{" +
+                "    \"determinism\":\"DETERMINISTIC\"," +
+                "    \"language\":\"CPP\"," +
+                "    \"nullCallClause\":\"RETURNS_NULL_ON_NULL_INPUT\"" +
+                "  }" +
+                "}]" +
+                "}";
+        bindEndpoint("/v1/functions", body);
+
+        DriverSidecarFunctionRegistryTool tool = newTool();
+
+        List<? extends SqlFunction> functions = tool.getWorkerFunctions();
+        assertThat(functions).hasSize(1);
+        assertThat(functions.get(0).getSignature().getName().toString())
+                .isEqualTo("presto.default.my_scalar");
+    }
+
+    @Test
+    public void testCachedAcrossCalls()
+    {
+        bindEndpoint("/v1/functions", "{}");
+        DriverSidecarFunctionRegistryTool tool = newTool();
+
+        tool.getWorkerFunctions();
+        tool.getWorkerFunctions();
+        tool.getRpcFunctionNames();
+
+        assertThat(fetchCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testHttpErrorThrowsPrestoException()
+    {
+        server.createContext("/v1/functions", exchange -> {
+            fetchCount.incrementAndGet();
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+        server.start();
+
+        DriverSidecarFunctionRegistryTool tool = newTool();
+
+        assertThatThrownBy(tool::getWorkerFunctions)
+                .isInstanceOf(PrestoException.class)
+                .hasMessageContaining("HTTP 500");
+    }
+
+    @Test
+    public void testRpcFunctionNamesPicksOnlyRpcEntries()
+    {
+        String body = "{" +
+                "\"plain_fn\": [" + scalarMetaFragment(false) + "]," +
+                "\"RPC_FN\": [" + scalarMetaFragment(true) + "]" +
+                "}";
+        bindEndpoint("/v1/functions", body);
+
+        DriverSidecarFunctionRegistryTool tool = newTool();
+
+        assertThat(tool.getRpcFunctionNames()).containsExactly("rpc_fn");
+    }
+
+    private void bindEndpoint(String path, String body)
+    {
+        HttpHandler handler = new HttpHandler()
+        {
+            @Override
+            public void handle(HttpExchange exchange)
+                    throws IOException
+            {
+                fetchCount.incrementAndGet();
+                byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            }
+        };
+        server.createContext(path, handler);
+        server.start();
+    }
+
+    private DriverSidecarFunctionRegistryTool newTool()
+    {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(5, TimeUnit.SECONDS)
+                .build();
+        FixedUriSidecarProcessFactory factory = new FixedUriSidecarProcessFactory(baseUri);
+        return new DriverSidecarFunctionRegistryTool(client, CODEC, factory);
+    }
+
+    private static String scalarMetaFragment(boolean rpc)
+    {
+        return "{" +
+                "  \"docString\":\"\"," +
+                "  \"functionKind\":\"SCALAR\"," +
+                "  \"outputType\":\"bigint\"," +
+                "  \"paramTypes\":[]," +
+                "  \"schema\":\"default\"," +
+                "  \"variableArity\":false," +
+                "  \"longVariableConstraints\":[]," +
+                "  \"typeVariableConstraints\":[]," +
+                "  \"isRpcFunction\":" + rpc + "," +
+                "  \"routineCharacteristics\":{" +
+                "    \"determinism\":\"DETERMINISTIC\"," +
+                "    \"language\":\"CPP\"," +
+                "    \"nullCallClause\":\"RETURNS_NULL_ON_NULL_INPUT\"" +
+                "  }" +
+                "}";
+    }
+
+    /**
+     * Test stand-in for {@link MetadataSidecarProcessFactory} that returns a fixed URI rather
+     * than spawning a process. We cannot easily mock the real factory here because it has a
+     * non-trivial constructor wiring; this avoids that complexity.
+     */
+    private static class FixedUriSidecarProcessFactory
+            extends MetadataSidecarProcessFactory
+    {
+        private final URI uri;
+
+        FixedUriSidecarProcessFactory(URI uri)
+        {
+            super(
+                    new OkHttpClient(),
+                    java.util.concurrent.Executors.newSingleThreadExecutor(),
+                    java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),
+                    JsonCodec.jsonCodec(com.facebook.presto.client.ServerInfo.class),
+                    new MetadataSidecarConfig().setExecutablePath("/bin/echo"),
+                    java.util.Optional::empty);
+            this.uri = uri;
+        }
+
+        @Override
+        public URI getOrStart()
+        {
+            return uri;
+        }
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestMetadataSidecarConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestMetadataSidecarConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.airlift.units.Duration;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class TestMetadataSidecarConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(MetadataSidecarConfig.class)
+                .setEnabled(false)
+                .setExecutablePath(null)
+                .setProgramArguments("")
+                .setStartupTimeout(new Duration(2, TimeUnit.MINUTES))
+                .setStorageOncallName("presto_oncall")
+                .setStorageUserName("presto")
+                .setStorageServiceName("warm_storage_service"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("metadata-sidecar.enabled", "true")
+                .put("metadata-sidecar.executable-path", "/opt/presto_server")
+                .put("metadata-sidecar.program-arguments", "--logtostderr")
+                .put("metadata-sidecar.startup-timeout", "30s")
+                .put("metadata-sidecar.storage-oncall-name", "custom_oncall")
+                .put("metadata-sidecar.storage-user-name", "custom_user")
+                .put("metadata-sidecar.storage-service-name", "custom_svc")
+                .build();
+
+        MetadataSidecarConfig expected = new MetadataSidecarConfig()
+                .setEnabled(true)
+                .setExecutablePath("/opt/presto_server")
+                .setProgramArguments("--logtostderr")
+                .setStartupTimeout(new Duration(30, TimeUnit.SECONDS))
+                .setStorageOncallName("custom_oncall")
+                .setStorageUserName("custom_user")
+                .setStorageServiceName("custom_svc");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestMetadataSidecarProcessSmoke.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestMetadataSidecarProcessSmoke.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.functionNamespace.JsonBasedUdfFunctionMetadata;
+import com.facebook.presto.spi.function.SqlFunction;
+import okhttp3.OkHttpClient;
+import org.testng.SkipException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end smoke test that boots a real {@code presto_server} binary in metadata-sidecar
+ * mode, fetches {@code /v1/functions}, and asserts the registry tool returns a substantial
+ * set of {@code SqlInvokedFunction} instances.
+ *
+ * <p>Skipped unless the {@code PRESTO_SERVER_BINARY} environment variable points to an
+ * executable native worker binary. To run locally:
+ *
+ * <pre>{@code
+ *   PRESTO_SERVER_BINARY=/path/to/presto_server \
+ *     mvn -f .../presto-spark-base test -Dtest=TestMetadataSidecarProcessSmoke ...
+ * }</pre>
+ */
+@Test(singleThreaded = true)
+public class TestMetadataSidecarProcessSmoke
+{
+    private static final String BINARY_ENV_VAR = "PRESTO_SERVER_BINARY";
+
+    private MetadataSidecarProcessFactory factory;
+    private OkHttpClient httpClient;
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        String binary = System.getenv(BINARY_ENV_VAR);
+        if (binary == null || !new File(binary).canExecute()) {
+            throw new SkipException(BINARY_ENV_VAR + " env var must point to an executable presto_server binary");
+        }
+        httpClient = new OkHttpClient.Builder()
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .build();
+        executor = Executors.newSingleThreadExecutor();
+        scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+
+        MetadataSidecarConfig config = new MetadataSidecarConfig()
+                .setEnabled(true)
+                .setExecutablePath(binary);
+        factory = new MetadataSidecarProcessFactory(
+                httpClient,
+                executor,
+                scheduledExecutor,
+                jsonCodec(ServerInfo.class),
+                config,
+                Optional::empty);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        if (factory != null) {
+            factory.close();
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testEndToEndFunctionFetch()
+    {
+        JsonCodec<Map<String, List<JsonBasedUdfFunctionMetadata>>> codec =
+                mapJsonCodec(String.class, listJsonCodec(JsonBasedUdfFunctionMetadata.class));
+
+        DriverSidecarFunctionRegistryTool tool =
+                new DriverSidecarFunctionRegistryTool(httpClient, codec, factory);
+
+        List<? extends SqlFunction> functions = tool.getWorkerFunctions();
+
+        // We expect at least a few hundred — the actual fb_presto_cpp:main payload has ~2873
+        // signatures across ~813 unique names, but be lenient here so the assertion still
+        // holds for thinner OSS presto_server builds.
+        assertThat(functions.size()).isGreaterThan(100);
+        boolean hasPrestoDefault = functions.stream()
+                .map(f -> f.getSignature().getName().toString())
+                .anyMatch(name -> name.startsWith("presto.default."));
+        assertThat(hasPrestoDefault).isTrue();
+    }
+}


### PR DESCRIPTION
Summary:
## Description

Introduces infrastructure for the presto-on-spark driver to launch a metadata-only Velox sidecar process at bootstrap, fetch the registered native function definitions over HTTP from its `/v1/functions` endpoint, and register them into `FunctionAndTypeManager` as built-in functions before query planning begins.

New classes (all in `presto-spark-base`, package `com.facebook.presto.spark.execution.nativeprocess`):

| Class | Purpose |
|---|---|
| `MetadataSidecarConfig` | Airlift `Config` for `metadata-sidecar.enabled` and `metadata-sidecar.executable-path` |
| `MetadataSidecarProcess` | Concrete `AbstractNativeProcess` subclass that writes a sidecar-only etc/ tree (no shuffle, no task discovery) |
| `MetadataSidecarProcessFactory` | Lifecycle owner; lazily starts the sidecar, exposes the `SidecarBinaryLocator` interface for binary discovery |
| `DriverSidecarFunctionRegistryTool` | `WorkerFunctionRegistryTool` implementation that boots the sidecar, GETs `/v1/functions`, deserializes `JsonBasedUdfFunctionMetadata`, converts to `SqlInvokedFunction` via `WorkerFunctionUtil`, then shuts the sidecar down |
| `DriverSidecarModule` | Guice wiring; binds the above + an `ForMetadataSidecar`-qualified OkHttp client and executors |
| `ForMetadataSidecar` | Binding annotation |

The feature is **disabled by default**. Two configs gate activation: `metadata-sidecar.enabled` (off by default) and the upstream `built-in-sidecar-functions-enabled` (off by default in `FeaturesConfig`). The bootstrap call site is added in a follow-up diff in this stack.

## Motivation and Context

When presto-on-spark uses Velox for execution, the Velox workers know about a superset of functions compared to the Java engine — many native UDFs have no Java implementation at all (e.g. native-only Velox built-ins). Today such functions fail at the driver during query analysis with `FUNCTION_NOT_FOUND` because the Java planner only knows about Java-registered functions, even though the Velox executors could happily evaluate them.

Mirroring the design used by Prestissimo's `NativeSidecarFunctionRegistryTool` (which fetches function metadata from a sidecar at coordinator boot), this diff adds the analogous machinery for the presto-on-spark driver. After registration, the planner can resolve native-only function references and the query proceeds normally.

`SidecarBinaryLocator` is an interface (with a default Optional-empty binding) so deployments can plug in their own way of discovering the sidecar binary on disk — the Java module deliberately doesn't depend on any deployment-specific launcher.

## Impact

Disabled by default; no behavior change unless the operator opts in. When enabled:

- A short-lived sidecar process spawns at driver bootstrap (~1-2s; shut down before planning begins).
- One additional bootstrap step issues an HTTP GET against the local sidecar.
- Native function metadata becomes available in `FunctionAndTypeManager` as built-in `SqlInvokedFunction`s.
- No effect on executors; module bindings stay lazy when not on the driver.

## Test Plan

- Unit tests: `TestMetadataSidecarConfig`, `TestMetadataSidecarProcessSmoke`, `TestDriverSidecarFunctionRegistryTool` — verify config binding, sidecar lifecycle, and the JSON → `SqlInvokedFunction` conversion path.


## Contributor checklist

- [x] My PR adheres to the code style of this project.
- [x] My code builds clean without any errors or warnings.
- [x] I have included tests in my PR.
- [x] I am willing to help maintain this change if there are any issues in the future.
Differential Revision: D103025711

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add a driver-side metadata sidecar that registers native-only Velox functions into the Java planner at driver bootstrap
```


