### PR TITLE
refactor(planner): Extract shared expression rewriter for MV query optimizer (#27732)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -33,15 +33,20 @@ import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Rollup;
+import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.Table;
 import com.google.common.collect.ImmutableList;
@@ -401,6 +406,47 @@ public final class MaterializedViewUtils
         else {
             return combineDisjuncts(disjuncts);
         }
+    }
+
+    public static FunctionCall rewriteAssociativeFunction(FunctionCall node, Expression derivedColumnExpression)
+    {
+        if (node.isDistinct()) {
+            throw new SemanticException(NOT_SUPPORTED, node,
+                    node.getName().getSuffix() + "(DISTINCT) is not supported for materialized view query rewrite optimization");
+        }
+        return new FunctionCall(
+                node.getName().equals(COUNT) ? SUM : node.getName(),
+                node.getWindow(),
+                node.getFilter(),
+                node.getOrderBy(),
+                node.isDistinct(),
+                node.isIgnoreNulls(),
+                ImmutableList.of(derivedColumnExpression));
+    }
+
+    public static GroupingElement rewriteGroupingElement(GroupingElement element, java.util.function.Function<Expression, Expression> rewriter)
+    {
+        if (element instanceof GroupingSets) {
+            ImmutableList.Builder<List<Expression>> rewrittenSets = ImmutableList.builder();
+            for (List<Expression> set : ((GroupingSets) element).getSets()) {
+                rewrittenSets.add(set.stream().map(rewriter).collect(toImmutableList()));
+            }
+            return new GroupingSets(rewrittenSets.build());
+        }
+
+        List<Expression> rewritten = element.getExpressions().stream()
+                .map(rewriter)
+                .collect(toImmutableList());
+        if (element instanceof SimpleGroupBy) {
+            return new SimpleGroupBy(rewritten);
+        }
+        if (element instanceof Cube) {
+            return new Cube(rewritten);
+        }
+        if (element instanceof Rollup) {
+            return new Rollup(rewritten);
+        }
+        return element;
     }
 
     public static Relation resolveTableName(Relation relation, Session session, Metadata metadata)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.MaterializedViewUtils;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.sql.MaterializedViewUtils.ASSOCIATIVE_REWRITE_FUNCTIONS;
+import static com.facebook.presto.sql.MaterializedViewUtils.NON_ASSOCIATIVE_REWRITE_FUNCTIONS;
+import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewExpressionRewriter
+{
+    private final MaterializedViewInfo mvInfo;
+    private final Set<String> builtInScalarFunctionNames;
+    private Optional<Set<Expression>> expressionsInGroupBy = Optional.empty();
+
+    public MaterializedViewExpressionRewriter(MaterializedViewInfo mvInfo, Set<String> builtInScalarFunctionNames)
+    {
+        this.mvInfo = requireNonNull(mvInfo, "mvInfo is null");
+        this.builtInScalarFunctionNames = requireNonNull(builtInScalarFunctionNames, "builtInScalarFunctionNames is null");
+    }
+
+    public void setExpressionsInGroupBy(Optional<Set<Expression>> expressionsInGroupBy)
+    {
+        this.expressionsInGroupBy = requireNonNull(expressionsInGroupBy, "expressionsInGroupBy is null");
+    }
+
+    public Expression rewriteIdentifier(Identifier node)
+    {
+        Map<Expression, Identifier> columnMap = mvInfo.getBaseToViewColumnMap();
+        if (!columnMap.containsKey(node)) {
+            throw new IllegalStateException("Materialized view definition does not contain mapping for the column: " + node.getValue());
+        }
+        return new Identifier(columnMap.get(node).getValue(), node.isDelimited());
+    }
+
+    public Expression rewriteFunctionCall(FunctionCall node, Function<Expression, Expression> argRewriter)
+    {
+        Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
+
+        if (NON_ASSOCIATIVE_REWRITE_FUNCTIONS.containsKey(node.getName())) {
+            return MaterializedViewUtils.rewriteNonAssociativeFunction(node, baseToViewColumnMap);
+        }
+
+        if (!ASSOCIATIVE_REWRITE_FUNCTIONS.contains(node.getName())) {
+            if (!isScalarFunction(node)) {
+                throw new SemanticException(NOT_SUPPORTED, node, "Unsupported function for materialized view rewrite: " + node.getName());
+            }
+            return rebuildWithRewrittenArgs(node, argRewriter);
+        }
+
+        if (baseToViewColumnMap.containsKey(node)) {
+            return MaterializedViewUtils.rewriteAssociativeFunction(node, baseToViewColumnMap.get(node));
+        }
+
+        if (mvInfo.getGroupBy().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Materialized view does not pre-compute aggregate: " + node.getName());
+        }
+
+        return rebuildWithRewrittenArgs(node, argRewriter);
+    }
+
+    public boolean isScalarFunction(FunctionCall functionCall)
+    {
+        return !functionCall.getWindow().isPresent()
+                && builtInScalarFunctionNames.contains(functionCall.getName().getSuffix().toLowerCase(Locale.ENGLISH));
+    }
+
+    // Determines whether an expression in a SELECT clause can be safely rewritten
+    // when the materialized view has a GROUP BY. Returns false for dimension columns
+    // (which require matching GROUP BY in the base query) and true for expressions
+    // that can be rolled up or computed from the MV's pre-aggregated data.
+    public boolean isRewritableWithMvGroupBy(Set<Expression> mvGroupBy, Expression expression)
+    {
+        // Dimension column — MV collapses rows on this column, not rewritable
+        // without matching GROUP BY in the base query
+        if (isExpressionInMvGroupBy(expression, mvGroupBy)) {
+            return false;
+        }
+
+        // Rewritable aggregate (SUM, COUNT, MIN, MAX, AVG) — rollup is always safe
+        if (expression instanceof FunctionCall
+                && (ASSOCIATIVE_REWRITE_FUNCTIONS.contains(((FunctionCall) expression).getName())
+                || MaterializedViewUtils.validateNonAssociativeFunctionRewrite(
+                        (FunctionCall) expression, mvInfo.getBaseToViewColumnMap()))) {
+            return true;
+        }
+
+        // Non-dimension column mapped in MV — safe to rewrite
+        if (mvInfo.getBaseToViewColumnMap().containsKey(expression)) {
+            return true;
+        }
+
+        // Scalar expression (IF, CAST, ABS, arithmetic, etc.) — safe only when
+        // the base query has GROUP BY. Without GROUP BY, the MV collapses rows
+        // and these expressions would silently lose duplicates.
+        if (expressionsInGroupBy.isPresent()
+                && !(expression instanceof Identifier)
+                && (!(expression instanceof FunctionCall) || isScalarFunction((FunctionCall) expression))) {
+            return true;
+        }
+
+        // Unrecognized expression — not rewritable
+        return false;
+    }
+
+    public boolean isExpressionInMvGroupBy(Expression expression, Set<Expression> mvGroupBy)
+    {
+        if (mvGroupBy.contains(expression)) {
+            return true;
+        }
+        Identifier viewColumn = mvInfo.getBaseToViewColumnMap().get(expression);
+        return viewColumn != null && mvGroupBy.contains(viewColumn);
+    }
+
+    private static FunctionCall rebuildWithRewrittenArgs(FunctionCall node, Function<Expression, Expression> argRewriter)
+    {
+        ImmutableList.Builder<Expression> rewrittenArgs = ImmutableList.builder();
+        for (Expression argument : node.getArguments()) {
+            rewrittenArgs.add(argRewriter.apply(argument));
+        }
+        return new FunctionCall(
+                node.getName(),
+                node.getWindow(),
+                node.getFilter(),
+                node.getOrderBy(),
+                node.isDistinct(),
+                node.isIgnoreNulls(),
+                rewrittenArgs.build());
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -46,7 +46,6 @@ import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
-import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Except;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
@@ -54,7 +53,6 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
-import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -75,13 +73,11 @@ import com.facebook.presto.sql.tree.QueryBody;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.QueryWithMVRewriteCandidates;
 import com.facebook.presto.sql.tree.Relation;
-import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.SampledRelation;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SelectItem;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
-import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.Table;
@@ -97,7 +93,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -115,10 +110,6 @@ import static com.facebook.presto.sql.ExpressionUtils.removeExpressionPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeGroupingElementPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeSingleColumnPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeSortItemPrefix;
-import static com.facebook.presto.sql.MaterializedViewUtils.ASSOCIATIVE_REWRITE_FUNCTIONS;
-import static com.facebook.presto.sql.MaterializedViewUtils.COUNT;
-import static com.facebook.presto.sql.MaterializedViewUtils.NON_ASSOCIATIVE_REWRITE_FUNCTIONS;
-import static com.facebook.presto.sql.MaterializedViewUtils.SUM;
 import static com.facebook.presto.sql.MaterializedViewUtils.resolveTableName;
 import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
@@ -432,6 +423,7 @@ public class MaterializedViewQueryOptimizer
         private final QualifiedObjectName materializedViewName;
 
         private MaterializedViewInfo materializedViewInfo;
+        private MaterializedViewExpressionRewriter expressionRewriter;
         private Optional<Identifier> removablePrefix = Optional.empty();
         private Optional<Set<Expression>> expressionsInGroupBy = Optional.empty();
 
@@ -452,6 +444,7 @@ public class MaterializedViewQueryOptimizer
                 MaterializedViewInformationExtractor materializedViewInformationExtractor = new MaterializedViewInformationExtractor();
                 materializedViewInformationExtractor.process(materializedViewQuery);
                 materializedViewInfo = materializedViewInformationExtractor.getMaterializedViewInfo();
+                expressionRewriter = new MaterializedViewExpressionRewriter(materializedViewInfo, builtInScalarFunctionNames);
 
                 QuerySpecification rewrittenQuerySpecification = (QuerySpecification) process(querySpecification);
 
@@ -539,7 +532,7 @@ public class MaterializedViewQueryOptimizer
                                     throw new IllegalStateException("GROUP BY ordinal references non-single-column select item");
                                 }
                             }
-                            if (!isExpressionInMvGroupBy(resolved, groupByOfMaterializedView.get()) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(resolved)) {
+                            if (!expressionRewriter.isExpressionInMvGroupBy(resolved, groupByOfMaterializedView.get()) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(resolved)) {
                                 throw new IllegalStateException(format("Grouping element %s is not present in materialized view groupBy field", element));
                             }
                             // Store the resolved expression so visitSingleColumn can match against it
@@ -551,6 +544,7 @@ public class MaterializedViewQueryOptimizer
                     }
                 }
                 expressionsInGroupBy = Optional.of(expressionsInGroupByBuilder.build());
+                expressionRewriter.setExpressionsInGroupBy(expressionsInGroupBy);
             }
 
             if (materializedViewInfo.getWhereClause().isPresent()) {
@@ -619,7 +613,7 @@ public class MaterializedViewQueryOptimizer
             Optional<Set<Expression>> groupByOfMaterializedView = materializedViewInfo.getGroupBy();
             // TODO: Replace this logic with rule-based validation framework.
             if (groupByOfMaterializedView.isPresent() &&
-                    !isRewritableWithMvGroupBy(groupByOfMaterializedView.get(), expression) &&
+                    !expressionRewriter.isRewritableWithMvGroupBy(groupByOfMaterializedView.get(), expression) &&
                     (!expressionsInGroupBy.isPresent() || !expressionsInGroupBy.get().contains(expression))) {
                 throw new IllegalStateException("Query a column presents in materialized view group by: " + expression.toString());
             }
@@ -652,10 +646,7 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitIdentifier(Identifier node, Void context)
         {
-            if (!materializedViewInfo.getBaseToViewColumnMap().containsKey(node)) {
-                throw new IllegalStateException("Materialized view definition does not contain mapping for the column: " + node.getValue());
-            }
-            return new Identifier((materializedViewInfo.getBaseToViewColumnMap().get(node)).getValue(), node.isDelimited());
+            return expressionRewriter.rewriteIdentifier(node);
         }
 
         @Override
@@ -671,58 +662,7 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitFunctionCall(FunctionCall node, Void context)
         {
-            ImmutableList.Builder<Expression> rewrittenArguments = ImmutableList.builder();
-
-            Map<Expression, Identifier> baseToViewColumnMap = materializedViewInfo.getBaseToViewColumnMap();
-
-            if (NON_ASSOCIATIVE_REWRITE_FUNCTIONS.containsKey(node.getName())) {
-                return MaterializedViewUtils.rewriteNonAssociativeFunction(node, baseToViewColumnMap);
-            }
-
-            if (!ASSOCIATIVE_REWRITE_FUNCTIONS.contains(node.getName())) {
-                if (!isScalarFunction(node)) {
-                    throw new SemanticException(NOT_SUPPORTED, node, "Unsupported function for materialized view rewrite: " + node.getName());
-                }
-                // Scalar function (CONCAT, JSON_EXTRACT, ABS, etc.) — rewrite arguments recursively
-                for (Expression argument : node.getArguments()) {
-                    rewrittenArguments.add((Expression) process(argument, context));
-                }
-                return new FunctionCall(
-                        node.getName(),
-                        node.getWindow(),
-                        node.getFilter(),
-                        node.getOrderBy(),
-                        node.isDistinct(),
-                        node.isIgnoreNulls(),
-                        rewrittenArguments.build());
-            }
-
-            if (baseToViewColumnMap.containsKey(node)) {
-                Identifier derivedColumn = baseToViewColumnMap.get(node);
-
-                if (node.getName().equals(COUNT)) {
-                    return rewriteCountAsSum(node, derivedColumn);
-                }
-                // TODO: We should be able to add more functions (e.g. BOOL_AND, BOOL_OR) to simple associative case
-                rewrittenArguments.add(derivedColumn);
-            }
-            else {
-                if (materializedViewInfo.getGroupBy().isPresent()) {
-                    throw new SemanticException(NOT_SUPPORTED, node, "Materialized view does not pre-compute aggregate: " + node.getName());
-                }
-                for (Expression argument : node.getArguments()) {
-                    rewrittenArguments.add((Expression) process(argument, context));
-                }
-            }
-
-            return new FunctionCall(
-                    node.getName(),
-                    node.getWindow(),
-                    node.getFilter(),
-                    node.getOrderBy(),
-                    node.isDistinct(),
-                    node.isIgnoreNulls(),
-                    rewrittenArguments.build());
+            return expressionRewriter.rewriteFunctionCall(node, arg -> (Expression) process(arg, context));
         }
 
         @Override
@@ -860,7 +800,9 @@ public class MaterializedViewQueryOptimizer
         {
             ImmutableList.Builder<GroupingElement> rewrittenGroupBy = ImmutableList.builder();
             for (GroupingElement element : node.getGroupingElements()) {
-                rewrittenGroupBy.add((GroupingElement) process(removeGroupingElementPrefix(element, removablePrefix), context));
+                rewrittenGroupBy.add(MaterializedViewUtils.rewriteGroupingElement(
+                        removeGroupingElementPrefix(element, removablePrefix),
+                        expr -> (Expression) process(removeExpressionPrefix(expr, removablePrefix), context)));
             }
             return new GroupBy(node.isDistinct(), rewrittenGroupBy.build());
         }
@@ -871,138 +813,17 @@ public class MaterializedViewQueryOptimizer
             ImmutableList.Builder<SortItem> rewrittenOrderBy = ImmutableList.builder();
             for (SortItem sortItem : node.getSortItems()) {
                 sortItem = removeSortItemPrefix(sortItem, removablePrefix);
-                // Ordinal references (e.g. ORDER BY 3) refer to SELECT items which are already validated
                 Expression sortKey = sortItem.getSortKey();
                 if (!(sortKey instanceof LongLiteral)
                         && !materializedViewInfo.getBaseToViewColumnMap().containsKey(sortKey)) {
                     throw new IllegalStateException(format("Sort key %s is not present in materialized view select fields", sortKey));
                 }
-                rewrittenOrderBy.add((SortItem) process(sortItem, context));
+                rewrittenOrderBy.add(new SortItem(
+                        (Expression) process(sortItem.getSortKey(), context),
+                        sortItem.getOrdering(),
+                        sortItem.getNullOrdering()));
             }
             return new OrderBy(rewrittenOrderBy.build());
-        }
-
-        @Override
-        protected Node visitSortItem(SortItem node, Void context)
-        {
-            return new SortItem((Expression) process(node.getSortKey(), context), node.getOrdering(), node.getNullOrdering());
-        }
-
-        @Override
-        protected Node visitSimpleGroupBy(SimpleGroupBy node, Void context)
-        {
-            return new SimpleGroupBy(rewriteGroupByExpressions(node.getExpressions(), context));
-        }
-
-        @Override
-        protected Node visitCube(Cube node, Void context)
-        {
-            return new Cube(rewriteGroupByExpressions(node.getExpressions(), context));
-        }
-
-        @Override
-        protected Node visitRollup(Rollup node, Void context)
-        {
-            return new Rollup(rewriteGroupByExpressions(node.getExpressions(), context));
-        }
-
-        @Override
-        protected Node visitGroupingSets(GroupingSets node, Void context)
-        {
-            ImmutableList.Builder<List<Expression>> rewrittenSets = ImmutableList.builder();
-            for (List<Expression> set : node.getSets()) {
-                rewrittenSets.add(rewriteGroupByExpressions(set, context));
-            }
-            return new GroupingSets(rewrittenSets.build());
-        }
-
-        private List<Expression> rewriteGroupByExpressions(List<Expression> expressions, Void context)
-        {
-            ImmutableList.Builder<Expression> rewritten = ImmutableList.builder();
-            for (Expression column : expressions) {
-                rewritten.add((Expression) process(removeExpressionPrefix(column, removablePrefix), context));
-            }
-            return rewritten.build();
-        }
-
-        private boolean isRewritableWithMvGroupBy(Set<Expression> mvGroupBy, Expression expression)
-        {
-            // Dimension column — MV collapses rows on this column, not rewritable
-            // without matching GROUP BY in the base query
-            if (isExpressionInMvGroupBy(expression, mvGroupBy)) {
-                return false;
-            }
-
-            // Rewritable aggregate (SUM, COUNT, MIN, MAX, AVG) — rollup is always safe
-            if (expression instanceof FunctionCall
-                    && (ASSOCIATIVE_REWRITE_FUNCTIONS.contains(((FunctionCall) expression).getName())
-                    || MaterializedViewUtils.validateNonAssociativeFunctionRewrite(
-                            (FunctionCall) expression, materializedViewInfo.getBaseToViewColumnMap()))) {
-                return true;
-            }
-
-            // Non-dimension column mapped in MV — safe to rewrite
-            if (materializedViewInfo.getBaseToViewColumnMap().containsKey(expression)) {
-                return true;
-            }
-
-            // Scalar expression (IF, CAST, ABS, arithmetic, etc.) — safe only when
-            // the base query has GROUP BY. Without GROUP BY, the MV collapses rows
-            // and these expressions would silently lose duplicates.
-            if (expressionsInGroupBy.isPresent()
-                    && !(expression instanceof Identifier)
-                    && (!(expression instanceof FunctionCall) || isScalarFunction((FunctionCall) expression))) {
-                return true;
-            }
-
-            // Unrecognized expression — not rewritable
-            return false;
-        }
-
-        private boolean isExpressionInMvGroupBy(Expression expression, Set<Expression> mvGroupBy)
-        {
-            if (mvGroupBy.contains(expression)) {
-                return true;
-            }
-            Identifier viewColumn = materializedViewInfo.getBaseToViewColumnMap().get(expression);
-            return viewColumn != null && mvGroupBy.contains(viewColumn);
-        }
-
-        private boolean isScalarFunction(FunctionCall functionCall)
-        {
-            return !functionCall.getWindow().isPresent()
-                    && builtInScalarFunctionNames.contains(functionCall.getName().getSuffix().toLowerCase(Locale.ENGLISH));
-        }
-
-        /**
-         * This is special-cased for now as COUNT is the only non-associative
-         * function supported by materialized view rewrites. In the future, we will want to
-         * support more non-associative functions and explore more
-         * extensible options.
-         * <p>
-         * Functions in optimized materialized view queries are by default expanded to
-         * func(column_derived_from_func_in_mv). This only works for associative
-         * functions. Count is non-associative: COUNT(x \ union y) != COUNT(Count(x), COUNT(y)).
-         * Rather, COUNT(x \ union y) == SUM(COUNT(x), COUNT(y). This is what we do here.
-         */
-        private FunctionCall rewriteCountAsSum(FunctionCall node, Expression derivedColumnName)
-        {
-            if (!node.getName().equals(COUNT)) {
-                throw new SemanticException(NOT_SUPPORTED, node, "Provided function was not COUNT");
-            }
-
-            if (node.isDistinct()) {
-                throw new SemanticException(NOT_SUPPORTED, node, "COUNT(DISTINCT) is not supported for materialized view query rewrite optimization");
-            }
-
-            return new FunctionCall(
-                    SUM,
-                    node.getWindow(),
-                    node.getFilter(),
-                    node.getOrderBy(),
-                    node.isDistinct(),
-                    node.isIgnoreNulls(),
-                    ImmutableList.of(derivedColumnName));
         }
 
         private RowExpression convertToRowExpression(Expression expression, Scope scope)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -178,6 +178,41 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testWithSumDistinct()
+    {
+        // SUM(DISTINCT) with GROUP BY rollup must NOT be rewritten — rolling up
+        // pre-aggregated values with DISTINCT produces wrong results.
+        String originalViewSql = format("SELECT SUM(DISTINCT(a)) as a_sum, b FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(DISTINCT(a)) FROM %s GROUP BY b", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // SUM(DISTINCT) on base table must not match MV with SUM (non-distinct)
+        originalViewSql = format("SELECT SUM((a)) as a_sum FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(DISTINCT(a)) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testCountStarRewrite()
+    {
+        // COUNT(*) rewritten to SUM(cnt) when MV pre-computes it
+        String originalViewSql = format("SELECT b, COUNT(*) as cnt FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT b, COUNT(*) FROM %s GROUP BY b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT b, SUM(cnt) FROM %s GROUP BY b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // COUNT(*) rollup without GROUP BY in query
+        baseQuerySql = format("SELECT COUNT(*) FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(cnt) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: COUNT(*) when MV does not pre-compute it
+        originalViewSql = format("SELECT SUM(a) as a_sum, b FROM %s GROUP BY b", BASE_TABLE_1);
+        baseQuerySql = format("SELECT COUNT(*) FROM %s GROUP BY b", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithArithmeticBinary()
     {
         String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);


### PR DESCRIPTION
Summary:

Extracts a new `MaterializedViewExpressionRewriter` from `MaterializedViewQueryOptimizer` that centralizes all expression-level MV rewriting logic for the single-table path: column resolution (`rewriteIdentifier`), function-call rewriting (`rewriteFunctionCall`), and SELECT validation (`isRewritableWithMvGroupBy`, `isExpressionInMvGroupBy`).

This enables both the existing single-table `QuerySpecificationRewriter` and the upcoming JOIN-aware rewriter (D103812393) to share the same expression rewriting logic. New query shape support (e.g., new aggregate functions) only needs to be added once.

Changes:
- New `MaterializedViewExpressionRewriter` with `rewriteIdentifier`, `rewriteFunctionCall` (callback-based arg recursion), `isScalarFunction`, `isRewritableWithMvGroupBy`, `isExpressionInMvGroupBy`, and `setExpressionsInGroupBy`
- Function call handling: associative (SUM/MIN/MAX keep name, COUNT renamed to SUM), non-associative (AVG/APPROX_DISTINCT), DISTINCT rejection for all associative functions
- `MaterializedViewUtils`: added `rewriteAssociativeFunction` (collapsed `rewriteCountAsSum` inline), `rewriteGroupingElement` (handles SimpleGroupBy, Cube, Rollup, GroupingSets)
- `MaterializedViewQueryOptimizer`: single-table path delegates to shared rewriter; removed ~190 lines of inlined logic (visitFunctionCall, visitSimpleGroupBy, visitCube, visitRollup, visitGroupingSets, visitSortItem, isRewritableWithMvGroupBy, isExpressionInMvGroupBy, isScalarFunction, rewriteCountAsSum)
- New tests: `testWithSumDistinct` (SUM(DISTINCT) rollup rejection), `testCountStarRewrite` (COUNT(*) to SUM(cnt) rollup + rejection when not pre-computed)

Differential Revision: D103812394

```
== NO RELEASE NOTE ==
```


