### PR TITLE
fix: Fall back to HTTP when consumer fragment runs on coordinator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -389,18 +389,18 @@ public abstract class BasePlanFragmenter
         //  - a child (producer) fragment contains coordinator-only nodes, OR
         //  - the current (consumer) fragment runs on the coordinator.
         TransportType transportType = TransportType.HTTP;
-        boolean anyChildOnCoordinator = exchange.getSources().stream()
-                .anyMatch(source -> containsCoordinatorOnlyNode(source));
-        boolean parentIsCoordinator = context.get().hasCoordinatorOnlyDistribution();
-        if (!anyChildOnCoordinator && !parentIsCoordinator) {
+        boolean producerOnCoordinator = exchange.getSources().stream()
+                .anyMatch(PlannerUtils::containsCoordinatorOnlyNode);
+        boolean consumerOnCoordinator = context.get().hasCoordinatorOnlyDistribution();
+        if (!producerOnCoordinator && !consumerOnCoordinator) {
             transportType = TransportType.ANY;
         }
-        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s childOnCoord=%s parentIsCoord=%s",
+        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s producerOnCoord=%s consumerOnCoord=%s",
                 exchange.getId(),
                 transportType,
                 context.get().getPartitioningHandle(),
-                anyChildOnCoordinator,
-                parentIsCoordinator);
+                producerOnCoordinator,
+                consumerOnCoordinator);
 
         ImmutableList.Builder<SubPlan> builder = ImmutableList.builder();
         for (int sourceIndex = 0; sourceIndex < exchange.getSources().size(); sourceIndex++) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -385,17 +385,22 @@ public abstract class BasePlanFragmenter
         setDistributionForExchange(exchange.getType(), partitioningScheme, context);
 
         // Use ANY (e.g. UCX) for worker-to-worker exchanges, but fall back to
-        // HTTP when a child fragment runs on the coordinator (which only speaks HTTP).
+        // HTTP when either side touches the coordinator (which only speaks HTTP):
+        //  - a child (producer) fragment contains coordinator-only nodes, OR
+        //  - the current (consumer) fragment runs on the coordinator.
         TransportType transportType = TransportType.HTTP;
         boolean anyChildOnCoordinator = exchange.getSources().stream()
-                .anyMatch(PlannerUtils::containsCoordinatorOnlyNode);
-        if (!anyChildOnCoordinator) {
+                .anyMatch(source -> containsCoordinatorOnlyNode(source));
+        boolean parentIsCoordinator = context.get().hasCoordinatorOnlyDistribution();
+        if (!anyChildOnCoordinator && !parentIsCoordinator) {
             transportType = TransportType.ANY;
         }
-        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s",
+        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s childOnCoord=%s parentIsCoord=%s",
                 exchange.getId(),
                 transportType,
-                context.get().getPartitioningHandle());
+                context.get().getPartitioningHandle(),
+                anyChildOnCoordinator,
+                parentIsCoordinator);
 
         ImmutableList.Builder<SubPlan> builder = ImmutableList.builder();
         for (int sourceIndex = 0; sourceIndex < exchange.getSources().size(); sourceIndex++) {
@@ -662,6 +667,11 @@ public abstract class BasePlanFragmenter
             partitioningHandle = Optional.of(COORDINATOR_DISTRIBUTION);
 
             return this;
+        }
+
+        public boolean hasCoordinatorOnlyDistribution()
+        {
+            return partitioningHandle.isPresent() && partitioningHandle.get().isCoordinatorOnly();
         }
 
         public FragmentProperties addPartitionedSource(PlanNodeId source)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestBasePlanFragmenterTransportType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestBasePlanFragmenterTransportType.java
@@ -192,6 +192,31 @@ public class TestBasePlanFragmenterTransportType
         assertEquals(props.getOutputTransportType(), TransportType.ANY);
     }
 
+    @Test
+    public void testHasCoordinatorOnlyDistribution()
+    {
+        BasePlanFragmenter.FragmentProperties props = new BasePlanFragmenter.FragmentProperties(
+                new com.facebook.presto.spi.plan.PartitioningScheme(
+                        com.facebook.presto.spi.plan.Partitioning.create(
+                                SystemPartitioningHandle.SINGLE_DISTRIBUTION,
+                                ImmutableList.of()),
+                        ImmutableList.of(col)));
+        // Default is not coordinator-only
+        assertFalse(props.hasCoordinatorOnlyDistribution());
+
+        // After setting coordinator-only distribution via a coordinator-only node, it returns true
+        ValuesNode source = planBuilder.values(col);
+        ExplainAnalyzeNode explainAnalyze = new ExplainAnalyzeNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                source,
+                col,
+                false,
+                ExplainFormat.Type.TEXT);
+        props.setCoordinatorOnlyDistribution(explainAnalyze);
+        assertTrue(props.hasCoordinatorOnlyDistribution());
+    }
+
     // -----------------------------------------------------------------------
     // Tests for PlanFragment transport type serialization
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix exchange transport type selection to also check whether the **consumer** (parent) fragment runs on the coordinator, not just the producer (child) fragments.
- Previously (introduced in #27355), the transport annotation logic only checked whether child fragments contained coordinator-only nodes. This missed the case where the current fragment itself has coordinator-only distribution (e.g., `ExplainAnalyze`), causing it to incorrectly select `ANY` transport for an exchange whose consumer is the coordinator — which only speaks HTTP.
- Add `hasCoordinatorOnlyDistribution()` helper on `FragmentProperties` and a corresponding unit test.

## Motivation and Context
PR #27355 introduced explicit transport type annotations (`HTTP`/`ANY`) on plan fragments so that C++ workers can select the appropriate exchange mechanism — enabling UCX/RDMA-based transfers for worker-to-worker exchanges while falling back to HTTP for exchanges involving the coordinator (which only supports HTTP). The original logic correctly identified producer fragments running on the coordinator but did not account for consumer fragments on the coordinator. This fix closes that gap.

## Test plan
- [x] New unit test `testHasCoordinatorOnlyDistribution` validates the helper method
- [ ] Existing `TestBasePlanFragmenterTransportType` tests continue to pass (to be confirmed by CI)
- [ ] Verify end-to-end with a query that triggers coordinator-only distribution (e.g., `EXPLAIN ANALYZE`)

## Release Notes

```
== NO RELEASE NOTE ==
```