### PR TITLE
fix: Load coordinator plugins before standard plugins across bundles

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -90,29 +90,16 @@ public class PluginManagerUtil
             return;
         }
 
+        List<String> pluginsToLoad = new ArrayList<>();
+
         for (File file : listFiles(installedPluginsDir)) {
             if (file.isDirectory()) {
-                loadPlugin(
-                        file.getAbsolutePath(),
-                        resolver,
-                        spiPackages,
-                        coordinatorPluginServicesFile,
-                        pluginServicesFile,
-                        pluginInstaller,
-                        parent);
+                pluginsToLoad.add(file.getAbsolutePath());
             }
         }
 
-        for (String plugin : plugins) {
-            loadPlugin(
-                    plugin,
-                    resolver,
-                    spiPackages,
-                    coordinatorPluginServicesFile,
-                    pluginServicesFile,
-                    pluginInstaller,
-                    parent);
-        }
+        pluginsToLoad.addAll(plugins);
+        loadPlugins(pluginsToLoad, resolver, spiPackages, coordinatorPluginServicesFile, pluginServicesFile, pluginInstaller, parent);
 
         if (metadata != null) {
             metadata.verifyComparableOrderableContract();
@@ -121,8 +108,8 @@ public class PluginManagerUtil
         pluginsLoaded.set(true);
     }
 
-    public static void loadPlugin(
-            String plugin,
+    public static void loadPlugins(
+            List<String> pluginsList,
             ArtifactResolver resolver,
             List<String> spiPackages,
             String coordinatorPluginServicesFile,
@@ -131,23 +118,47 @@ public class PluginManagerUtil
             ClassLoader parent)
             throws Exception
     {
-        log.info("-- Loading plugin %s --", plugin);
-        URLClassLoader pluginClassLoader = buildClassLoader(
-                plugin,
-                resolver,
-                spiPackages,
-                coordinatorPluginServicesFile,
-                pluginServicesFile,
-                parent);
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader)) {
-            loadPlugin(pluginClassLoader, RouterPlugin.class, pluginInstaller);
-            loadPlugin(pluginClassLoader, CoordinatorPlugin.class, pluginInstaller);
-            loadPlugin(pluginClassLoader, Plugin.class, pluginInstaller);
+        List<PluginClassLoaderHandle> pluginClassLoaders = new ArrayList<>();
+        try {
+            for (String plugin : pluginsList) {
+                pluginClassLoaders.add(new PluginClassLoaderHandle(
+                        plugin,
+                        buildClassLoader(
+                                plugin,
+                                resolver,
+                                spiPackages,
+                                coordinatorPluginServicesFile,
+                                pluginServicesFile,
+                                parent)));
+            }
         }
-        log.info("-- Finished loading plugin %s --", plugin);
+        catch (Exception e) {
+            closePluginClassLoaders(pluginClassLoaders);
+            throw e;
+        }
+
+        // Ensuring all coordinator plugins are installed before any plugins across all plugin bundles.
+        // router plugins ordering is not relevant here.
+        loadPlugins(pluginClassLoaders, CoordinatorPlugin.class, pluginInstaller);
+        loadPlugins(pluginClassLoaders, Plugin.class, pluginInstaller);
+        loadPlugins(pluginClassLoaders, RouterPlugin.class, pluginInstaller);
     }
 
-    public static void loadPlugin(
+    private static void loadPlugins(
+            List<PluginClassLoaderHandle> pluginClassLoaders,
+            Class<?> clazz,
+            PluginInstaller pluginInstaller)
+    {
+        for (PluginClassLoaderHandle pluginClassLoader : pluginClassLoaders) {
+            log.info("-- Loading %s from plugin %s --", clazz.getSimpleName(), pluginClassLoader.getPlugin());
+            try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader.getClassLoader())) {
+                loadPlugin(pluginClassLoader.getClassLoader(), clazz, pluginInstaller);
+            }
+            log.info("-- Finished loading %s from plugin %s --", clazz.getSimpleName(), pluginClassLoader.getPlugin());
+        }
+    }
+
+    private static void loadPlugin(
             URLClassLoader pluginClassLoader,
             Class<?> clazz,
             PluginInstaller pluginInstaller)
@@ -161,6 +172,7 @@ public class PluginManagerUtil
 
         for (Object plugin : plugins) {
             log.info("Installing %s", plugin.getClass().getName());
+
             if (plugin instanceof Plugin) {
                 pluginInstaller.installPlugin((Plugin) plugin);
             }
@@ -291,6 +303,40 @@ public class PluginManagerUtil
         Set<String> plugins = discoverPlugins(artifact, classLoader, servicesFile, className);
         if (!plugins.isEmpty()) {
             writePluginServices(plugins, artifact.getFile(), servicesFile);
+        }
+    }
+
+    private static void closePluginClassLoaders(List<PluginClassLoaderHandle> pluginClassLoaders)
+    {
+        for (PluginClassLoaderHandle pluginClassLoader : pluginClassLoaders) {
+            try {
+                pluginClassLoader.getClassLoader().close();
+            }
+            catch (IOException e) {
+                log.warn(e, "Failed to close plugin classloader for %s", pluginClassLoader.getPlugin());
+            }
+        }
+    }
+
+    private static class PluginClassLoaderHandle
+    {
+        private final String plugin;
+        private final URLClassLoader classLoader;
+
+        private PluginClassLoaderHandle(String plugin, URLClassLoader classLoader)
+        {
+            this.plugin = plugin;
+            this.classLoader = classLoader;
+        }
+
+        public String getPlugin()
+        {
+            return plugin;
+        }
+
+        public URLClassLoader getClassLoader()
+        {
+            return classLoader;
         }
     }
 }


### PR DESCRIPTION
## Description
Load all `CoordinatorPlugin` implementations before standard `Plugin` implementations across plugin bundles, instead of relying on bundle name ordering.

## Motivation and Context
Plugin bundles are loaded in sorted order, so a standard plugin can be installed before a coordinator plugin that performs required server-side setup. This can cause plugin initialization to happen against incomplete coordinator state.

## Impact
No impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Reorder plugin initialization by batching plugin classloader creation and enforcing a fixed loading sequence for coordinator, regular, and router plugins.

Enhancements:
- Refactor plugin loading to collect all plugin paths first and then load them via a unified multi-plugin loader.
- Introduce a helper structure to track plugin identifiers with their classloaders and enhance logging around per-plugin, per-type loading progress.

## Summary by Sourcery

Ensure coordinator plugins are installed before standard plugins across all plugin bundles by centralizing plugin classloader creation and enforcing a consistent loading order.

Enhancements:
- Batch plugin bundle discovery and load them via a unified multi-plugin loader instead of loading each bundle independently.
- Enforce a global loading sequence that installs coordinator plugins before regular and router plugins across all plugin bundles.
- Improve plugin loading logging and resource handling by tracking plugin identifiers alongside their classloaders and closing classloaders on failures.