### PR TITLE
feat(planner): Add JOIN support to MV query optimizer

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -1999,6 +1999,114 @@ public class TestHiveMaterializedViewLogicalPlanner
     }
 
     @Test
+    public void testJoinWithCteRewritesCteBodyOnly()
+    {
+        // CTE body is rewritten via single-table MV path; outer JOIN skips CTE leaf gracefully
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+
+        String baseTable = "test_cte_orders";
+        String mvName = "test_cte_orders_mv";
+
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, totalprice, '2021-07-11' AS ds FROM orders WHERE orderkey < 1000", baseTable));
+
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, MAX(totalprice) AS max_price, ds FROM %s GROUP BY orderkey, ds", mvName, baseTable));
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2021-07-11'", mvName), 255);
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, baseTable, ImmutableList.of(mvName));
+
+            // CTE body queries baseTable (has MV) → rewritten inside CTE
+            // Outer JOIN with lineitem (no MV) → CTE leaf skipped, lineitem unchanged
+            String query = format("WITH cte AS (SELECT orderkey, MAX(totalprice) AS max_price FROM %s " +
+                    "WHERE ds = '2021-07-11' GROUP BY orderkey) " +
+                    "SELECT c.orderkey, c.max_price, l.quantity " +
+                    "FROM cte c JOIN lineitem l ON c.orderkey = l.orderkey " +
+                    "WHERE c.orderkey = 1 ORDER BY l.quantity", baseTable);
+
+            MaterializedResult optimized = computeActual(queryOptimizationWithMaterializedView, query);
+            MaterializedResult baseline = computeActual(query);
+            assertEquals(baseline, optimized);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + mvName);
+            queryRunner.execute("DROP TABLE IF EXISTS " + baseTable);
+        }
+    }
+
+    @Test
+    public void testJoinWithCteRewritesBothCteAndJoinTable()
+    {
+        // Both the CTE body and the JOIN table have MVs → both are rewritten independently
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+
+        String ordersTable = "test_cte_both_orders";
+        String suppTable = "test_cte_both_supp";
+        String ordersMv = "test_cte_both_orders_mv";
+        String suppMv = "test_cte_both_supp_mv";
+
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, totalprice, '2021-07-11' AS ds FROM orders WHERE orderkey < 1000", ordersTable));
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT suppkey, name, '2021-07-11' AS ds FROM supplier WHERE suppkey < 100", suppTable));
+
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, MAX(totalprice) AS max_price, ds FROM %s GROUP BY orderkey, ds", ordersMv, ordersTable));
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT suppkey, name, ds FROM %s", suppMv, suppTable));
+
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2021-07-11'", ordersMv), 255);
+            queryRunner.execute(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2021-07-11'", suppMv));
+
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, ordersTable, ImmutableList.of(ordersMv));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, suppTable, ImmutableList.of(suppMv));
+
+            // CTE body queries ordersTable (has MV) → rewritten
+            // Outer query JOINs CTE with suppTable (has MV) → suppTable rewritten by JOIN rewriter
+            String query = format("WITH order_agg AS (SELECT orderkey, MAX(totalprice) AS max_price FROM %s " +
+                    "WHERE ds = '2021-07-11' GROUP BY orderkey) " +
+                    "SELECT s.name, SUM(o.max_price) AS total_price " +
+                    "FROM order_agg o JOIN %s s ON o.orderkey = s.suppkey " +
+                    "WHERE s.ds = '2021-07-11' " +
+                    "GROUP BY s.name ORDER BY total_price DESC LIMIT 5", ordersTable, suppTable);
+
+            MaterializedResult optimized = computeActual(queryOptimizationWithMaterializedView, query);
+            MaterializedResult baseline = computeActual(query);
+            assertEquals(baseline, optimized);
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + ordersMv);
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + suppMv);
+            queryRunner.execute("DROP TABLE IF EXISTS " + ordersTable);
+            queryRunner.execute("DROP TABLE IF EXISTS " + suppTable);
+        }
+    }
+
+    @Test
+    public void testJoinWithCteNeitherRewritten()
+    {
+        // Neither CTE body nor JOIN table has an MV — query runs unchanged, no crash
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+
+        String query = "WITH cte AS (SELECT orderkey, totalprice FROM orders WHERE orderkey < 10) " +
+                "SELECT c.orderkey, c.totalprice, l.quantity " +
+                "FROM cte c JOIN lineitem l ON c.orderkey = l.orderkey " +
+                "ORDER BY c.orderkey, l.quantity LIMIT 10";
+        MaterializedResult optimized = computeActual(queryOptimizationWithMaterializedView, query);
+        MaterializedResult baseline = computeActual(query);
+        assertEquals(baseline, optimized);
+    }
+
+    @Test
     public void testSubqueryMaterializedViewAggregateWithAndJoin()
     {
         Session queryOptimizationWithMaterializedView = Session.builder(getSession())

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
@@ -14,33 +14,71 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.sql.MaterializedViewUtils;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.SortItem;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static com.facebook.presto.sql.MaterializedViewUtils.ASSOCIATIVE_REWRITE_FUNCTIONS;
 import static com.facebook.presto.sql.MaterializedViewUtils.NON_ASSOCIATIVE_REWRITE_FUNCTIONS;
+import static com.facebook.presto.sql.MaterializedViewUtils.rewriteAssociativeFunction;
+import static com.facebook.presto.sql.MaterializedViewUtils.rewriteGroupingElement;
 import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class MaterializedViewExpressionRewriter
 {
     private final MaterializedViewInfo mvInfo;
     private final Set<String> builtInScalarFunctionNames;
+    private final Optional<Identifier> tablePrefix;
+    private final Optional<Identifier> mvPrefix;
     private Optional<Set<Expression>> expressionsInGroupBy = Optional.empty();
 
     public MaterializedViewExpressionRewriter(MaterializedViewInfo mvInfo, Set<String> builtInScalarFunctionNames)
     {
+        this(mvInfo, builtInScalarFunctionNames, Optional.empty(), Optional.empty());
+    }
+
+    public MaterializedViewExpressionRewriter(
+            Optional<Identifier> tablePrefix,
+            Optional<Identifier> mvPrefix,
+            MaterializedViewInfo mvInfo)
+    {
+        this(mvInfo, ImmutableSet.of(), tablePrefix, mvPrefix);
+    }
+
+    private MaterializedViewExpressionRewriter(
+            MaterializedViewInfo mvInfo,
+            Set<String> builtInScalarFunctionNames,
+            Optional<Identifier> tablePrefix,
+            Optional<Identifier> mvPrefix)
+    {
         this.mvInfo = requireNonNull(mvInfo, "mvInfo is null");
         this.builtInScalarFunctionNames = requireNonNull(builtInScalarFunctionNames, "builtInScalarFunctionNames is null");
+        this.tablePrefix = requireNonNull(tablePrefix, "tablePrefix is null");
+        this.mvPrefix = requireNonNull(mvPrefix, "mvPrefix is null");
     }
 
     public void setExpressionsInGroupBy(Optional<Set<Expression>> expressionsInGroupBy)
@@ -73,7 +111,7 @@ public class MaterializedViewExpressionRewriter
         }
 
         if (baseToViewColumnMap.containsKey(node)) {
-            return MaterializedViewUtils.rewriteAssociativeFunction(node, baseToViewColumnMap.get(node));
+            return rewriteAssociativeFunction(node, baseToViewColumnMap.get(node));
         }
 
         if (mvInfo.getGroupBy().isPresent()) {
@@ -150,5 +188,220 @@ public class MaterializedViewExpressionRewriter
                 node.isDistinct(),
                 node.isIgnoreNulls(),
                 rewrittenArgs.build());
+    }
+
+    public Expression rewriteExpression(Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (belongsToRewrittenTable(node)) {
+                    return resolveColumnInJoinMode(node.getField());
+                }
+                return node;
+            }
+
+            @Override
+            public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                return rewriteFunctionCallInJoinMode(node);
+            }
+        }, expression);
+    }
+
+    public SingleColumn rewriteSingleColumn(SingleColumn node)
+    {
+        Expression expression = node.getExpression();
+        Expression rewritten = rewriteExpression(expression);
+        Optional<Identifier> alias = node.getAlias();
+
+        if (!alias.isPresent()
+                && expression instanceof DereferenceExpression
+                && rewritten instanceof DereferenceExpression
+                && !((DereferenceExpression) expression).getField().equals(((DereferenceExpression) rewritten).getField())) {
+            alias = Optional.of(((DereferenceExpression) expression).getField());
+        }
+        return new SingleColumn(rewritten, alias);
+    }
+
+    public GroupBy rewriteGroupBy(GroupBy groupBy, List<SelectItem> selectItems)
+    {
+        ImmutableList.Builder<GroupingElement> rewrittenElements = ImmutableList.builder();
+        for (GroupingElement element : groupBy.getGroupingElements()) {
+            rewrittenElements.add(rewriteGroupingElement(element, expr -> rewriteGroupByExpression(expr, selectItems)));
+        }
+        return new GroupBy(groupBy.isDistinct(), rewrittenElements.build());
+    }
+
+    public OrderBy rewriteOrderBy(OrderBy orderBy)
+    {
+        ImmutableList.Builder<SortItem> rewrittenItems = ImmutableList.builder();
+        for (SortItem sortItem : orderBy.getSortItems()) {
+            rewrittenItems.add(new SortItem(
+                    rewriteExpression(sortItem.getSortKey()),
+                    sortItem.getOrdering(),
+                    sortItem.getNullOrdering()));
+        }
+        return new OrderBy(rewrittenItems.build());
+    }
+
+    public boolean belongsToRewrittenTable(Expression expression)
+    {
+        if (!tablePrefix.isPresent()) {
+            return false;
+        }
+        if (expression instanceof DereferenceExpression) {
+            DereferenceExpression deref = (DereferenceExpression) expression;
+            return deref.getBase() instanceof Identifier && tablePrefix.get().equals(deref.getBase());
+        }
+        return false;
+    }
+
+    public Expression stripPrefix(Expression expression)
+    {
+        if (tablePrefix.isPresent() && expression instanceof DereferenceExpression) {
+            DereferenceExpression deref = (DereferenceExpression) expression;
+            if (deref.getBase() instanceof Identifier && tablePrefix.get().equals(deref.getBase())) {
+                return deref.getField();
+            }
+        }
+        return expression;
+    }
+
+    public boolean referencesRewrittenTable(Expression expression)
+    {
+        AtomicBoolean found = new AtomicBoolean(false);
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+            {
+                if (belongsToRewrittenTable(node)) {
+                    found.set(true);
+                }
+                return null;
+            }
+        }.process(expression, null);
+        return found.get();
+    }
+
+    public boolean referencesOtherTable(Expression expression)
+    {
+        AtomicBoolean found = new AtomicBoolean(false);
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+            {
+                if (!belongsToRewrittenTable(node) && node.getBase() instanceof Identifier) {
+                    found.set(true);
+                }
+                return null;
+            }
+        }.process(expression, null);
+        return found.get();
+    }
+
+    private Expression resolveColumnInJoinMode(Expression lookup)
+    {
+        Map<Expression, Identifier> columnMap = mvInfo.getBaseToViewColumnMap();
+        if (!columnMap.containsKey(lookup)) {
+            throw new IllegalStateException("Column " + lookup + " not covered by materialized view");
+        }
+        return new DereferenceExpression(mvPrefix.get(), columnMap.get(lookup));
+    }
+
+    private Expression rewriteFunctionCallInJoinMode(FunctionCall node)
+    {
+        boolean refRewritten = referencesRewrittenTable(node);
+        boolean refOther = referencesOtherTable(node);
+
+        if (!refRewritten && !refOther) {
+            if (mvInfo.getGroupBy().isPresent()) {
+                return rewriteTablelessAggregate(node);
+            }
+            return node;
+        }
+        if (!refRewritten && refOther) {
+            if (mvInfo.getGroupBy().isPresent()) {
+                throw new IllegalStateException(
+                        "Aggregate on non-rewritten table columns not supported when materialized view has GROUP BY: " + node.getName());
+            }
+            return node;
+        }
+        if (refRewritten && refOther) {
+            throw new IllegalStateException("Mixed-table aggregate not supported for materialized view join rewrite");
+        }
+
+        // Strip table prefix and delegate to the shared rewriter.
+        // rewriteFunctionCall returns results with bare Identifiers;
+        // addMvPrefixToExpression wraps them with the MV table prefix.
+        FunctionCall strippedCall = stripPrefixFromFunctionCall(node);
+        Expression result = rewriteFunctionCall(strippedCall, this::rewriteBareArg);
+        return addMvPrefixToExpression(result);
+    }
+
+    private Expression rewriteTablelessAggregate(FunctionCall node)
+    {
+        Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
+        if (baseToViewColumnMap.containsKey(node)) {
+            Identifier derivedColumn = baseToViewColumnMap.get(node);
+            return rewriteAssociativeFunction(node, new DereferenceExpression(mvPrefix.get(), derivedColumn));
+        }
+        throw new IllegalStateException("Aggregate " + node.getName() + " without column references cannot be rewritten with pre-aggregated materialized view");
+    }
+
+    private FunctionCall stripPrefixFromFunctionCall(FunctionCall functionCall)
+    {
+        return (FunctionCall) ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (belongsToRewrittenTable(node)) {
+                    return node.getField();
+                }
+                return node;
+            }
+        }, functionCall);
+    }
+
+    private Expression addMvPrefixToExpression(Expression expression)
+    {
+        Identifier prefix = mvPrefix.get();
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                return new DereferenceExpression(prefix, node);
+            }
+        }, expression);
+    }
+
+    private Expression rewriteBareArg(Expression arg)
+    {
+        if (arg instanceof Identifier) {
+            return rewriteIdentifier((Identifier) arg);
+        }
+        throw new IllegalStateException("Complex expression in aggregate argument not supported for JOIN mode materialized view rewrite: " + arg);
+    }
+
+    private Expression rewriteGroupByExpression(Expression expression, List<SelectItem> selectItems)
+    {
+        if (expression instanceof LongLiteral) {
+            int ordinal = toIntExact(((LongLiteral) expression).getValue());
+            if (ordinal >= 1 && ordinal <= selectItems.size()) {
+                SelectItem selectItem = selectItems.get(ordinal - 1);
+                if (selectItem instanceof SingleColumn) {
+                    Expression resolved = stripPrefix(((SingleColumn) selectItem).getExpression());
+                    return rewriteExpression(resolved);
+                }
+            }
+            return expression;
+        }
+        return rewriteExpression(expression);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewJoinQueryRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewJoinQueryRewriter.java
@@ -1,0 +1,540 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.AliasedRelation;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Join;
+import com.facebook.presto.sql.tree.JoinCriteria;
+import com.facebook.presto.sql.tree.JoinOn;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.Table;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.SystemSessionProperties.isMaterializedViewDataConsistencyEnabled;
+import static com.facebook.presto.common.RuntimeMetricName.MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZED_WITH_MATERIALIZED_VIEW_SUBQUERY_COUNT;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
+import static com.facebook.presto.sql.MaterializedViewUtils.ASSOCIATIVE_REWRITE_FUNCTIONS;
+import static com.facebook.presto.sql.MaterializedViewUtils.NON_ASSOCIATIVE_REWRITE_FUNCTIONS;
+import static com.facebook.presto.sql.MaterializedViewUtils.SUPPORTED_FUNCTION_CALLS;
+import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
+import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewJoinQueryRewriter
+{
+    private static final Logger log = Logger.get(MaterializedViewJoinQueryRewriter.class);
+
+    private final Metadata metadata;
+    private final Session session;
+    private final SqlParser sqlParser;
+    private final MetadataResolver metadataResolver;
+
+    public MaterializedViewJoinQueryRewriter(Metadata metadata, Session session, SqlParser sqlParser)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.session = requireNonNull(session, "session is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.metadataResolver = requireNonNull(metadata.getMetadataResolver(session), "metadataResolver is null");
+    }
+
+    // TODO: Support cost-based MV selection for JOIN queries (analogous to
+    // isMaterializedViewQueryRewriteCostBasedSelectionEnabled in the single-table path).
+    // Currently takes the first compatible MV per leaf. Requires changes to
+    // QueryWithMVRewriteCandidates / MVRewriteCandidatesNode / SelectLowestCostMVRewrite
+    // to handle combinatorial multi-leaf candidates.
+    public QuerySpecification tryRewrite(QuerySpecification querySpecification, Relation joinRelation)
+    {
+        List<JoinLeafInfo> leaves = collectJoinLeaves(joinRelation);
+
+        for (JoinLeafInfo leaf : leaves) {
+            // Schema-qualified leaves (e.g. FROM s1.t1) produce nested DereferenceExpression
+            // column refs (s1.t1.a) whose base is not a simple Identifier — the prefix-based
+            // column rewriter can't match them, so leave the query unchanged.
+            if (leaf.table.getName().getParts().size() > 1) {
+                continue;
+            }
+            QualifiedObjectName tableName = createQualifiedObjectName(session, leaf.table, leaf.table.getName(), metadata);
+            if (!metadataResolver.getTableHandle(tableName).isPresent()) {
+                continue;
+            }
+            List<QualifiedObjectName> referencedMVs = metadata.getReferencedMaterializedViews(session, tableName);
+
+            for (QualifiedObjectName mvName : referencedMVs) {
+                QuerySpecification rewritten = new JoinRewriteContext(mvName, leaf).rewrite(querySpecification, joinRelation);
+                if (rewritten != querySpecification) {
+                    return rewritten;
+                }
+            }
+        }
+        return querySpecification;
+    }
+
+    /**
+     * Collects only the top-level leaves of a JOIN tree. Subqueries (TableSubquery,
+     * AliasedRelation wrapping non-Table relations) are treated as opaque — their
+     * inner tables are not surfaced as JOIN leaves, since substituting them would
+     * change the subquery's semantics out from under it.
+     */
+    private static List<JoinLeafInfo> collectJoinLeaves(Relation relation)
+    {
+        ImmutableList.Builder<JoinLeafInfo> leaves = ImmutableList.builder();
+        collectJoinLeavesRecursive(relation, leaves);
+        return leaves.build();
+    }
+
+    private static void collectJoinLeavesRecursive(Relation relation, ImmutableList.Builder<JoinLeafInfo> leaves)
+    {
+        if (relation instanceof Join) {
+            Join join = (Join) relation;
+            collectJoinLeavesRecursive(join.getLeft(), leaves);
+            collectJoinLeavesRecursive(join.getRight(), leaves);
+            return;
+        }
+        if (relation instanceof Table) {
+            Table table = (Table) relation;
+            leaves.add(new JoinLeafInfo(table, new Identifier(table.getName().toString())));
+            return;
+        }
+        if (relation instanceof AliasedRelation) {
+            AliasedRelation aliased = (AliasedRelation) relation;
+            if (aliased.getRelation() instanceof Table) {
+                leaves.add(new JoinLeafInfo((Table) aliased.getRelation(), aliased.getAlias()));
+            }
+            // AliasedRelation wrapping a subquery: opaque, do not descend.
+        }
+        // TableSubquery, Lateral, SampledRelation, etc.: opaque, do not descend.
+    }
+
+    static class JoinLeafInfo
+    {
+        final Table table;
+        final Identifier prefix;
+
+        JoinLeafInfo(Table table, Identifier prefix)
+        {
+            this.table = requireNonNull(table, "table is null");
+            this.prefix = requireNonNull(prefix, "prefix is null");
+        }
+    }
+
+    private class JoinRewriteContext
+    {
+        private final QualifiedObjectName materializedViewName;
+        private final Identifier swappedPrefix;
+        private final Table swappedTable;
+        private Table materializedViewTable;
+        private Identifier mvPrefix;
+        private MaterializedViewInfo mvInfo;
+        private MaterializedViewExpressionRewriter expressionRewriter;
+
+        JoinRewriteContext(QualifiedObjectName materializedViewName, JoinLeafInfo swappedLeaf)
+        {
+            this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+            this.swappedPrefix = swappedLeaf.prefix;
+            this.swappedTable = swappedLeaf.table;
+        }
+
+        public QuerySpecification rewrite(QuerySpecification querySpecification, Relation joinRelation)
+        {
+            try {
+                MaterializedViewDefinition mvDef = metadataResolver.getMaterializedView(materializedViewName).orElseThrow(() ->
+                        new IllegalStateException("Materialized view definition not present in metadata as expected."));
+                materializedViewTable = new Table(QualifiedName.of(mvDef.getTable()));
+                mvPrefix = isAliasedLeaf() ? swappedPrefix : new Identifier(mvDef.getTable());
+
+                Query mvQuery = (Query) sqlParser.createStatement(mvDef.getOriginalSql(), createParsingOptions(session));
+                MaterializedViewInformationExtractor extractor = new MaterializedViewInformationExtractor();
+                extractor.process(mvQuery);
+                mvInfo = extractor.getMaterializedViewInfo();
+                expressionRewriter = new MaterializedViewExpressionRewriter(
+                        Optional.of(swappedPrefix), Optional.of(mvPrefix), mvInfo);
+
+                if (!isEligibleForRewrite(querySpecification, joinRelation)) {
+                    return querySpecification;
+                }
+
+                Relation newFrom = rewriteJoinRelation(joinRelation);
+                Select newSelect = rewriteSelect(querySpecification.getSelect());
+                Optional<Expression> newWhere = querySpecification.getWhere().map(expressionRewriter::rewriteExpression);
+                Optional<GroupBy> newGroupBy = querySpecification.getGroupBy().map(gb ->
+                        expressionRewriter.rewriteGroupBy(gb, querySpecification.getSelect().getSelectItems()));
+                Optional<OrderBy> newOrderBy = querySpecification.getOrderBy().map(expressionRewriter::rewriteOrderBy);
+
+                if (isMaterializedViewDataConsistencyEnabled(session)) {
+                    // TupleDomain.all() is stricter than extracting partition predicates from the
+                    // WHERE clause, which is complex for JOINs (WHERE references multiple tables).
+                    // Partition-level stitching is handled downstream by the physical plan optimizer.
+                    MaterializedViewStatus status = metadataResolver.getMaterializedViewStatus(materializedViewName, TupleDomain.all());
+                    if (!status.isPartiallyMaterialized() && !status.isFullyMaterialized()) {
+                        session.getRuntimeStats().addMetricValue(MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW_COUNT, NONE, 1);
+                        return querySpecification;
+                    }
+                }
+
+                session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW_SUBQUERY_COUNT, NONE, 1);
+                return new QuerySpecification(
+                        newSelect,
+                        Optional.of(newFrom),
+                        newWhere,
+                        newGroupBy,
+                        querySpecification.getHaving(),
+                        newOrderBy,
+                        querySpecification.getOffset(),
+                        querySpecification.getLimit());
+            }
+            catch (Exception e) {
+                log.warn(e, "Join MV rewrite failed for materialized view %s", materializedViewName);
+                return querySpecification;
+            }
+        }
+
+        private boolean isEligibleForRewrite(QuerySpecification querySpecification, Relation joinRelation)
+        {
+            if (mvInfo.getWhereClause().isPresent()) {
+                log.debug("JOIN MV rewrite rejected: MV has WHERE clause. MV=%s", materializedViewName);
+                return false;
+            }
+            if (querySpecification.getHaving().isPresent()) {
+                log.debug("JOIN MV rewrite rejected: query has HAVING. MV=%s", materializedViewName);
+                return false;
+            }
+            if (mvInfo.getGroupBy().isPresent()) {
+                if (!querySpecification.getGroupBy().isPresent()) {
+                    if (!isAggregateOnlySelect(querySpecification)) {
+                        log.debug("JOIN MV rewrite rejected: MV has GROUP BY but query selects non-aggregate columns without GROUP BY. MV=%s", materializedViewName);
+                        return false;
+                    }
+                }
+                if (!isSafeJoinTypeForGroupByMv(joinRelation)) {
+                    log.debug("JOIN MV rewrite rejected: unsafe join type. MV=%s", materializedViewName);
+                    return false;
+                }
+            }
+            if (!isGroupByCovered(querySpecification)) {
+                log.debug("JOIN MV rewrite rejected: GROUP BY not covered. MV=%s", materializedViewName);
+                return false;
+            }
+            if (!areColumnsCovered(querySpecification, joinRelation)) {
+                log.debug("JOIN MV rewrite rejected: columns not covered. MV=%s", materializedViewName);
+                return false;
+            }
+            if (!areAggregatesCompatible(querySpecification)) {
+                log.debug("JOIN MV rewrite rejected: aggregates not compatible. MV=%s", materializedViewName);
+                return false;
+            }
+            return true;
+        }
+
+        private boolean isAliasedLeaf()
+        {
+            return !swappedPrefix.equals(new Identifier(swappedTable.getName().toString()));
+        }
+
+        // --- Validation ---
+
+        private boolean isAggregateOnlySelect(QuerySpecification querySpecification)
+        {
+            for (SelectItem item : querySpecification.getSelect().getSelectItems()) {
+                if (!(item instanceof SingleColumn)) {
+                    return false;
+                }
+                Expression expr = ((SingleColumn) item).getExpression();
+                if (expr instanceof FunctionCall && SUPPORTED_FUNCTION_CALLS.contains(((FunctionCall) expr).getName())) {
+                    continue;
+                }
+                // Any non-aggregate column (from any table) without GROUP BY is unsafe
+                return false;
+            }
+            return true;
+        }
+
+        private boolean isGroupByCovered(QuerySpecification querySpecification)
+        {
+            if (!querySpecification.getGroupBy().isPresent()) {
+                return true;
+            }
+            Optional<Set<Expression>> mvGroupBy = mvInfo.getGroupBy();
+            if (!mvGroupBy.isPresent()) {
+                return true;
+            }
+            Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
+
+            for (GroupingElement element : querySpecification.getGroupBy().get().getGroupingElements()) {
+                for (Expression expr : element.getExpressions()) {
+                    if (!expressionRewriter.belongsToRewrittenTable(expr)) {
+                        continue;
+                    }
+                    Expression stripped = expressionRewriter.stripPrefix(expr);
+                    if (!mvGroupBy.get().contains(stripped) || !baseToViewColumnMap.containsKey(stripped)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private boolean areColumnsCovered(QuerySpecification querySpecification, Relation joinRelation)
+        {
+            Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
+            AtomicBoolean covered = new AtomicBoolean(true);
+
+            DefaultTraversalVisitor<Void, Void> checker = new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitFunctionCall(FunctionCall node, Void context)
+                {
+                    // Skip traversing into aggregate function arguments —
+                    // aggregate coverage is checked separately by areAggregatesCompatible
+                    if (SUPPORTED_FUNCTION_CALLS.contains(node.getName())) {
+                        return null;
+                    }
+                    return super.visitFunctionCall(node, context);
+                }
+
+                @Override
+                protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+                {
+                    if (expressionRewriter.belongsToRewrittenTable(node)) {
+                        if (!baseToViewColumnMap.containsKey(node.getField())) {
+                            covered.set(false);
+                        }
+                    }
+                    return null;
+                }
+            };
+
+            for (SelectItem item : querySpecification.getSelect().getSelectItems()) {
+                if (item instanceof SingleColumn) {
+                    checker.process(((SingleColumn) item).getExpression(), null);
+                }
+            }
+            querySpecification.getWhere().ifPresent(where -> checker.process(where, null));
+            querySpecification.getOrderBy().ifPresent(orderBy ->
+                    orderBy.getSortItems().forEach(sortItem -> checker.process(sortItem.getSortKey(), null)));
+
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitJoin(Join node, Void context)
+                {
+                    node.getCriteria().ifPresent(criteria -> {
+                        if (criteria instanceof JoinOn) {
+                            checker.process(((JoinOn) criteria).getExpression(), null);
+                        }
+                    });
+                    return super.visitJoin(node, context);
+                }
+            }.process(joinRelation, null);
+
+            return covered.get();
+        }
+
+        private boolean areAggregatesCompatible(QuerySpecification querySpecification)
+        {
+            Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
+
+            for (SelectItem item : querySpecification.getSelect().getSelectItems()) {
+                if (!(item instanceof SingleColumn)) {
+                    continue;
+                }
+                Expression expr = ((SingleColumn) item).getExpression();
+                if (!(expr instanceof FunctionCall)) {
+                    continue;
+                }
+                FunctionCall funcCall = (FunctionCall) expr;
+                if (!SUPPORTED_FUNCTION_CALLS.contains(funcCall.getName())) {
+                    continue;
+                }
+
+                boolean refRewritten = expressionRewriter.referencesRewrittenTable(funcCall);
+                boolean refOther = expressionRewriter.referencesOtherTable(funcCall);
+
+                if (refRewritten && refOther) {
+                    return false;
+                }
+                if (!refRewritten && !refOther && mvInfo.getGroupBy().isPresent()) {
+                    if (!baseToViewColumnMap.containsKey(funcCall)) {
+                        return false;
+                    }
+                }
+                if (!refRewritten && refOther && mvInfo.getGroupBy().isPresent()) {
+                    return false;
+                }
+                if (refRewritten && !refOther && mvInfo.getGroupBy().isPresent()) {
+                    if (!ASSOCIATIVE_REWRITE_FUNCTIONS.contains(funcCall.getName())
+                            && !NON_ASSOCIATIVE_REWRITE_FUNCTIONS.containsKey(funcCall.getName())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private boolean isSafeJoinTypeForGroupByMv(Relation relation)
+        {
+            if (relation instanceof Join) {
+                Join join = (Join) relation;
+                Join.Type type = join.getType();
+                if (type == Join.Type.INNER || type == Join.Type.CROSS) {
+                    return isSafeJoinTypeForGroupByMv(join.getLeft()) && isSafeJoinTypeForGroupByMv(join.getRight());
+                }
+                if (type == Join.Type.LEFT) {
+                    return !containsSwappedLeaf(join.getLeft()) && isSafeJoinTypeForGroupByMv(join.getRight());
+                }
+                if (type == Join.Type.RIGHT) {
+                    return isSafeJoinTypeForGroupByMv(join.getLeft()) && !containsSwappedLeaf(join.getRight());
+                }
+                return false;
+            }
+            return true;
+        }
+
+        private boolean containsSwappedLeaf(Relation relation)
+        {
+            AtomicBoolean found = new AtomicBoolean(false);
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitTable(Table node, Void context)
+                {
+                    if (!isAliasedLeaf() && swappedPrefix.equals(new Identifier(node.getName().toString()))) {
+                        found.set(true);
+                    }
+                    return null;
+                }
+
+                @Override
+                protected Void visitAliasedRelation(AliasedRelation node, Void context)
+                {
+                    if (node.getRelation() instanceof Table && swappedPrefix.equals(node.getAlias())) {
+                        found.set(true);
+                        return null;
+                    }
+                    return super.visitAliasedRelation(node, context);
+                }
+            }.process(relation, null);
+            return found.get();
+        }
+
+        // --- Join tree rewriting ---
+
+        private Relation rewriteJoinRelation(Relation relation)
+        {
+            return (Relation) new AstVisitor<Node, Void>()
+            {
+                @Override
+                protected Node visitTable(Table node, Void context)
+                {
+                    // Only swap bare (unaliased) tables. Aliased tables are handled
+                    // by visitAliasedRelation — if we also matched here, a self-join
+                    // like FROM t1 JOIN t1 AS x would swap BOTH sides.
+                    if (!isAliasedLeaf() && swappedPrefix.equals(new Identifier(node.getName().toString()))) {
+                        return materializedViewTable;
+                    }
+                    return node;
+                }
+
+                @Override
+                protected Node visitAliasedRelation(AliasedRelation node, Void context)
+                {
+                    if (node.getRelation() instanceof Table && swappedPrefix.equals(node.getAlias())) {
+                        return new AliasedRelation(materializedViewTable, node.getAlias(), node.getColumnNames());
+                    }
+                    // Do not recurse into the inner Table — that would match by table
+                    // name and swap a different leaf (e.g. t1 inside "t1 AS x").
+                    if (node.getRelation() instanceof Table) {
+                        return node;
+                    }
+                    Relation newRelation = (Relation) process(node.getRelation());
+                    if (newRelation == node.getRelation()) {
+                        return node;
+                    }
+                    return new AliasedRelation(newRelation, node.getAlias(), node.getColumnNames());
+                }
+
+                @Override
+                protected Node visitJoin(Join node, Void context)
+                {
+                    Relation newLeft = (Relation) process(node.getLeft());
+                    Relation newRight = (Relation) process(node.getRight());
+                    Optional<JoinCriteria> newCriteria = node.getCriteria().map(JoinRewriteContext.this::rewriteJoinCriteria);
+                    return new Join(node.getType(), newLeft, newRight, newCriteria);
+                }
+
+                @Override
+                protected Node visitNode(Node node, Void context)
+                {
+                    return node;
+                }
+            }.process(relation);
+        }
+
+        private JoinCriteria rewriteJoinCriteria(JoinCriteria criteria)
+        {
+            if (criteria instanceof JoinOn) {
+                return new JoinOn(expressionRewriter.rewriteExpression(((JoinOn) criteria).getExpression()));
+            }
+            return criteria;
+        }
+
+        // --- Query component rewriting (delegates to shared expressionRewriter) ---
+
+        private Select rewriteSelect(Select select)
+        {
+            ImmutableList.Builder<SelectItem> rewrittenItems = ImmutableList.builder();
+            for (SelectItem item : select.getSelectItems()) {
+                if (item instanceof SingleColumn) {
+                    rewrittenItems.add(expressionRewriter.rewriteSingleColumn((SingleColumn) item));
+                }
+                else {
+                    rewrittenItems.add(item);
+                }
+            }
+            return new Select(select.isDistinct(), rewrittenItems.build());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -183,6 +183,13 @@ public class MaterializedViewQueryOptimizer
             return rewriteQuerySpecificationIfCompatible(node, (Table) ((AliasedRelation) from).getRelation());
         }
 
+        if (from instanceof Join) {
+            Node result = new MaterializedViewJoinQueryRewriter(metadata, session, sqlParser).tryRewrite(node, from);
+            if (result != node) {
+                return result;
+            }
+        }
+
         Relation newFrom = processSameType(from);
         if (from == newFrom) {
             return node;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -63,6 +63,16 @@ public class TestMaterializedViewQueryOptimizer
     public void setupDomainTranslator()
     {
         domainTranslator = new RowExpressionDomainTranslator(metadata);
+        // AbstractAnalyzerTest pre-registers a global "s1.mv1" materialized view
+        // backed by t2. JOIN tests below use t2 as a non-target join partner and
+        // expect it to remain unrewritten; drop the global MV so the JOIN
+        // rewriter only sees test-specific MVs created via assertOptimizedQuery.
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(TEST_SESSION, (Session session) -> {
+                    metadata.dropMaterializedView(session, QualifiedObjectName.valueOf(TPCH_CATALOG, SESSION_SCHEMA, "mv1"));
+                });
     }
 
     @Test
@@ -1190,6 +1200,7 @@ public class TestMaterializedViewQueryOptimizer
 
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
+        // Single-table MV covering t1 columns used in a JOIN query — should now rewrite
         originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
         baseQuerySql = format(
                 "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.c",
@@ -1199,8 +1210,16 @@ public class TestMaterializedViewQueryOptimizer
                 BASE_TABLE_2,
                 BASE_TABLE_1,
                 BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.c",
+                VIEW_1,
+                BASE_TABLE_2,
+                VIEW_1,
+                BASE_TABLE_2,
+                VIEW_1,
+                BASE_TABLE_2);
 
-        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 
     @Test
@@ -2178,6 +2197,1727 @@ public class TestMaterializedViewQueryOptimizer
         expectedRewrittenSql = format("SELECT a, b FROM %s WHERE b = 'UK'", VIEW_1);
 
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, ImmutableMap.of(BASE_TABLE_1, ImmutableMap.of(VIEW_1, originalViewSql)));
+    }
+
+    // ---- JOIN MV Rewrite Tests ----
+
+    @Test
+    public void testJoinSimpleColumnRewrite()
+    {
+        // MV covers all columns of t1 used in the query (no GROUP BY in MV)
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2, VIEW_1, BASE_TABLE_2, VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithGroupByMatchingMv()
+    {
+        // MV GROUP BY matches exactly the query's GROUP BY columns from t1
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.sum_b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                VIEW_1, VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithGroupBySuperset()
+    {
+        // MV GROUP BY (a, c) is a superset of query's GROUP BY from t1 (a only)
+        String originalViewSql = format("SELECT a, c, SUM(b) AS sum_b FROM %s GROUP BY a, c", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.sum_b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                VIEW_1, VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountToSumRewrite()
+    {
+        // COUNT(t1.a) should be rewritten to SUM(mv.count_a)
+        String originalViewSql = format("SELECT a, COUNT(b) AS count_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(%s.b), %s.a AS t2_a FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.count_b), %s.a AS t2_a FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithMinMax()
+    {
+        // MIN and MAX are associative — should be rewritten directly
+        String originalViewSql = format("SELECT a, MIN(b) AS min_b, MAX(b) AS max_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, MIN(%s.b), MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, MIN(%s.min_b), MAX(%s.max_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithWhereOnOtherTable()
+    {
+        // WHERE clause on non-swapped table should pass through unchanged
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b > 10",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b > 10",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithWhereOnBothTables()
+    {
+        // WHERE references both tables — swapped table columns should be rewritten
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.c > 5 AND %s.b > 10",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.c > 5 AND %s.b > 10",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithOrderBy()
+    {
+        // ORDER BY on swapped table column should be rewritten
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a ORDER BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a ORDER BY %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithTableAlias()
+    {
+        // Tables with aliases — prefix should use alias
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT x.a, y.b FROM %s x JOIN %s y ON x.a = y.a",
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT x.a, y.b FROM %s x JOIN %s y ON x.a = y.a",
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithColumnRename()
+    {
+        // MV renames columns — original column name should be aliased in SELECT
+        String originalViewSql = format("SELECT a AS col_a, b AS col_b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.col_a AS a, %s.col_b AS b FROM %s JOIN %s ON %s.col_a = %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNestedJoinWithMvOnFirstTable()
+    {
+        // t1 JOIN t2 JOIN t3 pattern (nested join), MV on t1
+        // Note: t3 has columns a, b (same as t2 for AbstractAnalyzerTest setup)
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_3, BASE_TABLE_1, BASE_TABLE_3);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2, VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_3, VIEW_1, BASE_TABLE_3);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithMultipleAggregates()
+    {
+        // Multiple aggregates on swapped table
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b, SUM(c) AS sum_c FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b), SUM(%s.c) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.sum_b), SUM(%s.sum_c) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithConditionalAggregate()
+    {
+        // SUM(IF(...)) conditional aggregate in JOIN mode — MV pre-computes it
+        String originalViewSql = format("SELECT a, SUM(IF(c > 0, b, 0)) AS cond_sum, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(%s.c > 0, %s.b, 0)) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cond_sum) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Mixed: conditional + simple aggregate together
+        baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(%s.c > 0, %s.b, 0)), SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cond_sum), SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinConditionalAggregateWithCaseExpression()
+    {
+        // CASE WHEN inside aggregate — deeply nested prefix stripping
+        String originalViewSql = format("SELECT a, SUM(CASE WHEN c > 0 THEN b ELSE 0 END) AS case_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(CASE WHEN %s.c > 0 THEN %s.b ELSE 0 END) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.case_sum) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinConditionalAggregateNotInMv()
+    {
+        // SUM(IF(...)) NOT pre-computed in MV — should NOT rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(%s.c > 0, %s.b, 0)) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNestedArithmeticInAggregate()
+    {
+        // SUM(a * b + c) — nested arithmetic inside aggregate, prefix stripping must be recursive
+        String originalViewSql = format("SELECT a, SUM(b * c) AS prod_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b * %s.c) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.prod_sum) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinConditionalCountStar()
+    {
+        // COUNT(*) alongside conditional aggregate — both should rewrite
+        String originalViewSql = format("SELECT a, SUM(IF(c > 0, b, 0)) AS cond_sum, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(%s.c > 0, %s.b, 0)), COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cond_sum), SUM(%s.cnt) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithGroupByOnBothTables()
+    {
+        // GROUP BY has columns from both tables
+        String originalViewSql = format("SELECT a, c, SUM(b) AS sum_b FROM %s GROUP BY a, c", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.c, SUM(%s.b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.c, %s.b",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.c, SUM(%s.sum_b), %s.b AS t2_b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.c, %s.b",
+                VIEW_1, VIEW_1, VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinDeepNestedConditionalAggregate()
+    {
+        // Deeply nested prefix stripping: SUM(IF(COALESCE(t1.a, 0) > 0, t1.b * t1.c, 0))
+        String originalViewSql = format("SELECT a, SUM(IF(COALESCE(a, 0) > 0, b * c, 0)) AS deep_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(COALESCE(%s.a, 0) > 0, %s.b * %s.c, 0)) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.deep_sum) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Negative: same structure but expression NOT in MV — should reject
+        baseQuerySql = format(
+                "SELECT %s.a, SUM(IF(COALESCE(%s.a, 0) > 0, %s.b + %s.c, 0)) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCaseWhenInsideAggregate()
+    {
+        // SUM(CASE WHEN ... IN (...) THEN ... END) — nested IN predicate
+        String originalViewSql = format("SELECT a, SUM(CASE WHEN a IN (1, 2) THEN b ELSE 0 END) AS case_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(CASE WHEN %s.a IN (1, 2) THEN %s.b ELSE 0 END) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.case_sum) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWhereOnMvGroupByColumn()
+    {
+        // WHERE on a column that's in the MV GROUP BY — filter applies after swap, safe
+        String originalViewSql = format("SELECT a, c, SUM(b) AS sum_b FROM %s GROUP BY a, c", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountStarRollupWithGroupBy()
+    {
+        // COUNT(*) → SUM(cnt) rollup in JOIN with GROUP BY subset
+        String originalViewSql = format("SELECT a, c, COUNT(*) AS cnt, SUM(b) AS sum_b FROM %s GROUP BY a, c", BASE_TABLE_1);
+
+        // GROUP BY subset of MV GROUP BY
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cnt) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // COUNT(*) + SUM together in rollup
+        baseQuerySql = format(
+                "SELECT %s.a, COUNT(*), SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cnt), SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinScalarAggregateWithWhereOnOtherTable()
+    {
+        // Scalar aggregate (no GROUP BY) with WHERE on non-swapped table — should rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b > 10",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b > 10",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Negative: non-aggregate column from swapped table without GROUP BY — should reject
+        baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b > 10",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteUnmatchedAggregateWithGroupBy()
+    {
+        // MAX(t1.b) when MV only has SUM(b) — should NOT rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteSumDistinct()
+    {
+        // SUM(DISTINCT t1.b) — should NOT rewrite even if SUM(b) is in MV
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(DISTINCT %s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteMixedTableAggregate()
+    {
+        // SUM(t1.b * t2.a) — mixed-table aggregate should reject
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUM(%s.b * %s.a) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteAggregateOnGroupByColumn()
+    {
+        // SUM(t1.a) where a is a GROUP BY column in MV — the MV collapses rows,
+        // so SUM(a) on MV gives a*1 per group instead of a*N. Must NOT rewrite.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUM(%s.a) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteCountWithFilterInsideMvGroup()
+    {
+        // COUNT(*) with WHERE that filters within MV groups — MV pre-counts all
+        // statuses per region, but query only wants status='active'. After swap
+        // the filter can't reduce the pre-computed count. Must NOT rewrite.
+        String originalViewSql = format("SELECT a, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a WHERE %s.c > 0 GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2);
+        // WHERE on swapped table column 'c' that's NOT a GROUP BY column — MV doesn't
+        // have 'c', so column coverage check should reject
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewritePartialGroupByOverlap()
+    {
+        // JOIN on (a, c) but MV only groups by (a) — MV has one row per 'a',
+        // but the JOIN expects per-(a,c). Fan-out is wrong after swap.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a AND %s.c = %s.b GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        // JOIN uses t1.c which is not in MV — column coverage should reject
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteLeftJoinPreservedSideWithAggregate()
+    {
+        // LEFT JOIN where MV is on preserved (left) side with GROUP BY —
+        // null-padding semantics change when MV collapses rows
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s LEFT JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteFullJoinWithAggregate()
+    {
+        // FULL JOIN with GROUP BY MV — both sides are preserved, neither can be swapped
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s FULL JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteQueryGroupByNotInMvGroupBy()
+    {
+        // Query GROUP BY column 'c' is NOT in MV GROUP BY (a) — rollup impossible,
+        // MV has collapsed rows across 'c' values. Would produce wrong aggregates.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.c, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.c, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteQueryGroupByExpressionNotInMv()
+    {
+        // Query GROUP BY has expression SUBSTR(t1.a, 1, 2), MV GROUP BY has bare 'a'.
+        // The granularity differs — MV groups per 'a', query groups per SUBSTR(a).
+        // Even though MV is finer-grained, the expression isn't in the MV column map.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUBSTR(CAST(%s.a AS VARCHAR), 1, 2), SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY SUBSTR(CAST(%s.a AS VARCHAR), 1, 2), %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteQueryGroupByOrdinal()
+    {
+        // GROUP BY ordinal (GROUP BY 1) — ordinals reference SELECT items.
+        // The isGroupByCovered check must handle ordinals correctly.
+        // Here GROUP BY 1 = t1.c which is NOT in MV GROUP BY (a) — should reject.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.c, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY 1, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteMvGroupByExpressionQueryGroupByIdentifier()
+    {
+        // MV GROUP BY has expression (a + 0), query GROUP BY has bare 'a'.
+        // Expression vs identifier mismatch — can't roll up because the MV's
+        // grouping granularity is on the expression, not the raw column.
+        String originalViewSql = format("SELECT a + 0 AS expr_a, SUM(b) AS sum_b FROM %s GROUP BY a + 0", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteQueryGroupBySubsetMissing()
+    {
+        // MV GROUP BY (a, c), query GROUP BY (a, d).
+        // 'd' is NOT in MV GROUP BY — can't roll up over 'd'.
+        String originalViewSql = format("SELECT a, c, SUM(b) AS sum_b FROM %s GROUP BY a, c", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.d, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWhenMvMissesColumn()
+    {
+        // MV doesn't cover column 'c' used in JOIN ON — should not rewrite
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWhenGroupByNotInMv()
+    {
+        // Query GROUP BY t1.c but MV only has GROUP BY a — should not rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.c, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.c, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWhenMvHasWhereClause()
+    {
+        // MV has WHERE clause — JOIN rewrite not supported (v1 restriction)
+        String originalViewSql = format("SELECT a, b, c FROM %s WHERE a > 5", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a > 10",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWhenMvHasJoin()
+    {
+        // MV itself has a JOIN — MaterializedViewInformationExtractor rejects non-Table FROM
+        String originalViewSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.c",
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWhenSelectColumnNotInMv()
+    {
+        // SELECT references t1.d but MV only has a, b — should not rewrite
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.d, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteWithHaving()
+    {
+        // HAVING clause is not supported — should not rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a HAVING SUM(%s.b) > 10",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteCountDistinct()
+    {
+        // COUNT(DISTINCT) in JOIN should not be rewritten — non-decomposable
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(DISTINCT %s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteUnmatchedAggregate()
+    {
+        // Aggregate not pre-computed in MV should not be rewritten in JOIN mode
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithMvOnSecondTable()
+    {
+        // MV is on t2, not t1 — verify rewriting the right (second) table in JOIN
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_2, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithNoGroupByInQueryOrMv()
+    {
+        // Neither query nor MV has GROUP BY — simple column rewrite
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinScalarAggregateWithoutGroupBy()
+    {
+        // Query has no GROUP BY but selects only aggregates — safe rollup
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+
+        // SUM rollup without GROUP BY
+        String baseQuerySql = format(
+                "SELECT SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // COUNT(*) rollup to SUM(cnt) without GROUP BY
+        baseQuerySql = format(
+                "SELECT COUNT(*) FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        expectedRewrittenSql = format(
+                "SELECT SUM(%s.cnt) FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Non-swapped column in SELECT without GROUP BY — should NOT rewrite
+        baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithCompoundJoinCondition()
+    {
+        // JOIN ON with AND condition — both sides should be rewritten
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a FROM %s JOIN %s ON %s.a = %s.a AND %s.b > 5",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a FROM %s JOIN %s ON %s.a = %s.a AND %s.b > 5",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountStarRewrite()
+    {
+        // COUNT(*) has no column references — must be looked up in baseToViewColumnMap
+        // and rewritten to SUM(mv.cnt) when MV has GROUP BY
+        String originalViewSql = format("SELECT a, COUNT(*) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cnt) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountStarNoGroupByInMv()
+    {
+        // COUNT(*) with no GROUP BY in MV — passes through unchanged (MV has raw rows)
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountStarNoMatchInMv()
+    {
+        // COUNT(*) with GROUP BY in MV but MV has no COUNT(*) column — should reject rewrite
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinWithGroupByMv()
+    {
+        // Self-join with pre-aggregated MV — SUM on non-swapped side would get wrong
+        // fan-out, so the rewrite must be rejected
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT o1.a, SUM(o1.b), SUM(o2.b) FROM %s o1 JOIN %s o2 ON o1.a = o2.a GROUP BY o1.a",
+                BASE_TABLE_1, BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinOnlySwappedSideAggregate()
+    {
+        // Self-join but aggregate ONLY on the swapped side (o1) — safe to rewrite one side.
+        // The first leaf (o1) is tried: SUM(o1.b) references swapped table, o2.a is in GROUP BY
+        // (not aggregated) — no non-swapped aggregate → rewrite allowed for o1.
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT o1.a, SUM(o1.b), o2.a FROM %s o1 JOIN %s o2 ON o1.a = o2.a GROUP BY o1.a, o2.a",
+                BASE_TABLE_1, BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT o1.a, SUM(o1.sum_b), o2.a FROM %s o1 JOIN %s o2 ON o1.a = o2.a GROUP BY o1.a, o2.a",
+                VIEW_1, BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinNoGroupByInMv()
+    {
+        // Self-join with no GROUP BY in MV — both sides use raw rows, safe to rewrite one side.
+        // Only the first leaf (o1) gets rewritten (loop returns after first success).
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT o1.a, SUM(o1.b), SUM(o2.b) FROM %s o1 JOIN %s o2 ON o1.a = o2.a GROUP BY o1.a",
+                BASE_TABLE_1, BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT o1.a, SUM(o1.b), SUM(o2.b) FROM %s o1 JOIN %s o2 ON o1.a = o2.a GROUP BY o1.a",
+                VIEW_1, BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinUnaliasedAndAliased()
+    {
+        // FROM t1 JOIN t1 AS x — only the unaliased t1 should be swapped.
+        // x must remain pointing to the base table.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, x.b FROM %s JOIN %s x ON %s.a = x.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, x.b FROM %s JOIN %s x ON %s.a = x.a",
+                VIEW_1,
+                VIEW_1, BASE_TABLE_1,
+                VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinAliasedAndUnaliased()
+    {
+        // FROM t1 AS x JOIN t1 — only the aliased x should be swapped (first leaf).
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT x.a, %s.b FROM %s x JOIN %s ON x.a = %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT x.a, %s.b FROM %s x JOIN %s ON x.a = %s.a",
+                BASE_TABLE_1,
+                VIEW_1, BASE_TABLE_1,
+                BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinBothUnaliased()
+    {
+        // FROM t1 JOIN t1 — both have the same prefix "t1", first leaf swapped.
+        // Second t1 is also unaliased with the same name — but collectJoinLeaves
+        // returns them as separate entries and we only swap the first compatible one.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1);
+        // Both leaves have the same prefix — the rewriter swaps both (expected behavior
+        // for unaliased self-join since both use the same prefix for column refs)
+        String expectedRewrittenSql = format(
+                "SELECT %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1,
+                VIEW_1, VIEW_1,
+                VIEW_1, VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinBothAliased()
+    {
+        // FROM t1 AS x JOIN t1 AS y — only x (first leaf) should be swapped.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT x.a, y.b FROM %s x JOIN %s y ON x.a = y.a",
+                BASE_TABLE_1, BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT x.a, y.b FROM %s x JOIN %s y ON x.a = y.a",
+                VIEW_1, BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinThreeWaySelfJoinTwoAliases()
+    {
+        // FROM t1 AS a JOIN t1 AS b JOIN t2 — first leaf (a) swapped, b and t2 unchanged.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT x.a, y.b, %s.a FROM %s x JOIN %s y ON x.a = y.a JOIN %s ON y.a = %s.a",
+                BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_2, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT x.a, y.b, %s.a FROM %s x JOIN %s y ON x.a = y.a JOIN %s ON y.a = %s.a",
+                BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_1,
+                BASE_TABLE_2, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSelfJoinUnaliasedWithGroupByMv()
+    {
+        // FROM t1 JOIN t1 AS x with GROUP BY MV — only the unaliased leaf should be
+        // considered for swapping. If both were swapped, x.col references would not
+        // resolve against the MV (expressionRewriter only has tablePrefix=t1, not x).
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b), SUM(x.b) FROM %s JOIN %s x ON %s.a = x.a GROUP BY %s.a, x.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_1);
+        // The unaliased t1 can be swapped; aggregate on x (non-swapped) would change
+        // fan-out with GROUP BY MV, so the rewrite is rejected
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteAggregateOnNonSwappedTable()
+    {
+        // MV has GROUP BY — aggregate on non-swapped table columns would get wrong
+        // fan-out because MV collapses rows, so rewrite must be rejected
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b), SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinAggregateOnNonSwappedTableNoGroupByInMv()
+    {
+        // MV has no GROUP BY — aggregate on non-swapped table is fine (no cardinality change)
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinLeftOuterJoinNoGroupByMv()
+    {
+        // LEFT JOIN with no GROUP BY in MV — table swap is safe (raw rows, no cardinality change)
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s LEFT JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s LEFT JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteLeftJoinMvOnLeftSideWithGroupBy()
+    {
+        // LEFT JOIN with GROUP BY MV on LEFT (preserved) side — MV collapses rows,
+        // changes null-padding behavior → reject
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s LEFT JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinLeftJoinMvOnRightSideWithGroupBy()
+    {
+        // LEFT JOIN with GROUP BY MV on RIGHT (non-preserved) side — safe because
+        // the preserved (left) side keeps all its rows, MV just provides matching data
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s LEFT JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s LEFT JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_2, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteRightJoinMvOnRightSideWithGroupBy()
+    {
+        // RIGHT JOIN with GROUP BY MV on RIGHT (preserved) side → reject
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s RIGHT JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteFullOuterJoinWithGroupByMv()
+    {
+        // FULL JOIN with GROUP BY MV → reject (both sides preserved)
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s FULL JOIN %s ON %s.a = %s.a GROUP BY %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCrossJoin()
+    {
+        // CROSS JOIN — no ON condition, just column projection
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s CROSS JOIN %s",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s CROSS JOIN %s",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteAggregateFunctionNotInMvMap()
+    {
+        // Query uses MAX(t1.b) but MV only has SUM(b) — MAX not in MV column map, should reject
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinMixedTableArithmetic()
+    {
+        // Arithmetic expression referencing both tables outside aggregate — should pass through
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a + %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a + %s.a FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinOnlyGroupByNoAggregates()
+    {
+        // GROUP BY on both tables but no aggregates at all — simple column rewrite
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.b",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSchemaQualifiedTableName()
+    {
+        // Schema-qualified name s1.t1 — DereferenceExpression is nested:
+        // DereferenceExpression(DereferenceExpression(s1, t1), a) — base is not a simple Identifier.
+        // Column refs using schema.table.column won't match the swapped prefix,
+        // so columns won't be rewritten → rewrite should be rejected (column not covered).
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.%s.a, %s.b FROM %s.%s JOIN %s ON %s.%s.a = %s.a",
+                SESSION_SCHEMA, BASE_TABLE_1, BASE_TABLE_2,
+                SESSION_SCHEMA, BASE_TABLE_1, BASE_TABLE_2,
+                SESSION_SCHEMA, BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithIsNull()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b IS NULL",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.b IS NULL",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithInPredicate()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a IN (1, 2, 3)",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a IN (1, 2, 3)",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithBetween()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a BETWEEN 1 AND 10",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a BETWEEN 1 AND 10",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithCoalesce()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT COALESCE(%s.a, 0), %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT COALESCE(%s.a, 0), %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithNotExpression()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE NOT (%s.b > 5)",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE NOT (%s.b > 5)",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithCaseExpression()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT CASE WHEN %s.a > 0 THEN %s.a ELSE 0 END, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT CASE WHEN %s.a > 0 THEN %s.a ELSE 0 END, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinPlainMvWithAggregateOnSwappedTable()
+    {
+        // Plain MV (no GROUP BY) — aggregate on swapped table columns should rewrite
+        // by just substituting column references. No rollup needed.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUM(%s.a), %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.b",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT SUM(%s.a), %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.b",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinPlainMvWithCountOnSwappedTable()
+    {
+        // Plain MV (no GROUP BY) — COUNT on swapped table rewrites by substituting column refs
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT COUNT(%s.a), %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.b",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT COUNT(%s.a), %s.b FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.b",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinPlainMvWithMinMaxOnSwappedTable()
+    {
+        // Plain MV (no GROUP BY) — MIN/MAX on swapped table
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT MIN(%s.a), MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT MIN(%s.a), MAX(%s.b) FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinCountStarCorrectWithMvGroupBySupersetOfJoinKey()
+    {
+        // Property test: COUNT(*) → SUM(cnt) is correct in a JOIN IFF the MV's GROUP BY
+        // key is a superset of the JOIN key columns from the swapped table.
+        // areColumnsCovered enforces this implicitly (JOIN key columns must be in MV column
+        // map → must be in MV GROUP BY). This test documents the invariant explicitly.
+
+        // MV GROUP BY (a) — JOIN ON (t1.a = t2.a) — JOIN key {a} ⊆ MV GROUP BY {a} → correct
+        String originalViewSql = format("SELECT a, COUNT(*) AS cnt, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SUM(%s.cnt) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Negative: JOIN ON (t1.a = t2.a AND t1.c = t2.b) — JOIN key {a, c} but MV GROUP BY {a}
+        // c is not in MV column map → areColumnsCovered rejects → COUNT rollup never happens
+        baseQuerySql = format(
+                "SELECT %s.a, COUNT(*) FROM %s JOIN %s ON %s.a = %s.a AND %s.c = %s.b GROUP BY %s.a, %s.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinParenthesizedJoinTraversal()
+    {
+        // Parenthesized JOIN: FROM (t1 JOIN t2 ON ...) JOIN t3 ON ...
+        // The parser produces nested Join nodes — collectJoinLeavesRecursive should
+        // descend into both sides and find all three leaves.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.a FROM (%s JOIN %s ON %s.a = %s.a) JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.a FROM (%s JOIN %s ON %s.a = %s.a) JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                BASE_TABLE_2, VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSubqueryInFromTreatedAsOpaque()
+    {
+        // FROM (SELECT * FROM t1) sub JOIN t2 — the subquery wraps t1 in a TableSubquery.
+        // collectJoinLeavesRecursive should NOT descend into the subquery.
+        // Only t2 is a leaf — and if MV is on t1, it should NOT be rewritten via JOIN path.
+        // (The subquery's inner query may be rewritten by the single-table path separately.)
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_2);
+        String baseQuerySql = format(
+                "SELECT sub.a, %s.a FROM (SELECT a, b FROM %s) sub JOIN %s ON sub.a = %s.a",
+                BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT sub.a, %s.a FROM (SELECT a, b FROM %s) sub JOIN %s ON sub.a = %s.a",
+                VIEW_1,
+                BASE_TABLE_1, VIEW_1,
+                VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_2, VIEW_1);
+    }
+
+    @Test
+    public void testJoinNoRewriteMvWithWhereClause()
+    {
+        // MV has WHERE clause — filter containment not implemented for JOINs, reject
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s WHERE c > 0 GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinThreeWayMvOnMiddleTable()
+    {
+        // Three-way JOIN: FROM t1 JOIN t2 JOIN t1 — MV is on t2 (the middle table).
+        // collectJoinLeaves must find t2 regardless of position.
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b, %s.a FROM %s JOIN %s ON %s.a = %s.a JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b, %s.a FROM %s JOIN %s ON %s.a = %s.a JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, VIEW_1, BASE_TABLE_1,
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1,
+                BASE_TABLE_1, VIEW_1, BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_2, VIEW_1);
+    }
+
+    @Test
+    public void testJoinDuplicateColumnNamesAcrossTables()
+    {
+        // Both t1 and t2 have column 'a'. After MV swap on t1, t1.a → mv.a but t2.a
+        // must remain unchanged. Tests that column resolution doesn't confuse them.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a",
+                VIEW_1, BASE_TABLE_2, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinDuplicateColumnNamesWithGroupByMv()
+    {
+        // Both tables have 'a'. MV GROUP BY (a) with SUM(b). Query groups by both a's.
+        // After swap, t1.a → mv.a (dimension), t2.a stays. SUM(t1.b) → SUM(mv.sum_b).
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.a, SUM(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.a, SUM(%s.sum_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, BASE_TABLE_2, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinUnionAllInFromTreatedAsOpaque()
+    {
+        // FROM t1 JOIN (SELECT ... UNION ALL SELECT ...) sub — the UNION is wrapped
+        // in a TableSubquery, which collectJoinLeaves treats as opaque.
+        // MV on t1 should NOT be found via the JOIN path for the UNION side.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, sub.a FROM %s JOIN (SELECT a FROM %s UNION ALL SELECT a FROM %s) sub ON %s.a = sub.a",
+                BASE_TABLE_1,
+                BASE_TABLE_1,
+                BASE_TABLE_2, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, sub.a FROM %s JOIN (SELECT a FROM %s UNION ALL SELECT a FROM %s) sub ON %s.a = sub.a",
+                VIEW_1,
+                VIEW_1,
+                BASE_TABLE_2, BASE_TABLE_2,
+                VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithWhereSubqueryDoesNotInterfere()
+    {
+        // WHERE with IN subquery — the subquery should not interfere with JOIN rewriting.
+        // The rewriter only touches JOIN leaves, not subqueries in WHERE.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a IN (1, 2, 3)",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, %s.b FROM %s JOIN %s ON %s.a = %s.a WHERE %s.a IN (1, 2, 3)",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 
     private void assertOptimizedQuery(String baseQuerySql, String expectedViewSql, String originalViewSql, String baseTableName, String originalViewName)


### PR DESCRIPTION
Summary:
Extends the AST-level MV query rewriter to substitute a base table inside a JOIN with a materialized view when the MV's columns fully cover that table's usage in the query. Uses the shared MaterializedViewExpressionRewriter (from the parent diff) for all expression-level rewriting.

Components:
- MaterializedViewJoinQueryRewriter: top-level driver for JOIN MV rewriting
- JoinRewriteContext: handles join tree transformation via AstVisitor, safety validation, MV freshness checks
- Recursive tryRewrite: after one leaf is swapped, recurses to try remaining leaves
- collectJoinLeaves via DefaultTraversalVisitor: walks the join tree to find leaf tables

Safety guards when MV has GROUP BY:
- Reject if query has no GROUP BY (MV would collapse rows)
- Reject aggregates over non-swapped table columns (fan-out changes results)
- Reject LEFT/RIGHT JOIN on the preserved side, and FULL OUTER JOIN
- COUNT(*) rewritten to SUM(mv.cnt) when MV has a matching column
- Upfront isEligibleForRewrite validation (no exception-based rejection)

```
== RELEASE NOTES ==

General Changes
* Add JOIN support to the materialized view query optimizer. Queries
  that join a base table covered by a materialized view with another
  table can now be rewritten to scan the materialized view in place
  of the base table, subject to safety guards (matching GROUP BY,
  no aggregates over non-swapped tables, supported join types).
```

Differential Revision: D103812393


