### PR TITLE
feat(spi): Add MaterializedViewStatistics to query event pipeline for MV debug info

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.session.ResourceEstimates;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.sql.analyzer.CTEInformationCollector;
+import com.facebook.presto.sql.analyzer.MaterializedViewInfoCollector;
 import com.facebook.presto.sql.planner.optimizations.OptimizerInformationCollector;
 import com.facebook.presto.sql.planner.optimizations.OptimizerResultCollector;
 import com.facebook.presto.transaction.TransactionManager;
@@ -109,6 +110,7 @@ public final class Session
     private final OptimizerInformationCollector optimizerInformationCollector = new OptimizerInformationCollector();
     private final OptimizerResultCollector optimizerResultCollector = new OptimizerResultCollector();
     private final CTEInformationCollector cteInformationCollector = new CTEInformationCollector();
+    private final MaterializedViewInfoCollector materializedViewInfoCollector = new MaterializedViewInfoCollector();
     private final Map<PlanNodeId, PlanNodeStatsEstimate> planNodeStatsMap = new HashMap<>();
     private final Map<PlanNodeId, PlanCostEstimate> planNodeCostMap = new HashMap<>();
 
@@ -349,6 +351,11 @@ public final class Session
     public CTEInformationCollector getCteInformationCollector()
     {
         return cteInformationCollector;
+    }
+
+    public MaterializedViewInfoCollector getMaterializedViewInfoCollector()
+    {
+        return materializedViewInfoCollector;
     }
 
     public Map<PlanNodeId, PlanNodeStatsEstimate> getPlanNodeStatsMap()

--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -282,6 +282,7 @@ public class QueryMonitor
                 Optional.empty(),
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty()));
 
         logQueryTimeline(queryInfo);
@@ -326,7 +327,8 @@ public class QueryMonitor
                         queryInfo.getPrestoSparkExecutionContext(),
                         getPlanHash(queryInfo.getPlanCanonicalInfo(), historyBasedPlanStatisticsTracker.getStatsEquivalentPlanRootNode(queryInfo.getQueryId())),
                         Optional.of(queryInfo.getPlanIdNodeMap()),
-                        Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateObject)));
+                        Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateObject),
+                        queryInfo.getMaterializedViewStatistics()));
 
         logQueryTimeline(queryInfo);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
+import com.facebook.presto.spi.eventlistener.MaterializedViewStatistics;
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -97,6 +98,7 @@ public class QueryInfo
     private final StatsAndCosts planStatsAndCosts;
     private final List<PlanOptimizerInformation> optimizerInformation;
     private final List<CTEInformation> cteInformationList;
+    private final Optional<MaterializedViewStatistics> materializedViewStatistics;
     private final Set<String> scalarFunctions;
     private final Set<String> aggregateFunctions;
     private final Set<String> windowFunctions;
@@ -144,6 +146,7 @@ public class QueryInfo
             @JsonProperty("planStatsAndCosts") StatsAndCosts planStatsAndCosts,
             @JsonProperty("optimizerInformation") List<PlanOptimizerInformation> optimizerInformation,
             @JsonProperty("cteInformation") List<CTEInformation> cteInformationList,
+            @JsonProperty("materializedViewStatistics") @Nullable MaterializedViewStatistics materializedViewStatistics,
             @JsonProperty("scalarFunctions") Set<String> scalarFunctions,
             @JsonProperty("aggregateFunctions") Set<String> aggregateFunctions,
             @JsonProperty("windowFunctions") Set<String> windowFunctions,
@@ -227,6 +230,7 @@ public class QueryInfo
         this.planStatsAndCosts = planStatsAndCosts;
         this.optimizerInformation = optimizerInformation;
         this.cteInformationList = cteInformationList;
+        this.materializedViewStatistics = Optional.ofNullable(materializedViewStatistics);
         this.scalarFunctions = scalarFunctions;
         this.aggregateFunctions = aggregateFunctions;
         this.windowFunctions = windowFunctions;
@@ -471,6 +475,12 @@ public class QueryInfo
     public List<CTEInformation> getCteInformationList()
     {
         return cteInformationList;
+    }
+
+    @JsonProperty
+    public Optional<MaterializedViewStatistics> getMaterializedViewStatistics()
+    {
+        return materializedViewStatistics;
     }
 
     @JsonProperty

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
+import com.facebook.presto.spi.eventlistener.MaterializedViewStatistics;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -476,6 +477,8 @@ public class QueryStateMachine
 
         List<StageId> runtimeOptimizedStages = allStages.stream().filter(StageInfo::isRuntimeOptimized).map(StageInfo::getStageId).collect(toImmutableList());
         QueryStats queryStats = getQueryStats(rootStage, allStages);
+        MaterializedViewStatistics mvStats = session.getMaterializedViewInfoCollector().getMaterializedViewStatistics();
+        MaterializedViewStatistics mvStatsOrNull = mvStats.isEmpty() ? null : mvStats;
         return new QueryInfo(
                 queryId,
                 session.toSessionRepresentation(),
@@ -514,6 +517,7 @@ public class QueryStateMachine
                 Optional.ofNullable(planStatsAndCosts.get()).orElseGet(StatsAndCosts::empty),
                 session.getOptimizerInformationCollector().getOptimizationInfo(),
                 session.getCteInformationCollector().getCTEInformationList(),
+                mvStatsOrNull,
                 scalarFunctions.get(),
                 aggregateFunctions.get(),
                 windowFunctions.get(),
@@ -1195,6 +1199,7 @@ public class QueryStateMachine
                 pruneHistogramsFromStatsAndCosts(queryInfo.getPlanStatsAndCosts()),
                 queryInfo.getOptimizerInformation(),
                 queryInfo.getCteInformationList(),
+                queryInfo.getMaterializedViewStatistics().orElse(null),
                 queryInfo.getScalarFunctions(),
                 queryInfo.getAggregateFunctions(),
                 queryInfo.getWindowFunctions(),
@@ -1315,6 +1320,7 @@ public class QueryStateMachine
                 StatsAndCosts.empty(),
                 queryInfo.getOptimizerInformation(),
                 queryInfo.getCteInformationList(),
+                queryInfo.getMaterializedViewStatistics().orElse(null),
                 queryInfo.getScalarFunctions(),
                 queryInfo.getAggregateFunctions(),
                 queryInfo.getWindowFunctions(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInfoCollector.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInfoCollector.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.eventlistener.MaterializedViewQueryInfo;
+import com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo;
+import com.facebook.presto.spi.eventlistener.MaterializedViewStatistics;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.ThreadSafe;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+@ThreadSafe
+public class MaterializedViewInfoCollector
+{
+    private static final int MAX_SAMPLE_PARTITIONS = 20;
+
+    @GuardedBy("this")
+    private final List<MaterializedViewQueryInfo> queryInfos = new ArrayList<>();
+
+    @GuardedBy("this")
+    private final List<MaterializedViewRewriteInfo> rewriteInfos = new ArrayList<>();
+
+    public synchronized void addQueryInfo(String materializedViewName, MaterializedViewStatus status)
+    {
+        List<String> baseTableNames = status.getPartitionsFromBaseTables().keySet().stream()
+                .map(SchemaTableName::toString)
+                .collect(toImmutableList());
+
+        List<String> sampleStalePartitions = new ArrayList<>();
+        int stalePartitionCount = 0;
+        for (MaterializedDataPredicates predicates : status.getPartitionsFromBaseTables().values()) {
+            for (TupleDomain<String> disjunct : predicates.getPredicateDisjuncts()) {
+                stalePartitionCount++;
+                if (sampleStalePartitions.size() < MAX_SAMPLE_PARTITIONS) {
+                    sampleStalePartitions.add(formatPartition(disjunct));
+                }
+            }
+        }
+
+        queryInfos.add(new MaterializedViewQueryInfo(
+                materializedViewName,
+                status.getMaterializedViewState(),
+                stalePartitionCount,
+                baseTableNames,
+                sampleStalePartitions));
+    }
+
+    public synchronized void addRewriteInfo(MaterializedViewRewriteInfo info)
+    {
+        rewriteInfos.add(info);
+    }
+
+    public synchronized List<MaterializedViewQueryInfo> getQueryInfos()
+    {
+        return ImmutableList.copyOf(queryInfos);
+    }
+
+    public synchronized List<MaterializedViewRewriteInfo> getRewriteInfos()
+    {
+        return ImmutableList.copyOf(rewriteInfos);
+    }
+
+    public synchronized MaterializedViewStatistics getMaterializedViewStatistics()
+    {
+        return new MaterializedViewStatistics(ImmutableList.copyOf(queryInfos), ImmutableList.copyOf(rewriteInfos));
+    }
+
+    private static String formatPartition(TupleDomain<String> disjunct)
+    {
+        if (disjunct.isNone() || !disjunct.getDomains().isPresent()) {
+            return "<none>";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Domain> entry : disjunct.getDomains().get().entrySet()) {
+            if (sb.length() > 0) {
+                sb.append('/');
+            }
+            sb.append(entry.getKey());
+            sb.append('=');
+            Domain domain = entry.getValue();
+            if (domain.isSingleValue()) {
+                Object value = domain.getSingleValue();
+                sb.append(value instanceof io.airlift.slice.Slice ? ((io.airlift.slice.Slice) value).toStringUtf8() : String.valueOf(value));
+            }
+            else {
+                sb.append("<complex>");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -29,6 +29,8 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
+import com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo;
+import com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo.RewriteStatus;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -365,6 +367,11 @@ public class MaterializedViewQueryOptimizer
 
         if (errorMessage.isPresent()) {
             log.warn("Rewrite failed for base table %s with error message { %s }. ", baseTable.getName(), errorMessage.get());
+            session.getMaterializedViewInfoCollector().addRewriteInfo(new MaterializedViewRewriteInfo(
+                    baseTable.getName().toString(),
+                    "",
+                    RewriteStatus.INCOMPATIBLE_SHAPE,
+                    errorMessage.get()));
             return querySpecification;
         }
 
@@ -375,13 +382,15 @@ public class MaterializedViewQueryOptimizer
         // TODO: Select the most compatible and efficient materialized view for query rewrite optimization https://github.com/prestodb/presto/issues/16431
         // TODO: Refactor query optimization code https://github.com/prestodb/presto/issues/16759
 
+        String baseTableName = baseTable.getName().toString();
+
         if (isMaterializedViewQueryRewriteCostBasedSelectionEnabled(session)) {
-            return rewriteWithAllCandidates(querySpecification, referencedMaterializedViews);
+            return rewriteWithAllCandidates(querySpecification, referencedMaterializedViews, baseTableName);
         }
 
         // Default path: return the first compatible MV
         for (QualifiedObjectName materializedViewName : referencedMaterializedViews) {
-            QuerySpecification rewrittenQuerySpecification = getRewrittenQuerySpecification(materializedViewName, querySpecification);
+            QuerySpecification rewrittenQuerySpecification = getRewrittenQuerySpecification(materializedViewName, querySpecification, baseTableName);
             if (rewrittenQuerySpecification != querySpecification) {
                 return rewrittenQuerySpecification;
             }
@@ -391,12 +400,13 @@ public class MaterializedViewQueryOptimizer
 
     private QueryBody rewriteWithAllCandidates(
             QuerySpecification originalQuery,
-            List<QualifiedObjectName> referencedMaterializedViews)
+            List<QualifiedObjectName> referencedMaterializedViews,
+            String baseTableName)
     {
         ImmutableList.Builder<QueryWithMVRewriteCandidates.MVRewriteCandidate> candidates = ImmutableList.builder();
 
         for (QualifiedObjectName materializedViewName : referencedMaterializedViews) {
-            QuerySpecification rewrittenQuerySpecification = getRewrittenQuerySpecification(materializedViewName, originalQuery);
+            QuerySpecification rewrittenQuerySpecification = getRewrittenQuerySpecification(materializedViewName, originalQuery, baseTableName);
             if (rewrittenQuerySpecification != originalQuery) {
                 candidates.add(new QueryWithMVRewriteCandidates.MVRewriteCandidate(
                         rewrittenQuerySpecification,
@@ -414,14 +424,14 @@ public class MaterializedViewQueryOptimizer
         return new QueryWithMVRewriteCandidates(originalQuery, candidateList);
     }
 
-    private QuerySpecification getRewrittenQuerySpecification(QualifiedObjectName materializedViewName, QuerySpecification originalQuerySpecification)
+    private QuerySpecification getRewrittenQuerySpecification(QualifiedObjectName materializedViewName, QuerySpecification originalQuerySpecification, String baseTableName)
     {
         MaterializedViewDefinition materializedViewDefinition = metadataResolver.getMaterializedView(materializedViewName).orElseThrow(() ->
                 new IllegalStateException("Materialized view definition not present in metadata as expected."));
         Table materializedViewTable = new Table(QualifiedName.of(materializedViewDefinition.getTable()));
         Query materializedViewQuery = (Query) sqlParser.createStatement(materializedViewDefinition.getOriginalSql(), createParsingOptions(session));
 
-        return new QuerySpecificationRewriter(materializedViewTable, materializedViewQuery, materializedViewName).rewrite(originalQuerySpecification);
+        return new QuerySpecificationRewriter(materializedViewTable, materializedViewQuery, materializedViewName, baseTableName).rewrite(originalQuerySpecification);
     }
 
     private class QuerySpecificationRewriter
@@ -430,6 +440,7 @@ public class MaterializedViewQueryOptimizer
         private final Table materializedView;
         private final Query materializedViewQuery;
         private final QualifiedObjectName materializedViewName;
+        private final String baseTableName;
 
         private MaterializedViewInfo materializedViewInfo;
         private Optional<Identifier> removablePrefix = Optional.empty();
@@ -438,11 +449,13 @@ public class MaterializedViewQueryOptimizer
         QuerySpecificationRewriter(
                 Table materializedView,
                 Query materializedViewQuery,
-                QualifiedObjectName materializedViewName)
+                QualifiedObjectName materializedViewName,
+                String baseTableName)
         {
             this.materializedView = requireNonNull(materializedView, "materialized view is null");
             this.materializedViewQuery = requireNonNull(materializedViewQuery, "materialized view query is null");
             this.materializedViewName = requireNonNull(materializedViewName, "materialized view name is null");
+            this.baseTableName = requireNonNull(baseTableName, "base table name is null");
         }
 
         public QuerySpecification rewrite(QuerySpecification querySpecification)
@@ -461,6 +474,11 @@ public class MaterializedViewQueryOptimizer
 
                 if (!isMaterializedViewDataConsistencyEnabled(session)) {
                     session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW_SUBQUERY_COUNT, NONE, 1);
+                    session.getMaterializedViewInfoCollector().addRewriteInfo(new MaterializedViewRewriteInfo(
+                            baseTableName,
+                            materializedViewName.toString(),
+                            RewriteStatus.SUCCESS,
+                            null));
                     return rewrittenQuerySpecification;
                 }
 
@@ -468,12 +486,27 @@ public class MaterializedViewQueryOptimizer
                 MaterializedViewStatus materializedViewStatus = getMaterializedViewStatus(querySpecification);
                 if (materializedViewStatus.isPartiallyMaterialized() || materializedViewStatus.isFullyMaterialized()) {
                     session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW_SUBQUERY_COUNT, NONE, 1);
+                    session.getMaterializedViewInfoCollector().addRewriteInfo(new MaterializedViewRewriteInfo(
+                            baseTableName,
+                            materializedViewName.toString(),
+                            RewriteStatus.SUCCESS,
+                            null));
                     return rewrittenQuerySpecification;
                 }
                 session.getRuntimeStats().addMetricValue(MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW_COUNT, NONE, 1);
+                session.getMaterializedViewInfoCollector().addRewriteInfo(new MaterializedViewRewriteInfo(
+                        baseTableName,
+                        materializedViewName.toString(),
+                        RewriteStatus.MV_STATUS_CHECK_FAILED,
+                        "Too many partitions missing"));
                 return querySpecification;
             }
             catch (Exception e) {
+                session.getMaterializedViewInfoCollector().addRewriteInfo(new MaterializedViewRewriteInfo(
+                        baseTableName,
+                        materializedViewName.toString(),
+                        RewriteStatus.EXCEPTION,
+                        e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
                 return querySpecification;
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2716,6 +2716,10 @@ class StatementAnalyzer
         {
             MaterializedViewStatus materializedViewStatus = getMaterializedViewStatus(materializedViewName, scope, materializedView);
 
+            session.getMaterializedViewInfoCollector().addQueryInfo(
+                    materializedViewName.toString(),
+                    materializedViewStatus);
+
             String materializedViewCreateSql = materializedViewDefinition.getOriginalSql();
 
             if (materializedViewStatus.isNotMaterialized() || materializedViewStatus.isTooManyPartitionsMissing()) {

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -200,6 +200,7 @@ public class TestQueryInfo
                 StatsAndCosts.empty(),
                 ImmutableList.of(),
                 ImmutableList.of(),
+                null,
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -156,6 +156,7 @@ public class TestBasicQueryInfo
                         StatsAndCosts.empty(),
                         ImmutableList.of(),
                         ImmutableList.of(),
+                        null,
                         ImmutableSet.of(),
                         ImmutableSet.of(),
                         ImmutableSet.of(),

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -316,6 +316,7 @@ public class TestQueryStateInfo
                 StatsAndCosts.empty(),
                 ImmutableList.of(),
                 ImmutableList.of(),
+                null,
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewInfoCollector.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewInfoCollector.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.eventlistener.MaterializedViewQueryInfo;
+import com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.FULLY_MATERIALIZED;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestMaterializedViewInfoCollector
+{
+    @Test
+    public void testEmptyCollector()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        assertTrue(collector.getQueryInfos().isEmpty());
+        assertTrue(collector.getRewriteInfos().isEmpty());
+    }
+
+    @Test
+    public void testAddQueryInfoFullyMaterialized()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        MaterializedViewStatus status = new MaterializedViewStatus(FULLY_MATERIALIZED);
+        collector.addQueryInfo("catalog.schema.mv1", status);
+
+        List<MaterializedViewQueryInfo> infos = collector.getQueryInfos();
+        assertEquals(infos.size(), 1);
+
+        MaterializedViewQueryInfo info = infos.get(0);
+        assertEquals(info.getMaterializedViewName(), "catalog.schema.mv1");
+        assertEquals(info.getFreshnessState(), FULLY_MATERIALIZED);
+        assertEquals(info.getStalePartitionCount(), 0);
+        assertTrue(info.getBaseTableNames().isEmpty());
+        assertTrue(info.getSampleStalePartitions().isEmpty());
+    }
+
+    @Test
+    public void testAddQueryInfoPartiallyMaterialized()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+
+        SchemaTableName baseTable = new SchemaTableName("schema1", "base_table");
+        MaterializedDataPredicates predicates = new MaterializedDataPredicates(
+                ImmutableList.of(TupleDomain.none(), TupleDomain.none()),
+                ImmutableList.of("ds"));
+
+        MaterializedViewStatus status = new MaterializedViewStatus(
+                PARTIALLY_MATERIALIZED,
+                ImmutableMap.of(baseTable, predicates),
+                Optional.of(1000L));
+
+        collector.addQueryInfo("catalog.schema.mv2", status);
+
+        List<MaterializedViewQueryInfo> infos = collector.getQueryInfos();
+        assertEquals(infos.size(), 1);
+
+        MaterializedViewQueryInfo info = infos.get(0);
+        assertEquals(info.getFreshnessState(), PARTIALLY_MATERIALIZED);
+        assertEquals(info.getStalePartitionCount(), 2);
+        assertEquals(info.getBaseTableNames(), ImmutableList.of("schema1.base_table"));
+    }
+
+    @Test
+    public void testAddRewriteInfoSuccess()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        MaterializedViewRewriteInfo info = new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv1",
+                "SUCCESS",
+                null);
+        collector.addRewriteInfo(info);
+
+        List<MaterializedViewRewriteInfo> infos = collector.getRewriteInfos();
+        assertEquals(infos.size(), 1);
+        assertEquals(infos.get(0).getBaseTableName(), "schema.base_table");
+        assertEquals(infos.get(0).getMaterializedViewName(), "schema.mv1");
+        assertEquals(infos.get(0).getStatus(), "SUCCESS");
+        assertNull(infos.get(0).getFailureReason());
+    }
+
+    @Test
+    public void testAddRewriteInfoFailure()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        MaterializedViewRewriteInfo info = new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv1",
+                "INCOMPATIBLE_SHAPE",
+                "query shape does not match");
+        collector.addRewriteInfo(info);
+
+        List<MaterializedViewRewriteInfo> infos = collector.getRewriteInfos();
+        assertEquals(infos.size(), 1);
+        assertEquals(infos.get(0).getStatus(), "INCOMPATIBLE_SHAPE");
+        assertEquals(infos.get(0).getFailureReason(), "query shape does not match");
+    }
+
+    @Test
+    public void testMultipleMvsPerBaseTable()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        collector.addRewriteInfo(new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv1",
+                "SUCCESS",
+                null));
+        collector.addRewriteInfo(new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv2",
+                "INCOMPATIBLE_SHAPE",
+                "missing columns"));
+
+        List<MaterializedViewRewriteInfo> infos = collector.getRewriteInfos();
+        assertEquals(infos.size(), 2);
+        assertEquals(infos.get(0).getMaterializedViewName(), "schema.mv1");
+        assertEquals(infos.get(1).getMaterializedViewName(), "schema.mv2");
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testReturnedQueryInfoListIsImmutable()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        collector.addQueryInfo("catalog.schema.mv1", new MaterializedViewStatus(FULLY_MATERIALIZED));
+        collector.getQueryInfos().add(new MaterializedViewQueryInfo(
+                "x", FULLY_MATERIALIZED, 0, ImmutableList.of(), ImmutableList.of()));
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testReturnedRewriteInfoListIsImmutable()
+    {
+        MaterializedViewInfoCollector collector = new MaterializedViewInfoCollector();
+        collector.addRewriteInfo(new MaterializedViewRewriteInfo(
+                "schema.base", "schema.mv", "SUCCESS", null));
+        collector.getRewriteInfos().add(new MaterializedViewRewriteInfo(
+                "x", "y", "z", null));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -2082,6 +2082,116 @@ public class TestMaterializedViewQueryOptimizer
                 });
     }
 
+    @Test
+    public void testCollectorPopulatedOnSuccessfulRewrite()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(TEST_SESSION, session -> {
+                    Query baseQuery = (Query) SQL_PARSER.createStatement(baseQuerySql, createParsingOptions(session));
+
+                    metadata.createMaterializedView(
+                            session,
+                            TPCH_CATALOG,
+                            null,
+                            createStubConnectorMaterializedViewDefinition(
+                                    VIEW_1,
+                                    originalViewSql,
+                                    SESSION_SCHEMA,
+                                    ImmutableList.of(new SchemaTableName(SESSION_SCHEMA, BASE_TABLE_1))),
+                            false);
+
+                    new MaterializedViewQueryOptimizer(
+                            metadata, session, SQL_PARSER, accessControl, domainTranslator)
+                            .process(baseQuery);
+
+                    List<com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo> rewriteInfos =
+                            session.getMaterializedViewInfoCollector().getRewriteInfos();
+
+                    assertEquals(rewriteInfos.isEmpty(), false, "Rewrite info should be populated after successful rewrite");
+
+                    boolean hasSuccess = rewriteInfos.stream().anyMatch(r -> "SUCCESS".equals(r.getStatus()));
+                    assertEquals(hasSuccess, true, "Should have a SUCCESS rewrite entry");
+
+                    com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo successInfo =
+                            rewriteInfos.stream().filter(r -> "SUCCESS".equals(r.getStatus())).findFirst().get();
+                    assertEquals(successInfo.getBaseTableName(), BASE_TABLE_1);
+
+                    metadata.dropMaterializedView(session, QualifiedObjectName.valueOf(TPCH_CATALOG, SESSION_SCHEMA, BASE_TABLE_1));
+                });
+    }
+
+    @Test
+    public void testCollectorPopulatedOnIncompatibleShape()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        // HAVING clause is rejected by MaterializedViewRewriteQueryShapeValidator
+        String baseQuerySql = format("SELECT a, count(b) FROM %s GROUP BY a HAVING count(b) > 1", BASE_TABLE_1);
+
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(TEST_SESSION, session -> {
+                    Query baseQuery = (Query) SQL_PARSER.createStatement(baseQuerySql, createParsingOptions(session));
+
+                    metadata.createMaterializedView(
+                            session,
+                            TPCH_CATALOG,
+                            null,
+                            createStubConnectorMaterializedViewDefinition(
+                                    VIEW_1,
+                                    originalViewSql,
+                                    SESSION_SCHEMA,
+                                    ImmutableList.of(new SchemaTableName(SESSION_SCHEMA, BASE_TABLE_1))),
+                            false);
+
+                    new MaterializedViewQueryOptimizer(
+                            metadata, session, SQL_PARSER, accessControl, domainTranslator)
+                            .process(baseQuery);
+
+                    List<com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo> rewriteInfos =
+                            session.getMaterializedViewInfoCollector().getRewriteInfos();
+
+                    assertEquals(rewriteInfos.isEmpty(), false, "Rewrite info should be populated for incompatible shape");
+
+                    boolean hasIncompatible = rewriteInfos.stream().anyMatch(r -> "INCOMPATIBLE_SHAPE".equals(r.getStatus()));
+                    assertEquals(hasIncompatible, true, "Should have an INCOMPATIBLE_SHAPE rewrite entry");
+
+                    com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo info =
+                            rewriteInfos.stream().filter(r -> "INCOMPATIBLE_SHAPE".equals(r.getStatus())).findFirst().get();
+                    assertEquals(info.getBaseTableName(), BASE_TABLE_1);
+
+                    metadata.dropMaterializedView(session, QualifiedObjectName.valueOf(TPCH_CATALOG, SESSION_SCHEMA, BASE_TABLE_1));
+                });
+    }
+
+    @Test
+    public void testCollectorEmptyWhenNoMvReferenced()
+    {
+        // Query a table that has no referenced MVs (t7 is never used as a base table for any MV)
+        String baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_7);
+
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(TEST_SESSION, session -> {
+                    Query baseQuery = (Query) SQL_PARSER.createStatement(baseQuerySql, createParsingOptions(session));
+
+                    new MaterializedViewQueryOptimizer(
+                            metadata, session, SQL_PARSER, accessControl, domainTranslator)
+                            .process(baseQuery);
+
+                    List<com.facebook.presto.spi.eventlistener.MaterializedViewRewriteInfo> rewriteInfos =
+                            session.getMaterializedViewInfoCollector().getRewriteInfos();
+
+                    assertEquals(rewriteInfos.isEmpty(), true, "No rewrite info when no MVs exist for the table");
+                });
+    }
+
     private MaterializedViewDefinition createStubConnectorMaterializedViewDefinition(String viewName, String viewSql, String schema, List<SchemaTableName> baseTables)
     {
         return new MaterializedViewDefinition(

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -218,7 +218,8 @@ public class TestEventListenerManager
                 prestoSparkExecutionContext,
                 hboPlanHash,
                 planIdNodeMap,
-                Optional.of(updateInfo.getUpdateObject()));
+                Optional.of(updateInfo.getUpdateObject()),
+                Optional.empty());
     }
 
     public static QueryStatistics createDummyQueryStatistics()

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/PrestoEventData.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/PrestoEventData.java
@@ -149,7 +149,8 @@ public final class PrestoEventData
                 Optional.empty(), // prestoSparkExecutionContext
                 Collections.emptyMap(), // hboPlanHash
                 Optional.empty(), // planNodeIdMap
-                Optional.empty()); // qualifiedName
+                Optional.empty(), // qualifiedName
+                Optional.empty()); // materializedViewStatistics
 
         queryCreatedEvent = new QueryCreatedEvent(
                 Instant.parse("2025-04-28T11:23:55.384424Z"),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -387,6 +387,7 @@ public class PrestoSparkQueryExecutionFactory
                 planAndMore.map(PlanAndMore::getPlan).map(Plan::getStatsAndCosts).orElseGet(StatsAndCosts::empty),
                 session.getOptimizerInformationCollector().getOptimizationInfo(),
                 ImmutableList.of(),
+                null,
                 planAndMore.map(PlanAndMore::getInvokedScalarFunctions).orElseGet(ImmutableSet::of),
                 planAndMore.map(PlanAndMore::getInvokedAggregateFunctions).orElseGet(ImmutableSet::of),
                 planAndMore.map(PlanAndMore::getInvokedWindowFunctions).orElseGet(ImmutableSet::of),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewQueryInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewQueryInfo.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewQueryInfo
+{
+    private final String materializedViewName;
+    private final MaterializedViewState freshnessState;
+    private final int stalePartitionCount;
+    private final List<String> baseTableNames;
+    private final List<String> sampleStalePartitions;
+
+    @JsonCreator
+    public MaterializedViewQueryInfo(
+            @JsonProperty("materializedViewName") String materializedViewName,
+            @JsonProperty("freshnessState") MaterializedViewState freshnessState,
+            @JsonProperty("stalePartitionCount") int stalePartitionCount,
+            @JsonProperty("baseTableNames") List<String> baseTableNames,
+            @JsonProperty("sampleStalePartitions") List<String> sampleStalePartitions)
+    {
+        this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+        this.freshnessState = requireNonNull(freshnessState, "freshnessState is null");
+        this.stalePartitionCount = stalePartitionCount;
+        this.baseTableNames = requireNonNull(baseTableNames, "baseTableNames is null");
+        this.sampleStalePartitions = requireNonNull(sampleStalePartitions, "sampleStalePartitions is null");
+    }
+
+    @JsonProperty
+    public String getMaterializedViewName()
+    {
+        return materializedViewName;
+    }
+
+    @JsonProperty
+    public MaterializedViewState getFreshnessState()
+    {
+        return freshnessState;
+    }
+
+    @JsonProperty
+    public int getStalePartitionCount()
+    {
+        return stalePartitionCount;
+    }
+
+    @JsonProperty
+    public List<String> getBaseTableNames()
+    {
+        return baseTableNames;
+    }
+
+    @JsonProperty
+    public List<String> getSampleStalePartitions()
+    {
+        return sampleStalePartitions;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewRewriteInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewRewriteInfo.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewRewriteInfo
+{
+    public enum RewriteStatus
+    {
+        SUCCESS,
+        NO_MV_FOUND,
+        INCOMPATIBLE_SHAPE,
+        MV_STATUS_CHECK_FAILED,
+        EXCEPTION
+    }
+
+    private final String baseTableName;
+    private final String materializedViewName;
+    private final String status;
+    private final String failureReason;
+
+    @JsonCreator
+    public MaterializedViewRewriteInfo(
+            @JsonProperty("baseTableName") String baseTableName,
+            @JsonProperty("materializedViewName") String materializedViewName,
+            @JsonProperty("status") String status,
+            @JsonProperty("failureReason") @Nullable String failureReason)
+    {
+        this.baseTableName = requireNonNull(baseTableName, "baseTableName is null");
+        this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+        this.status = requireNonNull(status, "status is null");
+        this.failureReason = failureReason;
+    }
+
+    public MaterializedViewRewriteInfo(
+            String baseTableName,
+            String materializedViewName,
+            RewriteStatus status,
+            @Nullable String failureReason)
+    {
+        this(baseTableName, materializedViewName, status.name(), failureReason);
+    }
+
+    @JsonProperty
+    public String getBaseTableName()
+    {
+        return baseTableName;
+    }
+
+    @JsonProperty
+    public String getMaterializedViewName()
+    {
+        return materializedViewName;
+    }
+
+    @JsonProperty
+    public String getStatus()
+    {
+        return status;
+    }
+
+    @Nullable
+    @JsonProperty
+    public String getFailureReason()
+    {
+        return failureReason;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/MaterializedViewStatistics.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewStatistics
+{
+    private final List<MaterializedViewQueryInfo> queryInfos;
+    private final List<MaterializedViewRewriteInfo> rewriteInfos;
+
+    @JsonCreator
+    public MaterializedViewStatistics(
+            @JsonProperty("queryInfos") List<MaterializedViewQueryInfo> queryInfos,
+            @JsonProperty("rewriteInfos") List<MaterializedViewRewriteInfo> rewriteInfos)
+    {
+        this.queryInfos = requireNonNull(queryInfos, "queryInfos is null");
+        this.rewriteInfos = requireNonNull(rewriteInfos, "rewriteInfos is null");
+    }
+
+    @JsonProperty
+    public List<MaterializedViewQueryInfo> getQueryInfos()
+    {
+        return queryInfos;
+    }
+
+    @JsonProperty
+    public List<MaterializedViewRewriteInfo> getRewriteInfos()
+    {
+        return rewriteInfos;
+    }
+
+    public boolean isEmpty()
+    {
+        return queryInfos.isEmpty() && rewriteInfos.isEmpty();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -60,6 +60,7 @@ public class QueryCompletedEvent
     private final Map<PlanCanonicalizationStrategy, String> hboPlanHash;
     private final Optional<Map<PlanNodeId, PlanNode>> planIdNodeMap;
     private final Optional<String> qualifiedName;
+    private final Optional<MaterializedViewStatistics> materializedViewStatistics;
 
     public QueryCompletedEvent(
             QueryMetadata metadata,
@@ -89,7 +90,8 @@ public class QueryCompletedEvent
             Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext,
             Map<PlanCanonicalizationStrategy, String> hboPlanHash,
             Optional<Map<PlanNodeId, PlanNode>> planNodeIdMap,
-            Optional<String> qualifiedName)
+            Optional<String> qualifiedName,
+            Optional<MaterializedViewStatistics> materializedViewStatistics)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
@@ -119,6 +121,7 @@ public class QueryCompletedEvent
         this.hboPlanHash = requireNonNull(hboPlanHash, "planHash is null");
         this.planIdNodeMap = requireNonNull(planNodeIdMap, "planNodeIdMap is null");
         this.qualifiedName = qualifiedName;
+        this.materializedViewStatistics = requireNonNull(materializedViewStatistics, "materializedViewStatistics is null");
     }
 
     public QueryMetadata getMetadata()
@@ -259,5 +262,10 @@ public class QueryCompletedEvent
     public Optional<String> getQualifiedName()
     {
         return qualifiedName;
+    }
+
+    public Optional<MaterializedViewStatistics> getMaterializedViewStatistics()
+    {
+        return materializedViewStatistics;
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/eventlistener/TestMaterializedViewEventClasses.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/eventlistener/TestMaterializedViewEventClasses.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static org.testng.Assert.assertEquals;
+
+public class TestMaterializedViewEventClasses
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module());
+
+    @Test
+    public void testQueryInfoRoundtrip()
+            throws Exception
+    {
+        MaterializedViewQueryInfo original = new MaterializedViewQueryInfo(
+                "catalog.schema.mv1",
+                PARTIALLY_MATERIALIZED,
+                3,
+                Arrays.asList("schema.base1", "schema.base2"),
+                Arrays.asList("ds=2024-01-01", "ds=2024-01-02"));
+
+        String json = MAPPER.writeValueAsString(original);
+        MaterializedViewQueryInfo deserialized = MAPPER.readValue(json, MaterializedViewQueryInfo.class);
+
+        assertEquals(deserialized.getMaterializedViewName(), original.getMaterializedViewName());
+        assertEquals(deserialized.getFreshnessState(), original.getFreshnessState());
+        assertEquals(deserialized.getStalePartitionCount(), original.getStalePartitionCount());
+        assertEquals(deserialized.getBaseTableNames(), original.getBaseTableNames());
+        assertEquals(deserialized.getSampleStalePartitions(), original.getSampleStalePartitions());
+    }
+
+    @Test
+    public void testRewriteInfoRoundtrip()
+            throws Exception
+    {
+        MaterializedViewRewriteInfo original = new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv1",
+                "SUCCESS",
+                null);
+
+        String json = MAPPER.writeValueAsString(original);
+        MaterializedViewRewriteInfo deserialized = MAPPER.readValue(json, MaterializedViewRewriteInfo.class);
+
+        assertEquals(deserialized.getBaseTableName(), original.getBaseTableName());
+        assertEquals(deserialized.getMaterializedViewName(), original.getMaterializedViewName());
+        assertEquals(deserialized.getStatus(), original.getStatus());
+        assertEquals(deserialized.getFailureReason(), original.getFailureReason());
+    }
+
+    @Test
+    public void testRewriteInfoRoundtripWithFailureReason()
+            throws Exception
+    {
+        MaterializedViewRewriteInfo original = new MaterializedViewRewriteInfo(
+                "schema.base_table",
+                "schema.mv2",
+                "INCOMPATIBLE_SHAPE",
+                "query shape does not match MV definition");
+
+        String json = MAPPER.writeValueAsString(original);
+        MaterializedViewRewriteInfo deserialized = MAPPER.readValue(json, MaterializedViewRewriteInfo.class);
+
+        assertEquals(deserialized.getBaseTableName(), original.getBaseTableName());
+        assertEquals(deserialized.getMaterializedViewName(), original.getMaterializedViewName());
+        assertEquals(deserialized.getStatus(), original.getStatus());
+        assertEquals(deserialized.getFailureReason(), "query shape does not match MV definition");
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -546,6 +546,7 @@ public class TestQueryManager
                 StatsAndCosts.empty(),
                 ImmutableList.of(),
                 ImmutableList.of(),
+                null,
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),


### PR DESCRIPTION
Summary:
Adds structured materialized view metadata tracking to the query event pipeline. Two new SPI data classes (`MaterializedViewQueryInfo`, `MaterializedViewRewriteInfo`) wrapped in `MaterializedViewStatistics` capture MV freshness state and query rewrite outcomes per base table / MV pair.

Uses the collector-on-Session pattern (like `OptimizerInformationCollector`). `MaterializedViewInfoCollector` on `Session` is populated in `StatementAnalyzer.getMaterializedViewSQL()` for freshness and `MaterializedViewQueryOptimizer` for rewrite outcomes. Data flows through QueryStateMachine -> QueryInfo -> QueryMonitor -> QueryCompletedEvent as `Optional<MaterializedViewStatistics>`.

== RELEASE NOTES ==

General Changes
* Add `MaterializedViewStatistics` to `QueryCompletedEvent` containing per-MV freshness state (`MaterializedViewQueryInfo`) and per-base-table rewrite outcomes (`MaterializedViewRewriteInfo`). Event listeners can use this to track which materialized views were considered during query optimization, their freshness state, and whether query rewriting succeeded or failed with a categorized reason.

Differential Revision: D104112464


