### PR TITLE
feat: MetadataExtractor: prefetch source table for CREATE VECTOR INDEX

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Analyze;
+import com.facebook.presto.sql.tree.CreateVectorIndex;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.Identifier;
@@ -249,6 +250,21 @@ public class MetadataExtractor
 
             context.addTable(tableName);
             return super.visitAnalyze(node, context);
+        }
+
+        @Override
+        protected Void visitCreateVectorIndex(CreateVectorIndex node, MetadataExtractorContext context)
+        {
+            QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getTableName(), metadata);
+            if (tableName.getObjectName().isEmpty()) {
+                throw new SemanticException(MISSING_TABLE, node, "Table name is empty");
+            }
+            if (tableName.getSchemaName().isEmpty()) {
+                throw new SemanticException(MISSING_SCHEMA, node, "Schema name is empty");
+            }
+
+            context.addTable(tableName);
+            return super.visitCreateVectorIndex(node, context);
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -25,14 +25,21 @@ import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.planner.CompilerConfig;
+import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.tracing.TracingConfig;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
@@ -100,6 +107,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WILDCARD_WITHOU
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WINDOW_FUNCTION_ORDERBY_LITERAL;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WINDOW_REQUIRES_OVER;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -2432,5 +2440,53 @@ public class TestAnalyzer
         // UPDATING FOR with invalid column reference
         assertFails(MISSING_ATTRIBUTE, ".*",
                 "CREATE VECTOR INDEX test_index ON t14(id, embedding_real) UPDATING FOR nonexistent_col > 10");
+    }
+
+    // Regression test for the MetadataExtractor.Visitor missing a
+    // visitCreateVectorIndex override. With pre_process_metadata_calls=true
+    // (the default on prism interactive clusters), the extractor walks the
+    // parsed AST and prefetches metadata for every referenced table in
+    // parallel before analysis. CreateVectorIndex.getChildren() does not
+    // expose its source table as a Table AST child (the table name is a
+    // QualifiedName field), so without an explicit override the source
+    // table is never registered for prefetch. The downstream analyzer
+    // lookup then takes the cache-only branch in MetadataUtils, finds
+    // nothing, and throws VIEW_NOT_FOUND with an empty available-views
+    // list. This test asserts the override is in place and that CVI
+    // analysis succeeds when the prefetcher is enabled.
+    @Test
+    public void testCreateVectorIndexWithPreProcessMetadataCalls()
+    {
+        Session preProcessEnabledSession = Session.builder(CLIENT_SESSION)
+                .setSystemProperty(SystemSessionProperties.PRE_PROCESS_METADATA_CALLS, "true")
+                .build();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            transaction(transactionManager, accessControl)
+                    .singleStatement()
+                    .readUncommitted()
+                    .readOnly()
+                    .execute(preProcessEnabledSession, session -> {
+                        String query = "CREATE VECTOR INDEX test_index ON t14(id, embedding_real)";
+                        Analyzer analyzer = new Analyzer(
+                                session,
+                                metadata,
+                                SQL_PARSER,
+                                new AllowAllAccessControl(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                ImmutableMap.of(),
+                                WarningCollector.NOOP,
+                                Optional.of(executor),
+                                query,
+                                new ViewDefinitionReferences());
+                        Statement statement = SQL_PARSER.createStatement(query);
+                        analyzer.analyzeSemantic(statement, false);
+                    });
+        }
+        finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
Summary:
`CREATE VECTOR INDEX` queries fail at the analyzer phase with `View %s not found, the available view names are: []` whenever the session has `pre_process_metadata_calls=true`, even though the source table exists. 

Root cause: `MetadataExtractor.Visitor` walks the parsed AST before analysis to prefetch metadata for every referenced table in parallel. It has explicit overrides for `visitTable`, `visitInsert`, `visitDelete`, and `visitAnalyze`, but not for `visitCreateVectorIndex`. `CreateVectorIndex.getChildren()` exposes only `[columns, updatingFor, properties]` — the source table is stored as a `QualifiedName` field, not a `Table` AST child — so `DefaultTraversalVisitor`'s default traversal walks past the source table without ever calling `visitTable`. The prefetcher therefore registers nothing in the cache. `MetadataExtractor.populateMetadataHandle` still flips `metadataHandle.preProcessMetadataCalls = true` unconditionally, committing the analyzer to cache-only metadata lookups. When `StatementAnalyzer.visitCreateVectorIndex` later resolves the source table, `MetadataUtils.getViewDefinition` takes the cache-only branch in `MetadataHandle.getViewDefinition`, finds nothing, and throws.

Reviewed By: zhichenxu-meta

Differential Revision: D103477751



```
== NO RELEASE NOTE ==
```


