### PR TITLE
feat: Support extending verifier QueryRewriter (#27703)

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -355,6 +355,11 @@ Name                                        Description
 
                                             Declare the function arguments as identifiers if they need to be applied to
                                             the function substitute.
+``query-rewriter-factory``                  Defines the ``QueryRewriterFactory`` implementation to bind at startup.
+                                            Defaults to ``default``, which will use ``VerificationQueryRewriterFactory``.
+                                            Anyone extending or overriding ``QueryRewriter`` with their own implementation
+                                            can use a unique config value to control binding their own ``QueryRewriterFactory``
+                                            implementation and disable the default binding.
 =========================================== ===============================================================================
 
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
@@ -16,6 +16,7 @@ package com.facebook.presto.verifier.framework;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
@@ -29,6 +30,7 @@ public enum QueryType
     QUERY(Query.class),
     CREATE_VIEW(CreateView.class),
     CREATE_TABLE(CreateTable.class),
+    DELETE(Delete.class),
     UNSUPPORTED();
 
     private final Optional<Class<? extends Statement>> statementClass;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -110,6 +110,7 @@ public class VerificationFactory
         switch (queryType) {
             case CREATE_TABLE_AS_SELECT:
             case INSERT:
+            case DELETE:
                 if (verifierConfig.isExtendedVerification()) {
                     return new ExtendedVerification(
                             queryActions,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.verifier.rewrite.FunctionCallRewriter.FunctionCallSubstitute;
+import static com.facebook.presto.verifier.rewrite.VerificationQueryRewriterFactory.VERIFICATION_QUERY_REWRITER_FACTORY;
 import static com.facebook.presto.verifier.source.MySqlSourceQuerySupplier.MYSQL_SOURCE_QUERY_SUPPLIER;
 import static java.util.Locale.ENGLISH;
 
@@ -73,6 +74,8 @@ public class VerifierConfig
     private boolean jsonParseSafetyWrapperEnabled;
 
     private Multimap<String, FunctionCallSubstitute> functionSubstitutes = ImmutableMultimap.of();
+
+    private String queryRewriterFactory = VERIFICATION_QUERY_REWRITER_FACTORY;
 
     @NotNull
     public Optional<Set<String>> getWhitelist()
@@ -483,6 +486,22 @@ public class VerifierConfig
     public VerifierConfig setFunctionSubstitutes(String functionSubstitutes)
     {
         this.functionSubstitutes = FunctionCallRewriter.validateAndConstructFunctionCallSubstituteMap(functionSubstitutes);
+        return this;
+    }
+
+    @NotNull
+    public String getQueryRewriterFactory()
+    {
+        return queryRewriterFactory;
+    }
+
+    @ConfigDescription("The type of QueryRewriterFactory to use. Defaults to 'default' to use the bundled" +
+            " VerificationQueryRewriterFactory. Set to a custom string to disable the default and allow binding" +
+            " your own implementation.")
+    @Config("query-rewriter-factory")
+    public VerifierConfig setQueryRewriterFactory(String queryRewriterFactory)
+    {
+        this.queryRewriterFactory = queryRewriterFactory;
         return this;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.tree.ComparisonExpression.Operator;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Expression;
@@ -54,6 +55,7 @@ import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.verifier.framework.ClusterType;
 import com.facebook.presto.verifier.framework.Column;
@@ -114,6 +116,28 @@ import static java.util.UUID.randomUUID;
 
 public class QueryRewriter
 {
+    private static final class SubstitutedStatement<T extends Statement>
+    {
+        private final T statement;
+        private final Optional<String> functionSubstitutions;
+
+        public SubstitutedStatement(T statement, Optional<String> functionSubstitutions)
+        {
+            this.statement = requireNonNull(statement, "statement is null");
+            this.functionSubstitutions = requireNonNull(functionSubstitutions, "functionSubstitutions is null");
+        }
+
+        public T getStatement()
+        {
+            return statement;
+        }
+
+        public Optional<String> getFunctionSubstitutions()
+        {
+            return functionSubstitutions;
+        }
+    }
+
     private final SqlParser sqlParser;
     private final TypeManager typeManager;
     private final BlockEncodingSerde blockEncodingSerde;
@@ -176,9 +200,9 @@ public class QueryRewriter
      * Operates directly on the AST to avoid fragile SQL format/re-parse round-trips
      * that silently fail on complex queries with lambdas or internal function patterns.
      */
-    private static Query applyJsonParseSafetyWrapper(Query query)
+    private static <T extends Statement> T applyJsonParseSafetyWrapper(T query)
     {
-        return (Query) new JsonParseTryWrapper().process(query, null);
+        return (T) new JsonParseTryWrapper().process(query, null);
     }
 
     /**
@@ -244,193 +268,244 @@ public class QueryRewriter
 
         if (statement instanceof CreateTableAsSelect) {
             CreateTableAsSelect createTableAsSelect = (CreateTableAsSelect) statement;
-            Query createQuery = createTableAsSelect.getQuery();
-
-            Optional<String> functionSubstitutions = Optional.empty();
-            if (functionCallRewriter.isPresent()) {
-                FunctionCallRewriter.RewriterResult rewriterResult = functionCallRewriter.get().rewrite(createQuery);
-                createQuery = (Query) rewriterResult.getRewrittenNode();
-                functionSubstitutions = rewriterResult.getSubstitutions();
-            }
-            // Apply safety wrapper for json_parse() calls to prevent failures on malformed JSON
-            if (jsonParseSafetyWrapperEnabled) {
-                createQuery = applyJsonParseSafetyWrapper(createQuery);
-            }
-            if (shouldReuseTable && !functionSubstitutions.isPresent()) {
-                Optional<Expression> partitionsPredicate = getPartitionsPredicate(createTableAsSelect.getName(), queryConfiguration.getPartitions());
-                if (partitionsPredicate.isPresent()) {
-                    return new QueryObjectBundle(
-                            createTableAsSelect.getName(),
-                            ImmutableList.of(),
-                            createTableAsSelect,
-                            ImmutableList.of(),
-                            clusterType,
-                            Optional.empty(),
-                            partitionsPredicate,
-                            true);
-                }
-            }
-
-            QualifiedName temporaryTableName = generateTemporaryName(Optional.of(createTableAsSelect.getName()), prefix);
-            return new QueryObjectBundle(
-                    temporaryTableName,
-                    ImmutableList.of(),
-                    new CreateTableAsSelect(
-                            temporaryTableName,
-                            createQuery,
-                            createTableAsSelect.isNotExists(),
-                            applyPropertyOverride(createTableAsSelect.getProperties(), properties),
-                            createTableAsSelect.isWithData(),
-                            createTableAsSelect.getColumnAliases(),
-                            createTableAsSelect.getComment()),
-                    ImmutableList.of(new DropTable(temporaryTableName, true)),
-                    clusterType,
-                    functionSubstitutions,
-                    Optional.empty(),
-                    false);
+            return rewriteCreateTableAsSelect(createTableAsSelect, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
         }
         if (statement instanceof Insert) {
             Insert insert = (Insert) statement;
-            QualifiedName originalTableName = insert.getTarget();
-            Query insertQuery = insert.getQuery();
-
-            Optional<String> functionSubstitutions = Optional.empty();
-            if (functionCallRewriter.isPresent()) {
-                FunctionCallRewriter.RewriterResult rewriterResult = functionCallRewriter.get().rewrite(insertQuery);
-                insertQuery = (Query) rewriterResult.getRewrittenNode();
-                functionSubstitutions = rewriterResult.getSubstitutions();
-            }
-            // Apply safety wrapper for json_parse() calls
-            if (jsonParseSafetyWrapperEnabled) {
-                insertQuery = applyJsonParseSafetyWrapper(insertQuery);
-            }
-            if (shouldReuseTable && !functionSubstitutions.isPresent()) {
-                Optional<Expression> partitionsPredicate = getPartitionsPredicate(originalTableName, queryConfiguration.getPartitions());
-                if (partitionsPredicate.isPresent()) {
-                    return new QueryObjectBundle(
-                            originalTableName,
-                            ImmutableList.of(),
-                            insert,
-                            ImmutableList.of(),
-                            clusterType,
-                            Optional.empty(),
-                            partitionsPredicate,
-                            true);
-                }
-            }
-
-            QualifiedName temporaryTableName = generateTemporaryName(Optional.of(originalTableName), prefix);
-            return new QueryObjectBundle(
-                    temporaryTableName,
-                    ImmutableList.of(
-                            new CreateTable(
-                                    temporaryTableName,
-                                    ImmutableList.of(new LikeClause(originalTableName, Optional.of(INCLUDING))),
-                                    false,
-                                    properties,
-                                    Optional.empty())),
-                    new Insert(
-                            temporaryTableName,
-                            insert.getColumns(),
-                            insertQuery),
-                    ImmutableList.of(new DropTable(temporaryTableName, true)),
-                    clusterType,
-                    functionSubstitutions,
-                    Optional.empty(),
-                    false);
+            return rewriteInsert(insert, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
         }
         if (statement instanceof Query) {
             Query queryBody = (Query) statement;
-
-            Optional<String> functionSubstitutions = Optional.empty();
-            if (functionCallRewriter.isPresent()) {
-                FunctionCallRewriter.RewriterResult rewriterResult = functionCallRewriter.get().rewrite(queryBody);
-                queryBody = (Query) rewriterResult.getRewrittenNode();
-                functionSubstitutions = rewriterResult.getSubstitutions();
-            }
-            // Apply safety wrapper for json_parse() calls
-            if (jsonParseSafetyWrapperEnabled) {
-                queryBody = applyJsonParseSafetyWrapper(queryBody);
-            }
-
-            QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
-            ResultSetMetaData metadata = getResultMetadata(queryBody);
-            List<Identifier> columnAliases = generateStorageColumnAliases(metadata);
-            queryBody = rewriteNonStorableColumns(queryBody, metadata);
-            return new QueryObjectBundle(
-                    temporaryTableName,
-                    ImmutableList.of(),
-                    new CreateTableAsSelect(
-                            temporaryTableName,
-                            queryBody,
-                            false,
-                            properties,
-                            true,
-                            Optional.of(columnAliases),
-                            Optional.empty()),
-                    ImmutableList.of(new DropTable(temporaryTableName, true)),
-                    clusterType,
-                    functionSubstitutions,
-                    Optional.empty(),
-                    false);
+            return rewriteQuery(queryBody, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
         }
         if (statement instanceof CreateView) {
             CreateView createView = (CreateView) statement;
-            QualifiedName temporaryViewName = generateTemporaryName(Optional.empty(), prefix);
-            ImmutableList.Builder<Statement> setupQueries = ImmutableList.builder();
-
-            // Check to see if there is an existing view with the specified view name.
-            // If view exists, create a temporary view that are has the same definition as the existing view.
-            // Otherwise, do not pre-create temporary view.
-            try {
-                String createExistingViewQuery = getOnlyElement(prestoAction.execute(
-                        new ShowCreate(VIEW, createView.getName()),
-                        REWRITE,
-                        SHOW_CREATE_VIEW_CONVERTER).getResults());
-                CreateView createExistingView = (CreateView) sqlParser.createStatement(createExistingViewQuery, PARSING_OPTIONS);
-                setupQueries.add(new CreateView(
-                        temporaryViewName,
-                        createExistingView.getQuery(),
-                        false,
-                        createExistingView.getSecurity()));
-            }
-            catch (QueryException e) {
-                // no-op
-            }
-            return new QueryObjectBundle(
-                    temporaryViewName,
-                    setupQueries.build(),
-                    new CreateView(
-                            temporaryViewName,
-                            createView.getQuery(),
-                            createView.isReplace(),
-                            createView.getSecurity()),
-                    ImmutableList.of(new DropView(temporaryViewName, true)),
-                    clusterType,
-                    Optional.empty(),
-                    Optional.empty(),
-                    false);
+            return rewriteCreateView(createView, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
         }
         if (statement instanceof CreateTable) {
             CreateTable createTable = (CreateTable) statement;
-            QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
-            return new QueryObjectBundle(
-                    temporaryTableName,
-                    ImmutableList.of(),
-                    new CreateTable(
-                            temporaryTableName,
-                            createTable.getElements(),
-                            createTable.isNotExists(),
-                            applyPropertyOverride(createTable.getProperties(), properties),
-                            createTable.getComment()),
-                    ImmutableList.of(new DropTable(temporaryTableName, true)),
-                    clusterType,
-                    Optional.empty(),
-                    Optional.empty(),
-                    false);
+            return rewriteCreateTable(createTable, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
+        }
+        if (statement instanceof Delete) {
+            Delete delete = (Delete) statement;
+            return rewriteDelete(delete, queryConfiguration, clusterType, shouldReuseTable, prefix, properties);
         }
 
         throw new IllegalStateException(format("Unsupported query type: %s", statement.getClass()));
+    }
+
+    protected QueryObjectBundle rewriteCreateTableAsSelect(CreateTableAsSelect createTableAsSelect, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        SubstitutedStatement<Query> substitutedQuery = rewriteQueryFunctions(createTableAsSelect.getQuery());
+        Query createQuery = substitutedQuery.getStatement();
+        Optional<String> functionSubstitutions = substitutedQuery.getFunctionSubstitutions();
+
+        if (shouldReuseTable && !functionSubstitutions.isPresent()) {
+            Optional<Expression> partitionsPredicate = getPartitionsPredicate(createTableAsSelect.getName(), queryConfiguration.getPartitions());
+            if (partitionsPredicate.isPresent()) {
+                return new QueryObjectBundle(
+                        createTableAsSelect.getName(),
+                        ImmutableList.of(),
+                        createTableAsSelect,
+                        ImmutableList.of(),
+                        clusterType,
+                        Optional.empty(),
+                        partitionsPredicate,
+                        true);
+            }
+        }
+
+        QualifiedName temporaryTableName = generateTemporaryName(Optional.of(createTableAsSelect.getName()), prefix);
+        return new QueryObjectBundle(
+                temporaryTableName,
+                ImmutableList.of(),
+                new CreateTableAsSelect(
+                        temporaryTableName,
+                        createQuery,
+                        createTableAsSelect.isNotExists(),
+                        applyPropertyOverride(createTableAsSelect.getProperties(), properties),
+                        createTableAsSelect.isWithData(),
+                        createTableAsSelect.getColumnAliases(),
+                        createTableAsSelect.getComment()),
+                ImmutableList.of(new DropTable(temporaryTableName, true)),
+                clusterType,
+                functionSubstitutions,
+                Optional.empty(),
+                false);
+    }
+
+    protected QueryObjectBundle rewriteInsert(Insert insert, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        QualifiedName originalTableName = insert.getTarget();
+        SubstitutedStatement<Query> substitutedQuery = rewriteQueryFunctions(insert.getQuery());
+        Query insertQuery = substitutedQuery.getStatement();
+        Optional<String> functionSubstitutions = substitutedQuery.getFunctionSubstitutions();
+
+        if (shouldReuseTable && !functionSubstitutions.isPresent()) {
+            Optional<Expression> partitionsPredicate = getPartitionsPredicate(originalTableName, queryConfiguration.getPartitions());
+            if (partitionsPredicate.isPresent()) {
+                return new QueryObjectBundle(
+                        originalTableName,
+                        ImmutableList.of(),
+                        insert,
+                        ImmutableList.of(),
+                        clusterType,
+                        Optional.empty(),
+                        partitionsPredicate,
+                        true);
+            }
+        }
+
+        QualifiedName temporaryTableName = generateTemporaryName(Optional.of(originalTableName), prefix);
+        return new QueryObjectBundle(
+                temporaryTableName,
+                ImmutableList.of(
+                        new CreateTable(
+                                temporaryTableName,
+                                ImmutableList.of(new LikeClause(originalTableName, Optional.of(INCLUDING))),
+                                false,
+                                properties,
+                                Optional.empty())),
+                new Insert(
+                        temporaryTableName,
+                        insert.getColumns(),
+                        insertQuery),
+                ImmutableList.of(new DropTable(temporaryTableName, true)),
+                clusterType,
+                functionSubstitutions,
+                Optional.empty(),
+                false);
+    }
+
+    protected QueryObjectBundle rewriteQuery(Query queryBody, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        SubstitutedStatement<Query> substitutedQuery = rewriteQueryFunctions(queryBody);
+        queryBody = substitutedQuery.getStatement();
+        Optional<String> functionSubstitutions = substitutedQuery.getFunctionSubstitutions();
+
+        QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
+        ResultSetMetaData metadata = getResultMetadata(queryBody);
+        List<Identifier> columnAliases = generateStorageColumnAliases(metadata);
+        queryBody = rewriteNonStorableColumns(queryBody, metadata);
+        return new QueryObjectBundle(
+                temporaryTableName,
+                ImmutableList.of(),
+                new CreateTableAsSelect(
+                        temporaryTableName,
+                        queryBody,
+                        false,
+                        properties,
+                        true,
+                        Optional.of(columnAliases),
+                        Optional.empty()),
+                ImmutableList.of(new DropTable(temporaryTableName, true)),
+                clusterType,
+                functionSubstitutions,
+                Optional.empty(),
+                false);
+    }
+
+    protected QueryObjectBundle rewriteCreateView(CreateView createView, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        QualifiedName temporaryViewName = generateTemporaryName(Optional.empty(), prefix);
+        ImmutableList.Builder<Statement> setupQueries = ImmutableList.builder();
+
+        // Check to see if there is an existing view with the specified view name.
+        // If view exists, create a temporary view that are has the same definition as the existing view.
+        // Otherwise, do not pre-create temporary view.
+        try {
+            String createExistingViewQuery = getOnlyElement(prestoAction.execute(
+                    new ShowCreate(VIEW, createView.getName()),
+                    REWRITE,
+                    SHOW_CREATE_VIEW_CONVERTER).getResults());
+            CreateView createExistingView = (CreateView) sqlParser.createStatement(createExistingViewQuery, PARSING_OPTIONS);
+            setupQueries.add(new CreateView(
+                    temporaryViewName,
+                    createExistingView.getQuery(),
+                    false,
+                    createExistingView.getSecurity()));
+        }
+        catch (QueryException e) {
+            // no-op
+        }
+        return new QueryObjectBundle(
+                temporaryViewName,
+                setupQueries.build(),
+                new CreateView(
+                        temporaryViewName,
+                        createView.getQuery(),
+                        createView.isReplace(),
+                        createView.getSecurity()),
+                ImmutableList.of(new DropView(temporaryViewName, true)),
+                clusterType,
+                Optional.empty(),
+                Optional.empty(),
+                false);
+    }
+
+    protected QueryObjectBundle rewriteCreateTable(CreateTable createTable, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
+        return new QueryObjectBundle(
+                temporaryTableName,
+                ImmutableList.of(),
+                new CreateTable(
+                        temporaryTableName,
+                        createTable.getElements(),
+                        createTable.isNotExists(),
+                        applyPropertyOverride(createTable.getProperties(), properties),
+                        createTable.getComment()),
+                ImmutableList.of(new DropTable(temporaryTableName, true)),
+                clusterType,
+                Optional.empty(),
+                Optional.empty(),
+                false);
+    }
+
+    protected QueryObjectBundle rewriteDelete(Delete delete, QueryConfiguration queryConfiguration, ClusterType clusterType, boolean shouldReuseTable, QualifiedName prefix, List<Property> properties)
+    {
+        Query selectQuery = getSelectFromDelete(delete, queryConfiguration);
+        SubstitutedStatement<Delete> substitutedDelete = rewriteQueryFunctions(delete);
+        delete = substitutedDelete.getStatement();
+        Optional<String> functionSubstitutions = substitutedDelete.getFunctionSubstitutions();
+        SubstitutedStatement<Query> substitutedSelect = rewriteQueryFunctions(selectQuery);
+        selectQuery = substitutedSelect.getStatement();
+
+        QualifiedName temporaryTableName = generateTemporaryName(Optional.of(delete.getTable().getName()), prefix);
+        return new QueryObjectBundle(
+                temporaryTableName,
+                ImmutableList.of(
+                        new CreateTableAsSelect(
+                                temporaryTableName,
+                                selectQuery,
+                                false,
+                                properties,
+                                true,
+                                Optional.empty(),
+                                Optional.empty())),
+                new Delete(
+                        new Table(temporaryTableName),
+                        delete.getWhere()),
+                ImmutableList.of(new DropTable(temporaryTableName, true)),
+                clusterType,
+                functionSubstitutions,
+                Optional.empty(),
+                false);
+    }
+
+    protected Query getSelectFromDelete(Delete delete, QueryConfiguration queryConfiguration)
+    {
+        Optional<Expression> partitionsPredicate = getPartitionsPredicate(delete.getTable().getName(), queryConfiguration.getPartitions());
+        QuerySpecification spec = new QuerySpecification(
+                new Select(false, ImmutableList.of(new AllColumns())),
+                Optional.of(delete.getTable()),
+                partitionsPredicate,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        return new Query(Optional.empty(), spec, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     private QualifiedName generateTemporaryName(Optional<QualifiedName> originalName, QualifiedName prefix)
@@ -490,6 +565,22 @@ public class QueryRewriter
             zeroRowQuery = new Query(query.getWith(), query.getQueryBody(), Optional.empty(), Optional.empty(), Optional.of("0"));
         }
         return prestoAction.execute(zeroRowQuery, REWRITE, ResultSetConverter.DEFAULT).getMetadata();
+    }
+
+    private <T extends Statement> SubstitutedStatement<T> rewriteQueryFunctions(T query)
+    {
+        Optional<String> functionSubstitutions = Optional.empty();
+        if (functionCallRewriter.isPresent()) {
+            FunctionCallRewriter.RewriterResult rewriterResult = functionCallRewriter.get().rewrite(query);
+            query = (T) rewriterResult.getRewrittenNode();
+            functionSubstitutions = rewriterResult.getSubstitutions();
+        }
+        // Apply safety wrapper for json_parse() calls to prevent failures on malformed JSON
+        if (jsonParseSafetyWrapperEnabled) {
+            query = applyJsonParseSafetyWrapper(query);
+        }
+
+        return new SubstitutedStatement<>(query, functionSubstitutions);
     }
 
     private Query rewriteNonStorableColumns(Query query, ResultSetMetaData metadata)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
@@ -46,6 +46,8 @@ import static java.util.Objects.requireNonNull;
 public class VerificationQueryRewriterFactory
         implements QueryRewriterFactory
 {
+    public static final String VERIFICATION_QUERY_REWRITER_FACTORY = "default";
+
     private final SqlParser sqlParser;
     private final TypeManager typeManager;
     private final BlockEncodingSerde blockEncodingSerde;
@@ -96,7 +98,7 @@ public class VerificationQueryRewriterFactory
                 jsonParseSafetyWrapperEnabled);
     }
 
-    private static List<Property> constructProperties(Map<String, Object> propertiesMap)
+    public static List<Property> constructProperties(Map<String, Object> propertiesMap)
     {
         ImmutableList.Builder<Property> properties = ImmutableList.builder();
         for (Entry<String, Object> entry : propertiesMap.entrySet()) {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterModule.java
@@ -13,22 +13,28 @@
  */
 package com.facebook.presto.verifier.rewrite;
 
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.presto.verifier.annotation.ForControl;
 import com.facebook.presto.verifier.annotation.ForTest;
+import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.google.inject.Binder;
-import com.google.inject.Module;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.presto.verifier.rewrite.VerificationQueryRewriterFactory.VERIFICATION_QUERY_REWRITER_FACTORY;
 
 public class VerificationQueryRewriterModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    public void setup(Binder binder)
     {
+        String queryRewriterFactoryType = buildConfigObject(VerifierConfig.class).getQueryRewriterFactory();
+
         configBinder(binder).bindConfig(QueryRewriteConfig.class, ForControl.class, "control");
         configBinder(binder).bindConfig(QueryRewriteConfig.class, ForTest.class, "test");
 
-        binder.bind(QueryRewriterFactory.class).to(VerificationQueryRewriterFactory.class);
+        if (VERIFICATION_QUERY_REWRITER_FACTORY.equals(queryRewriterFactoryType)) {
+            binder.bind(QueryRewriterFactory.class).to(VerificationQueryRewriterFactory.class);
+        }
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -57,7 +57,8 @@ public class TestVerifierConfig
                 .setSaveSnapshot(false)
                 .setFunctionSubstitutes(null)
                 .setValidateStringAsDouble(false)
-                .setJsonParseSafetyWrapperEnabled(false));
+                .setJsonParseSafetyWrapperEnabled(false)
+                .setQueryRewriterFactory("default"));
     }
 
     @Test
@@ -94,6 +95,7 @@ public class TestVerifierConfig
                 .put("function-substitutes", "/approx_distinct(c)/count(c)/")
                 .put("validate-string-as-double", "true")
                 .put("json-parse-safety-wrapper-enabled", "true")
+                .put("query-rewriter-factory", "custom-rewriter")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -125,7 +127,8 @@ public class TestVerifierConfig
                 .setSaveSnapshot(true)
                 .setFunctionSubstitutes("/approx_distinct(c)/count(c)/")
                 .setValidateStringAsDouble(true)
-                .setJsonParseSafetyWrapperEnabled(true);
+                .setJsonParseSafetyWrapperEnabled(true)
+                .setQueryRewriterFactory("custom-rewriter");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -218,6 +218,69 @@ public class TestQueryRewriter
     }
 
     @Test
+    public void testRewriteDelete()
+    {
+        assertShadowed(
+                getQueryRewriter(),
+                "DELETE FROM test_table WHERE a > 10 AND b = 'foo'",
+                "local.tmp",
+                ImmutableList.of("CREATE TABLE %s\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT *\n" +
+                        "FROM\n" +
+                        "  test_table"),
+                "DELETE FROM %s WHERE a > 10 AND b = 'foo'",
+                ImmutableList.of("DROP TABLE IF EXISTS %s"));
+    }
+
+    @Test
+    public void testRewriteDeleteWithoutWhere()
+    {
+        assertShadowed(
+                getQueryRewriter(),
+                "DELETE FROM test_table",
+                "local.tmp",
+                ImmutableList.of("CREATE TABLE %s\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT *\n" +
+                        "FROM\n" +
+                        "  test_table"),
+                "DELETE FROM %s",
+                ImmutableList.of("DROP TABLE IF EXISTS %s"));
+    }
+
+    @Test
+    public void testRewriteDeleteWithFunctionsAndJson()
+    {
+        assertShadowed(
+                getQueryRewriter(),
+                "DELETE FROM test_table WHERE lower(json_extract_scalar(json_parse(payload), '$.status')) = 'deleted'",
+                "local.tmp",
+                ImmutableList.of("CREATE TABLE %s\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT *\n" +
+                        "FROM\n" +
+                        "  test_table"),
+                "DELETE FROM %s WHERE lower(json_extract_scalar(TRY(json_parse(payload)), '$.status')) = 'deleted'",
+                ImmutableList.of("DROP TABLE IF EXISTS %s"));
+    }
+
+    @Test
     public void testTemporaryTableName()
     {
         QueryRewriter tableNameRewriter = getQueryRewriter(new QueryRewriteConfig().setTablePrefix("tmp"), VERIFIER_CONFIG);


### PR DESCRIPTION
Summary:

The QueryRewriter class handles critical setup for running INSERT, CTAS, and other mutation queries with Presto Verifier.  However, it is difficult to customize this behavior due to how it is embedded within the overall QueryRewriter logic.  This change supports easier extension by:
1. Separating out specific rewriting functionality for each statement type into a separate method.  For example, handling for `INSERT` queries moves to a `rewriteInsert()` method.
2. Adding a `query-rewriter-factory` configuration property to `VerifierConfig`.  This property value gates binding the `QueryRewriterFactory` class for injection, allowing other implementors to configure their own class implementation in other Guice modules.

Differential Revision: D95338505


