### PR TITLE
fix(ui): Fix timeline legend layout with gaps between colored bars

### DIFF
--- a/presto-ui/src/components/QuerySplitsView.tsx
+++ b/presto-ui/src/components/QuerySplitsView.tsx
@@ -120,25 +120,18 @@ export default function SplitView({ data, show }): React.ReactElement {
 
     return (
         <div className={clsx(!show && "visually-hidden")}>
-            <div id="legend" className="row">
-                <div>
+            <div id="legend">
+                <div className="legend-bars">
                     <div className="red bar"></div>
-                    <div className="text">Created</div>
-                </div>
-                <div>
                     <div className="green bar"></div>
-                    <div className="text">First split started</div>
-                </div>
-                <div>
                     <div className="blue bar"></div>
-                    <div className="text">Last split started</div>
-                </div>
-                <div>
                     <div className="orange bar"></div>
-                    <div className="text">Last split ended</div>
                 </div>
-                <div>
-                    <div className="bar empty"></div>
+                <div className="legend-labels">
+                    <div className="text">Created</div>
+                    <div className="text">First split started</div>
+                    <div className="text">Last split started</div>
+                    <div className="text">Last split ended</div>
                     <div className="text">Ended</div>
                 </div>
             </div>

--- a/presto-ui/src/components/Splits.tsx
+++ b/presto-ui/src/components/Splits.tsx
@@ -171,25 +171,18 @@ export default function Split(): React.ReactElement {
                     </div>
                 </div>
             )}
-            <div id="legend" className="row">
-                <div>
+            <div id="legend">
+                <div className="legend-bars">
                     <div className="red bar"></div>
-                    <div className="text">Created</div>
-                </div>
-                <div>
                     <div className="green bar"></div>
-                    <div className="text">First split started</div>
-                </div>
-                <div>
                     <div className="blue bar"></div>
-                    <div className="text">Last split started</div>
-                </div>
-                <div>
                     <div className="orange bar"></div>
-                    <div className="text">Last split ended</div>
                 </div>
-                <div>
-                    <div className="bar empty"></div>
+                <div className="legend-labels">
+                    <div className="text">Created</div>
+                    <div className="text">First split started</div>
+                    <div className="text">Last split started</div>
+                    <div className="text">Last split ended</div>
                     <div className="text">Ended</div>
                 </div>
             </div>

--- a/presto-ui/src/static/assets/presto.css
+++ b/presto-ui/src/static/assets/presto.css
@@ -59,11 +59,61 @@ pre {
 /** Bootstrap overrides **/
 /** =================== **/
 
-#legend > div{
+#legend {
+    padding: 10px 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#legend .legend-bars {
+    display: flex;
+    width: 800px;
+    margin-bottom: 5px;
+}
+
+#legend .legend-bars .bar {
+    border-style: solid;
+    border-width: 1px;
     width: 200px;
-    margin-left: 60px;
+    height: 4px;
+    flex-shrink: 0;
+}
+
+#legend .legend-labels {
+    display: flex;
+    width: 800px;
+    justify-content: space-between;
+}
+
+#legend .legend-labels .text {
     font-size: 14px;
-    color:#999999;
+    color: #999999;
+    white-space: nowrap;
+}
+
+#legend .red {
+    background-color: #F2DEDE;
+    border-color: #F2AEAE;
+}
+
+#legend .green {
+    background-color: #DFF0DB;
+    border-color: #B8F0AA;
+}
+
+#legend .blue {
+    background-color: #E3E9FC;
+    border-color: #B0C3FC;
+}
+
+#legend .orange {
+    background-color: #FFA500;
+    border-color: #B0C3FC;
+}
+
+#legend .empty {
+    border-style: none;
 }
 
 .search-bar{
@@ -158,7 +208,7 @@ pre {
 }
 
 .dropdown-menu > li > a:hover {
-    color: #fff; 
+    color: #fff;
     background-color: #d7d4d4;
 }
 
@@ -254,7 +304,6 @@ pre {
 .navbar img {
     width: 40px;
     height: auto;
-    
 }
 
 .navbar-cluster-info {

--- a/presto-ui/src/static/timeline.html
+++ b/presto-ui/src/static/timeline.html
@@ -66,39 +66,6 @@
             background-color: #FFA500;
             border-color: #B0C3FC;
         }
-        #legend {
-            padding: 10px 40px;
-            display: grid;
-            grid-template-columns: 1fr 200px 200px 200px 200px 1fr;
-        }
-        #legend .bar {
-            border-style: solid;
-            border-width: 1px;
-            width: 200px;
-            height: 4px;
-        }
-        #legend .text {
-            margin-left: -20px;
-        }
-        #legend .red {
-            background-color: #F2DEDE;
-            border-color: #F2AEAE;
-        }
-        #legend .green {
-            background-color: #DFF0DB;
-            border-color: #B8F0AA;
-        }
-        #legend .blue {
-            background-color: #E3E9FC;
-            border-color: #B0C3FC;
-        }
-        #legend .orange {
-            background-color: #FFA500;
-            border-color: #B0C3FC;
-        }
-        #legend .empty {
-            border-style: none;
-        }
     </style>
 </head>
 


### PR DESCRIPTION
## Description
The timeline legend had layout issues with gaps appearing between the
colored phase bars due to conflicting CSS margin settings. This fix
restructures the legend to use a flexbox layout with separate containers
for bars and labels, and moves all legend CSS to presto.css for React
component support.

Changes:
- Restructure legend HTML in Splits.tsx and QuerySplitsView.tsx to use
  separate .legend-bars and .legend-labels containers
- Move all legend CSS rules from timeline.html inline styles to presto.css
  so React components have access to the styles
- Replace generic '#legend > div { width: 200px; }' with specific rules
  for .legend-bars and .legend-labels containers to fix width constraint
  that would break flex layout
- Bars now display continuously without gaps (800px width, 4x200px bars)
- Labels positioned at phase boundaries using justify-content: space-between

The legend now correctly displays with bars aligned continuously and text
labels positioned at the appropriate phase transition points. React
components now share the same CSS from presto.css instead of relying on
inline styles.

## Motivation and Context
I found the legend part of the `Splits` view is incorrect. Need to fix it.

## Impact
No API change. Correct the layout of the legend of the `Splits` view of the `Query Details` page.

## Test Plan
Check the legend after the change.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update the Splits view timeline legend layout to render continuous phase bars and correctly aligned labels using a flexbox-based structure.

Enhancements:
- Restructure the timeline legend markup in Splits and QuerySplitsView to separate phase bars from their labels for more predictable layout.
- Adjust the timeline legend CSS to use a fixed-width flexbox layout for bars and labels, eliminating spacing gaps between colored bars.
- Simplify global legend styling in presto.css by removing conflicting margins that distorted the legend appearance.