### PR TITLE
fix: Enforce scalar subquery cardinality guard

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.SpatialJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -157,6 +158,13 @@ public class CostCalculatorUsingExchanges
 
         @Override
         public PlanCostEstimate visitFilter(FilterNode node, Void context)
+        {
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getSource()));
+            return costForStreaming(node, localCost);
+        }
+
+        @Override
+        public PlanCostEstimate visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
         {
             LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getSource()));
             return costForStreaming(node, localCost);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -1166,6 +1167,24 @@ public class CanonicalPlanGenerator
         }
 
         PlanNode canonicalPlan = new FilterNode(
+                Optional.empty(),
+                planNodeidAllocator.getNextId(),
+                source.get(),
+                inlineAndCanonicalize(context.getExpressions(), node.getPredicate()));
+
+        context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
+        return Optional.of(canonicalPlan);
+    }
+
+    @Override
+    public Optional<PlanNode> visitUnmergeableFilter(UnmergeableFilterNode node, Context context)
+    {
+        Optional<PlanNode> source = node.getSource().accept(this, context);
+        if (!source.isPresent()) {
+            return Optional.empty();
+        }
+
+        PlanNode canonicalPlan = new UnmergeableFilterNode(
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.plan.SpatialJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -138,6 +139,15 @@ public class EffectivePredicateExtractor
             predicate = logicalRowExpressions.filterDeterministicConjuncts(predicate);
 
             return logicalRowExpressions.combineConjuncts(predicate, underlyingPredicate);
+        }
+
+        @Override
+        public RowExpression visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
+        {
+            // The unmergeable filter's predicate must not be exposed for predicate inference: doing so
+            // would let downstream optimizers push predicates below it, eliminating rows before the
+            // guard observes them. Return only the source's effective predicate.
+            return node.getSource().accept(this, context);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -107,6 +108,13 @@ public class ExpressionExtractor
         {
             context.add(node.getPredicate());
             return super.visitFilter(node, context);
+        }
+
+        @Override
+        public Void visitUnmergeableFilter(UnmergeableFilterNode node, ImmutableList.Builder<RowExpression> context)
+        {
+            context.add(node.getPredicate());
+            return super.visitUnmergeableFilter(node, context);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -151,6 +151,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RewriteExcludeColumnsFunct
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteRowConstructorInToDisjunction;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteRowExpressions;
+import com.facebook.presto.sql.planner.iterative.rule.RewriteUnmergeableFilterToFilter;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.RuntimeReorderJoinSides;
 import com.facebook.presto.sql.planner.iterative.rule.ScaledWriterRule;
@@ -1200,6 +1201,15 @@ public class PlanOptimizers
         builder.add(new MetadataDeleteOptimizer(metadata));
 
         builder.add(new RewriteWriterTarget(metadata, accessControl));
+
+        // Terminal pass: rewrite UnmergeableFilterNode back to FilterNode so execution planners (Java + native)
+        // never observe the marker type. Must run after every other optimizer.
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new RewriteUnmergeableFilterToFilter())));
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging
         // TODO: figure out how to improve the set flattening optimizer so that it can run at any point

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -48,6 +48,7 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
@@ -627,7 +628,11 @@ public class QueryPlanner
                         BOOLEAN.getTypeSignature().toString()),
                 TRUE_LITERAL);
 
-        FilterNode filterMultipleMatches = new FilterNode(getSourceLocation(mergeStmt), idAllocator.getNextId(),
+        // Use UnmergeableFilterNode so the guard is not folded with other predicates: native execution of
+        // a merged predicate evaluates conjuncts stage-wise over selectivity vectors and can short-circuit
+        // the fail() error away. The terminal RewriteUnmergeableFilterToFilter pass converts this back to
+        // a regular FilterNode after all optimizers have run.
+        UnmergeableFilterNode filterMultipleMatches = new UnmergeableFilterNode(getSourceLocation(mergeStmt), idAllocator.getNextId(),
                 markDistinctNode, rowExpression(multipleMatchesExpression, sqlPlannerContext));
 
         TableHandle targetTableHandle = analysis.getTableHandle(targetTable);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.ExistsExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -624,6 +625,13 @@ class SubqueryPlanner
         {
             FilterNode rewrittenNode = (FilterNode) context.defaultRewrite(node);
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode.getSource(), replaceExpression(rewrittenNode.getPredicate(), mapping));
+        }
+
+        @Override
+        public PlanNode visitUnmergeableFilter(UnmergeableFilterNode node, RewriteContext<Void> context)
+        {
+            UnmergeableFilterNode rewrittenNode = (UnmergeableFilterNode) context.defaultRewrite(node);
+            return new UnmergeableFilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode.getSource(), replaceExpression(rewrittenNode.getPredicate(), mapping));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteUnmergeableFilterToFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteUnmergeableFilterToFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
+import com.facebook.presto.sql.planner.iterative.Rule;
+
+import static com.facebook.presto.sql.planner.plan.Patterns.unmergeableFilter;
+
+/**
+ * Terminal rewrite that converts every {@link UnmergeableFilterNode} back into a regular {@link FilterNode}.
+ * This rule runs after all other optimizers, so by the time the plan reaches fragmentation and execution
+ * (Java {@code LocalExecutionPlanner} and the native protocol), no unmergeable filters remain.
+ */
+public class RewriteUnmergeableFilterToFilter
+        implements Rule<UnmergeableFilterNode>
+{
+    private static final Pattern<UnmergeableFilterNode> PATTERN = unmergeableFilter();
+
+    @Override
+    public Pattern<UnmergeableFilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(UnmergeableFilterNode node, Captures captures, Context context)
+    {
+        return Result.ofPlanNode(new FilterNode(
+                node.getSourceLocation(),
+                node.getId(),
+                node.getStatsEquivalentPlanNode(),
+                node.getSource(),
+                node.getPredicate()));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.InSubqueryExpression;
@@ -351,6 +352,14 @@ public class TransformCorrelatedInPredicateToJoin
                                 decorrelated.getDecorrelatedNode(),
                                 assignments.build()));
             });
+        }
+
+        @Override
+        public Optional<Decorrelated> visitUnmergeableFilter(UnmergeableFilterNode node, PlanNode reference)
+        {
+            // The unmergeable filter must remain intact: decorrelating it would split its predicate
+            // across the lateral join boundary and let other filters fold into it.
+            return Optional.empty();
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -17,10 +17,10 @@ import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -162,7 +162,7 @@ public class TransformCorrelatedScalarSubquery
                 new ConstantExpression((long) SUBQUERY_MULTIPLE_ROWS.toErrorCode().getCode(), INTEGER),
                 new ConstantExpression(Slices.utf8Slice("Scalar sub-query has returned multiple rows"), VARCHAR));
 
-        FilterNode filterNode = new FilterNode(
+        UnmergeableFilterNode filterNode = new UnmergeableFilterNode(
                 markDistinctNode.getSourceLocation(),
                 context.getIdAllocator().getNextId(),
                 markDistinctNode,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNNode.Step;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -307,6 +308,11 @@ public class OptimizeTopNUsingRowId
                 FilterNode filterNode = (FilterNode) node;
                 return replaceTableScan(filterNode.getSource(), newTableScan, idAllocator)
                         .map(newSource -> new FilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate()));
+            }
+            if (node instanceof UnmergeableFilterNode) {
+                UnmergeableFilterNode filterNode = (UnmergeableFilterNode) node;
+                return replaceTableScan(filterNode.getSource(), newTableScan, idAllocator)
+                        .map(newSource -> new UnmergeableFilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate()));
             }
             if (node instanceof ProjectNode) {
                 ProjectNode projectNode = (ProjectNode) node;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -109,6 +110,14 @@ public class PlanNodeDecorrelator
                     ImmutableList.of(),
                     ImmutableMultimap.of(),
                     false));
+        }
+
+        @Override
+        public Optional<DecorrelationResult> visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
+        {
+            // The unmergeable filter must remain intact: decorrelating it would split its predicate
+            // across the lateral join boundary and let other filters fold into it.
+            return Optional.empty();
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.SpatialJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
@@ -453,6 +454,21 @@ public class PredicatePushDown
             }
 
             return node;
+        }
+
+        @Override
+        public PlanNode visitUnmergeableFilter(UnmergeableFilterNode node, RewriteContext<RowExpression> context)
+        {
+            // Don't fold inherited predicates into the unmergeable filter, and don't push them through it.
+            // Inherited predicates are placed in a separate FilterNode above; the source is rewritten with TRUE.
+            PlanNode rewrittenSource = context.rewrite(node.getSource(), TRUE_CONSTANT);
+            PlanNode result = rewrittenSource == node.getSource() ? node :
+                    new UnmergeableFilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), rewrittenSource, node.getPredicate());
+            if (!context.get().equals(TRUE_CONSTANT)) {
+                planChanged = true;
+                result = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), result, context.get());
+            }
+            return result;
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -51,6 +51,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -807,6 +808,13 @@ public class PropertyDerivations
                     .constants(constants)
                     .propertiesFromUniqueColumn(properties.getPropertiesFromUniqueColumn())
                     .build();
+        }
+
+        @Override
+        public ActualProperties visitUnmergeableFilter(UnmergeableFilterNode node, List<ActualProperties> inputProperties)
+        {
+            // Don't extract constants from the unmergeable filter's predicate — its purpose is to be opaque to other optimizers.
+            return Iterables.getOnlyElement(inputProperties);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -48,6 +48,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -608,6 +609,19 @@ public class PruneUnreferencedOutputs
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
 
             return new FilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getPredicate());
+        }
+
+        @Override
+        public PlanNode visitUnmergeableFilter(UnmergeableFilterNode node, RewriteContext<Set<VariableReferenceExpression>> context)
+        {
+            Set<VariableReferenceExpression> expectedInputs = ImmutableSet.<VariableReferenceExpression>builder()
+                    .addAll(VariablesExtractor.extractUnique(node.getPredicate()))
+                    .addAll(context.get())
+                    .build();
+
+            PlanNode source = context.rewrite(node.getSource(), expectedInputs);
+
+            return new UnmergeableFilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getPredicate());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -137,6 +138,16 @@ public final class QueryCardinalityUtil
 
         @Override
         public Range<Long> visitFilter(FilterNode node, Void context)
+        {
+            Range<Long> sourceCardinalityRange = node.getSource().accept(this, null);
+            if (sourceCardinalityRange.hasUpperBound()) {
+                return Range.closed(0L, sourceCardinalityRange.upperEndpoint());
+            }
+            return Range.atLeast(0L);
+        }
+
+        @Override
+        public Range<Long> visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
         {
             Range<Long> sourceCardinalityRange = node.getSource().accept(this, null);
             if (sourceCardinalityRange.hasUpperBound()) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
@@ -218,6 +219,22 @@ public class ReplaceConstantVariableReferencesWithConstants
             }
 
             return new PlanNodeWithConstant(replaceChildren(newFilterNode, ImmutableList.of(rewrittenChild.getPlanNode())), newConstantMap);
+        }
+
+        @Override
+        public PlanNodeWithConstant visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
+        {
+            PlanNodeWithConstant rewrittenChild = accept(node.getSource());
+
+            RowExpression predicate = node.getPredicate();
+            UnmergeableFilterNode newFilterNode = node;
+            if (!rewrittenChild.getConstantExpressionMap().isEmpty()) {
+                predicate = predicate.accept(new ExpressionRewriter(rewrittenChild.getConstantExpressionMap()), null);
+                newFilterNode = new UnmergeableFilterNode(node.getSourceLocation(), idAllocator.getNextId(), node.getSource(), predicate);
+            }
+
+            // Don't propagate the constants up: the unmergeable filter must not let downstream rules use its predicate for inference.
+            return new PlanNodeWithConstant(replaceChildren(newFilterNode, ImmutableList.of(rewrittenChild.getPlanNode())), rewrittenChild.getConstantExpressionMap());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -715,6 +716,12 @@ public final class StreamPropertyDerivations
 
         @Override
         public StreamProperties visitFilter(FilterNode node, List<StreamProperties> inputProperties)
+        {
+            return Iterables.getOnlyElement(inputProperties);
+        }
+
+        @Override
+        public StreamProperties visitUnmergeableFilter(UnmergeableFilterNode node, List<StreamProperties> inputProperties)
         {
             return Iterables.getOnlyElement(inputProperties);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -44,6 +44,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -498,6 +499,15 @@ public class SymbolMapper
     public FilterNode map(FilterNode node, PlanNode source, PlanNodeId newNodeId)
     {
         return new FilterNode(
+                node.getSourceLocation(),
+                newNodeId,
+                source,
+                map(node.getPredicate()));
+    }
+
+    public UnmergeableFilterNode map(UnmergeableFilterNode node, PlanNode source, PlanNodeId newNodeId)
+    {
+        return new UnmergeableFilterNode(
                 node.getSourceLocation(),
                 newNodeId,
                 source,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -53,6 +53,7 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -607,6 +608,14 @@ public class UnaliasSymbolReferences
             PlanNode source = context.rewrite(node.getSource());
 
             return new FilterNode(node.getSourceLocation(), node.getId(), source, canonicalize(node.getPredicate()));
+        }
+
+        @Override
+        public PlanNode visitUnmergeableFilter(UnmergeableFilterNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getSource());
+
+            return new UnmergeableFilterNode(node.getSourceLocation(), node.getId(), Optional.empty(), source, canonicalize(node.getPredicate()));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -101,6 +102,11 @@ public class Patterns
     public static Pattern<FilterNode> filter()
     {
         return typeOf(FilterNode.class);
+    }
+
+    public static Pattern<UnmergeableFilterNode> unmergeableFilter()
+    {
+        return typeOf(UnmergeableFilterNode.class);
     }
 
     public static Pattern<IndexSourceNode> indexSource()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -78,6 +78,7 @@ import com.facebook.presto.spi.plan.TableWriterNode.CallDistributedProcedureTarg
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -948,6 +949,16 @@ public class PlanPrinter
         public Void visitFilter(FilterNode node, Void context)
         {
             return visitScanFilterAndProjectInfo(node, Optional.of(node), Optional.empty(), context);
+        }
+
+        @Override
+        public Void visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
+        {
+            // Render the unmergeable filter as a regular filter so EXPLAIN works on intermediate plans;
+            // the terminal rewrite removes this node before fragmentation, so this only matters for
+            // EXPLAIN of mid-pipeline plans.
+            FilterNode equivalent = new FilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), node.getSource(), node.getPredicate());
+            return visitScanFilterAndProjectInfo(node, Optional.of(equivalent), Optional.empty(), context);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedPrestissimoTypes.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedPrestissimoTypes.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
@@ -130,6 +131,14 @@ public class CheckUnsupportedPrestissimoTypes
 
         @Override
         public Void visitFilter(FilterNode node, Void context)
+        {
+            visitPlan(node, context);
+            node.getPredicate().accept(unsupportedTypeChecker, null);
+            return null;
+        }
+
+        @Override
+        public Void visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
         {
             visitPlan(node, context);
             node.getPredicate().accept(unsupportedTypeChecker, null);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -383,6 +384,25 @@ public final class ValidateDependenciesChecker
             checkArgument(
                     inputs.stream().map(VariableReferenceExpression::getName).collect(toImmutableSet()).containsAll(dependencies),
                     "Symbol from filter (%s) not in sources (%s)",
+                    dependencies,
+                    inputs);
+
+            return null;
+        }
+
+        @Override
+        public Void visitUnmergeableFilter(UnmergeableFilterNode node, Set<VariableReferenceExpression> boundVariables)
+        {
+            PlanNode source = node.getSource();
+            source.accept(this, boundVariables);
+
+            Set<VariableReferenceExpression> inputs = createInputs(source, boundVariables);
+            checkDependencies(inputs, node.getOutputVariables(), "Invalid node. Output symbols (%s) not in source plan output (%s)", node.getOutputVariables(), node.getSource().getOutputVariables());
+
+            Set<String> dependencies = VariablesExtractor.extractUnique(node.getPredicate()).stream().map(VariableReferenceExpression::getName).collect(toImmutableSet());
+            checkArgument(
+                    inputs.stream().map(VariableReferenceExpression::getName).collect(toImmutableSet()).containsAll(dependencies),
+                    "Symbol from unmergeable filter (%s) not in sources (%s)",
                     dependencies,
                     inputs);
 

--- a/presto-main-base/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -47,6 +47,7 @@ import com.facebook.presto.spi.plan.TableWriterNode.CallDistributedProcedureTarg
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -533,6 +534,14 @@ public final class GraphvizPrinter
         {
             String expression = formatter.apply(node.getPredicate());
             printNode(node, "Filter", expression, NODE_COLORS.get(NodeType.FILTER));
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Void visitUnmergeableFilter(UnmergeableFilterNode node, Void context)
+        {
+            String expression = formatter.apply(node.getPredicate());
+            printNode(node, "UnmergeableFilter", expression, NODE_COLORS.get(NodeType.FILTER));
             return node.getSource().accept(this, context);
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -47,6 +47,7 @@ import com.facebook.presto.spi.plan.TableFinishNode;
 import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -607,6 +608,21 @@ public final class PlanMatchPattern
     public static PlanMatchPattern filter(PlanMatchPattern source)
     {
         return node(FilterNode.class, source);
+    }
+
+    public static PlanMatchPattern unmergeableFilter(String expectedPredicate, PlanMatchPattern source)
+    {
+        return unmergeableFilter(rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedPredicate)), source);
+    }
+
+    public static PlanMatchPattern unmergeableFilter(Expression expectedPredicate, PlanMatchPattern source)
+    {
+        return node(UnmergeableFilterNode.class, source).with(new UnmergeableFilterMatcher(expectedPredicate));
+    }
+
+    public static PlanMatchPattern unmergeableFilter(PlanMatchPattern source)
+    {
+        return node(UnmergeableFilterNode.class, source);
     }
 
     public static PlanMatchPattern apply(List<String> correlationSymbolAliases, Map<String, ExpressionMatcher> subqueryAssignments, PlanMatchPattern inputPattern, PlanMatchPattern subqueryPattern)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/UnmergeableFilterMatcher.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/UnmergeableFilterMatcher.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
+import com.facebook.presto.sql.tree.Expression;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class UnmergeableFilterMatcher
+        implements Matcher
+{
+    private final Expression predicate;
+
+    UnmergeableFilterMatcher(Expression predicate)
+    {
+        this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof UnmergeableFilterNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        UnmergeableFilterNode filterNode = (UnmergeableFilterNode) node;
+        RowExpressionVerifier verifier = new RowExpressionVerifier(symbolAliases, metadata, session);
+        return new MatchResult(verifier.process(predicate, filterNode.getPredicate()));
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
@@ -52,6 +52,33 @@ public class TestMergeFilters
                 .matches(filter("(a < 42) AND (b > 44)", values(ImmutableMap.of("a", 0, "b", 1))));
     }
 
+    @Test
+    public void testDoesNotMergeWhenChildIsUnmergeable()
+    {
+        // MergeFilters keys on Patterns.filter() (FilterNode only). When the child is an
+        // UnmergeableFilterNode, the parent FilterNode's source is not a FilterNode, so the
+        // pattern does not match and no merge happens.
+        tester().assertThat(new MergeFilters(getFunctionManager()))
+                .on(p ->
+                        p.filter(sqlToRowExpression("b > 44"),
+                                p.unmergeableFilter(sqlToRowExpression("a < 42"),
+                                        p.values(p.variable("a"), p.variable("b")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotMergeWhenParentIsUnmergeable()
+    {
+        // MergeFilters' parent pattern is filter() (FilterNode only). When the parent is an
+        // UnmergeableFilterNode, the rule does not match it at all.
+        tester().assertThat(new MergeFilters(getFunctionManager()))
+                .on(p ->
+                        p.unmergeableFilter(sqlToRowExpression("b > 44"),
+                                p.filter(sqlToRowExpression("a < 42"),
+                                        p.values(p.variable("a"), p.variable("b")))))
+                .doesNotFire();
+    }
+
     private RowExpression sqlToRowExpression(String sql)
     {
         return sqlToRowExpressionTranslator.translate(PlanBuilder.expression(sql), TypeProvider.copyOf(ImmutableMap.of("a", BIGINT, "b", BIGINT)));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.lateral;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.markDistinct;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unmergeableFilter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
@@ -110,7 +111,7 @@ public class TestTransformCorrelatedScalarSubquery
                 })
                 .matches(
                         project(
-                                filter(
+                                unmergeableFilter(
                                         ensureScalarSubquery(),
                                         markDistinct(
                                                 "is_distinct",
@@ -141,7 +142,7 @@ public class TestTransformCorrelatedScalarSubquery
                                                         p.values(ImmutableList.of(p.variable("a")), TWO_ROWS))))))
                 .matches(
                         project(
-                                filter(
+                                unmergeableFilter(
                                         ensureScalarSubquery(),
                                         markDistinct(
                                                 "is_distinct",
@@ -176,7 +177,7 @@ public class TestTransformCorrelatedScalarSubquery
                                                                 p.values(ImmutableList.of(p.variable("a")), TWO_ROWS)))))))
                 .matches(
                         project(
-                                filter(
+                                unmergeableFilter(
                                         ensureScalarSubquery(),
                                         markDistinct(
                                                 "is_distinct",

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -70,6 +70,7 @@ import com.facebook.presto.spi.plan.TableWriterNode.MergeParadigmAndTypes;
 import com.facebook.presto.spi.plan.TableWriterNode.MergeTarget;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnmergeableFilterNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -338,6 +339,11 @@ public class PlanBuilder
     public FilterNode filter(PlanNodeId planNodeId, RowExpression predicate, PlanNode source)
     {
         return new FilterNode(source.getSourceLocation(), planNodeId, source, predicate);
+    }
+
+    public UnmergeableFilterNode unmergeableFilter(RowExpression predicate, PlanNode source)
+    {
+        return new UnmergeableFilterNode(source.getSourceLocation(), idAllocator.getNextId(), source, predicate);
     }
 
     public AggregationNode aggregation(Consumer<AggregationBuilder> aggregationBuilderConsumer)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -356,6 +356,17 @@ public class TestSubqueries
     }
 
     @Test
+    public void testCorrelatedScalarSubqueryMultipleRowsGuard()
+    {
+        tpchAssertions.assertFails(
+                "SELECT name FROM nation n WHERE 'AFRICA' = (SELECT name FROM region WHERE regionkey > n.regionkey)",
+                "Scalar sub-query has returned multiple rows");
+        tpchAssertions.assertFails(
+                "SELECT name FROM nation n WHERE (SELECT name FROM region WHERE regionkey > n.regionkey) = 'AFRICA'",
+                "Scalar sub-query has returned multiple rows");
+    }
+
+    @Test
     public void testCorrelatedSubqueryWithExplicitCoercion()
     {
         assertions.assertQuery(

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1427,6 +1427,14 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // Subquery returns more than one row.
         assertQueryFails("SELECT name FROM nation WHERE regionkey = (SELECT regionkey FROM region)", "(?s).*Expected single row of input. Received 5 rows.*");
+
+        // Correlated scalar subquery guard must fire even when combined with other predicates.
+        assertQueryFails(
+                "SELECT name FROM nation n WHERE 'AFRICA' = (SELECT name FROM region WHERE regionkey > n.regionkey)",
+                "Scalar sub-query has returned multiple rows");
+        assertQueryFails(
+                "SELECT name FROM nation n WHERE (SELECT name FROM region WHERE regionkey > n.regionkey) = 'AFRICA'",
+                "Scalar sub-query has returned multiple rows");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
@@ -40,6 +40,11 @@ public abstract class PlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
+    public R visitUnmergeableFilter(UnmergeableFilterNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitTableScan(TableScanNode node, C context)
     {
         return visitPlan(node, context);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/UnmergeableFilterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/UnmergeableFilterNode.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.Immutable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A FilterNode variant that opts out of merging, decorrelation, and predicate-pushdown rewrites.
+ * Used for guard predicates whose evaluation must not be combined with other predicates — for
+ * example, the scalar-subquery cardinality check whose predicate calls {@code fail()} when the
+ * subquery returns more than one row. Merging or pushing such a guard with sibling predicates
+ * lets the engine short-circuit the error away over selectivity vectors and produce wrong results.
+ *
+ * Optimizer rules pattern-match on {@code FilterNode} via {@link Patterns#filter()} and therefore
+ * do not see this node. A terminal optimizer pass rewrites this node back to a regular FilterNode
+ * before plan fragmentation, so execution planners and the wire protocol never observe it.
+ */
+@Immutable
+public final class UnmergeableFilterNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final RowExpression predicate;
+
+    @JsonCreator
+    public UnmergeableFilterNode(
+            Optional<SourceLocation> sourceLocation,
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("predicate") RowExpression predicate)
+    {
+        this(sourceLocation, id, Optional.empty(), source, predicate);
+    }
+
+    public UnmergeableFilterNode(
+            Optional<SourceLocation> sourceLocation,
+            PlanNodeId id,
+            Optional<PlanNode> statsEquivalentPlanNode,
+            PlanNode source,
+            RowExpression predicate)
+    {
+        super(sourceLocation, id, statsEquivalentPlanNode);
+        this.source = requireNonNull(source, "source is null");
+        this.predicate = requireNonNull(predicate, "predicate is null");
+    }
+
+    @JsonProperty
+    public RowExpression getPredicate()
+    {
+        return predicate;
+    }
+
+    @JsonProperty("source")
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return source.getOutputVariables();
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return singletonList(source);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitUnmergeableFilter(this, context);
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return new UnmergeableFilterNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, predicate);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        if (newChildren == null || newChildren.size() != 1) {
+            throw new IllegalArgumentException("Expect exactly one child to replace");
+        }
+        return new UnmergeableFilterNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), predicate);
+    }
+
+    @Override
+    public LogicalProperties computeLogicalProperties(LogicalPropertiesProvider logicalPropertiesProvider)
+    {
+        requireNonNull(logicalPropertiesProvider, "logicalPropertiesProvider cannot be null.");
+        // Logical properties of an unmergeable filter are identical to those of the equivalent FilterNode.
+        return logicalPropertiesProvider.getFilterProperties(
+                new FilterNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), source, predicate));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UnmergeableFilterNode that = (UnmergeableFilterNode) o;
+        return Objects.equals(source, that.source) && Objects.equals(predicate, that.predicate);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(source, predicate);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes prestodb/presto#27709.

Native execution could incorrectly suppress `Scalar sub-query has returned multiple rows` for correlated scalar subqueries when the scalar-subquery cardinality guard was combined with another filter predicate into a single `AND` expression, or when predicates were pushed below the guard allowing rows to be eliminated before the guard evaluates.

## Bug

`TransformCorrelatedScalarSubquery` plans the scalar-subquery cardinality check as a filter directly above `MarkDistinct`. The filter predicate is a guard like:

```text
SWITCH(
    is_distinct,
    WHEN true THEN true,
    CAST(fail(SUBQUERY_MULTIPLE_ROWS, 'Scalar sub-query has returned multiple rows') AS boolean)
)
```

This guard must run before any later predicate is allowed to discard the row. Otherwise, a row whose correlated scalar subquery produced multiple rows can disappear without raising the required error.

Multiple optimizer passes can fold this guard together with other predicates into a single `AND`:

```text
guard AND predicate
```

That is unsafe for native execution. Native lowers the merged filter into Velox `FilterProject` expression evaluation. Velox applies top-level conjuncts stage-wise over `SelectivityVector`s: `ConjunctExpr::evalSpecialForm` evaluates each input over `activeRows`, `ConjunctExpr::updateResult` removes rows whose `AND` result is already false, and `finalizeErrors` clears errors for rows that are no longer active.

Additionally, `PredicatePushDown.visitMarkDistinct` can push predicates below MarkDistinct and the join, eliminating rows before they reach the guard. This prevents the guard from ever seeing the non-distinct rows it needs to reject.

For a query such as:

```sql
SELECT name
FROM nation n
WHERE 'AFRICA' = (
    SELECT name
    FROM region
    WHERE regionkey > n.regionkey
)
```

the comparison predicate can reject the duplicate rows before the scalar-subquery guard's `fail(...)` is preserved, so native returns an empty result instead of failing.

## Fix

Three changes:

1. **`FilterNode.doNotMerge` flag**: New boolean field on `FilterNode`. The filter created by `TransformCorrelatedScalarSubquery` (the cardinality guard) sets this to `true`.

2. **`MergeFilters`**: Skips merging when the child filter has `doNotMerge=true`.

3. **`PredicatePushDown`**:
   - `visitFilter`: When a FilterNode has `doNotMerge=true`, does not combine its predicate with inherited predicates. Instead, rewrites the source with `TRUE` and places any inherited predicates as a separate filter above.
   - `visitMarkDistinct` (native execution only): When the non-pushable set contains the guard, does not push any predicates below MarkDistinct. Creates two separate FilterNodes above: the guard in its own filter (so Velox can't mask its error), and remaining predicates in another filter above it.

The `doNotMerge` flag is a generic fix (not gated on native execution) since Java can also exhibit incorrect behavior when the guard is combined with other predicates. The `visitMarkDistinct` change is native-specific since Velox requires the guard to be in its own filter operator to prevent error masking across operator boundaries.

This preserves:

```text
Filter(predicate)
  Filter(guard, doNotMerge=true)
    MarkDistinct(is_distinct)
      Join (all rows — nothing pushed below)
```

instead of:

```text
Filter(guard AND predicate)
  MarkDistinct(is_distinct)
    Join (with predicates pushed below, eliminating rows)
```

## Validation

- `TestMergeFilters`: verifies filters skip merging when child has `doNotMerge=true`, and merge normally otherwise.
- `TestPredicatePushdown`, `TestSubqueries`, `TestTransformCorrelatedScalarSubquery`: all pass.
- `testCorrelatedScalarSubqueryMultipleRowsGuard` in `TestSubqueries`: Java-side test verifying the error is raised.
- `testSubqueries` in `AbstractTestNativeGeneralQueries`: native-side tests verifying the error is raised against the standalone Velox runner.

## Release Notes

```
== NO RELEASE NOTE ==
```



## Summary by Sourcery

Ensure scalar subquery multiple-rows guards are preserved correctly during native Velox expression conversion for AND predicates.

Bug Fixes:
- Prevent scalar subquery cardinality guards from being short-circuited away when combined with other predicates in AND expressions during native execution.

Enhancements:
- Detect scalar subquery multiple-rows guard patterns in converted expressions and rewrite AND conjunctions to enforce guard evaluation before other predicates.

## Summary by Sourcery

Prevent merging scalar subquery cardinality guard filters with other predicates when they depend on MarkDistinct marker variables, and add tests to cover the behavior in both planner rules and native execution.

Bug Fixes:
- Avoid merging filter predicates above MarkDistinct when the child filter references the MarkDistinct marker, preserving scalar subquery cardinality guard semantics during native execution.

Tests:
- Add planner tests verifying filters over MarkDistinct are merged only when they do not reference the MarkDistinct marker variable.
- Add native execution query tests ensuring correlated scalar subqueries correctly raise multiple-rows errors instead of being silently filtered out.

## Summary by Sourcery

Preserve scalar subquery cardinality guard behavior for native execution by preventing unsafe filter merging above MarkDistinct and adding coverage tests.

Bug Fixes:
- Avoid merging filters referencing MarkDistinct marker variables when native execution is enabled, preventing scalar subquery cardinality guards from being masked by other predicates.
- Adjust predicate pushdown over MarkDistinct to keep scalar subquery cardinality guards as separate filters in native execution so multiple-rows errors are not suppressed.

Tests:
- Extend MergeFilters rule tests to cover merging and skipping behavior over MarkDistinct for both native and Java execution paths.
- Add native execution query tests ensuring correlated scalar subqueries correctly raise multiple-rows errors even when additional predicates could filter the row.