### PR TITLE
feat(native-pos): Wire driver-side metadata sidecar into bootstrap

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -17,10 +17,12 @@ import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.airlift.json.JsonModule;
 import com.facebook.airlift.json.smile.SmileModule;
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.presto.builtin.tools.WorkerFunctionRegistryTool;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.eventlistener.EventListenerModule;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.warnings.WarningCollectorModule;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.security.AccessControlManager;
@@ -31,6 +33,7 @@ import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -229,6 +232,10 @@ public class PrestoSparkInjectorFactory
                     injector.getInstance(StaticFunctionNamespaceStore.class)
                             .loadFunctionNamespaceManagers(defaultAuthClientConfigs(nodeInfo.getNodeId()));
                 }
+            }
+            if (sparkProcessType.equals(DRIVER) && featuresConfig.isBuiltInSidecarFunctionsEnabled()) {
+                List<? extends SqlFunction> functions = injector.getInstance(WorkerFunctionRegistryTool.class).getWorkerFunctions();
+                injector.getInstance(FunctionAndTypeManager.class).registerWorkerFunctions(functions);
             }
             bootstrapTimer.endDriverModulesLoading();
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DriverSidecarModule.java
@@ -25,6 +25,7 @@ import okhttp3.OkHttpClient;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 
 /**
  * Guice module that wires the driver-side metadata sidecar.
@@ -68,6 +70,12 @@ public class DriverSidecarModule
         binder.bind(WorkerFunctionRegistryTool.class)
                 .to(DriverSidecarFunctionRegistryTool.class)
                 .in(Scopes.SINGLETON);
+        // Default: no automatic binary discovery — operators must set
+        // `metadata-sidecar.executable-path` in config. Deployments can override
+        // this binding to plug in a launcher-layer lookup.
+        newOptionalBinder(binder, MetadataSidecarProcessFactory.SidecarBinaryLocator.class)
+                .setDefault()
+                .toInstance(Optional::empty);
     }
 
     @Provides


### PR DESCRIPTION
Summary: Differential Revision: D103025710
## Description

Wires the driver-side metadata sidecar into the presto-on-spark bootstrap. After Airlift initializes, when both `built-in-sidecar-functions-enabled=true` and `sparkProcessType == DRIVER`, `PrestoSparkInjectorFactory` invokes `WorkerFunctionRegistryTool.getWorkerFunctions()` to fetch native function metadata from the sidecar and registers the result into `FunctionAndTypeManager` as built-in `SqlInvokedFunction`s.

Also adds the default `OptionalBinder<SidecarBinaryLocator>` binding (returns `Optional.empty`) to `DriverSidecarModule` so deployments can override with their own concrete locator without requiring a binding from this module.

## Motivation and Context

D103025711 introduced the metadata-sidecar machinery but did not call it. This diff adds the bootstrap call site, mirroring the equivalent code path in `PrestoServer` for Prestissimo's coordinator-side sidecar registration.

The companion change in `PrestoFacebookSparkServiceFactory` (Meta-internal) installs `DriverSidecarModule` on driver and executor JVMs so Airlift's strict-config check accepts the `metadata-sidecar.*` properties on both tiers.

## Impact

Disabled by default — `built-in-sidecar-functions-enabled` defaults to `false` in `FeaturesConfig`. When enabled by an operator, the only behavior change is a one-time bootstrap step that registers additional built-in functions; no effect on already-resolvable function references or query execution paths.

## Test Plan

End-to-end validation in D103025708 (paste P2298835496) — boots the sidecar from a real native worker binary on the driver, registers `koski_cosine_similarity` (a native-only Velox function with no Java implementation), plans an INSERT that uses it, and confirms native execution writes the expected rows.

## Contributor checklist

- [x] My PR adheres to the code style of this project.
- [x] My code builds clean without any errors or warnings.
- [x] I am willing to help maintain this change if there are any issues in the future.


## Release Notes

```
== RELEASE NOTES ==
General Presto-on-Spark Changes
* Update the driver-side metadata sidecar registration of worker functions into the Airlift bootstrap
```


