### PR TITLE
fix: UnsupportedOperationException for UnionNode in AddExchanges fixed parallelism path

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -282,9 +282,10 @@ public class AddExchanges
                             .anyMatch(x -> pattern.matcher(((CallExpression) x).getFunctionHandle().getName()).matches())) {
                         int taskCount = getRemoteFunctionFixedParallelismTaskCount(session);
                         checkState(taskCount > 0, "taskCount should be larger than 0");
-                        PlanNode newNode = roundRobinExchange(idAllocator.getNextId(), REMOTE_STREAMING, planWithProperties.getNode(), taskCount);
-                        newNode = ChildReplacer.replaceChildren(node, ImmutableList.of(newNode));
-                        return new PlanWithProperties(newNode, derivePropertiesRecursively(newNode));
+                        PlanNode exchangeNode = roundRobinExchange(idAllocator.getNextId(), REMOTE_STREAMING, planWithProperties.getNode(), taskCount);
+                        ActualProperties exchangeProperties = deriveProperties(exchangeNode, planWithProperties.getProperties());
+                        PlanNode newNode = ChildReplacer.replaceChildren(node, ImmutableList.of(exchangeNode));
+                        return new PlanWithProperties(newNode, deriveProperties(newNode, exchangeProperties));
                     }
                 }
             }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -886,14 +886,17 @@ public class TestAddExchangesPlansWithFunctions
     public void testRemoteFunctionFixedParallelismWithUnionAll()
     {
         // Test that REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM works correctly when
-        // a UNION ALL exists below the remote function projection.
+        // a UNION ALL exists below the remote function projection (via a GROUP BY
+        // that prevents the remote function from being pushed below the union).
         // Previously this crashed with "UnsupportedOperationException: not yet implemented: UnionNode"
         // because derivePropertiesRecursively walked into the UnionNode.
         assertNativeDistributedPlanWithSession(
                 "SELECT remote_foo(nationkey) FROM (" +
+                        "  SELECT nationkey FROM (" +
                         "    SELECT nationkey FROM nation WHERE nationkey < 5" +
                         "    UNION ALL" +
                         "    SELECT nationkey FROM nation WHERE nationkey >= 20" +
+                        "  ) GROUP BY nationkey" +
                         ")",
                 testSessionBuilder()
                         .setCatalog("tpch")

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -883,6 +883,37 @@ public class TestAddExchangesPlansWithFunctions
     }
 
     @Test
+    public void testRemoteFunctionFixedParallelismWithUnionAll()
+    {
+        // Test that REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM works correctly when
+        // a UNION ALL exists below the remote function projection (via an aggregation
+        // that prevents the remote function from being pushed below the union).
+        // Previously this crashed with "UnsupportedOperationException: not yet implemented: UnionNode"
+        // because derivePropertiesRecursively walked into the UnionNode.
+        assertNativeDistributedPlanWithSession(
+                "SELECT remote_foo(n_name) FROM (" +
+                        "  SELECT n_name, COUNT(*) AS cnt FROM (" +
+                        "    SELECT n_name FROM nation WHERE n_nationkey < 5" +
+                        "    UNION ALL" +
+                        "    SELECT n_name FROM nation WHERE n_nationkey >= 20" +
+                        "  ) GROUP BY n_name" +
+                        ")",
+                testSessionBuilder()
+                        .setCatalog("tpch")
+                        .setSchema("tiny")
+                        .setSystemProperty(REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM, "dummy.unittest.remote_foo")
+                        .setSystemProperty(REMOTE_FUNCTIONS_ENABLED, "true")
+                        .setSystemProperty(SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION, "true")
+                        .build(),
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER,
+                                project(ImmutableMap.of("remote_foo", expression("remote_foo(n_name)")),
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        tableScan("nation")))))));
+    }
+
+    @Test
     public void testRemoteFunctionNamesForFixedParallelismWithComplexRegex()
     {
         // Test complex regex pattern with character classes

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -907,7 +907,7 @@ public class TestAddExchangesPlansWithFunctions
                         .build(),
                 anyTree(
                         exchange(REMOTE_STREAMING, GATHER,
-                                anyTree(
+                                project(
                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                 anyTree(
                                                         tableScan("nation")))))));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -891,12 +891,12 @@ public class TestAddExchangesPlansWithFunctions
         // Previously this crashed with "UnsupportedOperationException: not yet implemented: UnionNode"
         // because derivePropertiesRecursively walked into the UnionNode.
         assertNativeDistributedPlanWithSession(
-                "SELECT remote_foo(n_name) FROM (" +
-                        "  SELECT n_name, COUNT(*) AS cnt FROM (" +
-                        "    SELECT n_name FROM nation WHERE n_nationkey < 5" +
+                "SELECT remote_foo(name) FROM (" +
+                        "  SELECT name, COUNT(*) AS cnt FROM (" +
+                        "    SELECT name FROM nation WHERE nationkey < 5" +
                         "    UNION ALL" +
-                        "    SELECT n_name FROM nation WHERE n_nationkey >= 20" +
-                        "  ) GROUP BY n_name" +
+                        "    SELECT name FROM nation WHERE nationkey >= 20" +
+                        "  ) GROUP BY name" +
                         ")",
                 testSessionBuilder()
                         .setCatalog("tpch")
@@ -907,7 +907,7 @@ public class TestAddExchangesPlansWithFunctions
                         .build(),
                 anyTree(
                         exchange(REMOTE_STREAMING, GATHER,
-                                project(ImmutableMap.of("remote_foo", expression("remote_foo(n_name)")),
+                                project(ImmutableMap.of("remote_foo", expression("remote_foo(name)")),
                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                 anyTree(
                                                         tableScan("nation")))))));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -886,17 +886,14 @@ public class TestAddExchangesPlansWithFunctions
     public void testRemoteFunctionFixedParallelismWithUnionAll()
     {
         // Test that REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM works correctly when
-        // a UNION ALL exists below the remote function projection (via an aggregation
-        // that prevents the remote function from being pushed below the union).
+        // a UNION ALL exists below the remote function projection.
         // Previously this crashed with "UnsupportedOperationException: not yet implemented: UnionNode"
         // because derivePropertiesRecursively walked into the UnionNode.
         assertNativeDistributedPlanWithSession(
-                "SELECT remote_foo(name) FROM (" +
-                        "  SELECT name, COUNT(*) AS cnt FROM (" +
-                        "    SELECT name FROM nation WHERE nationkey < 5" +
+                "SELECT remote_foo(nationkey) FROM (" +
+                        "    SELECT nationkey FROM nation WHERE nationkey < 5" +
                         "    UNION ALL" +
-                        "    SELECT name FROM nation WHERE nationkey >= 20" +
-                        "  ) GROUP BY name" +
+                        "    SELECT nationkey FROM nation WHERE nationkey >= 20" +
                         ")",
                 testSessionBuilder()
                         .setCatalog("tpch")
@@ -907,7 +904,7 @@ public class TestAddExchangesPlansWithFunctions
                         .build(),
                 anyTree(
                         exchange(REMOTE_STREAMING, GATHER,
-                                project(ImmutableMap.of("remote_foo", expression("remote_foo(name)")),
+                                project(ImmutableMap.of("remote_foo", expression("remote_foo(nationkey)")),
                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                 anyTree(
                                                         tableScan("nation")))))));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -907,7 +907,7 @@ public class TestAddExchangesPlansWithFunctions
                         .build(),
                 anyTree(
                         exchange(REMOTE_STREAMING, GATHER,
-                                project(ImmutableMap.of("remote_foo", expression("remote_foo(nationkey)")),
+                                anyTree(
                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                 anyTree(
                                                         tableScan("nation")))))));


### PR DESCRIPTION
## Description

Fixes a crash in `AddExchanges.visitProject` when `remote_function_names_for_fixed_parallelism` is enabled and a `UnionNode` exists below the remote function projection.

The issue: `visitProject` called `derivePropertiesRecursively` on the entire subtree after inserting a round-robin exchange for fixed parallelism. This fails when the subtree contains a `UnionNode` because `PropertyDerivations.Visitor` does not implement `visitUnion`.

The fix replaces `derivePropertiesRecursively` with per-node `deriveProperties` calls using child properties already available from `planChild`, matching how other visitor methods in `AddExchanges` derive properties via `rebaseAndDeriveProperties`.

## Motivation and Context

When a query applies a remote function (matched by `REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM`) on top of a `UNION ALL` — for example via an aggregation that prevents the remote function from being pushed below the union — the planner crashes with:

```
UnsupportedOperationException: not yet implemented: UnionNode
```

## Impact

- Bug fix only, no public API changes
- Only affects queries using `remote_function_names_for_fixed_parallelism` with `UnionNode` in the subtree

## Test Plan

- Added `testRemoteFunctionFixedParallelismWithUnionAll` regression test that reproduces the crash (UNION ALL below a remote function projection via aggregation)
- Existing `TestAddExchangesPlansWithFunctions` tests continue to pass

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix UnsupportedOperationException when using `remote_function_names_for_fixed_parallelism` with queries containing UNION ALL below the remote function projection.
```