### PR TITLE
[presto][rift][test] Add riftTier round-trip test to RPCPlanConverterTest

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -572,7 +572,8 @@ public class PruneUnreferencedOutputs
                     node.getArgumentColumns(),
                     node.getOutputVariable(),
                     node.getStreamingMode(),
-                    node.getDispatchBatchSize());
+                    node.getDispatchBatchSize(),
+                    node.getRiftTier());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -209,7 +209,8 @@ public class RpcFunctionOptimizer
                         argumentColumns.build(),
                         extracted.resultVar,
                         streamingMode,
-                        dispatchBatchSize);
+                        dispatchBatchSize,
+                        "");
 
                 currentSource = rpcNode;
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -859,7 +859,8 @@ public class UnaliasSymbolReferences
                     newArgumentColumns,
                     canonicalize(node.getOutputVariable()),
                     node.getStreamingMode(),
-                    node.getDispatchBatchSize());
+                    node.getDispatchBatchSize(),
+                    node.getRiftTier());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
@@ -48,6 +48,7 @@ public class RPCNode
     private final List<VariableReferenceExpression> outputVariables;
     private final StreamingMode streamingMode;
     private final int dispatchBatchSize;
+    private final String riftTier;
 
     @JsonCreator
     public RPCNode(
@@ -59,11 +60,13 @@ public class RPCNode
             @JsonProperty("argumentColumns") List<String> argumentColumns,
             @JsonProperty("outputVariable") VariableReferenceExpression outputVariable,
             @JsonProperty("streamingMode") StreamingMode streamingMode,
-            @JsonProperty("dispatchBatchSize") Integer dispatchBatchSize)
+            @JsonProperty("dispatchBatchSize") Integer dispatchBatchSize,
+            @JsonProperty("riftTier") String riftTier)
     {
         this(sourceLocation, id, Optional.empty(), source, functionName,
                 arguments, argumentColumns, outputVariable, streamingMode,
-                dispatchBatchSize != null ? dispatchBatchSize : 0);
+                dispatchBatchSize != null ? dispatchBatchSize : 0,
+                riftTier != null ? riftTier : "");
     }
 
     public RPCNode(
@@ -76,7 +79,8 @@ public class RPCNode
             List<String> argumentColumns,
             VariableReferenceExpression outputVariable,
             StreamingMode streamingMode,
-            int dispatchBatchSize)
+            int dispatchBatchSize,
+            String riftTier)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.source = requireNonNull(source, "source is null");
@@ -91,6 +95,7 @@ public class RPCNode
         this.outputVariable = requireNonNull(outputVariable, "outputVariable is null");
         this.streamingMode = streamingMode != null ? streamingMode : StreamingMode.PER_ROW;
         this.dispatchBatchSize = dispatchBatchSize;
+        this.riftTier = riftTier != null ? riftTier : "";
 
         ImmutableList.Builder<VariableReferenceExpression> outputs = ImmutableList.builder();
         outputs.addAll(source.getOutputVariables());
@@ -140,6 +145,12 @@ public class RPCNode
         return dispatchBatchSize;
     }
 
+    @JsonProperty
+    public String getRiftTier()
+    {
+        return riftTier;
+    }
+
     @Override
     @JsonProperty
     public List<VariableReferenceExpression> getOutputVariables()
@@ -172,7 +183,8 @@ public class RPCNode
                 argumentColumns,
                 outputVariable,
                 streamingMode,
-                dispatchBatchSize);
+                dispatchBatchSize,
+                riftTier);
     }
 
     @Override
@@ -188,6 +200,7 @@ public class RPCNode
                 argumentColumns,
                 outputVariable,
                 streamingMode,
-                dispatchBatchSize);
+                dispatchBatchSize,
+                riftTier);
     }
 }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2078,6 +2078,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RPCNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
+  VELOX_CHECK_NOT_NULL(node);
   // Convert the single source.
   auto sourceNode = toVeloxQueryPlan(node->source, tableWriteInfo, taskId);
 
@@ -2166,7 +2167,8 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       std::move(argumentTypes),
       std::move(constantInputs),
       veloxStreamingMode,
-      dispatchBatchSize);
+      dispatchBatchSize,
+      node->riftTier);
 }
 
 core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(

--- a/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
@@ -171,3 +171,34 @@ TEST_F(RPCPlanConverterTest, rpcNodeWithRegisteredFunction) {
   ASSERT_EQ(veloxRpcNode->constantInputs().size(), 1);
   EXPECT_EQ(veloxRpcNode->constantInputs()[0], nullptr);
 }
+
+// Test that the riftTier field set on the protocol RPCNode is round-tripped
+// through plan conversion to the resulting core::RPCNode. This guards the
+// coordinator-to-worker tier injection plumbing added for RIFT-on-MAST.
+TEST_F(RPCPlanConverterTest, rpcNodeRiftTierRoundTrip) {
+  // Register the RPC function so plan conversion succeeds.
+  exec_rpc::AsyncRPCFunctionRegistry::testingClear();
+  exec_rpc::AsyncRPCFunctionRegistry::registerFunction(
+      "fb_llm_inference", []() noexcept { return nullptr; });
+
+  // Build the protocol plan with a non-default riftTier value.
+  std::shared_ptr<protocol::ValuesNode> valuesNode = makeValuesNode();
+  std::shared_ptr<protocol::RPCNode> rpcNode = makeRPCNode(valuesNode);
+  ASSERT_NE(rpcNode, nullptr);
+  const std::string kExpectedRiftTier = "my_test_tier";
+  rpcNode->riftTier = kExpectedRiftTier;
+
+  // Convert the plan.
+  VeloxInteractiveQueryPlanConverter converter(queryCtx_.get(), pool_.get());
+  const core::PlanNodePtr veloxPlan = converter.toVeloxQueryPlan(
+      std::dynamic_pointer_cast<protocol::PlanNode>(rpcNode),
+      nullptr,
+      "20260124_042527_00001_gp3te.1.0.0.0");
+
+  // Verify the riftTier round-tripped to the core::RPCNode.
+  ASSERT_NE(veloxPlan, nullptr);
+  std::shared_ptr<const core::RPCNode> veloxRpcNode =
+      std::dynamic_pointer_cast<const core::RPCNode>(veloxPlan);
+  ASSERT_NE(veloxRpcNode, nullptr);
+  EXPECT_EQ(veloxRpcNode->riftTier(), kExpectedRiftTier);
+}

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -9535,6 +9535,13 @@ void to_json(json& j, const RPCNode& p) {
       "RPCNode",
       "Integer",
       "dispatchBatchSize");
+  to_json_key(
+      j,
+      "riftTier",
+      p.riftTier,
+      "RPCNode",
+      "String",
+      "riftTier");
 }
 
 void from_json(const json& j, RPCNode& p) {
@@ -9578,6 +9585,13 @@ void from_json(const json& j, RPCNode& p) {
       "RPCNode",
       "Integer",
       "dispatchBatchSize");
+  from_json_key(
+      j,
+      "riftTier",
+      p.riftTier,
+      "RPCNode",
+      "String",
+      "riftTier");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2154,6 +2154,7 @@ struct RPCNode : public PlanNode {
   VariableReferenceExpression outputVariable = {};
   RPCNodeStreamingMode streamingMode = {};
   Integer dispatchBatchSize = {};
+  String riftTier = {};
 
   RPCNode() noexcept;
 };


### PR DESCRIPTION
Summary:
Context:
D101105948 added a riftTier String field to protocol::RPCNode and plumbed it through PrestoToVeloxQueryPlan into core::RPCNode for coordinator-to-worker RIFT tier injection. The existing RPCPlanConverterTest covers function-name resolution but does not exercise riftTier, so a regression that drops the field on the floor would not be caught.

Motivation:
Add minimal coverage that asserts a non-default riftTier set on the protocol RPCNode is preserved by plan conversion onto the resulting core::RPCNode. This guards the new field end-to-end through the converter without requiring a live RIFT cluster.

This diff:
- Adds RPCPlanConverterTest.rpcNodeRiftTierRoundTrip: reuses the existing makeValuesNode/makeRPCNode helpers, sets rpcNode->riftTier = "my_test_tier", runs the plan through VeloxInteractiveQueryPlanConverter, and asserts the resulting core::RPCNode->riftTier() matches.

Differential Revision: D102037207

## Summary by Sourcery

Add support for propagating the riftTier field on RPC nodes through Presto planning and native execution, and add a regression test to validate the round-trip conversion.

New Features:
- Introduce a riftTier property on the Java planner RPCNode with JSON serialization support and exposure via a getter.

Enhancements:
- Propagate the riftTier field from protocol::RPCNode to core::RPCNode in Presto-to-Velox query plan conversion.
- Ensure planner optimizations that rebuild RPCNode instances preserve the riftTier field or explicitly set it when creating new nodes.

Tests:
- Add an RPCPlanConverterTest case that verifies a non-default riftTier on the protocol RPCNode is preserved on the resulting core::RPCNode after plan conversion.