### PR TITLE
fix: Enable partition-aware grouped execution for index joins

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPartitionAwareGroupedExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPartitionAwareGroupedExecution.java
@@ -716,15 +716,16 @@ public class TestPartitionAwareGroupedExecution
     public void testPartitionColumnNotInOutput()
     {
         // ds is used in the join but NOT in the SELECT or GROUP BY output.
-        // The SINGLE aggregation filters out ds from usable partition columns,
-        // so partition-aware falls back to standard grouped execution.
+        // Partition-aware is still used because ds participates in a joined
+        // equivalence class (t1.ds = t2.ds) and the visitProject preservation
+        // keeps it alive through projections above the join.
         @Language("SQL") String query =
                 "SELECT sum(t1.val2 + t2.val4) " +
                         "FROM test_pa_t1 t1 " +
                         "JOIN test_pa_t2 t2 ON t1.col = t2.col AND t1.ds = t2.ds";
 
         assertQueryWithSameQueryRunner(partitionAwareSession(), query, standardGroupedSession());
-        assertPartitionAwareNotUsed(partitionAwareSession(), query);
+        assertPartitionAwareUsed(partitionAwareSession(), query);
     }
 
     @Test

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
@@ -191,7 +191,7 @@ class GroupedExecutionTagger
     }
 
     /**
-     * Merge partition column tracking from both sides of a partitioned join (hash or merge).
+     * Merge partition column tracking from both sides of a partitioned join (hash, merge, or index).
      * For each equi-join clause where both sides have usable partition columns,
      * union the corresponding TableScanColumns in the union-find and track which vars participated.
      * Drop vars whose TableScanColumn is not in any equivalence class with a joined var.
@@ -359,14 +359,32 @@ class GroupedExecutionTagger
                     childProps.capableTableScanNodes, childProps.totalLifespans,
                     childProps.recoveryEligible);
         }
-        // Track partition columns through variable assignments (identity and renaming projections)
-        // Map new output var -> same TableScanColumn as the source var
+        // Track partition columns through variable assignments (identity and
+        // renaming projections). Map new output var -> same TableScanColumn as
+        // the source var.
         Map<VariableReferenceExpression, TableScanColumn> mappedPartitionColumns = new HashMap<>();
         for (Map.Entry<VariableReferenceExpression, RowExpression> entry : node.getAssignments().getMap().entrySet()) {
             if (entry.getValue() instanceof VariableReferenceExpression) {
                 VariableReferenceExpression sourceVar = (VariableReferenceExpression) entry.getValue();
                 TableScanColumn tsc = childProps.partitionColumns.get(sourceVar);
                 if (tsc != null) {
+                    mappedPartitionColumns.put(entry.getKey(), tsc);
+                }
+            }
+        }
+
+        // Preserve child partition columns that are not projected but
+        // participate in a joined equivalence class (size > 1 in the
+        // union-find). These are consumed by a join below this project and
+        // are needed for partition-aware scheduling even though they don't
+        // appear in the project output.
+        Map<GroupedExecutionTagger.TableScanColumn, Set<GroupedExecutionTagger.TableScanColumn>> equivalenceClasses =
+                childProps.partitionColumnUnionFind.getEquivalenceClasses();
+        for (Map.Entry<VariableReferenceExpression, TableScanColumn> entry : childProps.partitionColumns.entrySet()) {
+            if (!mappedPartitionColumns.containsKey(entry.getKey())) {
+                TableScanColumn tsc = entry.getValue();
+                Set<TableScanColumn> eqClass = equivalenceClasses.get(childProps.partitionColumnUnionFind.find(tsc));
+                if (eqClass != null && eqClass.size() > 1) {
                     mappedPartitionColumns.put(entry.getKey(), tsc);
                 }
             }
@@ -426,7 +444,21 @@ class GroupedExecutionTagger
     @Override
     public GroupedExecutionTagger.GroupedExecutionProperties visitTableScan(TableScanNode node, Void context)
     {
-        TableLayout layout = metadata.getLayout(session, node.getTable());
+        return getSourceNodeProperties(node.getId(), node.getTable(), node.getAssignments());
+    }
+
+    @Override
+    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexSource(IndexSourceNode node, Void context)
+    {
+        return getSourceNodeProperties(node.getId(), node.getTableHandle(), node.getAssignments());
+    }
+
+    private GroupedExecutionTagger.GroupedExecutionProperties getSourceNodeProperties(
+            PlanNodeId nodeId,
+            TableHandle tableHandle,
+            Map<VariableReferenceExpression, ColumnHandle> assignments)
+    {
+        TableLayout layout = metadata.getLayout(session, tableHandle);
         Optional<TableLayout.TablePartitioning> tablePartitioning = layout.getTablePartitioning();
         if (!tablePartitioning.isPresent()) {
             return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
@@ -444,9 +476,9 @@ class GroupedExecutionTagger
             Optional<DiscretePredicates> discretePredicates = layout.getDiscretePredicates();
             if (discretePredicates.isPresent()) {
                 Set<ColumnHandle> partitionCols = new HashSet<>(discretePredicates.get().getColumns());
-                for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : node.getAssignments().entrySet()) {
+                for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : assignments.entrySet()) {
                     if (partitionCols.contains(entry.getValue())) {
-                        TableScanColumn tsc = new TableScanColumn(node.getId(), entry.getValue());
+                        TableScanColumn tsc = new TableScanColumn(nodeId, entry.getValue());
                         partitionColumns.put(entry.getKey(), tsc);
                         unionFind.add(tsc);
                     }
@@ -457,37 +489,11 @@ class GroupedExecutionTagger
         return new GroupedExecutionTagger.GroupedExecutionProperties(
                 true,
                 false,
-                ImmutableList.of(node.getId()),
+                ImmutableList.of(nodeId),
                 partitionHandles.size(),
-                metadata.getConnectorCapabilities(session, node.getTable().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE),
+                metadata.getConnectorCapabilities(session, tableHandle.getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE),
                 partitionColumns,
                 unionFind);
-    }
-
-    @Override
-    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexSource(IndexSourceNode node, Void context)
-    {
-        return getSourceNodeGroupedExecutionProperties(node.getId(), node.getTableHandle());
-    }
-
-    private GroupedExecutionTagger.GroupedExecutionProperties getSourceNodeGroupedExecutionProperties(PlanNodeId nodeId, TableHandle tableHandle)
-    {
-        Optional<TableLayout.TablePartitioning> tablePartitioning = metadata.getLayout(session, tableHandle).getTablePartitioning();
-        if (!tablePartitioning.isPresent()) {
-            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
-        }
-        List<ConnectorPartitionHandle> partitionHandles = nodePartitioningManager.listPartitionHandles(session, tablePartitioning.get().getPartitioningHandle());
-        if (ImmutableList.of(NOT_PARTITIONED).equals(partitionHandles)) {
-            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
-        }
-        else {
-            return new GroupedExecutionTagger.GroupedExecutionProperties(
-                    true,
-                    false,
-                    ImmutableList.of(nodeId),
-                    partitionHandles.size(),
-                    metadata.getConnectorCapabilities(session, tableHandle.getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
-        }
     }
 
     @Override
@@ -500,24 +506,37 @@ class GroupedExecutionTagger
             return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
         }
 
-        // For index join with colocated execution, both probe and index sides must be capable
-        // and have the same number of lifespans (buckets)
+        // For index join with colocated execution, both probe and index sides
+        // must be capable and have the same number of lifespans (buckets).
+        // When partition-aware execution is enabled, partition columns from
+        // both sides are merged via mergeJoinSides so that the scheduler
+        // creates (bucket, partition) lifespans instead of bucket-only.
         if (probe.currentNodeCapable && index.currentNodeCapable) {
             if (probe.totalLifespans != index.totalLifespans) {
                 return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
             }
-            // Include both probe and index side scan nodes for grouped
-            // execution. Each bucket group gets its own index split,
-            // ensuring file alignment for colocated lookup joins.
-            ImmutableList.Builder<PlanNodeId> allScanNodes = ImmutableList.builder();
-            allScanNodes.addAll(probe.capableTableScanNodes);
-            allScanNodes.addAll(index.capableTableScanNodes);
-            return new GroupedExecutionTagger.GroupedExecutionProperties(
-                    true,
-                    true,
-                    allScanNodes.build(),
-                    probe.totalLifespans,
-                    probe.recoveryEligible && index.recoveryEligible);
+
+            if (!partitionAwareEnabled) {
+                // Include both probe and index side scan nodes for grouped
+                // execution. Each bucket group gets its own index split,
+                // ensuring file alignment for colocated lookup joins.
+                ImmutableList.Builder<PlanNodeId> allScanNodes = ImmutableList.builder();
+                allScanNodes.addAll(probe.capableTableScanNodes);
+                allScanNodes.addAll(index.capableTableScanNodes);
+                return new GroupedExecutionTagger.GroupedExecutionProperties(
+                        true,
+                        true,
+                        allScanNodes.build(),
+                        probe.totalLifespans,
+                        probe.recoveryEligible && index.recoveryEligible);
+            }
+
+            // Merge partition columns from both sides, using index join
+            // criteria to establish equivalence classes.
+            List<EquiJoinClause> criteria = node.getCriteria().stream()
+                    .map(c -> new EquiJoinClause(c.getProbe(), c.getIndex()))
+                    .collect(ImmutableList.toImmutableList());
+            return mergeJoinSides(probe, index, criteria);
         }
 
         // Probe-only grouped execution for index joins is not currently

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.Partitioning;
@@ -267,11 +268,11 @@ public class PlanFragmenterUtils
         // equal, the column names are also equal, so last-wins produces the same result.
         ImmutableMap.Builder<ColumnHandle, String> builder = ImmutableMap.builder();
         for (PlanNodeId scanNodeId : fragment.getTableScanSchedulingOrder()) {
-            Optional<TableScanNode> scanNodeOpt = findTableScanNode(fragment.getRoot(), scanNodeId);
-            if (!scanNodeOpt.isPresent()) {
+            Optional<TableHandle> tableHandleOpt = findSourceNodeTableHandle(fragment.getRoot(), scanNodeId);
+            if (!tableHandleOpt.isPresent()) {
                 return Optional.empty();
             }
-            Map<String, ColumnHandle> nameToHandle = metadata.getColumnHandles(session, scanNodeOpt.get().getTable());
+            Map<String, ColumnHandle> nameToHandle = metadata.getColumnHandles(session, tableHandleOpt.get());
             for (Map.Entry<String, ColumnHandle> entry : nameToHandle.entrySet()) {
                 builder.put(entry.getValue(), entry.getKey());
             }
@@ -336,11 +337,11 @@ public class PlanFragmenterUtils
             Map<PlanNodeId, Map<String, String>> perScanMappings)
     {
         for (PlanNodeId scanNodeId : fragment.getTableScanSchedulingOrder()) {
-            Optional<TableScanNode> scanNodeOpt = findTableScanNode(fragment.getRoot(), scanNodeId);
-            if (!scanNodeOpt.isPresent()) {
+            Optional<TableHandle> tableHandleOpt = findSourceNodeTableHandle(fragment.getRoot(), scanNodeId);
+            if (!tableHandleOpt.isPresent()) {
                 continue;
             }
-            TableLayout scanLayout = metadata.getLayout(session, scanNodeOpt.get().getTable());
+            TableLayout scanLayout = metadata.getLayout(session, tableHandleOpt.get());
             if (!scanLayout.getDiscretePredicates().isPresent()) {
                 continue;
             }
@@ -368,11 +369,11 @@ public class PlanFragmenterUtils
     {
         Set<Map<String, String>> combinedDistinctValues = null;
         for (PlanNodeId scanNodeId : fragment.getTableScanSchedulingOrder()) {
-            Optional<TableScanNode> scanNodeOpt = findTableScanNode(fragment.getRoot(), scanNodeId);
-            if (!scanNodeOpt.isPresent()) {
+            Optional<TableHandle> tableHandleOpt = findSourceNodeTableHandle(fragment.getRoot(), scanNodeId);
+            if (!tableHandleOpt.isPresent()) {
                 return ImmutableList.of();
             }
-            TableLayout layout = metadata.getLayout(session, scanNodeOpt.get().getTable());
+            TableLayout layout = metadata.getLayout(session, tableHandleOpt.get());
             if (!layout.getDiscretePredicates().isPresent()) {
                 return ImmutableList.of();
             }
@@ -425,11 +426,16 @@ public class PlanFragmenterUtils
         return ImmutableList.copyOf(combinedDistinctValues);
     }
 
-    private static Optional<TableScanNode> findTableScanNode(PlanNode root, PlanNodeId targetId)
+    private static Optional<TableHandle> findSourceNodeTableHandle(PlanNode root, PlanNodeId targetId)
     {
         for (PlanNode node : forTree(PlanNode::getSources).depthFirstPreOrder(root)) {
-            if (node instanceof TableScanNode && node.getId().equals(targetId)) {
-                return Optional.of((TableScanNode) node);
+            if (node.getId().equals(targetId)) {
+                if (node instanceof TableScanNode) {
+                    return Optional.of(((TableScanNode) node).getTable());
+                }
+                if (node instanceof IndexSourceNode) {
+                    return Optional.of(((IndexSourceNode) node).getTableHandle());
+                }
             }
         }
         return Optional.empty();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -248,6 +248,9 @@ public class SplitSourceFactory
 
             TableHandle table = node.getTableHandle();
             SplitSchedulingStrategy strategy = getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId());
+            Map<String, String> partitionColumnMapping = stageExecutionDescriptor.isScanGroupedExecution(node.getId())
+                    ? stageExecutionDescriptor.getPartitionColumnMapping(node.getId())
+                    : ImmutableMap.of();
 
             // Use LazySplitSource to defer the potentially expensive MetaStore
             // call (split enumeration) until splits are actually needed,
@@ -255,7 +258,7 @@ public class SplitSourceFactory
             // to be resolved by the connector's plan optimizer
             // (ApplyConnectorOptimization).
             SplitSource splitSource = new LazySplitSource(
-                    () -> splitSourceProvider.getSplits(session, table, strategy, warningCollector));
+                    () -> splitSourceProvider.getSplits(session, table, strategy, warningCollector, partitionColumnMapping));
             splitSources.add(splitSource);
 
             return ImmutableMap.of(node.getId(), splitSource);


### PR DESCRIPTION
Summary:

Partition-aware grouped execution schedules lifespans at (bucket, partition)
granularity instead of bucket-only, so each lifespan processes one partition. This was
implemented for TableScanNode and hash/merge joins but not for IndexSourceNode and
IndexJoinNode, causing index joins to receive all partitions in a single lifespan.

This change extends partition-aware grouped execution to index joins:

GroupedExecutionTagger:
- Extract getSourceNodeProperties() shared by visitTableScan and visitIndexSource to
collect partition columns from DiscretePredicates
- visitIndexJoin: merge partition columns from both sides via mergeJoinSides when
partition-aware is enabled, matching visitJoin behavior
- visitProject: preserve child partition columns that participate in a joined
equivalence class even when not projected in output. Without this, partition columns
consumed by an IndexJoinNode below the ProjectNode are dropped before reaching
analyzeGroupedExecution

PlanFragmenterUtils:
- Add findSourceNodeTableHandle() that resolves both TableScanNode and IndexSourceNode
by ID, replacing findTableScanNode() which only matched TableScanNode. Without this,
computePartitionValues() aborted when encountering an IndexSourceNode ID in the table
scan scheduling order

SplitSourceFactory:
- visitIndexSource: pass partitionColumnMapping from StageExecutionDescriptor to
getSplits, matching visitTableScan. Without this, HiveSplitManager created a PerBucket
split source instead of PerBucketPartitionAware for the index table

## Release Notes

```
== NO RELEASE NOTE ==
```

