### PR TITLE
[presto][rift] Wire RpcFunctionOptimizer to read meta_ai_rift_reuse_tier session property

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -572,7 +572,8 @@ public class PruneUnreferencedOutputs
                     node.getArgumentColumns(),
                     node.getOutputVariable(),
                     node.getStreamingMode(),
-                    node.getDispatchBatchSize());
+                    node.getDispatchBatchSize(),
+                    node.getRiftTier());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -209,7 +209,8 @@ public class RpcFunctionOptimizer
                         argumentColumns.build(),
                         extracted.resultVar,
                         streamingMode,
-                        dispatchBatchSize);
+                        dispatchBatchSize,
+                        "");
 
                 currentSource = rpcNode;
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -91,7 +91,17 @@ public class RpcFunctionOptimizer
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 
-        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get());
+        // Read the user-supplied RIFT reuse tier from the session and pass it to
+        // the rewriter so it can be propagated into every RPCNode produced by the
+        // optimizer. The session property is registered in presto-facebook-trunk
+        // (InternalSessionProperties#META_AI_RIFT_REUSE_TIER) but is read here via
+        // session.getSystemProperty to avoid a cross-module dependency.
+        String riftTier = session.getSystemProperty("meta_ai_rift_reuse_tier", String.class);
+        if (riftTier == null) {
+            riftTier = "";
+        }
+
+        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get(), riftTier);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -103,14 +113,16 @@ public class RpcFunctionOptimizer
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final Set<String> rpcFunctionNames;
+        private final String riftTier;
         private boolean planChanged;
 
-        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames)
+        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames, String riftTier)
         {
             this.session = requireNonNull(session, "session is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
             this.rpcFunctionNames = requireNonNull(rpcFunctionNames, "rpcFunctionNames is null");
+            this.riftTier = requireNonNull(riftTier, "riftTier is null");
         }
 
         public boolean isPlanChanged()
@@ -210,7 +222,7 @@ public class RpcFunctionOptimizer
                         extracted.resultVar,
                         streamingMode,
                         dispatchBatchSize,
-                        "");
+                        riftTier);
 
                 currentSource = rpcNode;
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -859,7 +859,8 @@ public class UnaliasSymbolReferences
                     newArgumentColumns,
                     canonicalize(node.getOutputVariable()),
                     node.getStreamingMode(),
-                    node.getDispatchBatchSize());
+                    node.getDispatchBatchSize(),
+                    node.getRiftTier());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
@@ -48,6 +48,7 @@ public class RPCNode
     private final List<VariableReferenceExpression> outputVariables;
     private final StreamingMode streamingMode;
     private final int dispatchBatchSize;
+    private final String riftTier;
 
     @JsonCreator
     public RPCNode(
@@ -59,11 +60,13 @@ public class RPCNode
             @JsonProperty("argumentColumns") List<String> argumentColumns,
             @JsonProperty("outputVariable") VariableReferenceExpression outputVariable,
             @JsonProperty("streamingMode") StreamingMode streamingMode,
-            @JsonProperty("dispatchBatchSize") Integer dispatchBatchSize)
+            @JsonProperty("dispatchBatchSize") Integer dispatchBatchSize,
+            @JsonProperty("riftTier") String riftTier)
     {
         this(sourceLocation, id, Optional.empty(), source, functionName,
                 arguments, argumentColumns, outputVariable, streamingMode,
-                dispatchBatchSize != null ? dispatchBatchSize : 0);
+                dispatchBatchSize != null ? dispatchBatchSize : 0,
+                riftTier != null ? riftTier : "");
     }
 
     public RPCNode(
@@ -76,7 +79,8 @@ public class RPCNode
             List<String> argumentColumns,
             VariableReferenceExpression outputVariable,
             StreamingMode streamingMode,
-            int dispatchBatchSize)
+            int dispatchBatchSize,
+            String riftTier)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.source = requireNonNull(source, "source is null");
@@ -91,6 +95,7 @@ public class RPCNode
         this.outputVariable = requireNonNull(outputVariable, "outputVariable is null");
         this.streamingMode = streamingMode != null ? streamingMode : StreamingMode.PER_ROW;
         this.dispatchBatchSize = dispatchBatchSize;
+        this.riftTier = riftTier != null ? riftTier : "";
 
         ImmutableList.Builder<VariableReferenceExpression> outputs = ImmutableList.builder();
         outputs.addAll(source.getOutputVariables());
@@ -140,6 +145,12 @@ public class RPCNode
         return dispatchBatchSize;
     }
 
+    @JsonProperty
+    public String getRiftTier()
+    {
+        return riftTier;
+    }
+
     @Override
     @JsonProperty
     public List<VariableReferenceExpression> getOutputVariables()
@@ -172,7 +183,8 @@ public class RPCNode
                 argumentColumns,
                 outputVariable,
                 streamingMode,
-                dispatchBatchSize);
+                dispatchBatchSize,
+                riftTier);
     }
 
     @Override
@@ -188,6 +200,7 @@ public class RPCNode
                 argumentColumns,
                 outputVariable,
                 streamingMode,
-                dispatchBatchSize);
+                dispatchBatchSize,
+                riftTier);
     }
 }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2078,6 +2078,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RPCNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
+  VELOX_CHECK_NOT_NULL(node);
   // Convert the single source.
   auto sourceNode = toVeloxQueryPlan(node->source, tableWriteInfo, taskId);
 
@@ -2166,7 +2167,8 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       std::move(argumentTypes),
       std::move(constantInputs),
       veloxStreamingMode,
-      dispatchBatchSize);
+      dispatchBatchSize,
+      node->riftTier);
 }
 
 core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(

--- a/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
@@ -171,3 +171,34 @@ TEST_F(RPCPlanConverterTest, rpcNodeWithRegisteredFunction) {
   ASSERT_EQ(veloxRpcNode->constantInputs().size(), 1);
   EXPECT_EQ(veloxRpcNode->constantInputs()[0], nullptr);
 }
+
+// Test that the riftTier field set on the protocol RPCNode is round-tripped
+// through plan conversion to the resulting core::RPCNode. This guards the
+// coordinator-to-worker tier injection plumbing added for RIFT-on-MAST.
+TEST_F(RPCPlanConverterTest, rpcNodeRiftTierRoundTrip) {
+  // Register the RPC function so plan conversion succeeds.
+  exec_rpc::AsyncRPCFunctionRegistry::testingClear();
+  exec_rpc::AsyncRPCFunctionRegistry::registerFunction(
+      "fb_llm_inference", []() noexcept { return nullptr; });
+
+  // Build the protocol plan with a non-default riftTier value.
+  std::shared_ptr<protocol::ValuesNode> valuesNode = makeValuesNode();
+  std::shared_ptr<protocol::RPCNode> rpcNode = makeRPCNode(valuesNode);
+  ASSERT_NE(rpcNode, nullptr);
+  const std::string kExpectedRiftTier = "my_test_tier";
+  rpcNode->riftTier = kExpectedRiftTier;
+
+  // Convert the plan.
+  VeloxInteractiveQueryPlanConverter converter(queryCtx_.get(), pool_.get());
+  const core::PlanNodePtr veloxPlan = converter.toVeloxQueryPlan(
+      std::dynamic_pointer_cast<protocol::PlanNode>(rpcNode),
+      nullptr,
+      "20260124_042527_00001_gp3te.1.0.0.0");
+
+  // Verify the riftTier round-tripped to the core::RPCNode.
+  ASSERT_NE(veloxPlan, nullptr);
+  std::shared_ptr<const core::RPCNode> veloxRpcNode =
+      std::dynamic_pointer_cast<const core::RPCNode>(veloxPlan);
+  ASSERT_NE(veloxRpcNode, nullptr);
+  EXPECT_EQ(veloxRpcNode->riftTier(), kExpectedRiftTier);
+}

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -9535,6 +9535,13 @@ void to_json(json& j, const RPCNode& p) {
       "RPCNode",
       "Integer",
       "dispatchBatchSize");
+  to_json_key(
+      j,
+      "riftTier",
+      p.riftTier,
+      "RPCNode",
+      "String",
+      "riftTier");
 }
 
 void from_json(const json& j, RPCNode& p) {
@@ -9578,6 +9585,13 @@ void from_json(const json& j, RPCNode& p) {
       "RPCNode",
       "Integer",
       "dispatchBatchSize");
+  from_json_key(
+      j,
+      "riftTier",
+      p.riftTier,
+      "RPCNode",
+      "String",
+      "riftTier");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2154,6 +2154,7 @@ struct RPCNode : public PlanNode {
   VariableReferenceExpression outputVariable = {};
   RPCNodeStreamingMode streamingMode = {};
   Integer dispatchBatchSize = {};
+  String riftTier = {};
 
   RPCNode() noexcept;
 };


### PR DESCRIPTION
Summary:
Before this change, RpcFunctionOptimizer.java:209 hardcoded "" for the
  riftTier ctor argument on every RPCNode. The 4 META_AI_RIFT_* session
  properties were declared in InternalSessionProperties.java:32-35 but
  never read by the optimizer. As a result, the entire 'tier injection'
  code path promised by D101101436's title was non-functional in
  production: every worker received riftTier="".

  This is the minimum-viable wiring per AI #5 from the validation report:
  read meta_ai_rift_reuse_tier from session and pass it as the trailing
  ctor arg of every RPCNode the optimizer produces.

  Patch shape (3 hunks, 1 file):
    1. optimize(): read session.getSystemProperty("meta_ai_rift_reuse_tier",
       String.class), null-coalesce to "", pass to Rewriter ctor.
    2. Rewriter inner class: add `private final String riftTier` field,
       add String parameter, requireNonNull init.
    3. new RPCNode(...) call: replace literal "" with this.riftTier.

  Cross-module note: the property is registered in presto-facebook-trunk
  (InternalSessionProperties.META_AI_RIFT_REUSE_TIER + getter at line 201)
  but is read here via session.getSystemProperty(name, type) directly to
  avoid adding a presto-facebook compile dep on presto-main-base.

  Follow-up (deferred): cross-module accessor for RiftClusterRegistry so
  the auto-spinup tier (not just user-supplied reuse tier) flows through
  the optimizer. Tracked as a follow-up task.

  Stacked on AI #2 fix (D103071816) and on the D101101436 stack. To be
  folded into D101101436 by the author or landed as a follow-up.

Differential Revision: D103073515

## Summary by Sourcery

Propagate the RIFT reuse tier from session properties through Java and native RPC plan nodes so it is preserved end-to-end during planning and native plan conversion.

New Features:
- Add a riftTier attribute to Java and native RPCNode representations, including JSON serialization and plan-node visitors, to carry the RIFT reuse tier.
- Read the meta_ai_rift_reuse_tier session property in RpcFunctionOptimizer and inject it into all RPCNodes produced by the optimizer, ensuring the tier information reaches workers.

Tests:
- Add a native RPC plan conversion test to verify that the riftTier set on a protocol RPCNode round-trips to the resulting core::RPCNode.