### PR TITLE
fix(plugin-iceberg): Do not check access control for MV data table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2766,10 +2766,10 @@ The following catalog properties affect how materialized view storage tables are
 ====================================================== ============================================================= ========================
 Property Name                                          Description                                                   Default
 ====================================================== ============================================================= ========================
-``iceberg.materialized-view-storage-prefix``           Prefix applied to auto-generated storage table names.        ``__mv_storage__``
+``iceberg.materialized-view-storage-prefix``           Prefix applied to auto-generated storage table names.         ``__mv_storage__``
 
-``iceberg.materialized-view-default-storage-schema``   Schema in which storage tables are created when the          (the view's own
-                                                       per-view ``storage_schema`` property is not set. Point at    schema)
+``iceberg.materialized-view-default-storage-schema``   Schema in which storage tables are created when the           (the view's own
+                                                       per-view ``storage_schema`` property is not set. Point at     schema)
                                                        a locked-down schema to keep storage tables out of users'
                                                        reach without affecting materialized view reads.
 ====================================================== ============================================================= ========================

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2763,16 +2763,16 @@ Catalog Configuration
 
 The following catalog properties affect how materialized view storage tables are named and located. They apply at materialized view creation time and can be overridden per-view via the ``storage_schema`` and ``storage_table`` table properties.
 
-================================================== ============================================================= ========================
-Property Name                                      Description                                                   Default
-================================================== ============================================================= ========================
-``iceberg.materialized-view-storage-prefix``       Prefix applied to auto-generated storage table names.         ``__mv_storage__``
+====================================================== ============================================================= ========================
+Property Name                                          Description                                                   Default
+====================================================== ============================================================= ========================
+``iceberg.materialized-view-storage-prefix``           Prefix applied to auto-generated storage table names.        ``__mv_storage__``
 
-``iceberg.materialized-view-default-storage-schema``  Schema in which storage tables are created when the         (the view's own
-                                                   per-view ``storage_schema`` property is not set. Point at     schema)
-                                                   a locked-down schema to keep storage tables out of users'
-                                                   reach without affecting materialized view reads.
-================================================== ============================================================= ========================
+``iceberg.materialized-view-default-storage-schema``   Schema in which storage tables are created when the          (the view's own
+                                                       per-view ``storage_schema`` property is not set. Point at    schema)
+                                                       a locked-down schema to keep storage tables out of users'
+                                                       reach without affecting materialized view reads.
+====================================================== ============================================================= ========================
 
 Table Properties
 ^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2758,6 +2758,22 @@ Storage
 
 Materialized views use a dedicated Iceberg storage table to persist the pre-computed results. By default, the storage table is created with the prefix ``__mv_storage__`` followed by the materialized view name in the same schema as the view.
 
+Catalog Configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+The following catalog properties affect how materialized view storage tables are named and located. They apply at materialized view creation time and can be overridden per-view via the ``storage_schema`` and ``storage_table`` table properties.
+
+================================================== ============================================================= ========================
+Property Name                                      Description                                                   Default
+================================================== ============================================================= ========================
+``iceberg.materialized-view-storage-prefix``       Prefix applied to auto-generated storage table names.         ``__mv_storage__``
+
+``iceberg.materialized-view-default-storage-schema``  Schema in which storage tables are created when the         (the view's own
+                                                   per-view ``storage_schema`` property is not set. Point at     schema)
+                                                   a locked-down schema to keep storage tables out of users'
+                                                   reach without affecting materialized view reads.
+================================================== ============================================================= ========================
+
 Table Properties
 ^^^^^^^^^^^^^^^^
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -204,8 +204,8 @@ import static com.facebook.presto.iceberg.IcebergMetadataColumn.MERGE_TARGET_ROW
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.IcebergPartitionType.ALL;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
-import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewMaxChangedPartitions;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewDefaultStorageSchema;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewMaxChangedPartitions;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewStoragePrefix;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -205,6 +205,7 @@ import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.IcebergPartitionType.ALL;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewMaxChangedPartitions;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewDefaultStorageSchema;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMaterializedViewStoragePrefix;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
@@ -2460,7 +2461,7 @@ public abstract class IcebergAbstractMetadata
             return getMaterializedViewStoragePrefix(session) + viewName.getTableName();
         });
         String schema = getStorageSchema(properties)
-                .orElse(viewName.getSchemaName());
+                .orElseGet(() -> getMaterializedViewDefaultStorageSchema(session).orElse(viewName.getSchemaName()));
         return new SchemaTableName(schema, tableName);
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -77,6 +77,7 @@ public class IcebergConfig
     private int splitManagerThreads = Runtime.getRuntime().availableProcessors();
     private DataSize maxStatisticsFileCacheSize = succinctDataSize(256, MEGABYTE);
     private String materializedViewStoragePrefix = "__mv_storage__";
+    private String materializedViewDefaultStorageSchema;
     private int materializedViewMaxChangedPartitions = 100;
 
     @NotNull
@@ -495,6 +496,21 @@ public class IcebergConfig
     public IcebergConfig setMaterializedViewStoragePrefix(String materializedViewStoragePrefix)
     {
         this.materializedViewStoragePrefix = materializedViewStoragePrefix;
+        return this;
+    }
+
+    public String getMaterializedViewDefaultStorageSchema()
+    {
+        return materializedViewDefaultStorageSchema;
+    }
+
+    @Config("iceberg.materialized-view-default-storage-schema")
+    @ConfigDescription("Default schema for materialized view storage tables when the storage_schema " +
+            "table property is not set. Defaults to the materialized view's own schema; point at a " +
+            "locked-down schema to keep storage tables out of users' reach.")
+    public IcebergConfig setMaterializedViewDefaultStorageSchema(String materializedViewDefaultStorageSchema)
+    {
+        this.materializedViewDefaultStorageSchema = materializedViewDefaultStorageSchema;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -72,6 +72,7 @@ public final class IcebergSessionProperties
     public static final String STATISTICS_KLL_SKETCH_K_PARAMETER = "statistics_kll_sketch_k_parameter";
     public static final String TARGET_SPLIT_SIZE_BYTES = "target_split_size_bytes";
     public static final String MATERIALIZED_VIEW_STORAGE_PREFIX = "materialized_view_storage_prefix";
+    public static final String MATERIALIZED_VIEW_DEFAULT_STORAGE_SCHEMA = "materialized_view_default_storage_schema";
     public static final String MAX_PARTITIONS_PER_WRITER = "max_partitions_per_writer";
     public static final String MATERIALIZED_VIEW_MAX_CHANGED_PARTITIONS = "materialized_view_max_changed_partitions";
 
@@ -244,6 +245,13 @@ public final class IcebergSessionProperties
                                 "When a custom table name is provided, it takes precedence over this prefix.",
                         icebergConfig.getMaterializedViewStoragePrefix(),
                         false))
+                .add(stringProperty(
+                        MATERIALIZED_VIEW_DEFAULT_STORAGE_SCHEMA,
+                        "Default schema for materialized view storage tables when the storage_schema " +
+                                "table property is not set. When unset (null), storage tables are created in the " +
+                                "same schema as the materialized view.",
+                        icebergConfig.getMaterializedViewDefaultStorageSchema(),
+                        false))
                 .add(integerProperty(
                         MATERIALIZED_VIEW_MAX_CHANGED_PARTITIONS,
                         "Maximum number of changed partitions to track for materialized view staleness detection. " +
@@ -402,6 +410,11 @@ public final class IcebergSessionProperties
     public static String getMaterializedViewStoragePrefix(ConnectorSession session)
     {
         return session.getProperty(MATERIALIZED_VIEW_STORAGE_PREFIX, String.class);
+    }
+
+    public static Optional<String> getMaterializedViewDefaultStorageSchema(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(MATERIALIZED_VIEW_DEFAULT_STORAGE_SCHEMA, String.class));
     }
 
     public static int getMaterializedViewMaxChangedPartitions(ConnectorSession session)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -75,6 +75,7 @@ public class TestIcebergConfig
                 .setMaxStatisticsFileCacheSize(succinctDataSize(256, MEGABYTE))
                 .setStatisticsKllSketchKParameter(1024)
                 .setMaterializedViewStoragePrefix("__mv_storage__")
+                .setMaterializedViewDefaultStorageSchema(null)
                 .setMaterializedViewMaxChangedPartitions(100));
     }
 
@@ -112,6 +113,7 @@ public class TestIcebergConfig
                 .put("iceberg.max-statistics-file-cache-size", "512MB")
                 .put("iceberg.statistics-kll-sketch-k-parameter", "4096")
                 .put("iceberg.materialized-view-storage-prefix", "custom_mv_prefix")
+                .put("iceberg.materialized-view-default-storage-schema", "_mv_storage")
                 .put("iceberg.materialized-view-max-changed-partitions", "2000")
                 .build();
 
@@ -146,6 +148,7 @@ public class TestIcebergConfig
                 .setMaxStatisticsFileCacheSize(succinctDataSize(512, MEGABYTE))
                 .setStatisticsKllSketchKParameter(4096)
                 .setMaterializedViewStoragePrefix("custom_mv_prefix")
+                .setMaterializedViewDefaultStorageSchema("_mv_storage")
                 .setMaterializedViewMaxChangedPartitions(2000);
 
         assertFullMapping(properties, expected);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.ViewExpression;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -27,6 +28,8 @@ import java.io.File;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STALE_DATA;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
+import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -4913,6 +4916,138 @@ public abstract class TestIcebergMaterializedViewsBase
             MaterializedResult withStorageResult = computeActual(withStorageSession, query);
             MaterializedResult skipStorageResult = computeActual(skipStorageSession, query);
             assertEqualsIgnoreOrder(skipStorageResult.getMaterializedRows(), withStorageResult.getMaterializedRows());
+        }
+    }
+
+    @Test
+    public void testDefaultStorageSchemaConfig()
+    {
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS mv_storage_isolated");
+        assertUpdate("CREATE TABLE test_default_storage_schema_base (id BIGINT, name VARCHAR)");
+        assertUpdate("INSERT INTO test_default_storage_schema_base VALUES (1, 'Alice'), (2, 'Bob')", 2);
+
+        Session sessionWithDefaultSchema = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "materialized_view_default_storage_schema", "mv_storage_isolated")
+                .build();
+
+        assertUpdate(sessionWithDefaultSchema, "CREATE MATERIALIZED VIEW test_default_storage_schema_mv AS " +
+                "SELECT id, name FROM test_default_storage_schema_base");
+
+        try {
+            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"__mv_storage__test_default_storage_schema_mv\"", "SELECT 0");
+            assertQueryFails("SELECT * FROM \"__mv_storage__test_default_storage_schema_mv\"", ".*does not exist.*");
+
+            assertMaterializedViewQuery(
+                    "SELECT * FROM test_default_storage_schema_mv ORDER BY id",
+                    "VALUES (1, 'Alice'), (2, 'Bob')");
+
+            assertRefreshAndFullyMaterialized("test_default_storage_schema_mv", 2);
+            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"__mv_storage__test_default_storage_schema_mv\"", "SELECT 2");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW test_default_storage_schema_mv");
+            assertUpdate("DROP TABLE test_default_storage_schema_base");
+            assertUpdate("DROP SCHEMA IF EXISTS mv_storage_isolated");
+        }
+    }
+
+    @Test
+    public void testSecurityDefinerDoesNotRequireStorageAccessForReader()
+    {
+        assertUpdate("CREATE TABLE mv_storage_acl_base (id BIGINT, value BIGINT)");
+        assertUpdate("INSERT INTO mv_storage_acl_base VALUES (1, 100), (2, 200), (3, 300)", 3);
+
+        assertUpdate("CREATE MATERIALIZED VIEW mv_storage_acl_mv SECURITY DEFINER AS " +
+                "SELECT id, value FROM mv_storage_acl_base");
+        assertUpdate("REFRESH MATERIALIZED VIEW mv_storage_acl_mv", 3);
+
+        try {
+            getQueryRunner().getAccessControl().deny(
+                    privilege("restricted_user", "__mv_storage__mv_storage_acl_mv", SELECT_COLUMN),
+                    privilege("restricted_user", "mv_storage_acl_base", SELECT_COLUMN));
+
+            Session restrictedSession = Session.builder(getQueryRunner().getDefaultSession())
+                    .setIdentity(new Identity("restricted_user", Optional.empty()))
+                    .build();
+
+            assertQuery(restrictedSession,
+                    "SELECT id, value FROM mv_storage_acl_mv ORDER BY id",
+                    "VALUES (1, 100), (2, 200), (3, 300)");
+
+            assertQueryFails(
+                    restrictedSession,
+                    "SELECT * FROM \"__mv_storage__mv_storage_acl_mv\"",
+                    ".*Access Denied.*");
+        }
+        finally {
+            getQueryRunner().getAccessControl().reset();
+            assertUpdate("DROP MATERIALIZED VIEW mv_storage_acl_mv");
+            assertUpdate("DROP TABLE mv_storage_acl_base");
+        }
+    }
+
+    @Test
+    public void testStorageSchemaLockdownEndToEnd()
+    {
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS mv_locked_storage");
+        assertUpdate("CREATE TABLE storage_lockdown_base (id BIGINT, value BIGINT)");
+        assertUpdate("INSERT INTO storage_lockdown_base VALUES (1, 100), (2, 200), (3, 300)", 3);
+
+        Session sessionWithDefaultSchema = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "materialized_view_default_storage_schema", "mv_locked_storage")
+                .build();
+
+        assertUpdate(sessionWithDefaultSchema, "CREATE MATERIALIZED VIEW storage_lockdown_definer_mv SECURITY DEFINER AS " +
+                "SELECT id, value FROM storage_lockdown_base");
+        assertUpdate(sessionWithDefaultSchema, "CREATE MATERIALIZED VIEW storage_lockdown_invoker_mv SECURITY INVOKER AS " +
+                "SELECT id, value FROM storage_lockdown_base");
+
+        String definerStorage = "__mv_storage__storage_lockdown_definer_mv";
+        String invokerStorage = "__mv_storage__storage_lockdown_invoker_mv";
+
+        try {
+            // Wildcard deny matches every identity, including the MV creator.
+            getQueryRunner().getAccessControl().deny(
+                    privilege(definerStorage, SELECT_COLUMN),
+                    privilege(invokerStorage, SELECT_COLUMN));
+
+            Session restrictedSession = Session.builder(getQueryRunner().getDefaultSession())
+                    .setIdentity(new Identity("restricted_user", Optional.empty()))
+                    .build();
+
+            assertUpdate(sessionWithDefaultSchema, "REFRESH MATERIALIZED VIEW storage_lockdown_definer_mv", 3);
+            assertUpdate(sessionWithDefaultSchema, "REFRESH MATERIALIZED VIEW storage_lockdown_invoker_mv", 3);
+
+            assertQuery(getSession(),
+                    "SELECT id, value FROM storage_lockdown_definer_mv ORDER BY id",
+                    "VALUES (1, 100), (2, 200), (3, 300)");
+            assertQuery(restrictedSession,
+                    "SELECT id, value FROM storage_lockdown_definer_mv ORDER BY id",
+                    "VALUES (1, 100), (2, 200), (3, 300)");
+
+            assertQuery(getSession(),
+                    "SELECT id, value FROM storage_lockdown_invoker_mv ORDER BY id",
+                    "VALUES (1, 100), (2, 200), (3, 300)");
+            assertQuery(restrictedSession,
+                    "SELECT id, value FROM storage_lockdown_invoker_mv ORDER BY id",
+                    "VALUES (1, 100), (2, 200), (3, 300)");
+
+            for (String storageTable : ImmutableList.of(definerStorage, invokerStorage)) {
+                String fullyQualified = "mv_locked_storage.\"" + storageTable + "\"";
+                assertQueryFails(getSession(),
+                        "SELECT * FROM " + fullyQualified,
+                        ".*Access Denied.*");
+                assertQueryFails(restrictedSession,
+                        "SELECT * FROM " + fullyQualified,
+                        ".*Access Denied.*");
+            }
+        }
+        finally {
+            getQueryRunner().getAccessControl().reset();
+            assertUpdate(sessionWithDefaultSchema, "DROP MATERIALIZED VIEW storage_lockdown_definer_mv");
+            assertUpdate(sessionWithDefaultSchema, "DROP MATERIALIZED VIEW storage_lockdown_invoker_mv");
+            assertUpdate("DROP TABLE storage_lockdown_base");
+            assertUpdate("DROP SCHEMA IF EXISTS mv_locked_storage");
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -924,12 +924,13 @@ class StatementAnalyzer
                     buildSubqueryWithPredicate(viewQuery, tablePredicates.get(toSchemaTableName(viewName)))
                     : viewQuery;
             // Check if the owner has SELECT permission on the base tables
+            String ownerSessionSchema = isLegacyMaterializedViews(session) ? view.getSchema() : viewName.getSchemaName();
             StatementAnalyzer queryAnalyzer = new StatementAnalyzer(
                     analysis,
                     metadata,
                     sqlParser,
                     accessControl,
-                    buildOwnerSession(session, view.getOwner(), metadata.getSessionPropertyManager(), viewName.getCatalogName(), view.getSchema()),
+                    buildOwnerSession(session, view.getOwner(), metadata.getSessionPropertyManager(), viewName.getCatalogName(), ownerSessionSchema),
                     warningCollector);
             queryAnalyzer.analyze(refreshQuery, Scope.create());
 
@@ -2652,7 +2653,7 @@ class StatementAnalyzer
 
                 Session materializedViewSession = createViewSession(
                         Optional.of(materializedViewName.getCatalogName()),
-                        Optional.of(materializedViewDefinition.getSchema()),
+                        Optional.of(materializedViewName.getSchemaName()),
                         queryIdentity);
 
                 StatementAnalyzer materializedViewAnalyzer = new StatementAnalyzer(
@@ -2664,8 +2665,31 @@ class StatementAnalyzer
                         warningCollector);
                 materializedViewAnalyzer.analyze(viewQuery, scope);
 
-                Scope queryScope = process(dataTable, scope);
-                RelationType relationType = queryScope.getRelationType().withOnlyVisibleFields().withAlias(materializedViewName.getObjectName(), null);
+                // The storage table is a system-managed implementation detail; access control on it
+                // is bypassed during MV expansion. Direct access by name still goes through the
+                // outer analyzer's accessControl.
+                StatementAnalyzer storageTableAnalyzer = new StatementAnalyzer(
+                        analysis,
+                        metadata,
+                        sqlParser,
+                        new AllowAllAccessControl(),
+                        session,
+                        warningCollector);
+                Scope queryScope = storageTableAnalyzer.analyze(dataTable, scope);
+                // Re-point each field's originTable at the MV name (as processView does) so the
+                // outer ExpressionAnalyzer records column refs against the MV, not the storage table.
+                List<Field> outputFields = queryScope.getRelationType().withOnlyVisibleFields().getAllFields().stream()
+                        .map(field -> Field.newQualified(
+                                field.getNodeLocation(),
+                                QualifiedName.of(materializedViewName.getObjectName()),
+                                field.getName(),
+                                field.getType(),
+                                field.isHidden(),
+                                Optional.of(materializedViewName),
+                                field.getOriginColumnName(),
+                                field.isAliased()))
+                        .collect(toImmutableList());
+                RelationType relationType = new RelationType(outputFields);
                 analysis.unregisterMaterializedViewForAnalysis(materializedView);
 
                 Scope accessControlScope = Scope.builder()


### PR DESCRIPTION
## Description

Treat Iceberg materialized view storage tables as system-managed:

- Skip access control on the storage table during MV expansion.
- Re-point analyzer output fields at the MV name so column refs are recorded against
  the MV, not the storage table.
- Use the MV's own schema (not the storage schema) for the view-query and refresh
  sessions.
- Add `iceberg.materialized-view-default-storage-schema` config to place storage
  tables in a single schema.

Direct queries against a storage table by name still go through normal access
control. Legacy materialized views are unchanged.

## Motivation and Context

The non-legacy MV path checked SELECT on the storage table against the session user.
That let an unprivileged user bypass `SECURITY DEFINER` by querying
`__mv_storage__<view>` directly, and prevented operators from locking down the
storage schema without breaking legitimate MV reads.

Storage tables are not user-facing — operators should be able to lock down the
storage schema and have that be the entire access-control story.

## Impact

- New config `iceberg.materialized-view-default-storage-schema` (default: unset).
  Per-MV `storage_schema` still overrides.
- Non-legacy MV reads no longer require any privilege on the storage table.
- View-query and refresh sessions use the MV's schema for unqualified name resolution.

## Test Plan

Test integration tests have been added.

## Contributor checklist

- [x] Please make sure your submission complies with our contributing guide, in particular code style and commit standards.
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new properties.
- [x] Release notes follow the guidelines.
- [x] Adequate tests added.
- [x] CI passed.
- [x] No new dependencies.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix access control for materialized view storage tables when ``legacy_materialized_views=false``: storage-table access control is bypassed during MV expansion, while direct queries by name still go through access control.
* Add ``iceberg.materialized-view-default-storage-schema`` config to route storage tables into a single schema. Defaults to the materialized view's own schema; per-MV ``storage_schema`` overrides.
```

## Summary by Sourcery

Treat Iceberg materialized view storage tables as system-managed resources and adjust analysis, configuration, and tests accordingly.

New Features:
- Add configurable default schema for Iceberg materialized view storage tables via the iceberg.materialized-view-default-storage-schema property.

Bug Fixes:
- Bypass access control checks on Iceberg materialized view storage tables during materialized view expansion while preserving access control for direct storage-table queries.
- Align materialized view analysis to resolve unqualified names and record column references against the materialized view schema instead of the underlying storage schema.

Enhancements:
- Extend statement analysis for refresh and query of materialized views to use the view’s schema for owner sessions when legacy materialized views are disabled.

Documentation:
- Document the new iceberg.materialized-view-default-storage-schema configuration option in the Iceberg connector documentation.

Tests:
- Add integration-style tests covering default storage schema behavior, SECURITY DEFINER access without storage privileges, and end-to-end access control when the storage schema is locked down.