### PR TITLE
test: Bump Velox submodule to include array_top_n transform PR (doNotReview) 

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
@@ -111,4 +111,67 @@ public class TestPrestoNativeArrayFunctionQueries
         assertQueryFails("SELECT array_top_n(a, b) FROM (VALUES(ARRAY[1, 2, 3], -2)) as t(a,b)",
                 "n >= 0 \\(-2 vs\\. 0\\) Parameter n: -2 to ARRAY_TOP_N is negative Top-level Expression: (presto|native)\\.default\\.array_top_n\\(field, field_0\\)");
     }
+
+    @Test
+    public void testArrayTopNTransform()
+    {
+
+        // Identity transform behaves like natural descending order.
+        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                "SELECT ARRAY[3, 2]");
+        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, 5, 3, 9, 2])) as t(a)",
+                "SELECT ARRAY[9, 5, 3]");
+
+        // Transform by absolute value (distinct keys keep ordering deterministic).
+        assertQuery("SELECT array_top_n(a, 3, x -> abs(x)) FROM (VALUES(ARRAY[-5, 2, -3, 4, 1])) as t(a)",
+                "SELECT ARRAY[-5, 4, -3]");
+
+        // Negated transform yields the smallest elements first.
+        assertQuery("SELECT array_top_n(a, 2, x -> 0 - x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                "SELECT ARRAY[1, 2]");
+
+        // Transform over strings (sort by length, longest first).
+        assertQuery("SELECT array_top_n(a, 2, x -> length(x)) FROM (VALUES(ARRAY['a', 'bbb', 'cc', 'dddd'])) as t(a)",
+                "SELECT ARRAY['dddd', 'bbb']");
+
+        // Null elements in the input are ordered last by their (null) key.
+        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, NULL, 3, NULL, 5])) as t(a)",
+                "SELECT ARRAY[5, 3, 1]");
+
+        // A transform that returns null pushes those elements to the end (stable by original index).
+        assertQuery("SELECT array_top_n(a, 3, x -> IF(x % 2 = 0, CAST(NULL AS INTEGER), x)) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                "SELECT ARRAY[3, 1, 2]");
+
+        // Duplicate elements are all retained when they tie for the top.
+        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[3, 1, 3, 2, 1, 3])) as t(a)",
+                "SELECT ARRAY[3, 3, 3]");
+
+        // n = 0 returns an empty array.
+        assertQuery("SELECT array_top_n(a, 0, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
+
+        // n larger than the array size returns the whole array, ordered.
+        assertQuery("SELECT array_top_n(a, 10, x -> x) FROM (VALUES(ARRAY[1, 2])) as t(a)",
+                "SELECT ARRAY[2, 1]");
+
+        // Empty and all-null inputs.
+        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[] AS ARRAY(INTEGER)))) as t(a)",
+                "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
+        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[NULL, NULL, NULL] AS ARRAY(INTEGER)))) as t(a)",
+                "SELECT CAST(ARRAY[NULL, NULL] AS ARRAY(INTEGER))");
+
+        // A null top-level array produces a null result.
+        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(NULL AS ARRAY(INTEGER)))) as t(a)",
+                "SELECT CAST(NULL AS ARRAY(INTEGER))");
+
+        // Larger numeric types.
+        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[100000000000, 200000000000, 50000000000])) as t(a)",
+                "SELECT ARRAY[200000000000, 100000000000]");
+        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[DOUBLE '1.5', DOUBLE '2.7', DOUBLE '0.3', DOUBLE '4.1'])) as t(a)",
+                "SELECT ARRAY[DOUBLE '4.1', DOUBLE '2.7', DOUBLE '1.5']");
+
+        // Negative n is rejected by the Velox implementation.
+        assertQueryFails("SELECT array_top_n(a, -1, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                ".*n must be greater than or equal to 0.*");
+    }
 }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
@@ -115,63 +115,74 @@ public class TestPrestoNativeArrayFunctionQueries
     @Test
     public void testArrayTopNTransform()
     {
+        // The single-argument transform overload of array_top_n is registered only through the native sidecar's
+        // function namespace. Without the sidecar the coordinator knows only the two-argument comparator overload,
+        // so a one-argument lambda fails analysis.
+        if (sidecarEnabled) {
+            // Identity transform behaves like natural descending order.
+            assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    "SELECT ARRAY[3, 2]");
+            assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, 5, 3, 9, 2])) as t(a)",
+                    "SELECT ARRAY[9, 5, 3]");
 
-        // Identity transform behaves like natural descending order.
-        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
-                "SELECT ARRAY[3, 2]");
-        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, 5, 3, 9, 2])) as t(a)",
-                "SELECT ARRAY[9, 5, 3]");
+            // Transform by absolute value (distinct keys keep ordering deterministic).
+            assertQuery("SELECT array_top_n(a, 3, x -> abs(x)) FROM (VALUES(ARRAY[-5, 2, -3, 4, 1])) as t(a)",
+                    "SELECT ARRAY[-5, 4, -3]");
 
-        // Transform by absolute value (distinct keys keep ordering deterministic).
-        assertQuery("SELECT array_top_n(a, 3, x -> abs(x)) FROM (VALUES(ARRAY[-5, 2, -3, 4, 1])) as t(a)",
-                "SELECT ARRAY[-5, 4, -3]");
+            // Negated transform yields the smallest elements first.
+            assertQuery("SELECT array_top_n(a, 2, x -> 0 - x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    "SELECT ARRAY[1, 2]");
 
-        // Negated transform yields the smallest elements first.
-        assertQuery("SELECT array_top_n(a, 2, x -> 0 - x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
-                "SELECT ARRAY[1, 2]");
+            // Transform over strings (sort by length, longest first).
+            assertQuery("SELECT array_top_n(a, 2, x -> length(x)) FROM (VALUES(ARRAY['a', 'bbb', 'cc', 'dddd'])) as t(a)",
+                    "SELECT ARRAY['dddd', 'bbb']");
 
-        // Transform over strings (sort by length, longest first).
-        assertQuery("SELECT array_top_n(a, 2, x -> length(x)) FROM (VALUES(ARRAY['a', 'bbb', 'cc', 'dddd'])) as t(a)",
-                "SELECT ARRAY['dddd', 'bbb']");
+            // Null elements in the input are ordered last by their (null) key.
+            assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, NULL, 3, NULL, 5])) as t(a)",
+                    "SELECT ARRAY[5, 3, 1]");
 
-        // Null elements in the input are ordered last by their (null) key.
-        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[1, NULL, 3, NULL, 5])) as t(a)",
-                "SELECT ARRAY[5, 3, 1]");
+            // A transform that returns null pushes those elements to the end (stable by original index).
+            assertQuery("SELECT array_top_n(a, 3, x -> IF(x % 2 = 0, CAST(NULL AS INTEGER), x)) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    "SELECT ARRAY[3, 1, 2]");
 
-        // A transform that returns null pushes those elements to the end (stable by original index).
-        assertQuery("SELECT array_top_n(a, 3, x -> IF(x % 2 = 0, CAST(NULL AS INTEGER), x)) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
-                "SELECT ARRAY[3, 1, 2]");
+            // Duplicate elements are all retained when they tie for the top.
+            assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[3, 1, 3, 2, 1, 3])) as t(a)",
+                    "SELECT ARRAY[3, 3, 3]");
 
-        // Duplicate elements are all retained when they tie for the top.
-        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[3, 1, 3, 2, 1, 3])) as t(a)",
-                "SELECT ARRAY[3, 3, 3]");
+            // n = 0 returns an empty array.
+            assertQuery("SELECT array_top_n(a, 0, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
 
-        // n = 0 returns an empty array.
-        assertQuery("SELECT array_top_n(a, 0, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
-                "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
+            // n larger than the array size returns the whole array, ordered.
+            assertQuery("SELECT array_top_n(a, 10, x -> x) FROM (VALUES(ARRAY[1, 2])) as t(a)",
+                    "SELECT ARRAY[2, 1]");
 
-        // n larger than the array size returns the whole array, ordered.
-        assertQuery("SELECT array_top_n(a, 10, x -> x) FROM (VALUES(ARRAY[1, 2])) as t(a)",
-                "SELECT ARRAY[2, 1]");
+            // Empty and all-null inputs.
+            assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[] AS ARRAY(INTEGER)))) as t(a)",
+                    "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
+            assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[NULL, NULL, NULL] AS ARRAY(INTEGER)))) as t(a)",
+                    "SELECT CAST(ARRAY[NULL, NULL] AS ARRAY(INTEGER))");
 
-        // Empty and all-null inputs.
-        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[] AS ARRAY(INTEGER)))) as t(a)",
-                "SELECT CAST(ARRAY[] AS ARRAY(INTEGER))");
-        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(ARRAY[NULL, NULL, NULL] AS ARRAY(INTEGER)))) as t(a)",
-                "SELECT CAST(ARRAY[NULL, NULL] AS ARRAY(INTEGER))");
+            // A null top-level array produces a null result.
+            assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(NULL AS ARRAY(INTEGER)))) as t(a)",
+                    "SELECT CAST(NULL AS ARRAY(INTEGER))");
 
-        // A null top-level array produces a null result.
-        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(CAST(NULL AS ARRAY(INTEGER)))) as t(a)",
-                "SELECT CAST(NULL AS ARRAY(INTEGER))");
+            // Larger numeric types.
+            assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[100000000000, 200000000000, 50000000000])) as t(a)",
+                    "SELECT ARRAY[200000000000, 100000000000]");
+            assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[DOUBLE '1.5', DOUBLE '2.7', DOUBLE '0.3', DOUBLE '4.1'])) as t(a)",
+                    "SELECT ARRAY[DOUBLE '4.1', DOUBLE '2.7', DOUBLE '1.5']");
 
-        // Larger numeric types.
-        assertQuery("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[100000000000, 200000000000, 50000000000])) as t(a)",
-                "SELECT ARRAY[200000000000, 100000000000]");
-        assertQuery("SELECT array_top_n(a, 3, x -> x) FROM (VALUES(ARRAY[DOUBLE '1.5', DOUBLE '2.7', DOUBLE '0.3', DOUBLE '4.1'])) as t(a)",
-                "SELECT ARRAY[DOUBLE '4.1', DOUBLE '2.7', DOUBLE '1.5']");
-
-        // Negative n is rejected by the Velox implementation.
-        assertQueryFails("SELECT array_top_n(a, -1, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
-                ".*n must be greater than or equal to 0.*");
+            // Negative n is rejected by the Velox implementation.
+            assertQueryFails("SELECT array_top_n(a, -1, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    ".*n must be greater than or equal to 0.*");
+        }
+        else {
+            String transformLambdaUnsupported = ".*Expected a lambda that takes 2 argument\\(s\\) but got 1.*";
+            assertQueryFails("SELECT array_top_n(a, 2, x -> x) FROM (VALUES(ARRAY[1, 2, 3])) as t(a)",
+                    transformLambdaUnsupported);
+            assertQueryFails("SELECT array_top_n(a, 3, x -> abs(x)) FROM (VALUES(ARRAY[-5, 2, -3, 4, 1])) as t(a)",
+                    transformLambdaUnsupported);
+        }
     }
 }


### PR DESCRIPTION
**CI-only PR (doNotReview).** Exercises Presto native end-to-end tests for the new `array_top_n(array(T), integer, function(T,U))` transform function.

Rebased on current `prestodb/presto` master. The velox submodule is pinned to **master's current velox** (`f53d18ba`) **plus the 5 commits from** https://github.com/facebookincubator/velox/pull/16048 — i.e. the only velox delta vs master is array_top_n itself, so any CI signal is attributable to this function alone.

- Velox pin: `075b93824` — hosted on `allenshen13/velox:array-top-n-on-master-pin` (fetchable from `facebookincubator/velox` via the shared fork network).
- Adds `presto-native-tests` e2e coverage for the transform overload, gated on the native sidecar (the 1-arg lambda overload is only registered in the sidecar function namespace).

Companion velox PR: https://github.com/facebookincubator/velox/pull/16048

```
== NO RELEASE NOTE ==
```