### PR TITLE
feat: Forward DeleteFile.dataSequenceNumber through Prestissimo protocol + bridge (#27717)

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -92,6 +92,41 @@ public interface ExtendedHiveMetastore
 
     MetastoreOperationResult persistTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Supplier<PartitionStatistics> update, Map<String, String> additionalParameters);
 
+    /**
+     * Atomically commit an Iceberg metadata location change using compare-and-swap
+     * (CAS) semantics.
+     *
+     * <p>For Iceberg tables, the CAS guard applies to the table's
+     * {@code metadata_location} parameter (the source of truth for the current
+     * Iceberg metadata file pointer): the commit succeeds only if
+     * {@code previousMetadataLocation} matches the current {@code metadata_location}
+     * value in the metastore. Implementations may update other table fields as
+     * required by the underlying metastore API; callers must not assume that only
+     * a specific field changes.
+     *
+     * <p>This is more reliable than the {@code alter_table} path used by
+     * {@link #persistTable} for Iceberg metadata commits, which has weak
+     * last-writer-wins semantics under concurrent commits.
+     *
+     * <p>CAS failures (i.e. when {@code previousMetadataLocation} does not match
+     * the metastore's current value) MUST be surfaced as a thrown exception.
+     * Implementations must not silently no-op on a CAS mismatch — callers rely
+     * on this for correctness.
+     *
+     * @param metastoreContext the metastore context
+     * @param databaseName the database name
+     * @param tableName the table name
+     * @param newMetadataLocation the new Iceberg metadata file location to commit
+     * @param previousMetadataLocation CAS guard: must match the current
+     *     {@code metadata_location} value in the metastore
+     * @return the metastore operation result
+     * @throws UnsupportedOperationException if the metastore implementation does not support this API
+     */
+    default MetastoreOperationResult commitTableData(MetastoreContext metastoreContext, String databaseName, String tableName, String newMetadataLocation, String previousMetadataLocation)
+    {
+        throw new UnsupportedOperationException("commitTableData is not supported by this metastore implementation");
+    }
+
     MetastoreOperationResult renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
 
     MetastoreOperationResult addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CommitTaskData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CommitTaskData.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,7 +31,16 @@ public class CommitTaskData
     private final FileFormat fileFormat;
     private final Optional<String> referencedDataFile;
     private final FileContent content;
+    private final OptionalLong contentOffset;
+    private final OptionalLong contentSizeInBytes;
+    private final OptionalLong recordCount;
 
+    /**
+     * Backward compatibility: pre-V3 CommitTaskData JSON payloads do not include
+     * contentOffset / contentSizeInBytes / recordCount, so Jackson passes {@code null}
+     * for these {@link OptionalLong} parameters when deserializing older fragments.
+     * The null-checks below normalize them to {@link OptionalLong#empty()}.
+     */
     @JsonCreator
     public CommitTaskData(
             @JsonProperty("path") String path,
@@ -40,7 +50,10 @@ public class CommitTaskData
             @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
             @JsonProperty("fileFormat") FileFormat fileFormat,
             @JsonProperty("referencedDataFile") String referencedDataFile,
-            @JsonProperty("content") FileContent content)
+            @JsonProperty("content") FileContent content,
+            @JsonProperty("contentOffset") OptionalLong contentOffset,
+            @JsonProperty("contentSizeInBytes") OptionalLong contentSizeInBytes,
+            @JsonProperty("recordCount") OptionalLong recordCount)
     {
         this.path = requireNonNull(path, "path is null");
         this.fileSizeInBytes = fileSizeInBytes;
@@ -50,6 +63,24 @@ public class CommitTaskData
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.referencedDataFile = Optional.ofNullable(referencedDataFile);
         this.content = requireNonNull(content, "content is null");
+        this.contentOffset = contentOffset != null ? contentOffset : OptionalLong.empty();
+        this.contentSizeInBytes = contentSizeInBytes != null ? contentSizeInBytes : OptionalLong.empty();
+        this.recordCount = recordCount != null ? recordCount : OptionalLong.empty();
+    }
+
+    public CommitTaskData(
+            String path,
+            long fileSizeInBytes,
+            MetricsWrapper metrics,
+            int partitionSpecId,
+            Optional<String> partitionDataJson,
+            FileFormat fileFormat,
+            String referencedDataFile,
+            FileContent content)
+    {
+        this(path, fileSizeInBytes, metrics, partitionSpecId, partitionDataJson,
+                fileFormat, referencedDataFile, content,
+                OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty());
     }
 
     @JsonProperty
@@ -98,5 +129,23 @@ public class CommitTaskData
     public FileContent getContent()
     {
         return content;
+    }
+
+    @JsonProperty
+    public OptionalLong getContentOffset()
+    {
+        return contentOffset;
+    }
+
+    @JsonProperty
+    public OptionalLong getContentSizeInBytes()
+    {
+        return contentSizeInBytes;
+    }
+
+    @JsonProperty
+    public OptionalLong getRecordCount()
+    {
+        return recordCount;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -27,7 +27,8 @@ public enum FileFormat
     PARQUET("parquet", true),
     AVRO("avro", true),
     METADATA("metadata.json", false),
-    PUFFIN("puffin", false);
+    PUFFIN("puffin", false),
+    DWRF("dwrf", true);
 
     private final String ext;
     private final boolean splittable;
@@ -90,6 +91,9 @@ public enum FileFormat
                 break;
             case PUFFIN:
                 fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
+                break;
+            case DWRF:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -344,9 +344,21 @@ public class HiveTableOperations
                 if (base == null) {
                     metastore.createTable(metastoreContext, table, privileges, emptyList());
                 }
+                else if (config.getCommitTableDataEnabled()) {
+                    // Use commit_table_data CAS API for atomic metadata-pointer swap.
+                    // This is more reliable than alter_table for Iceberg metadata
+                    // commits because it provides true compare-and-swap semantics on
+                    // the table's metadata_location parameter.
+                    try {
+                        metastore.commitTableData(metastoreContext, database, tableName, newMetadataLocation, currentMetadataLocation);
+                    }
+                    catch (UnsupportedOperationException e) {
+                        log.warn("commitTableData not supported by metastore, falling back to persistTable for %s.%s", database, tableName);
+                        persistTableFallback(metastoreContext, table, privileges, base);
+                    }
+                }
                 else {
-                    PartitionStatistics tableStats = metastore.getTableStatistics(metastoreContext, database, tableName);
-                    metastore.persistTable(metastoreContext, database, tableName, table, privileges, () -> tableStats, useHMSLock ? ImmutableMap.of() : hmsEnvContext(base.metadataFileLocation()));
+                    persistTableFallback(metastoreContext, table, privileges, base);
                 }
             }
             catch (AlreadyExistsException e) {
@@ -658,5 +670,24 @@ public class HiveTableOperations
 
     public enum CommitStatus {
         SUCCESS, FAILED, UNKNOWN
+    }
+
+    /**
+     * Persists the table metadata via the standard {@code persistTable} path,
+     * preserving existing table statistics and the HMS env-context (when not
+     * using HMS-side locking). Used both for the non-CAS commit path and as
+     * the fallback when the metastore does not support {@code commitTableData}.
+     */
+    private void persistTableFallback(MetastoreContext metastoreContext, Table table, PrincipalPrivileges privileges, TableMetadata base)
+    {
+        PartitionStatistics tableStats = metastore.getTableStatistics(metastoreContext, database, tableName);
+        metastore.persistTable(
+                metastoreContext,
+                database,
+                tableName,
+                table,
+                privileges,
+                () -> tableStats,
+                useHMSLock ? ImmutableMap.of() : hmsEnvContext(base.metadataFileLocation()));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -108,6 +108,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes.None;
@@ -115,6 +116,7 @@ import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
@@ -130,21 +132,30 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.puffin.BlobMetadata;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinReader;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.view.View;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -156,6 +167,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -268,17 +280,13 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.connector.RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.spi.transaction.IsolationLevel.SERIALIZABLE;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.transformValues;
-import static java.lang.Long.parseLong;
-import static java.lang.String.format;
-import static java.time.Duration.ofDays;
-import static java.util.Collections.singletonList;
-import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.DataOperations.APPEND;
 import static org.apache.iceberg.DataOperations.REPLACE;
 import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
@@ -288,6 +296,12 @@ import static org.apache.iceberg.SnapshotSummary.DELETED_RECORDS_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_EQ_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_POS_DELETES_PROP;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
+
+import static java.lang.Long.parseLong;
+import static java.lang.String.format;
+import static java.time.Duration.ofDays;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 
 public abstract class IcebergAbstractMetadata
         implements IcebergTransactionMetadata
@@ -417,6 +431,10 @@ public abstract class IcebergAbstractMetadata
         if (schema == null) {
             schema = metadata.schema();
         }
+
+        // Iceberg v3 column default values (initial-default / write-default) are supported.
+        // The Iceberg library handles applying defaults when reading files that were written
+        // before a column with a default was added via schema evolution.
 
         // Reject Iceberg table encryption
         if (!metadata.encryptionKeys().isEmpty() || snapshot.keyId() != null || metadata.properties().containsKey("encryption.key-id")) {
@@ -767,16 +785,53 @@ public abstract class IcebergAbstractMetadata
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
                 .collect(toImmutableList());
 
-        RowDelta rowDelta = icebergTable.newRowDelta();
-        writableTableHandle.getTableName().getSnapshotId().map(icebergTable::snapshot).ifPresent(s -> rowDelta.validateFromSnapshot(s.snapshotId()));
-        Optional<String> branchName = writableTableHandle.getTableName().getBranchName();
-        if (branchName.isPresent()) {
-            rowDelta.toBranch(branchName.get());
-        }
-
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
-        commitTasks.forEach(task -> handleTask(task, icebergTable, rowDelta, writtenFiles, referencedDataFiles));
+        Optional<String> branchName = writableTableHandle.getTableName().getBranchName();
+
+        // Phase 1: Merge DVs that conflict with existing DVs via RewriteFiles
+        Map<String, org.apache.iceberg.DeleteFile> existingDVs = findExistingDVs(icebergTable);
+        Set<String> mergedDataFiles = new HashSet<>();
+        if (!existingDVs.isEmpty()) {
+            Set<org.apache.iceberg.DeleteFile> oldDVsToRemove = new HashSet<>();
+            Set<org.apache.iceberg.DeleteFile> mergedDVsToAdd = new HashSet<>();
+            for (CommitTaskData task : commitTasks) {
+                if (task.getFileFormat() == com.facebook.presto.iceberg.FileFormat.PUFFIN &&
+                        task.getReferencedDataFile().isPresent() &&
+                        existingDVs.containsKey(task.getReferencedDataFile().get())) {
+                    String dataFile = task.getReferencedDataFile().get();
+                    org.apache.iceberg.DeleteFile existingDV = existingDVs.get(dataFile);
+                    org.apache.iceberg.DeleteFile mergedDV = createMergedDeletionVector(
+                            task, existingDV, icebergTable);
+                    oldDVsToRemove.add(existingDV);
+                    mergedDVsToAdd.add(mergedDV);
+                    mergedDataFiles.add(dataFile);
+                    writtenFiles.add(mergedDV.path().toString());
+                    referencedDataFiles.add(dataFile);
+                }
+            }
+            if (!oldDVsToRemove.isEmpty()) {
+                RewriteFiles rewriteFiles = icebergTable.newRewrite()
+                        .rewriteFiles(ImmutableSet.of(), oldDVsToRemove, ImmutableSet.of(), mergedDVsToAdd);
+                writableTableHandle.getTableName().getSnapshotId().map(icebergTable::snapshot)
+                        .ifPresent(s -> rewriteFiles.validateFromSnapshot(s.snapshotId()));
+                branchName.ifPresent(rewriteFiles::toBranch);
+                rewriteFiles.commit();
+            }
+        }
+
+        // Phase 2: Process remaining tasks via RowDelta
+        RowDelta rowDelta = icebergTable.newRowDelta();
+        writableTableHandle.getTableName().getSnapshotId().map(icebergTable::snapshot).ifPresent(s -> rowDelta.validateFromSnapshot(s.snapshotId()));
+        branchName.ifPresent(b -> rowDelta.toBranch(b));
+        for (CommitTaskData task : commitTasks) {
+            if (task.getFileFormat() == com.facebook.presto.iceberg.FileFormat.PUFFIN &&
+                    task.getReferencedDataFile().isPresent() &&
+                    mergedDataFiles.contains(task.getReferencedDataFile().get())) {
+                continue;
+            }
+            handleTask(task, icebergTable, rowDelta, writtenFiles, referencedDataFiles);
+        }
 
         rowDelta.validateDataFilesExist(referencedDataFiles.build());
         if (this.transactionContext.getIsolationLevel() == SERIALIZABLE) {
@@ -845,9 +900,118 @@ public abstract class IcebergAbstractMetadata
             deleteBuilder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
         }
 
+        // For PUFFIN deletion vectors: set content offset, content size, record count,
+        // and referenced data file path. These fields enable the Iceberg library to
+        // correctly read the DV blob from the PUFFIN container file.
+        if (task.getFileFormat() == com.facebook.presto.iceberg.FileFormat.PUFFIN) {
+            task.getContentOffset().ifPresent(deleteBuilder::withContentOffset);
+            task.getContentSizeInBytes().ifPresent(deleteBuilder::withContentSizeInBytes);
+            task.getRecordCount().ifPresent(deleteBuilder::withRecordCount);
+            task.getReferencedDataFile().ifPresent(deleteBuilder::withReferencedDataFile);
+        }
+
         rowDelta.addDeletes(deleteBuilder.build());
         writtenFiles.add(task.getPath());
         task.getReferencedDataFile().ifPresent(referencedDataFiles::add);
+    }
+
+    private Map<String, org.apache.iceberg.DeleteFile> findExistingDVs(Table icebergTable)
+    {
+        Map<String, org.apache.iceberg.DeleteFile> existingDVs = new HashMap<>();
+        Snapshot currentSnapshot = icebergTable.currentSnapshot();
+        if (currentSnapshot == null) {
+            return existingDVs;
+        }
+        try {
+            for (ManifestFile manifest : currentSnapshot.deleteManifests(icebergTable.io())) {
+                try (CloseableIterable<org.apache.iceberg.DeleteFile> deleteFiles =
+                        ManifestFiles.readDeleteManifest(manifest, icebergTable.io(), icebergTable.specs())) {
+                    for (org.apache.iceberg.DeleteFile deleteFile : deleteFiles) {
+                        if (ContentFileUtil.isDV(deleteFile) && deleteFile.referencedDataFile() != null) {
+                            existingDVs.put(ContentFileUtil.referencedDataFileLocation(deleteFile), deleteFile);
+                        }
+                    }
+                }
+            }
+        }
+        catch (IOException e) {
+            // Rethrow rather than swallow: silently producing an empty existingDVs map
+            // would skip the Phase 1 DV-merge below, leaving the previous DV live alongside
+            // the freshly written one — a spec violation (file-scoped DVs must be 1:1 per
+            // data file) that yields incorrect read results. Failing the commit is safer.
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to scan existing deletion vectors", e);
+        }
+        return existingDVs;
+    }
+
+    private org.apache.iceberg.DeleteFile createMergedDeletionVector(
+            CommitTaskData newTask,
+            org.apache.iceberg.DeleteFile existingDV,
+            Table icebergTable)
+    {
+        PartitionSpec partitionSpec = icebergTable.specs().get(newTask.getPartitionSpecId());
+        Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                .map(field -> field.transform().getResultType(
+                        icebergTable.schema().findType(field.sourceId())))
+                .toArray(Type[]::new);
+        org.apache.iceberg.StructLike partition = newTask.getPartitionDataJson().isPresent()
+                ? PartitionData.fromJson(newTask.getPartitionDataJson().get(), partitionColumnTypes)
+                : null;
+
+        String dataFile = newTask.getReferencedDataFile()
+                .orElseThrow(() -> new VerifyException("Deletion vector commit task is missing the referenced data file path"));
+
+        // Decode the new DV produced by IcebergDeletionVectorPageSink.
+        PositionDeleteIndex newPositions = readDeletionVectorIndex(icebergTable, newTask.getPath(), null);
+
+        // The OutputFileFactory inherits FileIO/EncryptionManager/LocationProvider from the table.
+        OutputFileFactory fileFactory = OutputFileFactory.builderFor(icebergTable, 0, 0L)
+                .format(FileFormat.PUFFIN)
+                .operationId(UUID.randomUUID().toString())
+                .build();
+
+        // Loader supplies the existing DV positions (with provenance) for the matching data file path.
+        java.util.function.Function<String, PositionDeleteIndex> loader = path ->
+                path.equals(dataFile) ? readDeletionVectorIndex(icebergTable, existingDV.path().toString(), existingDV) : null;
+
+        try (BaseDVFileWriter writer = new BaseDVFileWriter(fileFactory, loader)) {
+            newPositions.forEach(pos -> writer.delete(dataFile, pos, partitionSpec, partition));
+            writer.close();
+            List<org.apache.iceberg.DeleteFile> produced = writer.result().deleteFiles();
+            checkState(!produced.isEmpty(), "BaseDVFileWriter produced no DeleteFile for data file %s", dataFile);
+            return produced.get(0);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to write merged deletion vector", e);
+        }
+        catch (UncheckedIOException e) {
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to write merged deletion vector", e.getCause());
+        }
+    }
+
+    private static PositionDeleteIndex readDeletionVectorIndex(Table icebergTable, String dvPath, org.apache.iceberg.DeleteFile attribution)
+    {
+        try (PuffinReader reader = Puffin.read(icebergTable.io().newInputFile(dvPath)).build()) {
+            // Iceberg V3 file-scoped deletion vectors contain exactly one Puffin blob per file.
+            // Asserting this protects against malformed inputs and matches the spec.
+            List<BlobMetadata> blobs = reader.fileMetadata().blobs();
+            if (blobs.isEmpty()) {
+                return PositionDeleteIndex.empty();
+            }
+            checkState(blobs.size() == 1,
+                    "Iceberg V3 deletion vector file %s expected to contain exactly one blob but found %s",
+                    dvPath, blobs.size());
+            for (Pair<BlobMetadata, ByteBuffer> pair : reader.readAll(blobs)) {
+                ByteBuffer blobData = pair.second();
+                byte[] bytes = new byte[blobData.remaining()];
+                blobData.get(bytes);
+                return PositionDeleteIndex.deserialize(bytes, attribution);
+            }
+            return PositionDeleteIndex.empty();
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to read deletion vector: " + dvPath, e);
+        }
     }
 
     private void handleFinishData(CommitTaskData task, Table icebergTable, PartitionSpec partitionSpec, Type[] partitionColumnTypes, Consumer<DataFile> dataFileConsumer, ImmutableSet.Builder<String> writtenFiles)
@@ -911,12 +1075,19 @@ public abstract class IcebergAbstractMetadata
                     format("Iceberg table updates for format version %s are not supported yet", formatVersion));
         }
 
-        if (formatVersion < MIN_FORMAT_VERSION_FOR_DELETE ||
+        if (formatVersion < MIN_FORMAT_VERSION_FOR_DELETE) {
+            throw new PrestoException(ICEBERG_INVALID_FORMAT_VERSION,
+                    "Iceberg table updates require at least format version 2");
+        }
+
+        // V3+ tables use deletion vectors natively (inherently merge-on-read).
+        // V2 tables require explicit merge-on-read mode configuration.
+        if (formatVersion < 3 &&
                 !Optional.ofNullable(icebergTable.properties().get(TableProperties.UPDATE_MODE))
                         .map(mode -> mode.equals(MERGE_ON_READ.modeName()))
                         .orElse(false)) {
             throw new PrestoException(ICEBERG_INVALID_FORMAT_VERSION,
-                    "Iceberg table updates require at least format version 2 and update mode must be merge-on-read");
+                    "Iceberg V2 table updates require update mode to be merge-on-read");
         }
         validateTableMode(session, icebergTable);
 
@@ -935,7 +1106,7 @@ public abstract class IcebergAbstractMetadata
 
         Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs = transformValues(icebergTable.specs(), partitionSpec -> toPrestoPartitionSpec(partitionSpec, typeManager));
 
-        return new IcebergMergeTableHandle(icebergTableHandle, insertHandle, partitionSpecs);
+        return new IcebergMergeTableHandle(icebergTableHandle, insertHandle, partitionSpecs, formatVersion);
     }
 
     @Override
@@ -1512,7 +1683,8 @@ public abstract class IcebergAbstractMetadata
             throw new PrestoException(NOT_SUPPORTED,
                     format("Iceberg table updates for format version %s are not supported yet", formatVersion));
         }
-        if (getDeleteMode(icebergTable) == RowLevelOperationMode.COPY_ON_WRITE) {
+        // V3+ tables use deletion vectors natively; V2 requires explicit merge-on-read mode.
+        if (formatVersion < 3 && getDeleteMode(icebergTable) == RowLevelOperationMode.COPY_ON_WRITE) {
             throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely. To enable row level deletions, change the write.delete.mode table property to `merge-on-read`.");
         }
         validateTableMode(session, icebergTable);
@@ -1544,8 +1716,23 @@ public abstract class IcebergAbstractMetadata
                     .ofPositionDeletes()
                     .withPath(task.getPath())
                     .withFileSizeInBytes(task.getFileSizeInBytes())
-                    .withFormat(FileFormat.fromString(task.getFileFormat().name()))
-                    .withMetrics(task.getMetrics().metrics());
+                    .withFormat(FileFormat.fromString(task.getFileFormat().name()));
+
+            if (task.getFileFormat() == com.facebook.presto.iceberg.FileFormat.PUFFIN) {
+                builder.withRecordCount(task.getRecordCount().orElseThrow(() ->
+                        new VerifyException("recordCount required for deletion vector")));
+                builder.withContentOffset(task.getContentOffset().orElseThrow(() ->
+                        new VerifyException("contentOffset required for deletion vector")));
+                builder.withContentSizeInBytes(task.getContentSizeInBytes().orElseThrow(() ->
+                        new VerifyException("contentSizeInBytes required for deletion vector")));
+            }
+            else {
+                builder.withMetrics(task.getMetrics().metrics());
+            }
+
+            if (task.getReferencedDataFile().isPresent()) {
+                builder.withReferencedDataFile(task.getReferencedDataFile().get());
+            }
 
             if (!spec.fields().isEmpty()) {
                 String partitionDataJson = task.getPartitionDataJson()
@@ -1792,17 +1979,41 @@ public abstract class IcebergAbstractMetadata
                     format("Iceberg table updates for format version %s are not supported yet", formatVersion));
         }
 
-        if (formatVersion < MIN_FORMAT_VERSION_FOR_DELETE ||
+        // V3+ tables use deletion vectors natively (inherently merge-on-read).
+        // V2 tables require explicit merge-on-read mode configuration.
+        if (formatVersion < MIN_FORMAT_VERSION_FOR_DELETE) {
+            throw new RuntimeException("Iceberg table updates require at least format version 2");
+        }
+
+        if (formatVersion < 3 &&
                 !Optional.ofNullable(icebergTable.properties().get(TableProperties.UPDATE_MODE))
                         .map(mode -> mode.equals(MERGE_ON_READ.modeName()))
                         .orElse(false)) {
-            throw new RuntimeException("Iceberg table updates require at least format version 2 and update mode must be merge-on-read");
+            throw new RuntimeException("Iceberg V2 table updates require update mode to be merge-on-read");
         }
         validateTableMode(session, icebergTable);
-        return handle
-                .withUpdatedColumns(updatedColumns.stream()
+
+        Optional<Map<String, String>> storageProps = handle.getStorageProperties();
+        if (storageProps.isPresent() && !storageProps.get().containsKey("format-version")) {
+            Map<String, String> enhanced = new HashMap<>(storageProps.get());
+            enhanced.put("format-version", String.valueOf(formatVersion));
+            storageProps = Optional.of(enhanced);
+        }
+
+        return new IcebergTableHandle(
+                handle.getSchemaName(),
+                handle.getIcebergTableName(),
+                handle.isSnapshotSpecified(),
+                handle.getOutputPath(),
+                storageProps,
+                handle.getTableSchemaJson(),
+                handle.getPartitionSpecId(),
+                handle.getEqualityFieldIds(),
+                handle.getSortOrder(),
+                updatedColumns.stream()
                         .map(IcebergColumnHandle.class::cast)
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                handle.getMaterializedViewName());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -50,6 +50,7 @@ import com.facebook.presto.iceberg.procedure.ManifestFileCacheInvalidationProced
 import com.facebook.presto.iceberg.procedure.RegisterTableProcedure;
 import com.facebook.presto.iceberg.procedure.RemoveOrphanFiles;
 import com.facebook.presto.iceberg.procedure.RewriteDataFilesProcedure;
+import com.facebook.presto.iceberg.procedure.RewriteDeleteFilesProcedure;
 import com.facebook.presto.iceberg.procedure.RewriteManifestsProcedure;
 import com.facebook.presto.iceberg.procedure.RollbackToSnapshotProcedure;
 import com.facebook.presto.iceberg.procedure.RollbackToTimestampProcedure;
@@ -115,11 +116,12 @@ import static com.facebook.presto.orc.StripeMetadataSource.CacheableSlice;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
-import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class IcebergCommonModule
         extends AbstractConfigurationAwareModule
@@ -196,6 +198,7 @@ public class IcebergCommonModule
         procedures.addBinding().toProvider(StatisticsFileCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(ManifestFileCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(RewriteDataFilesProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RewriteDeleteFilesProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(RewriteManifestsProcedure.class).in(Scopes.SINGLETON);
         if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
             procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.presto.hive.HiveTransactionHandle;
 import com.facebook.presto.iceberg.function.IcebergBucketFunction;
+import com.facebook.presto.iceberg.function.VariantFunctions;
 import com.facebook.presto.iceberg.function.changelog.ApplyChangelogFunction;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionManager;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionMetadata;
@@ -50,6 +51,7 @@ import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTA
 import static com.facebook.presto.spi.transaction.IsolationLevel.REPEATABLE_READ;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.collect.Sets.immutableEnumSet;
+
 import static java.util.Objects.requireNonNull;
 
 public class IcebergConnector
@@ -256,6 +258,7 @@ public class IcebergConnector
                 .add(ApplyChangelogFunction.class)
                 .add(IcebergBucketFunction.class)
                 .add(IcebergBucketFunction.Bucket.class)
+                .add(VariantFunctions.class)
                 .build();
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -117,6 +117,7 @@ public class IcebergFileWriterFactory
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext, metricsConfig);
             case ORC:
+            case DWRF:
                 return createOrcWriter(outputPath, icebergSchema, jobConf, session);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
@@ -32,6 +32,7 @@ public class IcebergHiveTableOperationsConfig
     private double tableRefreshBackoffScaleFactor = 4.0;
     private int tableRefreshRetries = 20;
     private boolean lockingEnabled = true;
+    private boolean commitTableDataEnabled;
 
     @MinDuration("1ms")
     public Duration getTableRefreshBackoffMinSleepTime()
@@ -114,5 +115,23 @@ public class IcebergHiveTableOperationsConfig
     public boolean getLockingEnabled()
     {
         return lockingEnabled;
+    }
+
+    private boolean commitTableDataEnabled;
+
+    private boolean commitTableDataEnabled;
+
+    public boolean getCommitTableDataEnabled()
+    {
+        return commitTableDataEnabled;
+    }
+
+    @Config("iceberg.hive.commit-table-data-enabled")
+    @ConfigDescription("Use commit_table_data CAS API instead of alter_table for Iceberg metadata commits. " +
+            "Requires metastore support for the commit_table_data API.")
+    public IcebergHiveTableOperationsConfig setCommitTableDataEnabled(boolean commitTableDataEnabled)
+    {
+        this.commitTableDataEnabled = commitTableDataEnabled;
+        return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeSink.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.iceberg.delete.IcebergDeletePageSink;
+import com.facebook.presto.iceberg.delete.IcebergDeletionVectorPageSink;
 import com.facebook.presto.spi.ConnectorMergeSink;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorSession;
@@ -46,6 +47,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.plugin.base.util.Closables.closeAllSuppress;
 import static com.facebook.presto.spi.connector.MergePage.createDeleteAndInsertPages;
+
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -63,6 +65,7 @@ public class IcebergMergeSink
     private final Map<Integer, PartitionSpec> partitionsSpecs;
     private final ConnectorPageSink insertPageSink;
     private final int columnCount;
+    private final int formatVersion;
     private final Map<Slice, FileDeletion> fileDeletions = new HashMap<>();
 
     public IcebergMergeSink(
@@ -74,7 +77,8 @@ public class IcebergMergeSink
             FileFormat fileFormat,
             Map<Integer, PartitionSpec> partitionsSpecs,
             ConnectorPageSink insertPageSink,
-            int columnCount)
+            int columnCount,
+            int formatVersion)
     {
         this.locationProvider = requireNonNull(locationProvider, "locationProvider is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
@@ -85,6 +89,7 @@ public class IcebergMergeSink
         this.partitionsSpecs = requireNonNull(partitionsSpecs, "partitionsSpecs is null");
         this.insertPageSink = requireNonNull(insertPageSink, "insertPageSink is null");
         this.columnCount = columnCount;
+        this.formatVersion = formatVersion;
     }
 
     /**
@@ -129,7 +134,7 @@ public class IcebergMergeSink
 
             try {
                 fileDeletions.forEach((dataFilePath, deletion) -> {
-                    ConnectorPageSink sink = createPositionDeletePageSink(
+                    ConnectorPageSink sink = createDeleteSink(
                             dataFilePath.toStringUtf8(),
                             partitionsSpecs.get(deletion.partitionSpecId()),
                             deletion.partitionDataJson());
@@ -149,8 +154,21 @@ public class IcebergMergeSink
         insertPageSink.abort();
     }
 
-    private ConnectorPageSink createPositionDeletePageSink(String dataFilePath, PartitionSpec partitionSpec, String partitionDataJson)
+    private ConnectorPageSink createDeleteSink(String dataFilePath, PartitionSpec partitionSpec, String partitionDataJson)
     {
+        // V3+ tables use deletion vectors (PUFFIN format) for more efficient row-level deletes.
+        // V2 tables use traditional position delete files (Parquet format).
+        if (formatVersion >= 3) {
+            return new IcebergDeletionVectorPageSink(
+                    partitionSpec,
+                    Optional.of(partitionDataJson),
+                    locationProvider,
+                    hdfsEnvironment,
+                    new HdfsContext(session),
+                    jsonCodec,
+                    session,
+                    dataFilePath);
+        }
         return new IcebergDeletePageSink(
                 partitionSpec,
                 Optional.of(partitionDataJson),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeTableHandle.java
@@ -31,17 +31,20 @@ public class IcebergMergeTableHandle
     private final IcebergTableHandle tableHandle;
     private final IcebergInsertTableHandle insertTableHandle;
     private final Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs;
+    private final int formatVersion;
 
     @JsonCreator
     @ThriftConstructor
     public IcebergMergeTableHandle(
             @JsonProperty("tableHandle") IcebergTableHandle tableHandle,
             @JsonProperty("insertTableHandle") IcebergInsertTableHandle insertTableHandle,
-            @JsonProperty("partitionSpecs") Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs)
+            @JsonProperty("partitionSpecs") Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs,
+            @JsonProperty("formatVersion") int formatVersion)
     {
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.insertTableHandle = requireNonNull(insertTableHandle, "insertTableHandle is null");
         this.partitionSpecs = requireNonNull(partitionSpecs, "partitionSpecs is null");
+        this.formatVersion = formatVersion;
     }
 
     @Override
@@ -64,5 +67,12 @@ public class IcebergMergeTableHandle
     public Map<Integer, PrestoIcebergPartitionSpec> getPartitionSpecs()
     {
         return partitionSpecs;
+    }
+
+    @JsonProperty
+    @ThriftField(4)
+    public int getFormatVersion()
+    {
+        return formatVersion;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTa
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toIcebergPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toIcebergSchema;
 import static com.google.common.collect.Maps.transformValues;
+
 import static java.util.Objects.requireNonNull;
 
 public class IcebergPageSinkProvider
@@ -134,6 +135,7 @@ public class IcebergPageSinkProvider
                 tableHandle.getFileFormat(),
                 partitionSpecs,
                 pageSink,
-                tableHandle.getInputColumns().size());
+                tableHandle.getInputColumns().size(),
+                merge.getFormatVersion());
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -45,6 +45,7 @@ import com.facebook.presto.iceberg.changelog.ChangelogPageSource;
 import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.iceberg.delete.DeleteFilter;
 import com.facebook.presto.iceberg.delete.IcebergDeletePageSink;
+import com.facebook.presto.iceberg.delete.IcebergDeletionVectorPageSink;
 import com.facebook.presto.iceberg.delete.PositionDeleteFilter;
 import com.facebook.presto.iceberg.delete.RowPredicate;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
@@ -70,6 +71,7 @@ import com.facebook.presto.parquet.cache.ParquetMetadataSource;
 import com.facebook.presto.parquet.predicate.Predicate;
 import com.facebook.presto.parquet.reader.ParquetReader;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
@@ -95,7 +97,12 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.puffin.BlobMetadata;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinReader;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -186,10 +193,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
-import static java.lang.String.format;
-import static java.time.ZoneOffset.UTC;
-import static java.util.Locale.ENGLISH;
-import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.apache.iceberg.MetadataColumns.FILE_PATH;
@@ -197,6 +200,11 @@ import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 import static org.apache.iceberg.MetadataColumns.SPEC_ID;
 import static org.apache.parquet.io.ColumnIOConverter.constructField;
 import static org.apache.parquet.io.ColumnIOConverter.findNestedColumnIO;
+
+import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class IcebergPageSourceProvider
         implements ConnectorPageSourceProvider
@@ -888,17 +896,33 @@ public class IcebergPageSourceProvider
         verify(storageProperties.isPresent(), "storageProperties are null");
 
         LocationProvider locationProvider = getLocationProvider(table.getSchemaTableName(), outputPath.get(), storageProperties.get());
-        Supplier<IcebergDeletePageSink> deleteSinkSupplier = () -> new IcebergDeletePageSink(
-                partitionSpec,
-                split.getPartitionDataJson(),
-                locationProvider,
-                fileWriterFactory,
-                hdfsEnvironment,
-                hdfsContext,
-                jsonCodec,
-                session,
-                split.getPath(),
-                split.getFileFormat());
+        int tableFormatVersion = Integer.parseInt(
+                storageProperties.get().getOrDefault("format-version", "2"));
+        Supplier<ConnectorPageSink> deleteSinkSupplier;
+        if (tableFormatVersion >= 3) {
+            deleteSinkSupplier = () -> new IcebergDeletionVectorPageSink(
+                    partitionSpec,
+                    split.getPartitionDataJson(),
+                    locationProvider,
+                    hdfsEnvironment,
+                    hdfsContext,
+                    jsonCodec,
+                    session,
+                    split.getPath());
+        }
+        else {
+            deleteSinkSupplier = () -> new IcebergDeletePageSink(
+                    partitionSpec,
+                    split.getPartitionDataJson(),
+                    locationProvider,
+                    fileWriterFactory,
+                    hdfsEnvironment,
+                    hdfsContext,
+                    jsonCodec,
+                    session,
+                    split.getPath(),
+                    split.getFileFormat());
+        }
         boolean storeDeleteFilePath = icebergColumns.contains(DELETE_FILE_PATH_COLUMN_HANDLE);
         Supplier<List<DeleteFilter>> deleteFilters = memoize(() -> {
             // If equality deletes are optimized into a join they don't need to be applied here
@@ -1011,30 +1035,35 @@ public class IcebergPageSourceProvider
 
         for (DeleteFile delete : deleteFiles) {
             if (delete.content() == POSITION_DELETES) {
-                if (startRowPosition.isPresent()) {
-                    byte[] lowerBoundBytes = delete.getLowerBounds().get(DELETE_FILE_POS.fieldId());
-                    Optional<Long> positionLowerBound = Optional.ofNullable(lowerBoundBytes)
-                            .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
+                if (delete.format() == FileFormat.PUFFIN) {
+                    readDeletionVector(session, delete, deletedRows);
+                }
+                else {
+                    if (startRowPosition.isPresent()) {
+                        byte[] lowerBoundBytes = delete.getLowerBounds().get(DELETE_FILE_POS.fieldId());
+                        Optional<Long> positionLowerBound = Optional.ofNullable(lowerBoundBytes)
+                                .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
 
-                    byte[] upperBoundBytes = delete.getUpperBounds().get(DELETE_FILE_POS.fieldId());
-                    Optional<Long> positionUpperBound = Optional.ofNullable(upperBoundBytes)
-                            .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
+                        byte[] upperBoundBytes = delete.getUpperBounds().get(DELETE_FILE_POS.fieldId());
+                        Optional<Long> positionUpperBound = Optional.ofNullable(upperBoundBytes)
+                                .map(bytes -> Conversions.fromByteBuffer(DELETE_FILE_POS.type(), ByteBuffer.wrap(bytes)));
 
-                    if ((positionLowerBound.isPresent() && positionLowerBound.get() > endRowPosition.get()) ||
-                            (positionUpperBound.isPresent() && positionUpperBound.get() < startRowPosition.get())) {
-                        continue;
+                        if ((positionLowerBound.isPresent() && positionLowerBound.get() > endRowPosition.get()) ||
+                                (positionUpperBound.isPresent() && positionUpperBound.get() < startRowPosition.get())) {
+                            continue;
+                        }
                     }
-                }
 
-                try (ConnectorPageSource pageSource = openDeletes(session, delete, deleteColumns, deleteDomain)) {
-                    readPositionDeletes(pageSource, targetPath, deletedRows);
-                }
-                catch (IOException e) {
-                    throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, format("Cannot open Iceberg delete file: %s", delete.path()), e);
+                    try (ConnectorPageSource pageSource = openDeletes(session, delete, deleteColumns, deleteDomain)) {
+                        readPositionDeletes(pageSource, targetPath, deletedRows);
+                    }
+                    catch (IOException e) {
+                        throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, format("Cannot open Iceberg delete file: %s", delete.path()), e);
+                    }
                 }
                 if (storeDeleteFilePath) {
                     filters.add(new PositionDeleteFilter(deletedRows, delete.path()));
-                    deletedRows = new Roaring64Bitmap(); // Reset the deleted rows for the next file
+                    deletedRows = new Roaring64Bitmap();
                 }
             }
             else if (delete.content() == EQUALITY_DELETES) {
@@ -1061,6 +1090,34 @@ public class IcebergPageSourceProvider
         }
 
         return filters;
+    }
+
+    private void readDeletionVector(
+            ConnectorSession session,
+            DeleteFile delete,
+            LongBitmapDataProvider deletedRows)
+    {
+        HdfsContext hdfsContext = new HdfsContext(session);
+        InputFile inputFile = new HdfsInputFile(new Path(delete.path()), hdfsEnvironment, hdfsContext);
+        try (PuffinReader reader = hdfsEnvironment.doAs(session.getUser(), () -> Puffin.read(inputFile).build())) {
+            List<BlobMetadata> blobMetadataList = reader.fileMetadata().blobs();
+            if (blobMetadataList.isEmpty()) {
+                return;
+            }
+            for (org.apache.iceberg.util.Pair<BlobMetadata, ByteBuffer> pair : reader.readAll(blobMetadataList)) {
+                ByteBuffer blobData = pair.second();
+                byte[] bytes = new byte[blobData.remaining()];
+                blobData.get(bytes);
+                // Iceberg V3 DVs use the spec-compliant 64-bit Roaring portable bitmap with magic
+                // / length / CRC framing. Decode via Iceberg's native deserializer (matches what
+                // IcebergDeletionVectorPageSink writes via BaseDVFileWriter).
+                PositionDeleteIndex index = PositionDeleteIndex.deserialize(bytes, delete);
+                index.forEach((java.util.function.LongConsumer) deletedRows::addLong);
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, format("Cannot open Iceberg deletion vector file: %s", delete.path()), e);
+        }
     }
 
     private ConnectorPageSource openDeletes(
@@ -1128,6 +1185,37 @@ public class IcebergPageSourceProvider
                         predicate,
                         readerOptions,
                         ORC,
+                        getOrcMaxBufferSize(session),
+                        getOrcStreamBufferSize(session),
+                        getOrcLazyReadSmallRanges(session),
+                        isOrcBloomFiltersEnabled(session),
+                        hiveClientConfig.getDomainCompactionThreshold(),
+                        orcFileTailSource,
+                        stripeMetadataSourceFactory,
+                        fileFormatDataSourceStats,
+                        Optional.empty(),
+                        dwrfEncryptionProvider);
+            case DWRF:
+                OrcReaderOptions dwrfReaderOptions = OrcReaderOptions.builder()
+                        .withMaxMergeDistance(getOrcMaxMergeDistance(session))
+                        .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
+                        .withMaxBlockSize(getOrcMaxReadBlockSize(session))
+                        .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .build();
+
+                return createBatchOrcPageSource(
+                        hdfsEnvironment,
+                        session.getUser(),
+                        hdfsEnvironment.getConfiguration(hdfsContext, path),
+                        path,
+                        start,
+                        length,
+                        isCacheable,
+                        dataColumns,
+                        typeManager,
+                        predicate,
+                        dwrfReaderOptions,
+                        OrcEncoding.DWRF,
                         getOrcMaxBufferSize(session),
                         getOrcStreamBufferSize(session),
                         getOrcLazyReadSmallRanges(session),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -18,7 +18,6 @@ import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -49,12 +48,12 @@ import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeys;
 import static com.facebook.presto.iceberg.IcebergUtil.getTargetSplitSize;
 import static com.facebook.presto.iceberg.IcebergUtil.metadataColumnsMatchPredicates;
 import static com.facebook.presto.iceberg.IcebergUtil.partitionDataFromStructLike;
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.limit;
+import static org.apache.iceberg.util.TableScanUtil.splitFiles;
+
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.iceberg.util.TableScanUtil.splitFiles;
 
 public class IcebergSplitSource
         implements ConnectorSplitSource
@@ -136,13 +135,6 @@ public class IcebergSplitSource
     {
         PartitionSpec spec = task.spec();
         Optional<PartitionData> partitionData = partitionDataFromStructLike(spec, task.file().partition());
-
-        // Validate no PUFFIN deletion vectors (Iceberg v3 feature not yet supported)
-        for (org.apache.iceberg.DeleteFile deleteFile : task.deletes()) {
-            if (deleteFile.format() == org.apache.iceberg.FileFormat.PUFFIN) {
-                throw new PrestoException(NOT_SUPPORTED, "Iceberg deletion vectors (PUFFIN format) are not supported");
-            }
-        }
 
         // TODO: We should leverage residual expression and convert that to TupleDomain.
         //       The predicate here is used by readers for predicate push down at reader level,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUpdateablePageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUpdateablePageSource.java
@@ -21,8 +21,8 @@ import com.facebook.presto.common.block.RowBlock;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.hive.HivePartitionKey;
 import com.facebook.presto.iceberg.delete.DeleteFilter;
-import com.facebook.presto.iceberg.delete.IcebergDeletePageSink;
 import com.facebook.presto.iceberg.delete.RowPredicate;
+import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.UpdatablePageSource;
@@ -58,6 +58,7 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_COLUM
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -72,8 +73,8 @@ public class IcebergUpdateablePageSource
         implements UpdatablePageSource
 {
     private final ConnectorPageSource delegate;
-    private final Supplier<IcebergDeletePageSink> deleteSinkSupplier;
-    private IcebergDeletePageSink positionDeleteSink;
+    private final Supplier<ConnectorPageSink> deleteSinkSupplier;
+    private ConnectorPageSink positionDeleteSink;
     private final Supplier<Optional<RowPredicate>> deletePredicate;
     private final Supplier<List<DeleteFilter>> deleteFilters;
 
@@ -118,7 +119,7 @@ public class IcebergUpdateablePageSource
             ConnectorPageSource delegate,
             // represents the columns output by the delegate page source
             List<IcebergColumnHandle> delegateColumns,
-            Supplier<IcebergDeletePageSink> deleteSinkSupplier,
+            Supplier<ConnectorPageSink> deleteSinkSupplier,
             Supplier<Optional<RowPredicate>> deletePredicate,
             Supplier<List<DeleteFilter>> deleteFilters,
             Supplier<IcebergPageSink> updatedRowPageSinkSupplier,
@@ -338,7 +339,7 @@ public class IcebergUpdateablePageSource
     public CompletableFuture<Collection<Slice>> finish()
     {
         return Optional.ofNullable(positionDeleteSink)
-                .map(IcebergDeletePageSink::finish)
+                .map(ConnectorPageSink::finish)
                 .orElseGet(() -> completedFuture(ImmutableList.of()))
                 .thenCombine(
                         Optional.ofNullable(updatedRowPageSink).map(IcebergPageSink::finish)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -168,23 +168,6 @@ import static com.google.common.collect.Streams.mapWithIndex;
 import static com.google.common.collect.Streams.stream;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static java.lang.Double.doubleToLongBits;
-import static java.lang.Double.doubleToRawLongBits;
-import static java.lang.Double.longBitsToDouble;
-import static java.lang.Double.parseDouble;
-import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Float.intBitsToFloat;
-import static java.lang.Float.parseFloat;
-import static java.lang.Integer.parseInt;
-import static java.lang.Long.parseLong;
-import static java.lang.Math.toIntExact;
-import static java.lang.Math.ulp;
-import static java.lang.String.format;
-import static java.util.Collections.emptyIterator;
-import static java.util.Comparator.comparing;
-import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED;
@@ -221,11 +204,29 @@ import static org.apache.iceberg.TableProperties.WRITE_METADATA_LOCATION;
 import static org.apache.iceberg.types.Type.TypeID.BINARY;
 import static org.apache.iceberg.types.Type.TypeID.FIXED;
 
+import static java.lang.Double.doubleToLongBits;
+import static java.lang.Double.doubleToRawLongBits;
+import static java.lang.Double.longBitsToDouble;
+import static java.lang.Double.parseDouble;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Float.parseFloat;
+import static java.lang.Integer.parseInt;
+import static java.lang.Long.parseLong;
+import static java.lang.Math.toIntExact;
+import static java.lang.Math.ulp;
+import static java.lang.String.format;
+import static java.util.Collections.emptyIterator;
+import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 public final class IcebergUtil
 {
     private static final Logger log = Logger.get(IcebergUtil.class);
     public static final int MIN_FORMAT_VERSION_FOR_DELETE = 2;
-    public static final int MAX_FORMAT_VERSION_FOR_ROW_LEVEL_OPERATIONS = 2;
+    public static final int MAX_FORMAT_VERSION_FOR_ROW_LEVEL_OPERATIONS = 3;
     public static final int MAX_SUPPORTED_FORMAT_VERSION = 3;
 
     public static final long DOUBLE_POSITIVE_ZERO = 0x0000000000000000L;
@@ -564,10 +565,19 @@ public final class IcebergUtil
     public static Optional<Map<String, String>> tryGetProperties(Table table)
     {
         try {
-            return Optional.ofNullable(table.properties());
+            Map<String, String> properties = table.properties();
+            if (properties != null && table instanceof BaseTable) {
+                int formatVersion = ((BaseTable) table).operations().current().formatVersion();
+                if (!properties.containsKey("format-version")) {
+                    Map<String, String> enhanced = new HashMap<>(properties);
+                    enhanced.put("format-version", String.valueOf(formatVersion));
+                    return Optional.of(enhanced);
+                }
+            }
+            return Optional.ofNullable(properties);
         }
         catch (TableNotFoundException e) {
-            log.warn(String.format("Unable to fetch properties for table %s: %s", table.name(), e.getMessage()));
+            log.warn(String.format("Unable to fetch properties for table %s: %s", table.name(), e));
             return Optional.empty();
         }
     }
@@ -578,7 +588,7 @@ public final class IcebergUtil
             return Optional.ofNullable(table.currentSnapshot());
         }
         catch (TableNotFoundException e) {
-            log.warn(String.format("Unable to fetch snapshot for table %s: %s", table.name(), e.getMessage()));
+            log.warn(String.format("Unable to fetch snapshot for table %s: %s", table.name(), e));
             return Optional.empty();
         }
     }
@@ -589,7 +599,7 @@ public final class IcebergUtil
             return Optional.ofNullable(table.location());
         }
         catch (TableNotFoundException e) {
-            log.warn(String.format("Unable to fetch location for table %s: %s", table.name(), e.getMessage()));
+            log.warn(String.format("Unable to fetch location for table %s: %s", table.name(), e));
             return Optional.empty();
         }
     }
@@ -603,7 +613,7 @@ public final class IcebergUtil
                     .collect(toImmutableList());
         }
         catch (Exception e) {
-            log.warn(String.format("Unable to fetch sort fields for table %s: %s", table.name(), e.getMessage()));
+            log.warn(String.format("Unable to fetch sort fields for table %s: %s", table.name(), e));
             return ImmutableList.of();
         }
     }
@@ -709,7 +719,7 @@ public final class IcebergUtil
             return Optional.ofNullable(table.schema());
         }
         catch (TableNotFoundException e) {
-            log.warn(String.format("Unable to fetch schema for table %s: %s", table.name(), e.getMessage()));
+            log.warn(String.format("Unable to fetch schema for table %s: %s", table.name(), e));
             return Optional.empty();
         }
     }
@@ -801,7 +811,10 @@ public final class IcebergUtil
             case TIME:
             case TIMESTAMP:
                 return singleValue(prestoType, MICROSECONDS.toMillis((Long) value));
+            case TIMESTAMP_NANO:
+                return singleValue(prestoType, Math.floorDiv((Long) value, 1000L));
             case STRING:
+            case VARIANT:
                 return singleValue(prestoType, utf8Slice(value.toString()));
             case FLOAT:
                 return singleValue(prestoType, (long) floatToRawIntBits((Float) value));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
@@ -42,6 +42,7 @@ public final class DeleteFile
     private final List<Integer> equalityFieldIds;
     private final Map<Integer, byte[]> lowerBounds;
     private final Map<Integer, byte[]> upperBounds;
+    private final long dataSequenceNumber;
 
     public static DeleteFile fromIceberg(org.apache.iceberg.DeleteFile deleteFile)
     {
@@ -49,6 +50,8 @@ public final class DeleteFile
                 .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
         Map<Integer, byte[]> upperBounds = firstNonNull(deleteFile.upperBounds(), ImmutableMap.<Integer, ByteBuffer>of())
                 .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
+
+        long dataSequenceNumber = deleteFile.dataSequenceNumber() != null ? deleteFile.dataSequenceNumber() : 0L;
 
         return new DeleteFile(
                 fromIcebergFileContent(deleteFile.content()),
@@ -58,7 +61,8 @@ public final class DeleteFile
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
                 lowerBounds,
-                upperBounds);
+                upperBounds,
+                dataSequenceNumber);
     }
 
     @JsonCreator
@@ -70,7 +74,8 @@ public final class DeleteFile
             @JsonProperty("fileSizeInBytes") long fileSizeInBytes,
             @JsonProperty("equalityFieldIds") List<Integer> equalityFieldIds,
             @JsonProperty("lowerBounds") Map<Integer, byte[]> lowerBounds,
-            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds)
+            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds,
+            @JsonProperty("dataSequenceNumber") long dataSequenceNumber)
     {
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
@@ -80,6 +85,7 @@ public final class DeleteFile
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
         this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
         this.upperBounds = ImmutableMap.copyOf(requireNonNull(upperBounds, "upperBounds is null"));
+        this.dataSequenceNumber = dataSequenceNumber;
     }
 
     @JsonProperty
@@ -130,12 +136,19 @@ public final class DeleteFile
         return upperBounds;
     }
 
+    @JsonProperty
+    public long getDataSequenceNumber()
+    {
+        return dataSequenceNumber;
+    }
+
     @Override
     public String toString()
     {
         return toStringHelper(this)
                 .addValue(path)
                 .add("records", recordCount)
+                .add("dataSequenceNumber", dataSequenceNumber)
                 .toString();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/IcebergDeletionVectorPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/IcebergDeletionVectorPageSink.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.iceberg.CommitTaskData;
+import com.facebook.presto.iceberg.FileFormat;
+import com.facebook.presto.iceberg.MetricsWrapper;
+import com.facebook.presto.iceberg.PartitionData;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static com.facebook.presto.iceberg.IcebergUtil.partitionDataFromJson;
+import static com.facebook.presto.iceberg.delete.IcebergDeletionVectorWriterFactory.createPuffinOutputFileFactory;
+import static io.airlift.slice.Slices.wrappedBuffer;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+/**
+ * Writes Iceberg V3 Puffin deletion-vector (DV) files via the native
+ * {@link BaseDVFileWriter}.  The native writer emits spec-compliant
+ * {@code deletion-vector-v1} blobs (64-bit Roaring portable bitmap with the
+ * required magic / length / CRC framing) and populates blob properties
+ * ({@code referenced-data-file}, {@code cardinality}) automatically.
+ */
+public class IcebergDeletionVectorPageSink
+        implements ConnectorPageSink
+{
+    private final PartitionSpec partitionSpec;
+    private final Optional<PartitionData> partitionData;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final JsonCodec<CommitTaskData> jsonCodec;
+    private final ConnectorSession session;
+    private final String dataFile;
+    private final LocationProvider locationProvider;
+
+    private final Roaring64Bitmap collectedPositions = new Roaring64Bitmap();
+
+    public IcebergDeletionVectorPageSink(
+            PartitionSpec partitionSpec,
+            Optional<String> partitionDataAsJson,
+            LocationProvider locationProvider,
+            HdfsEnvironment hdfsEnvironment,
+            HdfsContext hdfsContext,
+            JsonCodec<CommitTaskData> jsonCodec,
+            ConnectorSession session,
+            String dataFile)
+    {
+        this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
+        this.partitionData = partitionDataFromJson(partitionSpec, partitionDataAsJson);
+        this.locationProvider = requireNonNull(locationProvider, "locationProvider is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
+        this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
+        this.session = requireNonNull(session, "session is null");
+        this.dataFile = requireNonNull(dataFile, "dataFile is null");
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return collectedPositions.getLongSizeInBytes();
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        if (page.getChannelCount() != 1) {
+            throw new PrestoException(ICEBERG_BAD_DATA,
+                    "Expecting Page with one channel but got " + page.getChannelCount());
+        }
+
+        Block block = page.getBlock(0);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            collectedPositions.addLong(BigintType.BIGINT.getLong(block, i));
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        if (collectedPositions.isEmpty()) {
+            return completedFuture(ImmutableList.of());
+        }
+
+        OutputFileFactory fileFactory = createPuffinOutputFileFactory(
+                hdfsEnvironment,
+                hdfsContext,
+                locationProvider,
+                partitionSpec,
+                UUID.randomUUID().toString(),
+                0,
+                0L);
+
+        // The writer is wrapped in try-with-resources so the underlying Puffin output
+        // stream is always closed, even if writer.delete(...) throws midway.
+        // First-write context: no previous-DV loader needed (the page-sink path always
+        // produces a brand-new DV; merging with existing DVs happens later in
+        // IcebergAbstractMetadata.finishWrite via createMergedDeletionVector).
+        org.apache.iceberg.io.DeleteWriteResult writeResult;
+        try (BaseDVFileWriter writer = new BaseDVFileWriter(fileFactory, path -> null)) {
+            collectedPositions.forEach((org.roaringbitmap.longlong.LongConsumer) pos ->
+                    writer.delete(dataFile, pos, partitionSpec, partitionData.orElse(null)));
+            writer.close();
+            writeResult = writer.result();
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, "Failed to write deletion vector puffin file", e);
+        }
+        catch (UncheckedIOException e) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, "Failed to write deletion vector puffin file", e.getCause());
+        }
+
+        ImmutableList.Builder<Slice> outputs = ImmutableList.builder();
+        for (DeleteFile deleteFile : writeResult.deleteFiles()) {
+            CommitTaskData task = new CommitTaskData(
+                    deleteFile.path().toString(),
+                    deleteFile.fileSizeInBytes(),
+                    new MetricsWrapper(new Metrics(deleteFile.recordCount(), null, null, null, null)),
+                    deleteFile.specId(),
+                    partitionData.map(PartitionData::toJson),
+                    FileFormat.PUFFIN,
+                    deleteFile.referencedDataFile() != null ? deleteFile.referencedDataFile() : dataFile,
+                    POSITION_DELETES,
+                    OptionalLong.of(deleteFile.contentOffset()),
+                    OptionalLong.of(deleteFile.contentSizeInBytes()),
+                    OptionalLong.of(deleteFile.recordCount()));
+            outputs.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
+        }
+        return completedFuture(outputs.build());
+    }
+
+    @Override
+    public void abort()
+    {
+        // Nothing to clean up since we write the Puffin file atomically in finish().
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/IcebergDeletionVectorWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/IcebergDeletionVectorWriterFactory.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.delete;
+
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.iceberg.HdfsInputFile;
+import com.facebook.presto.iceberg.HdfsOutputFile;
+import com.facebook.presto.iceberg.PrestoIcebergTableForMetricsConfig;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.OutputFileFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for building an {@link OutputFileFactory} configured for writing Puffin
+ * deletion-vector (DV) files via Iceberg's native {@link org.apache.iceberg.deletes.BaseDVFileWriter}.
+ *
+ * <p>The Iceberg builder requires a {@link org.apache.iceberg.Table} to read the
+ * partition spec, encryption manager and location provider.  Presto's page-sink path
+ * does not have a fully-loaded {@code Table} available, so this factory wraps the
+ * primitives Presto already has (HDFS environment, location provider, partition
+ * spec) into a minimal {@link org.apache.iceberg.Table} implementation that exposes
+ * just what {@link OutputFileFactory.Builder} needs.
+ */
+public final class IcebergDeletionVectorWriterFactory
+{
+    private IcebergDeletionVectorWriterFactory() {}
+
+    /**
+     * Builds an {@link OutputFileFactory} that writes Puffin DV files via Presto's
+     * HDFS plumbing (which already wraps {@code doAs} per session user).
+     *
+     * @param hdfsEnvironment Presto HDFS environment (provides {@code doAs}).
+     * @param hdfsContext     Per-query HDFS context (carries the user identity).
+     * @param locationProvider Iceberg location provider for the table.
+     * @param partitionSpec   Partition spec the produced DV files belong to.
+     * @param operationId     Stable identifier (e.g. session/query id) embedded
+     *                        in generated file names.
+     * @param partitionId     Logical partition id used in generated file names.
+     * @param taskId          Logical task id used in generated file names.
+     */
+    public static OutputFileFactory createPuffinOutputFileFactory(
+            HdfsEnvironment hdfsEnvironment,
+            HdfsContext hdfsContext,
+            LocationProvider locationProvider,
+            PartitionSpec partitionSpec,
+            String operationId,
+            int partitionId,
+            long taskId)
+    {
+        requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        requireNonNull(hdfsContext, "hdfsContext is null");
+        requireNonNull(locationProvider, "locationProvider is null");
+        requireNonNull(partitionSpec, "partitionSpec is null");
+        requireNonNull(operationId, "operationId is null");
+
+        FileIO io = new HdfsBackedFileIO(hdfsEnvironment, hdfsContext);
+        org.apache.iceberg.Table table = new MinimalDvTable(partitionSpec, locationProvider, io);
+        return OutputFileFactory.builderFor(table, partitionId, taskId)
+                .format(org.apache.iceberg.FileFormat.PUFFIN)
+                .operationId(operationId)
+                .ioSupplier(() -> io)
+                .build();
+    }
+
+    /**
+     * Lightweight {@link FileIO} implementation that delegates to Presto's
+     * {@link HdfsOutputFile} / {@link HdfsInputFile}.  Avoids pulling in the
+     * {@code ManifestFileCache} dependency that the production
+     * {@code com.facebook.presto.iceberg.HdfsFileIO} requires.
+     */
+    private static final class HdfsBackedFileIO
+            implements FileIO
+    {
+        private final HdfsEnvironment hdfsEnvironment;
+        private final HdfsContext hdfsContext;
+
+        HdfsBackedFileIO(HdfsEnvironment hdfsEnvironment, HdfsContext hdfsContext)
+        {
+            this.hdfsEnvironment = hdfsEnvironment;
+            this.hdfsContext = hdfsContext;
+        }
+
+        @Override
+        public InputFile newInputFile(String path)
+        {
+            return new HdfsInputFile(new Path(path), hdfsEnvironment, hdfsContext);
+        }
+
+        @Override
+        public OutputFile newOutputFile(String path)
+        {
+            return new HdfsOutputFile(new Path(path), hdfsEnvironment, hdfsContext);
+        }
+
+        @Override
+        public void deleteFile(String path)
+        {
+            throw new UnsupportedOperationException("HdfsBackedFileIO does not support deleteFile");
+        }
+    }
+
+    /**
+     * Minimal {@link org.apache.iceberg.Table} that exposes only the fields
+     * {@link OutputFileFactory.Builder} reads at build time
+     * ({@link #spec()}, {@link #locationProvider()}, {@link #encryption()})
+     * plus {@link #io()} as a fallback (overridden via {@code ioSupplier}).
+     */
+    private static final class MinimalDvTable
+            extends PrestoIcebergTableForMetricsConfig
+    {
+        private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
+        private static final Schema EMPTY_SCHEMA = new Schema();
+        private static final EncryptionManager PLAINTEXT_ENCRYPTION = PlaintextEncryptionManager.instance();
+
+        private final LocationProvider locationProvider;
+        private final FileIO io;
+
+        MinimalDvTable(PartitionSpec spec, LocationProvider locationProvider, FileIO io)
+        {
+            super(EMPTY_SCHEMA, spec, EMPTY_PROPERTIES, Optional.empty());
+            this.locationProvider = locationProvider;
+            this.io = io;
+        }
+
+        @Override
+        public LocationProvider locationProvider()
+        {
+            return locationProvider;
+        }
+
+        @Override
+        public EncryptionManager encryption()
+        {
+            return PLAINTEXT_ENCRYPTION;
+        }
+
+        // Defense-in-depth: also expose the FileIO via Table.io() so that any future
+        // Iceberg upgrade that bypasses OutputFileFactory.Builder.ioSupplier(...) and
+        // calls table.io() directly still routes through Presto's HDFS plumbing.
+        @Override
+        public FileIO io()
+        {
+            return io;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDeleteFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDeleteFilesProcedure.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.iceberg.IcebergAbstractMetadata;
+import com.facebook.presto.iceberg.IcebergMetadataFactory;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.procedure.Procedure.Argument;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Inject;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.puffin.BlobMetadata;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinReader;
+import org.apache.iceberg.util.ContentFileUtil;
+
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
+import static com.google.common.base.Preconditions.checkState;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Procedure to compact deletion vectors (DVs) on V3 Iceberg tables.
+ *
+ * When multiple DELETE operations target rows in the same data file, each produces
+ * a separate DV (Puffin file). This procedure merges all DVs per data file into
+ * a single consolidated DV, reducing metadata overhead and improving read performance.
+ *
+ * Usage: CALL iceberg.system.rewrite_delete_files('schema', 'table')
+ */
+public class RewriteDeleteFilesProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle REWRITE_DELETE_FILES = methodHandle(
+            RewriteDeleteFilesProcedure.class,
+            "rewriteDeleteFiles",
+            ConnectorSession.class,
+            String.class,
+            String.class);
+
+    private final IcebergMetadataFactory metadataFactory;
+
+    @Inject
+    public RewriteDeleteFilesProcedure(IcebergMetadataFactory metadataFactory)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "rewrite_delete_files",
+                ImmutableList.of(
+                        new Argument("schema", VARCHAR),
+                        new Argument("table_name", VARCHAR)),
+                REWRITE_DELETE_FILES.bindTo(this));
+    }
+
+    public void rewriteDeleteFiles(ConnectorSession clientSession, String schemaName, String tableName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+            IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) metadataFactory.create();
+            Table icebergTable = getIcebergTable(metadata, clientSession, schemaTableName);
+
+            int formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
+            if (formatVersion < 3) {
+                return;
+            }
+
+            // Group delete files by their referenced data file. Capture the partition tuple
+            // alongside so we can hand it to BaseDVFileWriter when writing the merged DV.
+            Map<String, List<DeleteFile>> dvsByDataFile = new HashMap<>();
+            Map<String, FileScanTask> taskByDataFile = new HashMap<>();
+
+            try (CloseableIterable<FileScanTask> tasks = icebergTable.newScan().planFiles()) {
+                CloseableIterator<FileScanTask> iterator = tasks.iterator();
+                while (iterator.hasNext()) {
+                    FileScanTask task = iterator.next();
+                    String dataFilePath = task.file().path().toString();
+                    for (DeleteFile deleteFile : task.deletes()) {
+                        if (ContentFileUtil.isDV(deleteFile)) {
+                            dvsByDataFile.computeIfAbsent(dataFilePath, k -> new ArrayList<>()).add(deleteFile);
+                            taskByDataFile.putIfAbsent(dataFilePath, task);
+                        }
+                    }
+                }
+                iterator.close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            // Find data files with multiple DVs that need compaction.
+            Set<DeleteFile> filesToRemove = new HashSet<>();
+            Set<DeleteFile> filesToAdd = new HashSet<>();
+
+            for (Map.Entry<String, List<DeleteFile>> entry : dvsByDataFile.entrySet()) {
+                List<DeleteFile> dvs = entry.getValue();
+                if (dvs.size() <= 1) {
+                    continue;
+                }
+
+                String dataFilePath = entry.getKey();
+                FileScanTask task = taskByDataFile.get(dataFilePath);
+                DeleteFile mergedDv = writeMergedDeletionVector(icebergTable, task, dataFilePath, dvs);
+                filesToRemove.addAll(dvs);
+                filesToAdd.add(mergedDv);
+            }
+
+            if (filesToRemove.isEmpty()) {
+                metadata.commit();
+                return;
+            }
+
+            // Commit the rewrite: remove old DVs, add merged DVs.
+            RewriteFiles rewriteFiles = icebergTable.newRewrite()
+                    .rewriteFiles(ImmutableSet.of(), filesToRemove, ImmutableSet.of(), filesToAdd);
+            rewriteFiles.commit();
+            metadata.commit();
+        }
+    }
+
+    private static DeleteFile writeMergedDeletionVector(
+            Table icebergTable,
+            FileScanTask task,
+            String dataFilePath,
+            List<DeleteFile> dvs)
+    {
+        PartitionSpec partitionSpec = task.spec();
+        StructLike partition = task.file().partition();
+
+        OutputFileFactory fileFactory = OutputFileFactory.builderFor(icebergTable, 0, 0L)
+                .format(FileFormat.PUFFIN)
+                .operationId(UUID.randomUUID().toString())
+                .build();
+
+        try (BaseDVFileWriter writer = new BaseDVFileWriter(fileFactory, path -> null)) {
+            // Feed every existing position into the writer; it dedupes internally.
+            for (DeleteFile dv : dvs) {
+                PositionDeleteIndex index = readDeletionVectorIndex(icebergTable, dv);
+                index.forEach((long pos) -> writer.delete(dataFilePath, pos, partitionSpec, partition));
+            }
+            writer.close();
+            List<DeleteFile> produced = writer.result().deleteFiles();
+            checkState(!produced.isEmpty(),
+                    "BaseDVFileWriter produced no DeleteFile when compacting %s DVs for %s",
+                    dvs.size(), dataFilePath);
+            return produced.get(0);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static PositionDeleteIndex readDeletionVectorIndex(Table icebergTable, DeleteFile dv)
+    {
+        try (PuffinReader reader = Puffin.read(icebergTable.io().newInputFile(dv.path().toString())).build()) {
+            List<BlobMetadata> blobs = reader.fileMetadata().blobs();
+            if (blobs.isEmpty()) {
+                return PositionDeleteIndex.empty();
+            }
+            for (org.apache.iceberg.util.Pair<BlobMetadata, ByteBuffer> pair : reader.readAll(blobs)) {
+                ByteBuffer blobData = pair.second();
+                byte[] bytes = new byte[blobData.remaining()];
+                blobData.get(bytes);
+                return PositionDeleteIndex.deserialize(bytes, dv);
+            }
+            return PositionDeleteIndex.empty();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -34,6 +34,7 @@ import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.parquet.FileParquetDataSource;
 import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -58,6 +59,7 @@ import java.util.Optional;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
@@ -68,10 +70,15 @@ import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvi
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.dataSizeSessionProperty;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.io.Files.createTempDir;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergFileWriter
 {
@@ -108,7 +115,63 @@ public class TestIcebergFileWriter
                                 HiveCompressionCodec.NONE,
                                 false,
                                 value -> HiveCompressionCodec.valueOf(((String) value).toUpperCase()),
-                                HiveCompressionCodec::name)));
+                                HiveCompressionCodec::name),
+                        // ORC properties needed by createOrcWriter (also used by DWRF dispatch).
+                        // HiveCommonSessionProperties.isOrcOptimizedWriterValidate() reads both.
+                        booleanProperty(
+                                "orc_optimized_writer_validate",
+                                "ORC: Force all validation for files",
+                                false,
+                                false),
+                        new PropertyMetadata<>(
+                                "orc_optimized_writer_validate_percentage",
+                                "ORC: Sample percentage for validation for files",
+                                DOUBLE,
+                                Double.class,
+                                0.0,
+                                false,
+                                value -> ((Number) value).doubleValue(),
+                                value -> value),
+                        // Additional ORC properties consumed unconditionally by createOrcWriter:
+                        //   getOrcOptimizedWriterValidateMode(session)        — line 247
+                        //   getOrcOptimizedWriterMinStripeSize(session)       — line 234
+                        //   getOrcOptimizedWriterMaxStripeSize(session)       — line 235
+                        //   getOrcOptimizedWriterMaxStripeRows(session)       — line 236
+                        //   getOrcOptimizedWriterMaxDictionaryMemory(session) — line 239
+                        //   getOrcStringStatisticsLimit(session)              — line 240
+                        // Without these, createOrcWriter throws NullPointerException reading
+                        // session.getProperty(name, ...) before the test ever reaches its
+                        // assertions, causing every test in this class to fail in @BeforeClass.
+                        stringProperty(
+                                "orc_optimized_writer_validate_mode",
+                                "ORC: Validate mode (BOTH, HASHED, DETAILED)",
+                                OrcWriteValidationMode.BOTH.name(),
+                                false),
+                        dataSizeSessionProperty(
+                                "orc_optimized_writer_min_stripe_size",
+                                "ORC: Min stripe size",
+                                new DataSize(32, DataSize.Unit.MEGABYTE),
+                                false),
+                        dataSizeSessionProperty(
+                                "orc_optimized_writer_max_stripe_size",
+                                "ORC: Max stripe size",
+                                new DataSize(64, DataSize.Unit.MEGABYTE),
+                                false),
+                        integerProperty(
+                                "orc_optimized_writer_max_stripe_rows",
+                                "ORC: Max stripe row count",
+                                10_000_000,
+                                false),
+                        dataSizeSessionProperty(
+                                "orc_optimized_writer_max_dictionary_memory",
+                                "ORC: Max dictionary memory",
+                                new DataSize(16, DataSize.Unit.MEGABYTE),
+                                false),
+                        dataSizeSessionProperty(
+                                "orc_string_statistics_limit",
+                                "ORC: String statistics limit",
+                                new DataSize(64, DataSize.Unit.BYTE),
+                                false)));
 
         Session session = testSessionBuilder(sessionPropertyManager)
                 .setCatalog(ICEBERG_CATALOG)
@@ -156,6 +219,35 @@ public class TestIcebergFileWriter
         MessageType writtenSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageType originalSchema = convert(icebergSchema, "table");
         assertEquals(originalSchema, writtenSchema);
+    }
+
+    @Test
+    public void testWriteDwrfFileDispatchesToOrcWriter()
+            throws Exception
+    {
+        Path path = new Path(createTempDir().getAbsolutePath() + "/test.dwrf");
+        Schema icebergSchema = toIcebergSchema(ImmutableList.of(
+                ColumnMetadata.builder().setName("a").setType(VARCHAR).build(),
+                ColumnMetadata.builder().setName("b").setType(INTEGER).build(),
+                ColumnMetadata.builder().setName("c").setType(TIMESTAMP).build(),
+                ColumnMetadata.builder().setName("d").setType(DATE).build()));
+        IcebergFileWriter icebergFileWriter = this.icebergFileWriterFactory.createFileWriter(path, icebergSchema, new JobConf(), connectorSession,
+                hdfsContext, FileFormat.DWRF, MetricsConfig.getDefault());
+        assertNotNull(icebergFileWriter, "createFileWriter must dispatch FileFormat.DWRF to a non-null writer");
+
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, TIMESTAMP, DATE)
+                .addSequencePage(100, 0, 0, 123, 100)
+                .addSequencePage(100, 100, 100, 223, 100)
+                .addSequencePage(100, 200, 200, 323, 100)
+                .build();
+        for (Page page : input) {
+            icebergFileWriter.appendRows(page);
+        }
+        icebergFileWriter.commit();
+
+        File dwrfFile = new File(path.toString());
+        assertTrue(dwrfFile.exists(), "DWRF dispatch should produce a writable output file");
+        assertTrue(dwrfFile.length() > 0, "DWRF dispatch should produce a non-empty output file");
     }
 
     private static class TestingTypeManager

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -15,6 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -28,22 +29,29 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.UUID;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import static java.lang.String.format;
 
 public class TestIcebergV3
         extends AbstractTestQueryFramework
@@ -70,6 +78,7 @@ public class TestIcebergV3
 
     @Test
     public void testCreateV3Table()
+            throws Exception
     {
         String tableName = "test_create_v3_table";
         try {
@@ -85,6 +94,7 @@ public class TestIcebergV3
 
     @Test
     public void testCreateUnsupportedFormatVersion()
+            throws Exception
     {
         String tableName = "test_create_v4_table";
         // Ensure clean state in case a previous run created the table
@@ -97,6 +107,7 @@ public class TestIcebergV3
 
     @Test
     public void testUpgradeV2ToV3()
+            throws Exception
     {
         String tableName = "test_upgrade_v2_to_v3";
         try {
@@ -122,6 +133,7 @@ public class TestIcebergV3
 
     @Test
     public void testInsertIntoV3Table()
+            throws Exception
     {
         String tableName = "test_insert_v3_table";
         try {
@@ -137,18 +149,42 @@ public class TestIcebergV3
     }
 
     @Test
-    public void testDeleteOnV3TableNotSupported()
+    public void testDeleteOnV3Table()
+            throws Exception
     {
         String tableName = "test_v3_delete";
         try {
             assertUpdate("CREATE TABLE " + tableName
-                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3', \"write.delete.mode\" = 'merge-on-read')");
+                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3')");
             assertUpdate("INSERT INTO " + tableName
                     + " VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0)", 3);
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0)");
-            assertThatThrownBy(() -> getQueryRunner().execute("DELETE FROM " + tableName + " WHERE id = 1"))
-                    .hasMessageContaining("Iceberg table updates for format version 3 are not supported yet");
+
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 1", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0), (3, 'Charlie', 300.0)");
+
+            Table table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+
+            // Verify DV metadata: the delete should have produced a PUFFIN-format deletion vector
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    for (org.apache.iceberg.DeleteFile deleteFile : task.deletes()) {
+                        assertEquals(deleteFile.format(), FileFormat.PUFFIN);
+                        assertTrue(deleteFile.path().toString().endsWith(".puffin"),
+                                "Deletion vector file should have .puffin extension");
+                        assertTrue(deleteFile.fileSizeInBytes() > 0,
+                                "Deletion vector file size should be positive");
+                    }
+                }
+            }
+
+            // Delete more rows
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 3", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0)");
         }
         finally {
             dropTable(tableName);
@@ -157,6 +193,7 @@ public class TestIcebergV3
 
     @Test
     public void testTruncateV3Table()
+            throws Exception
     {
         String tableName = "test_v3_truncate";
         try {
@@ -179,6 +216,7 @@ public class TestIcebergV3
 
     @Test
     public void testMetadataDeleteOnV3PartitionedTable()
+            throws Exception
     {
         String tableName = "test_v3_metadata_delete";
         try {
@@ -207,20 +245,26 @@ public class TestIcebergV3
     }
 
     @Test
-    public void testUpdateOnV3TableNotSupported()
+    public void testUpdateOnV3Table()
+            throws Exception
     {
         String tableName = "test_v3_update";
         try {
             assertUpdate("CREATE TABLE " + tableName
-                    + " (id INTEGER, name VARCHAR, status VARCHAR, score DOUBLE) WITH (\"format-version\" = '3', \"write.update.mode\" = 'merge-on-read')");
+                    + " (id INTEGER, name VARCHAR, status VARCHAR, score DOUBLE) WITH (\"format-version\" = '3')");
             assertUpdate("INSERT INTO " + tableName
                             + " VALUES (1, 'Alice', 'active', 85.5), (2, 'Bob', 'active', 92.0), (3, 'Charlie', 'inactive', 78.3)",
                     3);
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'Alice', 'active', 85.5), (2, 'Bob', 'active', 92.0), (3, 'Charlie', 'inactive', 78.3)");
-            assertThatThrownBy(() -> getQueryRunner()
-                    .execute("UPDATE " + tableName + " SET status = 'updated', score = 95.0 WHERE id = 1"))
-                    .hasMessageContaining("Iceberg table updates for format version 3 are not supported yet");
+
+            assertUpdate("UPDATE " + tableName + " SET status = 'updated', score = 95.0 WHERE id = 1", 1);
+            assertQuery("SELECT * FROM " + tableName + " WHERE id = 1",
+                    "VALUES (1, 'Alice', 'updated', 95.0)");
+
+            assertUpdate("UPDATE " + tableName + " SET status = 'retired' WHERE status = 'inactive'", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 'updated', 95.0), (2, 'Bob', 'active', 92.0), (3, 'Charlie', 'retired', 78.3)");
         }
         finally {
             dropTable(tableName);
@@ -228,13 +272,14 @@ public class TestIcebergV3
     }
 
     @Test
-    public void testMergeOnV3TableNotSupported()
+    public void testMergeOnV3Table()
+            throws Exception
     {
         String tableName = "test_v3_merge_target";
         String sourceTable = "test_v3_merge_source";
         try {
             assertUpdate("CREATE TABLE " + tableName
-                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3', \"write.update.mode\" = 'merge-on-read')");
+                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3')");
             assertUpdate("CREATE TABLE " + sourceTable + " (id INTEGER, name VARCHAR, value DOUBLE)");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0)", 2);
             assertUpdate("INSERT INTO " + sourceTable + " VALUES (1, 'Alice Updated', 150.0), (3, 'Charlie', 300.0)",
@@ -242,11 +287,15 @@ public class TestIcebergV3
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0)");
             assertQuery("SELECT * FROM " + sourceTable + " ORDER BY id",
                     "VALUES (1, 'Alice Updated', 150.0), (3, 'Charlie', 300.0)");
-            assertThatThrownBy(() -> getQueryRunner().execute(
+
+            assertUpdate(
                     "MERGE INTO " + tableName + " t USING " + sourceTable + " s ON t.id = s.id " +
                             "WHEN MATCHED THEN UPDATE SET name = s.name, value = s.value " +
-                            "WHEN NOT MATCHED THEN INSERT (id, name, value) VALUES (s.id, s.name, s.value)"))
-                    .hasMessageContaining("Iceberg table updates for format version 3 are not supported yet");
+                            "WHEN NOT MATCHED THEN INSERT (id, name, value) VALUES (s.id, s.name, s.value)",
+                    3);
+
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice Updated', 150.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0)");
         }
         finally {
             dropTable(tableName);
@@ -256,6 +305,7 @@ public class TestIcebergV3
 
     @Test
     public void testOptimizeOnV3Table()
+            throws Exception
     {
         String tableName = "test_v3_optimize";
         try {
@@ -279,10 +329,10 @@ public class TestIcebergV3
     }
 
     @Test
-    public void testPuffinDeletionVectorsNotSupported()
+    public void testPuffinDeletionVectorsAccepted()
             throws Exception
     {
-        String tableName = "test_puffin_deletion_vectors_not_supported";
+        String tableName = "test_puffin_deletion_vectors_accepted";
         try {
             assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two')", 2);
@@ -309,7 +359,20 @@ public class TestIcebergV3
                         .commit();
             }
 
-            assertQueryFails("SELECT * FROM " + tableName, "Iceberg deletion vectors.*PUFFIN.*not supported");
+            // The PUFFIN delete file is now accepted by the split source (no longer
+            // throws NOT_SUPPORTED). The query will fail downstream because the fake
+            // .puffin file doesn't exist on disk, but the important thing is that the
+            // coordinator no longer rejects it at split enumeration time.
+            try {
+                computeActual("SELECT * FROM " + tableName);
+            }
+            catch (RuntimeException e) {
+                // Verify the error is NOT the old "PUFFIN not supported" rejection.
+                // Other failures (e.g., fake .puffin file not on disk) are acceptable.
+                assertFalse(
+                        e.getMessage().contains("Iceberg deletion vectors") && e.getMessage().contains("not supported"),
+                        "PUFFIN deletion vectors should be accepted, not rejected: " + e.getMessage());
+            }
         }
         finally {
             dropTable(tableName);
@@ -318,6 +381,7 @@ public class TestIcebergV3
 
     @Test
     public void testV3SupportedOperations()
+            throws Exception
     {
         String tableName = "test_v3_supported";
         try {
@@ -359,6 +423,7 @@ public class TestIcebergV3
 
     @Test
     public void testSelectFromV3TableAfterInsert()
+            throws Exception
     {
         String tableName = "test_select_v3_table";
         try {
@@ -384,6 +449,7 @@ public class TestIcebergV3
 
     @Test
     public void testV3TableWithPartitioning()
+            throws Exception
     {
         String tableName = "test_v3_partitioned_table";
         try {
@@ -406,6 +472,7 @@ public class TestIcebergV3
 
     @Test
     public void testV3TableEncryptionNotSupported()
+            throws Exception
     {
         String tableName = "test_v3_encrypted";
         try {
@@ -444,6 +511,7 @@ public class TestIcebergV3
 
     @Test
     public void testAddColumnWithDefaultRequiresV3()
+            throws Exception
     {
         String tableName = "test_add_column_default_v2";
         try {
@@ -495,6 +563,548 @@ public class TestIcebergV3
         return catalogDirectory.toFile();
     }
 
+    @Test
+    public void testDeletionVectorEndToEnd()
+            throws Exception
+    {
+        String tableName = "test_dv_end_to_end";
+        try {
+            // Step 1: Create V3 table and insert data
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, 'five')", 5);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 5");
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, 'five')");
+
+            Table table = loadTable(tableName);
+
+            // Step 2: Write a real Puffin file with a valid spec-compliant deletion vector
+            // via Iceberg's native BaseDVFileWriter. We mark row positions 1 and 3 (0-indexed)
+            // as deleted — corresponding to (2, 'two') and (4, 'four') in insertion order.
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                DeleteFile puffinDeleteFile = writeDeletionVector(table, task, new long[] {1L, 3L});
+
+                // Step 3: Attach the Puffin DV file to the table using Iceberg API
+                table.newRowDelta()
+                        .addDeletes(puffinDeleteFile)
+                        .commit();
+            }
+
+            // Step 4: Verify coordinator-side metadata is correct.
+            // Reload the table and verify the DV file was committed with correct metadata.
+            table = loadTable(tableName);
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                java.util.List<org.apache.iceberg.DeleteFile> deletes = task.deletes();
+                assertFalse(deletes.isEmpty(), "Table should have deletion vector files");
+
+                org.apache.iceberg.DeleteFile dvFile = deletes.get(0);
+                assertEquals(dvFile.format(), FileFormat.PUFFIN, "Delete file should be PUFFIN format");
+                assertEquals(dvFile.recordCount(), 2, "Delete file should have 2 deleted records");
+                assertTrue(dvFile.fileSizeInBytes() > 0, "PUFFIN file size should be positive");
+            }
+
+            // Step 5: Verify the coordinator can enumerate splits without error.
+            // The query will attempt to read data. On a Java worker, the actual DV
+            // reading is not implemented (that's in Velox's DeletionVectorReader),
+            // so we verify the coordinator path succeeds by running a SELECT.
+            // The PUFFIN delete file will either be silently ignored by the Java
+            // page source (returning all 5 rows) or cause a non-DV-rejection error.
+            try {
+                computeActual("SELECT * FROM " + tableName);
+            }
+            catch (RuntimeException e) {
+                // The Java page source may fail trying to read the PUFFIN file as
+                // positional deletes (since it doesn't have a DV reader). That's expected.
+                // The important assertion is that the error is NOT the old
+                // "PUFFIN not supported" rejection from the coordinator.
+                assertFalse(
+                        e.getMessage().contains("Iceberg deletion vectors") && e.getMessage().contains("not supported"),
+                        "Coordinator should not reject PUFFIN deletion vectors: " + e.getMessage());
+
+                // Also verify it's not a file-not-found error (the Puffin file exists)
+                assertFalse(
+                        e.getMessage().contains("FileNotFoundException"),
+                        "PUFFIN file should exist on disk: " + e.getMessage());
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Writes a Puffin deletion-vector file via Iceberg's native {@link BaseDVFileWriter}
+     * and returns the resulting {@link DeleteFile} ready to be committed via
+     * {@code table.newRowDelta().addDeletes(...)}.  The native writer emits
+     * spec-compliant {@code deletion-vector-v1} blobs (64-bit Roaring portable bitmap
+     * with the required magic / length / CRC framing) — exactly what the production
+     * page-sink path produces in {@link com.facebook.presto.iceberg.delete.IcebergDeletionVectorPageSink}.
+     */
+    private static DeleteFile writeDeletionVector(Table table, FileScanTask task, long[] positions)
+            throws java.io.IOException
+    {
+        String dataFilePath = task.file().path().toString();
+        OutputFileFactory fileFactory = OutputFileFactory.builderFor(table, 0, 0L)
+                .format(FileFormat.PUFFIN)
+                .operationId(UUID.randomUUID().toString())
+                .build();
+        try (BaseDVFileWriter writer = new BaseDVFileWriter(fileFactory, path -> null)) {
+            for (long pos : positions) {
+                writer.delete(dataFilePath, pos, task.spec(), task.file().partition());
+            }
+            writer.close();
+            java.util.List<DeleteFile> produced = writer.result().deleteFiles();
+            org.testng.Assert.assertFalse(produced.isEmpty(),
+                    "BaseDVFileWriter produced no DeleteFile for fixture data file " + dataFilePath);
+            return produced.get(0);
+        }
+    }
+
+    @Test
+    public void testDeletionVectorDeletesAllRows()
+            throws Exception
+    {
+        String tableName = "test_dv_deletes_all_rows";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three')", 3);
+
+            Table table = loadTable(tableName);
+
+            // Write a DV that deletes all 3 rows (positions 0, 1, 2).
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                DeleteFile puffinDeleteFile = writeDeletionVector(table, task, new long[] {0L, 1L, 2L});
+
+                table.newRowDelta()
+                        .addDeletes(puffinDeleteFile)
+                        .commit();
+            }
+
+            // Verify the coordinator can enumerate splits. On Java workers the DV
+            // reader isn't implemented, so the query may either succeed (returning
+            // all rows because the Java page source ignores the DV) or fail with a
+            // non-rejection error. The key assertion is that it doesn't throw
+            // "PUFFIN not supported".
+            try {
+                computeActual("SELECT * FROM " + tableName);
+            }
+            catch (RuntimeException e) {
+                assertFalse(
+                        e.getMessage().contains("Iceberg deletion vectors") && e.getMessage().contains("not supported"),
+                        "Coordinator should not reject PUFFIN deletion vectors: " + e.getMessage());
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testDeletionVectorOnMultipleDataFiles()
+            throws Exception
+    {
+        String tableName = "test_dv_multiple_data_files";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            // Two separate inserts create two separate data files.
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three')", 3);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (4, 'four'), (5, 'five'), (6, 'six')", 3);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 6");
+
+            Table table = loadTable(tableName);
+
+            // Attach a DV only to the first data file (positions 0 and 2 → rows 1
+            // and 3 from the first insert). The second data file has no deletes.
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask firstTask = tasks.iterator().next();
+                DeleteFile puffinDeleteFile = writeDeletionVector(table, firstTask, new long[] {0L, 2L});
+
+                table.newRowDelta()
+                        .addDeletes(puffinDeleteFile)
+                        .commit();
+            }
+
+            // Verify coordinator metadata: only the first file's task should have deletes.
+            table = loadTable(tableName);
+            int tasksWithDeletes = 0;
+            int tasksWithoutDeletes = 0;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    if (task.deletes().isEmpty()) {
+                        tasksWithoutDeletes++;
+                    }
+                    else {
+                        tasksWithDeletes++;
+                        assertEquals(task.deletes().size(), 1, "First data file should have exactly 1 DV");
+                        assertEquals(task.deletes().get(0).format(), FileFormat.PUFFIN);
+                    }
+                }
+            }
+            assertEquals(tasksWithDeletes, 1, "Exactly one data file should have a DV");
+            assertEquals(tasksWithoutDeletes, 1, "Exactly one data file should have no deletes");
+
+            // Run a query — coordinator should enumerate splits without error.
+            try {
+                computeActual("SELECT * FROM " + tableName);
+            }
+            catch (RuntimeException e) {
+                assertFalse(
+                        e.getMessage().contains("Iceberg deletion vectors") && e.getMessage().contains("not supported"),
+                        "Coordinator should not reject PUFFIN deletion vectors: " + e.getMessage());
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testV3SchemaEvolution()
+            throws Exception
+    {
+        String tableName = "test_v3_schema_evolution";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two')", 2);
+
+            // Add a new column via Iceberg API
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("score", org.apache.iceberg.types.Types.DoubleType.get())
+                    .commit();
+
+            // New inserts include the new column
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'three', 99.5)", 1);
+
+            // Verify all rows are readable (old rows have NULL for the new column)
+            assertQuery("SELECT id, value FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+            assertQuery("SELECT id, score FROM " + tableName + " WHERE score IS NOT NULL",
+                    "VALUES (3, 99.5)");
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE score IS NULL", "SELECT 2");
+
+            // Rename a column
+            table = loadTable(tableName);
+            table.updateSchema()
+                    .renameColumn("value", "label")
+                    .commit();
+
+            // Verify reads still work after rename
+            assertQuery("SELECT id, label FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testV3MultipleSnapshotsWithDV()
+            throws Exception
+    {
+        String tableName = "test_v3_multi_snapshot_dv";
+        try {
+            // Snapshot 1: initial data
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three')", 3);
+
+            Table table = loadTable(tableName);
+            long snapshot1Id = table.currentSnapshot().snapshotId();
+
+            // Snapshot 2: attach a DV deleting row at position 1 (row id=2, 'two')
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                DeleteFile puffinDeleteFile = writeDeletionVector(table, task, new long[] {1L});
+
+                table.newRowDelta()
+                        .addDeletes(puffinDeleteFile)
+                        .commit();
+            }
+
+            // Snapshot 3: more data added after the DV
+            assertUpdate("INSERT INTO " + tableName + " VALUES (4, 'four'), (5, 'five')", 2);
+
+            // Verify the table now has 3 snapshots
+            table = loadTable(tableName);
+            int snapshotCount = 0;
+            for (org.apache.iceberg.Snapshot snapshot : table.snapshots()) {
+                snapshotCount++;
+            }
+            assertTrue(snapshotCount >= 3, "Table should have at least 3 snapshots, got: " + snapshotCount);
+
+            // Verify coordinator can enumerate all splits (including those with DVs
+            // and those from the post-DV insert).
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                int totalFiles = 0;
+                int filesWithDeletes = 0;
+                for (FileScanTask task : tasks) {
+                    totalFiles++;
+                    if (!task.deletes().isEmpty()) {
+                        filesWithDeletes++;
+                    }
+                }
+                assertEquals(totalFiles, 2, "Should have 2 data files (one from each insert)");
+                assertEquals(filesWithDeletes, 1, "Only the first data file should have DV deletes");
+            }
+
+            // Run a query to verify coordinator enumeration succeeds.
+            try {
+                computeActual("SELECT * FROM " + tableName);
+            }
+            catch (RuntimeException e) {
+                assertFalse(
+                        e.getMessage().contains("Iceberg deletion vectors") && e.getMessage().contains("not supported"),
+                        "Coordinator should not reject PUFFIN deletion vectors: " + e.getMessage());
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testV3DeletionVectorMetadataFields()
+            throws Exception
+    {
+        String tableName = "test_dv_metadata_fields";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two')", 2);
+
+            Table table = loadTable(tableName);
+
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                DeleteFile puffinDeleteFile = writeDeletionVector(table, task, new long[] {0L});
+
+                table.newRowDelta()
+                        .addDeletes(puffinDeleteFile)
+                        .commit();
+            }
+
+            // Verify the committed DV file has correct metadata fields.
+            table = loadTable(tableName);
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                java.util.List<org.apache.iceberg.DeleteFile> deletes = task.deletes();
+                assertFalse(deletes.isEmpty(), "Should have deletion vector files");
+
+                org.apache.iceberg.DeleteFile dvFile = deletes.get(0);
+                assertEquals(dvFile.format(), FileFormat.PUFFIN, "Format should be PUFFIN");
+                assertEquals(dvFile.recordCount(), 1, "Record count should match deleted positions");
+                assertTrue(dvFile.fileSizeInBytes() > 0, "File size must be positive");
+
+                // Verify the DV file path ends with .puffin as expected.
+                assertTrue(dvFile.path().toString().endsWith(".puffin"), "DV file should be a .puffin file");
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Verifies the produced Puffin file is spec-compliant per Iceberg V3:
+     *   - blob type is exactly "deletion-vector-v1" (not the legacy "deletion-vector-v2")
+     *   - the "referenced-data-file" property is present and matches the data file
+     *   - the "cardinality" property is present and matches the deleted-position count
+     *
+     * This protects the migration's main contract: that Velox's DeletionVectorReader
+     * (which expects spec-compliant DV blobs) can decode the files Presto writes.
+     */
+    @Test
+    public void testDeletionVectorIsSpecCompliant()
+            throws Exception
+    {
+        String tableName = "test_dv_spec_compliant";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')", 4);
+
+            Table table = loadTable(tableName);
+            DeleteFile dv;
+            String dataFilePath;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                dataFilePath = task.file().path().toString();
+                dv = writeDeletionVector(table, task, new long[] {0L, 2L});
+                table.newRowDelta().addDeletes(dv).commit();
+            }
+
+            // Open the produced Puffin file and inspect the blob metadata directly.
+            try (org.apache.iceberg.puffin.PuffinReader reader = org.apache.iceberg.puffin.Puffin
+                    .read(table.io().newInputFile(dv.path().toString()))
+                    .build()) {
+                java.util.List<org.apache.iceberg.puffin.BlobMetadata> blobs = reader.fileMetadata().blobs();
+                assertEquals(blobs.size(), 1, "Iceberg V3 file-scoped DV must contain exactly one blob");
+
+                org.apache.iceberg.puffin.BlobMetadata blob = blobs.get(0);
+                // SPEC: blob type for V3 file-scoped DV must be "deletion-vector-v1".
+                assertEquals(blob.type(), "deletion-vector-v1",
+                        "DV blob type must match Iceberg V3 spec; got: " + blob.type());
+
+                // SPEC: the blob carries the referenced-data-file and cardinality properties.
+                Map<String, String> props = blob.properties();
+                assertEquals(props.get("referenced-data-file"), dataFilePath,
+                        "referenced-data-file property must point at the source data file");
+                assertEquals(props.get("cardinality"), "2",
+                        "cardinality property must equal the count of deleted positions");
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Verifies BaseDVFileWriter / Roaring64Bitmap can round-trip a position larger
+     * than Integer.MAX_VALUE.  The pre-migration hand-rolled implementation used a
+     * 32-bit Roaring container which would silently truncate or corrupt such positions.
+     */
+    @Test
+    public void testDeletionVectorWithLargePosition()
+            throws Exception
+    {
+        String tableName = "test_dv_large_position";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1", 1);
+
+            Table table = loadTable(tableName);
+            DeleteFile dv;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                FileScanTask task = tasks.iterator().next();
+                // 5_000_000_000L > Integer.MAX_VALUE (~2.15e9) — only 64-bit Roaring can hold this.
+                long largePos = 5_000_000_000L;
+                dv = writeDeletionVector(table, task, new long[] {largePos});
+                // Read back via Iceberg's PositionDeleteIndex and verify the position is preserved.
+                try (org.apache.iceberg.puffin.PuffinReader reader = org.apache.iceberg.puffin.Puffin
+                        .read(table.io().newInputFile(dv.path().toString()))
+                        .build()) {
+                    org.apache.iceberg.util.Pair<org.apache.iceberg.puffin.BlobMetadata, java.nio.ByteBuffer> pair =
+                            reader.readAll(reader.fileMetadata().blobs()).iterator().next();
+                    java.nio.ByteBuffer buf = pair.second();
+                    byte[] bytes = new byte[buf.remaining()];
+                    buf.get(bytes);
+                    org.apache.iceberg.deletes.PositionDeleteIndex index =
+                            org.apache.iceberg.deletes.PositionDeleteIndex.deserialize(bytes, dv);
+                    assertTrue(index.isDeleted(largePos),
+                            "Position " + largePos + " should be present in the round-tripped DV");
+                    assertFalse(index.isDeleted(largePos - 1L),
+                            "Position " + (largePos - 1L) + " should NOT be marked as deleted");
+                }
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testV3WriteReadRoundTrip()
+            throws Exception
+    {
+        String tableName = "test_v3_write_read_round_trip";
+        try {
+            // Step 1: Create V3 table and insert initial data
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName
+                    + " VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)", 5);
+
+            // Step 2: Verify initial data via read path
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 5");
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)");
+
+            // Step 3: First DELETE via write path (produces DV #1)
+            assertUpdate("DELETE FROM " + tableName + " WHERE id IN (1, 3)", 2);
+
+            // Step 4: Verify read path filters DV #1 correctly
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)");
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 3");
+
+            // Step 5: Cross-validate DV #1 metadata via Iceberg API
+            Table table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+
+            int dvCount = 0;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    for (org.apache.iceberg.DeleteFile deleteFile : task.deletes()) {
+                        dvCount++;
+                        assertEquals(deleteFile.format(), FileFormat.PUFFIN,
+                                "Presto-written DV must use PUFFIN format");
+                        assertTrue(deleteFile.path().toString().endsWith(".puffin"),
+                                "DV file path must end with .puffin");
+                        assertTrue(deleteFile.fileSizeInBytes() > 0,
+                                "DV file size must be positive");
+                        assertTrue(deleteFile.contentOffset() >= 0,
+                                "DV content offset must be non-negative");
+                        assertTrue(deleteFile.contentSizeInBytes() > 0,
+                                "DV content size must be positive");
+                        assertTrue(deleteFile.recordCount() > 0,
+                                "DV record count must be positive");
+                    }
+                }
+            }
+            assertTrue(dvCount > 0, "Should have at least one deletion vector after DELETE");
+
+            // Step 6: Insert more data (creates a new data file alongside existing ones)
+            assertUpdate("INSERT INTO " + tableName
+                    + " VALUES (6, 'Frank', 600.0), (7, 'Grace', 700.0)", 2);
+
+            // Step 7: Verify read path handles mixed state: old data with DVs + new data
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0), (6, 'Frank', 600.0), (7, 'Grace', 700.0)");
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 5");
+
+            // Step 8: Second DELETE via write path (produces DV #2, targeting new and old data)
+            assertUpdate("DELETE FROM " + tableName + " WHERE id IN (2, 7)", 2);
+
+            // Step 9: Verify cumulative read path correctness with two rounds of DVs
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (4, 'Dave', 400.0), (5, 'Eve', 500.0), (6, 'Frank', 600.0)");
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 3");
+
+            // Step 10: Cross-validate cumulative DV metadata via Iceberg API
+            table = loadTable(tableName);
+            int totalDvs = 0;
+            int totalDataFiles = 0;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    totalDataFiles++;
+                    for (org.apache.iceberg.DeleteFile deleteFile : task.deletes()) {
+                        totalDvs++;
+                        assertEquals(deleteFile.format(), FileFormat.PUFFIN,
+                                "All DVs must use PUFFIN format");
+                        assertTrue(deleteFile.recordCount() > 0,
+                                "Each DV must have positive record count");
+                    }
+                }
+            }
+            assertTrue(totalDvs > 0, "Should have deletion vectors after two rounds of DELETE");
+            assertTrue(totalDataFiles > 0, "Should have data files remaining");
+
+            // Step 11: Verify aggregation works correctly over DV-filtered data
+            assertQuery("SELECT SUM(value) FROM " + tableName, "SELECT 1500.0");
+            assertQuery("SELECT MIN(id), MAX(id) FROM " + tableName, "VALUES (4, 6)");
+
+            // Step 12: Verify predicates work correctly with DVs
+            assertQuery("SELECT * FROM " + tableName + " WHERE value > 450.0 ORDER BY id",
+                    "VALUES (5, 'Eve', 500.0), (6, 'Frank', 600.0)");
+            assertQuery("SELECT * FROM " + tableName + " WHERE name LIKE '%a%' ORDER BY id",
+                    "VALUES (4, 'Dave', 400.0), (6, 'Frank', 600.0)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
     private void dropTableViaIceberg(String tableName)
     {
         Catalog catalog = CatalogUtil.loadCatalog(
@@ -502,5 +1112,502 @@ public class TestIcebergV3
                 getProperties(), new Configuration());
         catalog.dropTable(
                 TableIdentifier.of(TEST_SCHEMA, tableName), true);
+    }
+
+    @Test
+    public void testRewriteDeleteFilesProcedure()
+            throws Exception
+    {
+        String tableName = "test_rewrite_delete_files";
+        try {
+            // Step 1: Create V3 table and insert data
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, name VARCHAR, value DOUBLE) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName
+                    + " VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Carol', 300.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)", 5);
+
+            // Step 2: Perform multiple deletes to create multiple DVs per data file
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 1", 1);
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 3", 1);
+
+            // Step 3: Verify we have multiple delete files before compaction
+            Table table = loadTable(tableName);
+            int dvCountBefore = 0;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    dvCountBefore += task.deletes().size();
+                }
+            }
+            assertTrue(dvCountBefore >= 2, "Should have at least 2 DVs before compaction, got: " + dvCountBefore);
+
+            // Step 4: Verify data is correct before compaction
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)");
+
+            // Step 5: Run DV compaction
+            assertQuerySucceeds(format("CALL system.rewrite_delete_files('%s', '%s')", TEST_SCHEMA, tableName));
+
+            // Step 6: Verify data is still correct after compaction
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob', 200.0), (4, 'Dave', 400.0), (5, 'Eve', 500.0)");
+
+            // Step 7: Verify DVs were compacted (fewer or equal DVs)
+            table.refresh();
+            int dvCountAfter = 0;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    for (DeleteFile dv : task.deletes()) {
+                        dvCountAfter++;
+                        assertEquals(dv.format(), FileFormat.PUFFIN, "Compacted DV must use PUFFIN format");
+                    }
+                }
+            }
+            assertTrue(dvCountAfter <= dvCountBefore,
+                    "DV count after compaction (" + dvCountAfter + ") should be <= before (" + dvCountBefore + ")");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDeleteFilesOnV2Table()
+            throws Exception
+    {
+        String tableName = "test_rewrite_delete_files_v2";
+        try {
+            // V2 tables should be a no-op (no DVs to compact)
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, value VARCHAR) WITH (\"format-version\" = '2', delete_mode = 'merge-on-read')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three')", 3);
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 1", 1);
+
+            assertQuerySucceeds(format("CALL system.rewrite_delete_files('%s', '%s')", TEST_SCHEMA, tableName));
+
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'two'), (3, 'three')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testV3DefaultValues()
+            throws Exception
+    {
+        String tableName = "test_v3_default_values";
+        try {
+            // Step 1: Create V3 table and insert initial data
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'Alice'), (2, 'Bob')", 2);
+
+            // Step 2: Add column via Iceberg API (default values not yet supported in Iceberg 1.10.x)
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("score", org.apache.iceberg.types.Types.DoubleType.get())
+                    .commit();
+
+            // Step 3: Verify we can read old data — the new column should be NULL
+            assertQuery("SELECT id, name FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice'), (2, 'Bob')");
+
+            // Step 4: Insert new data with the new column
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'Carol', 300.0)", 1);
+
+            // Step 5: Verify new data reads correctly
+            assertQuery("SELECT id, name, score FROM " + tableName + " WHERE id = 3",
+                    "VALUES (3, 'Carol', 300.0)");
+
+            // Step 6: Verify old rows get NULL for the new column (schema evolution without default)
+            assertQuery("SELECT id, name, score FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', NULL), (2, 'Bob', NULL), (3, 'Carol', 300.0)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testMultiArgumentPartitionTransforms()
+            throws Exception
+    {
+        String tableName = "test_v3_multi_arg_transforms";
+        try {
+            // Create V3 table with bucket(4, id) partitioning
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, name VARCHAR, value DOUBLE)"
+                    + " WITH (\"format-version\" = '3', partitioning = ARRAY['bucket(id, 4)'])");
+
+            // Verify table was created with correct partition spec
+            Table table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+            assertEquals(table.spec().fields().size(), 1);
+            assertEquals(table.spec().fields().get(0).transform().toString(), "bucket[4]");
+
+            // Insert data — should distribute across buckets
+            assertUpdate("INSERT INTO " + tableName
+                    + " VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0), (4, 'Diana', 400.0)", 4);
+
+            // Verify data reads correctly
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0), (3, 'Charlie', 300.0), (4, 'Diana', 400.0)");
+
+            // Verify partition pruning works — query with equality predicate
+            assertQuery("SELECT name, value FROM " + tableName + " WHERE id = 2",
+                    "VALUES ('Bob', 200.0)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testTruncatePartitionTransform()
+            throws Exception
+    {
+        String tableName = "test_v3_truncate_transform";
+        try {
+            // Create V3 table with truncate(10, value) partitioning on a varchar column
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, category VARCHAR, amount DOUBLE)"
+                    + " WITH (\"format-version\" = '3', partitioning = ARRAY['truncate(category, 3)'])");
+
+            Table table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+            assertEquals(table.spec().fields().size(), 1);
+            assertEquals(table.spec().fields().get(0).transform().toString(), "truncate[3]");
+
+            // Insert data with varying category prefixes
+            assertUpdate("INSERT INTO " + tableName
+                    + " VALUES (1, 'food_pizza', 15.0), (2, 'food_burger', 12.0),"
+                    + " (3, 'drink_coffee', 5.0), (4, 'drink_tea', 3.0)", 4);
+
+            // Verify data reads correctly
+            assertQuery("SELECT id, category, amount FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'food_pizza', 15.0), (2, 'food_burger', 12.0),"
+                    + " (3, 'drink_coffee', 5.0), (4, 'drink_tea', 3.0)");
+
+            // Verify we can filter
+            assertQuery("SELECT id FROM " + tableName + " WHERE category = 'food_pizza'",
+                    "VALUES 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testNanosecondTimestampSchema()
+            throws Exception
+    {
+        String tableName = "test_v3_timestamp_nano";
+        try {
+            // Create V3 table with Presto
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+
+            // Add nanosecond timestamp columns via Iceberg API
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("ts_nano", Types.TimestampNanoType.withoutZone())
+                    .addColumn("ts_nano_tz", Types.TimestampNanoType.withZone())
+                    .commit();
+
+            // Verify Presto can read the schema with nanosecond columns
+            // ts_nano maps to timestamp microseconds, ts_nano_tz maps to timestamp with time zone
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 0");
+
+            // Insert data through Presto — the nanosecond columns accept null values
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES (1)", 1);
+            assertQuery("SELECT id FROM " + tableName, "VALUES 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantColumnSchema()
+            throws Exception
+    {
+        String tableName = "test_v3_variant";
+        try {
+            // Create V3 table with Presto
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+
+            // Add variant column via Iceberg API
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("data", Types.VariantType.get())
+                    .commit();
+
+            // Verify Presto can read the schema with the variant column
+            // Variant maps to JSON in Presto
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 0");
+
+            // Insert data — the variant column accepts null values
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES (1)", 1);
+            assertQuery("SELECT id FROM " + tableName, "VALUES 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantTypeEndToEnd()
+            throws Exception
+    {
+        String tableName = "test_v3_variant_e2e";
+        try {
+            // Step 1: Create V3 table and add variant columns via Iceberg schema evolution
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("metadata", Types.VariantType.get())
+                    .commit();
+
+            // Step 2: Verify empty table with variant column is queryable
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 0");
+
+            // Step 3: Insert data — variant column receives NULLs
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')", 3);
+
+            // Step 4: Verify full row reads including NULL variant values
+            assertQuery("SELECT id, name, metadata FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', NULL), (2, 'Bob', NULL), (3, 'Charlie', NULL)");
+
+            // Step 5: Test IS NULL predicate on variant column
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE metadata IS NULL", "SELECT 3");
+
+            // Step 6: Test filtering on non-variant columns with variant columns in projection
+            assertQuery("SELECT id, name, metadata FROM " + tableName + " WHERE id > 1 ORDER BY id",
+                    "VALUES (2, 'Bob', NULL), (3, 'Charlie', NULL)");
+
+            // Step 7: Test aggregation with variant columns in the table
+            assertQuery("SELECT count(*), min(id), max(id) FROM " + tableName, "VALUES (3, 1, 3)");
+            assertQuery("SELECT name, count(*) FROM " + tableName + " GROUP BY name ORDER BY name",
+                    "VALUES ('Alice', 1), ('Bob', 1), ('Charlie', 1)");
+
+            // Step 8: DELETE rows from a table with variant columns
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 2", 1);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 2");
+            assertQuery("SELECT id, name FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice'), (3, 'Charlie')");
+
+            // Step 9: Insert more data after deletion
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (4, 'Diana'), (5, 'Eve')", 2);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 4");
+
+            // Step 10: Verify mixed snapshots (pre-delete and post-delete) read correctly
+            assertQuery("SELECT id, name FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice'), (3, 'Charlie'), (4, 'Diana'), (5, 'Eve')");
+
+            // Step 11: Further schema evolution — add another variant column alongside the first
+            table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("tags", Types.VariantType.get())
+                    .commit();
+
+            // Step 12: Verify reads still work with two variant columns
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 4");
+            assertQuery("SELECT id, name FROM " + tableName + " WHERE id = 1",
+                    "VALUES (1, 'Alice')");
+
+            // Step 13: Insert with both variant columns NULL
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (6, 'Frank')", 1);
+            assertQuery("SELECT id, metadata, tags FROM " + tableName + " WHERE id = 6",
+                    "VALUES (6, NULL, NULL)");
+
+            // Step 14: Verify V3 format preserved through all operations
+            table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantColumnWithPartitioning()
+            throws Exception
+    {
+        String tableName = "test_v3_variant_partitioned";
+        try {
+            // Create V3 partitioned table with variant column
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, category VARCHAR) WITH (\"format-version\" = '3', partitioning = ARRAY['category'])");
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("data", Types.VariantType.get())
+                    .commit();
+
+            // Insert data into multiple partitions
+            assertUpdate("INSERT INTO " + tableName + " (id, category) VALUES (1, 'A'), (2, 'A'), (3, 'B'), (4, 'C')", 4);
+
+            // Verify partition pruning works with variant column present
+            assertQuery("SELECT id FROM " + tableName + " WHERE category = 'A' ORDER BY id",
+                    "VALUES 1, 2");
+            assertQuery("SELECT id FROM " + tableName + " WHERE category = 'B'",
+                    "VALUES 3");
+
+            // Verify cross-partition aggregation
+            assertQuery("SELECT category, count(*) FROM " + tableName + " GROUP BY category ORDER BY category",
+                    "VALUES ('A', 2), ('B', 1), ('C', 1)");
+
+            // Delete within a partition
+            assertUpdate("DELETE FROM " + tableName + " WHERE category = 'A'", 2);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 2");
+            assertQuery("SELECT id FROM " + tableName + " ORDER BY id",
+                    "VALUES 3, 4");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantJsonDataRoundTrip()
+            throws Exception
+    {
+        String tableName = "test_v3_variant_json_data";
+        try {
+            // Step 1: Create V3 table and add variant column via Iceberg API
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("metadata", Types.VariantType.get())
+                    .commit();
+
+            // Step 2: Insert rows with actual JSON data into the variant column.
+            // VARIANT maps to JSON in Presto; use SQL JSON '...' literal syntax.
+            assertUpdate("INSERT INTO " + tableName + " VALUES "
+                    + "(1, 'Alice', JSON '{\"age\":30,\"city\":\"NYC\"}'), "
+                    + "(2, 'Bob', JSON '{\"age\":25}'), "
+                    + "(3, 'Charlie', NULL)", 3);
+
+            // Step 3: Verify round-trip — JSON values survive write → Parquet → read
+            assertQuery("SELECT id, name, metadata FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', '{\"age\":30,\"city\":\"NYC\"}'), "
+                            + "(2, 'Bob', '{\"age\":25}'), "
+                            + "(3, 'Charlie', NULL)");
+
+            // Step 4: Test filtering on non-variant columns with variant data present
+            assertQuery("SELECT metadata FROM " + tableName + " WHERE id = 1",
+                    "VALUES ('{\"age\":30,\"city\":\"NYC\"}')");
+
+            // Step 5: Test IS NULL / IS NOT NULL on variant column with actual data
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE metadata IS NOT NULL", "SELECT 2");
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE metadata IS NULL", "SELECT 1");
+
+            // Step 6: Insert rows with different JSON value types (number, string, boolean)
+            assertUpdate("INSERT INTO " + tableName + " VALUES "
+                    + "(4, 'Diana', JSON '42'), "
+                    + "(5, 'Eve', JSON '\"simple string\"'), "
+                    + "(6, 'Frank', JSON 'true')", 3);
+
+            // Step 7: Verify all rows
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 6");
+            assertQuery("SELECT metadata FROM " + tableName + " WHERE id = 4", "VALUES ('42')");
+            assertQuery("SELECT metadata FROM " + tableName + " WHERE id = 6", "VALUES ('true')");
+
+            // Step 8: Delete rows with variant data
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 1", 1);
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE metadata IS NOT NULL", "SELECT 4");
+
+            // Step 9: Verify remaining data
+            assertQuery("SELECT id, name FROM " + tableName + " ORDER BY id",
+                    "VALUES (2, 'Bob'), (3, 'Charlie'), (4, 'Diana'), (5, 'Eve'), (6, 'Frank')");
+
+            // Step 10: Verify V3 format preserved
+            table = loadTable(tableName);
+            assertEquals(((BaseTable) table).operations().current().formatVersion(), 3);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantColumnWithDeleteAndUpdate()
+            throws Exception
+    {
+        String tableName = "test_v3_variant_dml";
+        try {
+            // Create V3 table with merge-on-read delete mode and variant column
+            assertUpdate("CREATE TABLE " + tableName
+                    + " (id INTEGER, name VARCHAR, score DOUBLE)"
+                    + " WITH (\"format-version\" = '3', \"write.delete.mode\" = 'merge-on-read', \"write.update.mode\" = 'merge-on-read')");
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("extra", Types.VariantType.get())
+                    .commit();
+
+            // Insert data
+            assertUpdate("INSERT INTO " + tableName + " (id, name, score) VALUES "
+                    + "(1, 'Alice', 85.5), (2, 'Bob', 92.0), (3, 'Charlie', 78.3), (4, 'Diana', 95.0)", 4);
+
+            // Verify initial data
+            assertQuery("SELECT id, name, score FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 85.5), (2, 'Bob', 92.0), (3, 'Charlie', 78.3), (4, 'Diana', 95.0)");
+
+            // Row-level DELETE (produces deletion vector)
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 2", 1);
+            assertQuery("SELECT id, name FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice'), (3, 'Charlie'), (4, 'Diana')");
+
+            // Verify DV metadata is PUFFIN format
+            table = loadTable(tableName);
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    for (org.apache.iceberg.DeleteFile deleteFile : task.deletes()) {
+                        assertEquals(deleteFile.format(), FileFormat.PUFFIN);
+                    }
+                }
+            }
+
+            // UPDATE on table with variant column
+            assertUpdate("UPDATE " + tableName + " SET score = 99.9 WHERE id = 1", 1);
+            assertQuery("SELECT id, name, score FROM " + tableName + " WHERE id = 1",
+                    "VALUES (1, 'Alice', 99.9)");
+
+            // Verify final state
+            assertQuery("SELECT id, name, score FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 99.9), (3, 'Charlie', 78.3), (4, 'Diana', 95.0)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testVariantWithJsonExtract()
+            throws Exception
+    {
+        String tableName = "test_v3_variant_json_extract";
+        try {
+            // Create V3 table and add Variant column via Iceberg API
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            Table table = loadTable(tableName);
+            table.updateSchema()
+                    .addColumn("metadata", Types.VariantType.get())
+                    .commit();
+
+            // Insert a row using SQL JSON literal syntax (Variant maps to JSON in Presto)
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, JSON '{\"age\":30,\"city\":\"NYC\"}')", 1);
+
+            // Verify json_extract_scalar works directly on the Variant column —
+            // the user-visible payoff of mapping Variant to JSON.
+            assertQuery(
+                    "SELECT json_extract_scalar(metadata, '$.city') FROM " + tableName + " WHERE id = 1",
+                    "VALUES ('NYC')");
+            assertQuery(
+                    "SELECT json_extract_scalar(metadata, '$.age') FROM " + tableName + " WHERE id = 1",
+                    "VALUES ('30')");
+        }
+        finally {
+            dropTable(tableName);
+        }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -74,6 +74,8 @@ import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.CallDistributedProcedureNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.MergeProcessorNode;
+import com.facebook.presto.sql.planner.plan.MergeWriterNode;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -504,6 +506,20 @@ public class PushdownSubfields
 
         @Override
         public PlanNode visitUpdate(UpdateNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSource().getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitMergeProcessor(MergeProcessorNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSource().getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitMergeWriter(MergeWriterNode node, RewriteContext<Context> context)
         {
             context.get().variables.addAll(node.getSource().getOutputVariables());
             return context.defaultRewrite(node, context.get());

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -182,7 +182,45 @@
             <artifactId>presto-spi</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-core</artifactId>
+          <version>${dep.iceberg.version}</version>
+          <scope>test</scope>
+      </dependency>
 
+      <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-api</artifactId>
+          <version>${dep.iceberg.version}</version>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>org.apache.iceberg</groupId>
+          <artifactId>iceberg-parquet</artifactId>
+          <version>${dep.iceberg.version}</version>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-column</artifactId>
+          <version>${dep.parquet.version}</version>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>com.facebook.presto.hadoop</groupId>
+          <artifactId>hadoop-apache</artifactId>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>com.facebook.presto</groupId>
+          <artifactId>presto-hdfs-core</artifactId>
+          <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parser</artifactId>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -30,6 +30,8 @@ velox::connector::hive::iceberg::FileContent toVeloxFileContent(
     return velox::connector::hive::iceberg::FileContent::kData;
   } else if (content == protocol::iceberg::FileContent::POSITION_DELETES) {
     return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
+  } else if (content == protocol::iceberg::FileContent::EQUALITY_DELETES) {
+    return velox::connector::hive::iceberg::FileContent::kEqualityDeletes;
   }
   VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
 }
@@ -40,9 +42,17 @@ velox::dwio::common::FileFormat toVeloxFileFormat(
     return velox::dwio::common::FileFormat::ORC;
   } else if (format == protocol::iceberg::FileFormat::PARQUET) {
     return velox::dwio::common::FileFormat::PARQUET;
-  } else if (format == protocol::iceberg::FileFormat::DWRF) {
+  } else if (
+      format == protocol::iceberg::FileFormat::DWRF ||
+      format == protocol::iceberg::FileFormat::PUFFIN) {
     // Iceberg DWRF is Meta's variant of the ORC on-disk family and is read by
     // Velox's DWRF reader.
+    // PUFFIN is used for Iceberg V3 deletion vectors. The DeletionVectorReader
+    // reads raw binary from the file and does not use the DWRF/Parquet reader,
+    // so we map PUFFIN to DWRF as a placeholder — the format value is not
+    // actually used by the reader. This mapping is only safe for deletion
+    // vector files; if PUFFIN is encountered for other file content types,
+    // the DV routing logic in toHiveIcebergSplit() must reclassify it first.
     return velox::dwio::common::FileFormat::DWRF;
   }
   VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
@@ -180,6 +190,9 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   VELOX_CHECK_NOT_NULL(
       icebergSplit, "Unexpected split type {}", connectorSplit->_type);
 
+  const auto dataSequenceNumber =
+      icebergSplit->dataSequenceNumber; // NOLINT(facebook-bugprone-unchecked-pointer-access)
+
   std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
   for (const auto& entry : icebergSplit->partitionKeys) {
     partitionKeys.emplace(
@@ -209,14 +222,16 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
         deleteFile.fileSizeInBytes,
         std::vector(deleteFile.equalityFieldIds),
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        deleteFile.dataSequenceNumber);
 
     deletes.emplace_back(icebergDeleteFile);
   }
 
+
   std::unordered_map<std::string, std::string> infoColumns = {
       {"$data_sequence_number",
-       std::to_string(icebergSplit->dataSequenceNumber)},
+       std::to_string(dataSequenceNumber)},
       {"$path", icebergSplit->path}};
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
@@ -231,7 +246,9 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
       nullptr,
       splitContext->cacheable,
       deletes,
-      infoColumns);
+      infoColumns,
+      std::nullopt,
+      dataSequenceNumber);
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -40,6 +40,10 @@ velox::dwio::common::FileFormat toVeloxFileFormat(
     return velox::dwio::common::FileFormat::ORC;
   } else if (format == protocol::iceberg::FileFormat::PARQUET) {
     return velox::dwio::common::FileFormat::PARQUET;
+  } else if (format == protocol::iceberg::FileFormat::DWRF) {
+    // Iceberg DWRF is Meta's variant of the ORC on-disk family and is read by
+    // Velox's DWRF reader.
+    return velox::dwio::common::FileFormat::DWRF;
   }
   VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -321,7 +321,8 @@ static const std::pair<FileFormat, json> FileFormat_enum_table[] =
         {FileFormat::PARQUET, "PARQUET"},
         {FileFormat::AVRO, "AVRO"},
         {FileFormat::METADATA, "METADATA"},
-        {FileFormat::PUFFIN, "PUFFIN"}};
+        {FileFormat::PUFFIN, "PUFFIN"},
+        {FileFormat::DWRF, "DWRF"}};
 void to_json(json& j, const FileFormat& e) {
   static_assert(std::is_enum<FileFormat>::value, "FileFormat must be an enum!");
   const auto* it = std::find_if(

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -387,6 +387,13 @@ void to_json(json& j, const DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  to_json_key(
+      j,
+      "dataSequenceNumber",
+      p.dataSequenceNumber,
+      "DeleteFile",
+      "int64_t",
+      "dataSequenceNumber");
 }
 
 void from_json(const json& j, DeleteFile& p) {
@@ -424,6 +431,13 @@ void from_json(const json& j, DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  from_json_key(
+      j,
+      "dataSequenceNumber",
+      p.dataSequenceNumber,
+      "DeleteFile",
+      "int64_t",
+      "dataSequenceNumber");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -84,7 +84,7 @@ extern void to_json(json& j, const FileContent& e);
 extern void from_json(const json& j, FileContent& e);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class FileFormat { ORC, PARQUET, AVRO, METADATA, PUFFIN };
+enum class FileFormat { ORC, PARQUET, AVRO, METADATA, PUFFIN, DWRF };
 extern void to_json(json& j, const FileFormat& e);
 extern void from_json(const json& j, FileFormat& e);
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -98,6 +98,7 @@ struct DeleteFile {
   List<Integer> equalityFieldIds = {};
   Map<Integer, String> lowerBounds = {};
   Map<Integer, String> upperBounds = {};
+  int64_t dataSequenceNumber = {};
 };
 void to_json(json& j, const DeleteFile& p);
 void from_json(const json& j, DeleteFile& p);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -688,7 +688,8 @@ public class PrestoNativeQueryRunnerUtils
                                 "presto.version=testversion%n" +
                                 "plan-consistency-check-enabled=true%n" +
                                 "system-memory-gb=4%n" +
-                                "http-server.http.port=0%n", discoveryUri);
+                                "http-server.http.port=0%n" +
+                                "http-server.bind-to-node-internal-address-only-enabled=true%n", discoveryUri);
 
                         if (isCoordinatorSidecarEnabled) {
                             configProperties = format("%s%n" +

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestIcebergEqualityDeletesNative.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestIcebergEqualityDeletesNative.java
@@ -1,0 +1,560 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.hive.s3.S3ConfigurationUpdater;
+import com.facebook.presto.iceberg.FileContent;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.iceberg.PartitionTransforms;
+import com.facebook.presto.iceberg.delete.DeleteFile;
+import com.facebook.presto.iceberg.hive.IcebergFileHiveMetastore;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.TableScanUtil;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.FileContent.EQUALITY_DELETES;
+import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.DELETE_AS_JOIN_REWRITE_ENABLED;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
+import static java.util.UUID.randomUUID;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class TestIcebergEqualityDeletesNative
+        extends AbstractTestQueryFramework
+{
+    private String fileFormat;
+
+    TestIcebergEqualityDeletesNative()
+    {
+        fileFormat = "PARQUET";
+    }
+
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils
+                .nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat("PARQUET").build();
+    }
+
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils
+                .javaIcebergQueryRunnerBuilder()
+                .setStorageFormat("PARQUET").build();
+    }
+
+    protected HdfsEnvironment getHdfsEnvironment()
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
+        HiveS3Config hiveS3Config = new HiveS3Config();
+        return getHdfsEnvironment(hiveClientConfig, metastoreClientConfig, hiveS3Config);
+    }
+
+    public static HdfsEnvironment getHdfsEnvironment(HiveClientConfig hiveClientConfig, MetastoreClientConfig metastoreClientConfig, HiveS3Config hiveS3Config)
+    {
+        S3ConfigurationUpdater s3ConfigurationUpdater = new PrestoS3ConfigurationUpdater(hiveS3Config);
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig, s3ConfigurationUpdater, ignored -> {}, ignored -> {}),
+                ImmutableSet.of(), hiveClientConfig);
+        return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
+    }
+
+    private Table updateTable(String tableName)
+    {
+        BaseTable table = (BaseTable) loadTable(tableName);
+        TableOperations operations = table.operations();
+        TableMetadata currentMetadata = operations.current();
+        operations.commit(currentMetadata, currentMetadata.upgradeToFormatVersion(2));
+
+        return table;
+    }
+
+    protected Path getCatalogDirectory()
+    {
+        java.nio.file.Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        return new Path(getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile().toURI());
+    }
+
+    protected ExtendedHiveMetastore getFileHiveMetastore()
+    {
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
+                getCatalogDirectory().toString(),
+                "test");
+        return memoizeMetastore(fileHiveMetastore, false, 1000, 0);
+    }
+
+    protected Table loadTable(String tableName)
+    {
+        tableName = normalizeIdentifier(tableName, ICEBERG_CATALOG);
+        CatalogManager catalogManager = getDistributedQueryRunner().getCoordinator().getCatalogManager();
+        ConnectorId connectorId = catalogManager.getCatalog(ICEBERG_CATALOG).get().getConnectorId();
+
+        return IcebergUtil.getHiveIcebergTable(getFileHiveMetastore(),
+                getHdfsEnvironment(),
+                new IcebergHiveTableOperationsConfig(),
+                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024 * 1024),
+                getQueryRunner().getDefaultSession().toConnectorSession(connectorId),
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                SchemaTableName.valueOf("tpch." + tableName));
+    }
+
+    private void testCheckDeleteFiles(Table icebergTable, int expectedSize, List<FileContent> expectedFileContent)
+    {
+        // check delete file list
+        TableScan tableScan = icebergTable.newScan().useSnapshot(icebergTable.currentSnapshot().snapshotId());
+        Iterator<FileScanTask> iterator = TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize()).iterator();
+        List<DeleteFile> deleteFiles = new ArrayList<>();
+        while (iterator.hasNext()) {
+            FileScanTask task = iterator.next();
+            List<org.apache.iceberg.DeleteFile> deletes = task.deletes();
+            deletes.forEach(delete -> deleteFiles.add(DeleteFile.fromIceberg(delete)));
+        }
+
+        assertEquals(deleteFiles.size(), expectedSize);
+        List<FileContent> fileContents = deleteFiles.stream().map(DeleteFile::content).sorted().collect(Collectors.toList());
+        assertEquals(fileContents, expectedFileContent);
+    }
+
+    private void writeEqualityDeleteToNationTable(Table icebergTable, Map<String, Object> overwriteValues)
+            throws Exception
+    {
+        writeEqualityDeleteToNationTable(icebergTable, overwriteValues, Collections.emptyMap());
+    }
+
+    private void writeEqualityDeleteToNationTable(Table icebergTable, Map<String, Object> overwriteValues, Map<String, Object> partitionValues)
+            throws Exception
+    {
+        java.nio.file.Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        File metastoreDir = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile();
+        Path metadataDir = new Path(metastoreDir.toURI());
+        String deleteFileName = "delete_file_" + randomUUID();
+        FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
+        Schema deleteRowSchema = icebergTable.schema().select(overwriteValues.keySet());
+        Parquet.DeleteWriteBuilder writerBuilder = Parquet.writeDeletes(HadoopOutputFile.fromPath(new Path(metadataDir, deleteFileName), fs))
+                .forTable(icebergTable)
+                .rowSchema(deleteRowSchema)
+                .createWriterFunc(GenericParquetWriter::create)
+                .equalityFieldIds(deleteRowSchema.columns().stream().map(Types.NestedField::fieldId).collect(Collectors.toList()))
+                .overwrite();
+
+        if (!partitionValues.isEmpty()) {
+            GenericRecord partitionData = GenericRecord.create(icebergTable.spec().partitionType());
+            writerBuilder.withPartition(partitionData.copy(partitionValues));
+        }
+
+        EqualityDeleteWriter<Object> writer = writerBuilder.buildEqualityWriter();
+
+        Record dataDelete = GenericRecord.create(deleteRowSchema);
+        try (Closeable ignored = writer) {
+            writer.write(dataDelete.copy(overwriteValues));
+        }
+        icebergTable.newRowDelta().addDeletes(writer.toDeleteFile()).commit();
+    }
+
+    private void writePositionDeleteToNationTable(Table icebergTable, String dataFilePath, long deletePos)
+            throws IOException
+    {
+        java.nio.file.Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        File metastoreDir = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile();
+        Path metadataDir = new Path(metastoreDir.toURI());
+        String deleteFileName = "delete_file_" + randomUUID();
+        FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
+        Path path = new Path(metadataDir, deleteFileName);
+        PositionDeleteWriter<Record> writer = Parquet.writeDeletes(HadoopOutputFile.fromPath(path, fs))
+                .createWriterFunc(GenericParquetWriter::create)
+                .forTable(icebergTable)
+                .overwrite()
+                .rowSchema(icebergTable.schema())
+                .withSpec(PartitionSpec.unpartitioned())
+                .buildPositionWriter();
+
+        PositionDelete<Record> positionDelete = PositionDelete.create();
+        PositionDelete<Record> record = positionDelete.set(dataFilePath, deletePos, GenericRecord.create(icebergTable.schema()));
+        try (Closeable ignored = writer) {
+            writer.write(record);
+        }
+
+        icebergTable.newRowDelta().addDeletes(writer.toDeleteFile()).commit();
+    }
+
+    private Session deleteAsJoinDisabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, DELETE_AS_JOIN_REWRITE_ENABLED, "false")
+                .build();
+    }
+
+    @Test
+    public void testEqualityDeleteWithPartitionColumnMissingInSelect()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        try {
+            assertUpdateExpected("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"write.format.default\" = '" + fileFormat + "', partitioning=ARRAY['a'])");
+            assertUpdateExpected("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (2, '1010'), (3, '1003')", 4);
+
+            Table icebergTable = updateTable(tableName);
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 2, "b", "1002"), ImmutableMap.of("a", 2));
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("b", "1010"), ImmutableMap.of("a", 2));
+            assertQuery(session, "SELECT b FROM " + tableName, "VALUES ('1001'), ('1003')");
+            assertQuery(session, "SELECT b FROM " + tableName + " WHERE a > 1", "VALUES ('1003')");
+
+            assertUpdateExpected("ALTER TABLE " + tableName + " ADD COLUMN c int WITH (partitioning = 'identity')");
+            assertUpdateExpected("INSERT INTO " + tableName + " VALUES (6, '1004', 1), (6, '1006', 2), (6, '1009', 2)", 3);
+            icebergTable = updateTable(tableName);
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 6, "c", 2, "b", "1006"),
+                    ImmutableMap.of("a", 6, "c", 2));
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("b", "1009"),
+                    ImmutableMap.of("a", 6, "c", 2));
+            assertQuery(session, "SELECT a, b FROM " + tableName, "VALUES (1, '1001'), (3, '1003'), (6, '1004')");
+            assertQuery(session, "SELECT a, b FROM " + tableName + " WHERE a in (1, 6) and c < 3", "VALUES (6, '1004')");
+
+            assertUpdateExpected("ALTER TABLE " + tableName + " ADD COLUMN d varchar WITH (partitioning = 'truncate(2)')");
+            assertUpdateExpected("INSERT INTO " + tableName + " VALUES (6, '1004', 1, 'th001'), (6, '1006', 2, 'th002'), (6, '1006', 3, 'ti003')", 3);
+            icebergTable = updateTable(tableName);
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 6, "c", 1, "d", "th001"),
+                    ImmutableMap.of("a", 6, "c", 1, "d_trunc", "th"));
+            testCheckDeleteFiles(icebergTable, 5, ImmutableList.of(EQUALITY_DELETES, EQUALITY_DELETES, EQUALITY_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+            assertQuery(session, "SELECT a, b, d FROM " + tableName, "VALUES (1, '1001', NULL), (3, '1003', NULL), (6, '1004', NULL), (6, '1006', 'th002'), (6, '1006', 'ti003')");
+            assertQuery(session, "SELECT a, b, d FROM " + tableName + " WHERE a in (1, 6) and d > 'th000'", "VALUES (6, '1006', 'th002'), (6, '1006', 'ti003')");
+        }
+        finally {
+            assertUpdateExpected("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testTableWithEqualityDelete()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_equality_delete" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(EQUALITY_DELETES));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+    }
+
+    @Test
+    public void testTableWithEqualityDeleteDifferentColumnOrder()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        // Specify equality delete filter with different column order from table definition
+        String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        // natiokey is before the equality delete column in the table schema, comment is after
+        assertQuery(session, "SELECT nationkey, comment FROM " + tableName);
+    }
+
+    @Test
+    public void testTableWithEqualityDeleteAndGroupByAndLimit()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        // Specify equality delete filter with different column order from table definition
+        String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
+        assertQuery(session, "SELECT * FROM " + tableName);
+
+        // Test group by
+        assertQuery(session, "SELECT nationkey FROM " + tableName + " group by nationkey");
+        // Test group by with limit
+        assertQuery(session, "SELECT nationkey FROM " + tableName + " group by nationkey limit 100");
+    }
+
+    @Test
+    public void testTableWithPositionDeleteAndEqualityDelete()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 24");
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 2, ImmutableList.of(POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+    }
+
+    @Test
+    public void testPartitionedTableWithEqualityDelete()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_equality_delete" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['nationkey'], \"write.format.default\" = '" + fileFormat + "') " + " AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "nationkey", 1L), ImmutableMap.of("nationkey", 1L));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey, comment FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithPartitions()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "', partitioning = ARRAY['nationkey']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+
+        List<Long> partitions = Arrays.asList(1L, 2L, 3L, 17L, 24L);
+        for (long nationKey : partitions) {
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L), ImmutableMap.of("nationkey", nationKey));
+        }
+        testCheckDeleteFiles(icebergTable, partitions.size(), partitions.stream().map(i -> EQUALITY_DELETES).collect(Collectors.toList()));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+        assertQuery(session, "SELECT name FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithHiddenPartitions()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "', partitioning = ARRAY['bucket(nationkey,100)']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+
+        PartitionTransforms.ColumnTransform columnTransform = PartitionTransforms.getColumnTransform(icebergTable.spec().fields().get(0), BIGINT);
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(5);
+        List<Long> partitions = Arrays.asList(1L, 2L, 3L, 17L, 24L);
+        partitions.forEach(p -> BIGINT.writeLong(builder, p));
+        Block partitionsBlock = columnTransform.getTransform().apply(builder.build());
+        for (int i = 0; i < partitionsBlock.getPositionCount(); i++) {
+            writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L), ImmutableMap.of("nationkey_bucket", partitionsBlock.getInt(i)));
+            assertQuery(session, "SELECT * FROM " + tableName);
+        }
+        testCheckDeleteFiles(icebergTable, partitions.size(), partitions.stream().map(i -> EQUALITY_DELETES).collect(Collectors.toList()));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+        assertQuery(session, "SELECT name FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithCompositeKey()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 0L, "name", "ALGERIA"));
+        testCheckDeleteFiles(icebergTable, 1, Stream.generate(() -> EQUALITY_DELETES).limit(1).collect(Collectors.toList()));
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+        assertQuery(session, "SELECT name FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithMultipleDeleteSchemas()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("nationkey", 10L));
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 2L, "nationkey", 9L));
+        testCheckDeleteFiles(icebergTable, 3, Stream.generate(() -> EQUALITY_DELETES).limit(3).collect(Collectors.toList()));
+        // TODO: Support querying from metadata table equality_deletes in native mode.
+        //assertQuery(session, "SELECT \"$data_sequence_number\", regionkey, nationkey FROM \"" + tableName + "$equality_deletes\"");
+        assertQuery(session, "SELECT * FROM " + tableName);
+        assertQuery(session, "SELECT regionkey FROM " + tableName);
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+    }
+
+    public void testTableWithPositionDeletesAndEqualityDeletes()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        Table icebergTable = updateTable(tableName);
+        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 24");
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
+        testCheckDeleteFiles(icebergTable, 2, ImmutableList.of(POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 19");
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+
+        writePositionDeleteToNationTable(icebergTable, dataFilePath, 7);
+        testCheckDeleteFiles(icebergTable, 3, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES));
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 18");
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 2L));
+        testCheckDeleteFiles(icebergTable, 4, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 13");
+        assertQuery(session, "SELECT nationkey FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithHiddenPartitionsEvolution()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"write.format.default\" = '" + fileFormat + "')");
+        assertUpdateExpected("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
+
+        Table icebergTable = updateTable(tableName);
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 2));
+        assertQuery(session, "SELECT * FROM " + tableName);
+
+        assertUpdateExpected("ALTER TABLE " + tableName + " ADD COLUMN c int WITH (partitioning = 'bucket(2)')");
+        assertUpdateExpected("INSERT INTO " + tableName + " VALUES (6, '1004', 1), (6, '1006', 2)", 2);
+        icebergTable = updateTable(tableName);
+        PartitionTransforms.ColumnTransform columnTransform = PartitionTransforms.getColumnTransform(icebergTable.spec().fields().get(0), INTEGER);
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(1);
+        List<Integer> partitions = Arrays.asList(1, 2);
+        partitions.forEach(p -> BIGINT.writeLong(builder, p));
+        Block partitionsBlock = columnTransform.getTransform().apply(builder.build());
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 6, "c", 2),
+                ImmutableMap.of("c_bucket", partitionsBlock.getInt(0)));
+        assertQuery(session, "SELECT * FROM " + tableName);
+
+        assertUpdateExpected("ALTER TABLE " + tableName + " ADD COLUMN d varchar WITH (partitioning = 'truncate(2)')");
+        assertUpdateExpected("INSERT INTO " + tableName + " VALUES (6, '1004', 1, 'th001'), (6, '1006', 2, 'th002')", 2);
+        icebergTable = updateTable(tableName);
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("a", 6, "c", 1),
+                ImmutableMap.of("c_bucket", partitionsBlock.getInt(0), "d_trunc", "th"));
+        testCheckDeleteFiles(icebergTable, 3, ImmutableList.of(EQUALITY_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+        assertQuery(session, "SELECT * FROM " + tableName);
+    }
+
+    @Test
+    public void testEqualityDeletesWithDataSequenceNumber()
+            throws Exception
+    {
+        Session session = deleteAsJoinDisabled();
+        String tableName = "test_v2_row_delete_" + randomTableSuffix();
+        String tableName2 = "test_v2_row_delete_2_" + randomTableSuffix();
+        assertUpdateExpected("CREATE TABLE " + tableName + "(id int, data varchar) WITH (\"write.format.default\" = '" + fileFormat + "')");
+        assertUpdateExpected("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+        assertUpdateExpected("CREATE TABLE " + tableName2 + "(id int, data varchar) WITH (\"write.format.default\" = '" + fileFormat + "')");
+        assertUpdateExpected("INSERT INTO " + tableName2 + " VALUES (1, 'a')", 1);
+
+        Table icebergTable = updateTable(tableName);
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("id", 1));
+
+        Table icebergTable2 = updateTable(tableName2);
+        writeEqualityDeleteToNationTable(icebergTable2, ImmutableMap.of("id", 1));
+
+        assertUpdateExpected("INSERT INTO " + tableName + " VALUES (1, 'b'), (2, 'a'), (3, 'a')", 3);
+        assertUpdateExpected("INSERT INTO " + tableName2 + " VALUES (1, 'b'), (2, 'a'), (3, 'a')", 3);
+
+        assertQuery(session, "SELECT * FROM " + tableName);
+
+        assertQuery(session, "SELECT \"$data_sequence_number\", * FROM " + tableName);
+
+        assertQuery(session, "SELECT a.\"$data_sequence_number\", b.\"$data_sequence_number\" from " + tableName + " as a, " + tableName2 + " as b where a.id = b.id");
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
@@ -55,7 +55,7 @@ public final class TableHandle
             ConnectorTransactionHandle transaction,
             ConnectorTableLayoutHandle connectorTableLayout)
     {
-        this(connectorId, connectorHandle, transaction, Optional.of(connectorTableLayout), Optional.empty());
+        this(connectorId, connectorHandle, transaction, Optional.ofNullable(connectorTableLayout), Optional.empty());
     }
 
     public TableHandle(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -301,6 +301,16 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertUpdate((QueryRunner) expectedQueryRunner, session, sql, OptionalLong.of(count), Optional.empty());
     }
 
+    protected void assertUpdateExpected(@Language("SQL") String sql)
+    {
+        QueryAssertions.assertUpdate((QueryRunner) expectedQueryRunner, getSession(), sql, OptionalLong.empty(), Optional.empty());
+    }
+
+    protected void assertUpdateExpected(@Language("SQL") String sql, long count)
+    {
+        QueryAssertions.assertUpdate((QueryRunner) expectedQueryRunner, getSession(), sql, OptionalLong.of(count), Optional.empty());
+    }
+
     protected void assertQuerySucceeds(Session session, @Language("SQL") String sql)
     {
         QueryAssertions.assertQuerySucceeds(queryRunner, session, sql);


### PR DESCRIPTION
Summary:

Stacked on D101602644 (Java side adds dataSequenceNumber to DeleteFile DTO).

Changes:
1. Regenerate presto_protocol_iceberg.{h,cpp} so the C++ DeleteFile struct
   carries the new int64_t dataSequenceNumber field round-tripped via JSON.
2. Forward deleteFile.dataSequenceNumber to the Velox IcebergDeleteFile
   constructor (9th arg) so Velox can apply Iceberg V2+ sequence-number
   filtering (an equality-delete file applies only to data files with
   strictly less data sequence number).

Without this, equality-deletes from older snapshots are mis-applied or
skipped on later snapshots, producing extra surviving rows in tests like
testEqualityDeleteWithPartitionColumnMissingInSelect.

== NO RELEASE NOTES ==

Reviewed By: xiaoxmeng

Differential Revision: D103436109
