### PR TITLE
[presto][rift] Add riftTier field to RPCNode for coordinator-to-worker tier injection (#27725)

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2078,6 +2078,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RPCNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
+  VELOX_CHECK_NOT_NULL(node);
   // Convert the single source.
   auto sourceNode = toVeloxQueryPlan(node->source, tableWriteInfo, taskId);
 


### PR DESCRIPTION
Summary:

Adds a riftTier field to the RPCNode plan node across all layers (Java →
C++ protocol → Velox) so the coordinator can pass the auto-provisioned RIFT
SMC tier to workers through the query plan.

This is the follow-up to D101101436 that completes the Mode 2 (auto-start)
data path. The RIFT CLI generates random tier names (e.g.,
smc.rift_amukher1_llama3_a3f1b2m), so the coordinator must communicate the
tier through the plan node rather than deterministic naming.

Changes across the full plan node chain:
- Java RPCNode: add riftTier field, both constructors, getter, pass through
  in replaceChildren/assignStatsEquivalentPlanNode
- Java RpcFunctionOptimizer: pass empty riftTier (coordinator injection TBD)
- Java UnaliasSymbolReferences, PruneUnreferencedOutputs: pass through
- C++ presto_protocol_core: add riftTier to RPCNode struct + serialization
- C++ PrestoToVeloxQueryPlan: pass node->riftTier to Velox RPCNode
- Velox PlanNode.h/cpp: add riftTier field, getter, serialize/deserialize
- AsyncRPCFunction.h: add virtual setRiftTier() method (default no-op)
- RPCOperator.cpp: call function_->setRiftTier() before initialize()
- FbLlmInference: implement setRiftTier(), use plan node tier with highest
  priority (options JSON > plan node riftTier > session property)

Differential Revision: D101105948


