### PR TITLE
fix: Correct error message for invalid catalog in CreateSchemaTask 

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -142,6 +142,7 @@ import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.sea
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_MATERIALIZED;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_SCHEMA;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -246,6 +247,16 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate(admin, "DROP TABLE new_schema.test");
 
         assertUpdate(admin, "DROP SCHEMA new_schema");
+
+        executeExclusively(() -> {
+            try {
+                getQueryRunner().getAccessControl().deny(privilege(admin.getUser(), "test", CREATE_SCHEMA));
+                assertQueryFails(admin, "CREATE SCHEMA invalid_catalog.test", "Catalog does not exist: invalid_catalog");
+            }
+            finally {
+                getQueryRunner().getAccessControl().reset();
+            }
+        });
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRestMaterializedViews.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRestMaterializedViews.java
@@ -76,6 +76,8 @@ public class TestIcebergRestMaterializedViews
         catalogProps.put("uri", serverUri);
         catalogProps.put("warehouse", warehouseLocation.getAbsolutePath());
         catalog.initialize("test_catalog", catalogProps);
+
+        getQueryRunner().execute("CREATE SCHEMA IF NOT EXISTS test_schema");
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
 import com.facebook.presto.spi.security.AccessControl;
@@ -58,6 +59,8 @@ import static com.facebook.presto.spi.StandardMaterializedViewProperties.isCross
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MATERIALIZED_VIEW_ALREADY_EXISTS;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
@@ -87,8 +90,17 @@ public class CreateMaterializedViewTask
     public ListenableFuture<?> execute(CreateMaterializedView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, WarningCollector warningCollector, String query)
     {
         QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getName(), metadata);
+        MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
 
-        Optional<TableHandle> viewHandle = metadata.getMetadataResolver(session).getTableHandle(viewName);
+        if (!metadataResolver.catalogExists(viewName.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", viewName.getCatalogName());
+        }
+
+        if (!metadataResolver.schemaExists(viewName.getCatalogSchemaName())) {
+            throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", viewName.getSchemaName());
+        }
+
+        Optional<TableHandle> viewHandle = metadataResolver.getTableHandle(viewName);
         if (viewHandle.isPresent()) {
             if (!statement.isNotExists()) {
                 throw new SemanticException(MATERIALIZED_VIEW_ALREADY_EXISTS, statement, "Materialized view '%s' already exists", viewName);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
@@ -55,7 +56,8 @@ public class CreateSchemaTask
     {
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()), metadata);
 
-        // TODO: validate that catalog exists
+        // Make sure catalog exists before access control checks
+        ConnectorId connectorId = getConnectorIdOrThrow(session, metadata, schema.getCatalogName());
 
         accessControl.checkCanCreateSchema(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), schema);
 
@@ -67,7 +69,7 @@ public class CreateSchemaTask
         }
 
         Map<String, Object> properties = metadata.getSchemaPropertyManager().getProperties(
-                getConnectorIdOrThrow(session, metadata, schema.getCatalogName()),
+                connectorId,
                 schema.getCatalogName(),
                 mapFromProperties(statement.getProperties()),
                 session,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
 import com.facebook.presto.spi.security.AccessControl;
@@ -30,6 +31,7 @@ import com.facebook.presto.spi.security.ViewSecurity;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Expression;
@@ -48,6 +50,8 @@ import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
 import static com.facebook.presto.spi.analyzer.ViewDefinition.ViewColumn;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
 import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -87,6 +91,15 @@ public class CreateViewTask
     public ListenableFuture<?> execute(CreateView statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, WarningCollector warningCollector, String query)
     {
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName(), metadata);
+        MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
+
+        if (!metadataResolver.catalogExists(name.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", name.getCatalogName());
+        }
+
+        if (!metadataResolver.schemaExists(name.getCatalogSchemaName())) {
+            throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", name.getSchemaName());
+        }
 
         accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), name);
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DropSchemaTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DropSchemaTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropSchema;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 
@@ -56,8 +58,13 @@ public class DropSchemaTask
         }
 
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()), metadata);
+        MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
 
-        if (!metadata.getMetadataResolver(session).schemaExists(schema)) {
+        if (!metadataResolver.catalogExists(schema.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", schema.getCatalogName());
+        }
+
+        if (!metadataResolver.schemaExists(schema)) {
             if (!statement.isExists()) {
                 throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", schema);
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DropTableTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DropTableTask.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropTable;
@@ -30,6 +31,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -47,8 +50,17 @@ public class DropTableTask
     public ListenableFuture<?> execute(DropTable statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, WarningCollector warningCollector, String query)
     {
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
+        MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
 
-        Optional<TableHandle> tableHandle = metadata.getMetadataResolver(session).getTableHandle(tableName);
+        if (!metadataResolver.catalogExists(tableName.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", tableName.getCatalogName());
+        }
+
+        if (!metadataResolver.schemaExists(tableName.getCatalogSchemaName())) {
+            throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", tableName.getSchemaName());
+        }
+
+        Optional<TableHandle> tableHandle = metadataResolver.getTableHandle(tableName);
         if (!tableHandle.isPresent()) {
             if (!statement.isExists()) {
                 throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
@@ -56,7 +68,7 @@ public class DropTableTask
             return immediateFuture(null);
         }
 
-        Optional<MaterializedViewDefinition> optionalMaterializedView = metadata.getMetadataResolver(session).getMaterializedView(tableName);
+        Optional<MaterializedViewDefinition> optionalMaterializedView = metadataResolver.getMaterializedView(tableName);
         if (optionalMaterializedView.isPresent()) {
             if (!statement.isExists()) {
                 throw new SemanticException(NOT_SUPPORTED, statement, "'%s' is a materialized view, not a table. Use DROP MATERIALIZED VIEW to drop.", tableName);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.SCHEMA_ALREADY_EXISTS;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -48,6 +49,10 @@ public class RenameSchemaTask
         CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()), metadata);
         CatalogSchemaName target = new CatalogSchemaName(source.getCatalogName(), statement.getTarget().getValue());
         MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
+
+        if (!metadataResolver.catalogExists(source.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", source.getCatalogName());
+        }
 
         if (!metadataResolver.schemaExists(source)) {
             throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", source);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/TruncateTableTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/TruncateTableTask.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -48,6 +50,14 @@ public class TruncateTableTask
     {
         MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
+
+        if (!metadataResolver.catalogExists(tableName.getCatalogName())) {
+            throw new SemanticException(MISSING_CATALOG, "Catalog '%s' does not exist", tableName.getCatalogName());
+        }
+
+        if (!metadataResolver.schemaExists(tableName.getCatalogSchemaName())) {
+            throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", tableName.getSchemaName());
+        }
 
         if (metadataResolver.isMaterializedView(tableName)) {
             throw new SemanticException(NOT_SUPPORTED, statement, "Cannot truncate a materialized view");

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
@@ -525,13 +525,14 @@ public class TestCreateMaterializedViewTask
                 @Override
                 public boolean catalogExists(String catalogName)
                 {
-                    return false;
+                    return CATALOG_NAME.equals(catalogName);
                 }
 
                 @Override
                 public boolean schemaExists(CatalogSchemaName schemaName)
                 {
-                    return false;
+                    return CATALOG_NAME.equals(schemaName.getCatalogName()) &&
+                            SCHEMA_NAME.equals(schemaName.getSchemaName());
                 }
 
                 @Override

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -143,8 +143,8 @@ public class TestMemorySmoke
         int tablesBeforeCreate = listMemoryTables().size();
 
         assertQueryFails("CREATE TABLE schema3.test_table3 (x date)", "Schema schema3 not found");
-        assertQueryFails("CREATE VIEW schema4.test_view4 AS SELECT 123 x", "Schema schema4 not found");
-        assertQueryFails("CREATE OR REPLACE VIEW schema5.test_view5 AS SELECT 123 x", "Schema schema5 not found");
+        assertQueryFails("CREATE VIEW schema4.test_view4 AS SELECT 123 x", ".*Schema 'schema4' does not exist");
+        assertQueryFails("CREATE OR REPLACE VIEW schema5.test_view5 AS SELECT 123 x", ".*Schema 'schema5' does not exist");
 
         int tablesAfterCreate = listMemoryTables().size();
         assertEquals(tablesBeforeCreate, tablesAfterCreate);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergMaterializedViews.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergMaterializedViews.java
@@ -47,6 +47,7 @@ public class TestPrestoNativeIcebergMaterializedViews
 
         serverUri = restServer.getBaseUrl().toString();
         super.init();
+        getQueryRunner().execute("CREATE SCHEMA IF NOT EXISTS test_schema");
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
## Description

Summary:
When using access control that has deny rules, trying to create a
schema under an invalid catalog will result in an access denined
error message instead of informing the user that the catalog is
invalid.

This fixes the error message by putting the catalog check before
running access control checks so it will error earlier and tell
the user the catalog is invalid.

## Motivation and Context
Presto should inform the user the catalog is invalid before going through access control.

Error message before fix:
```
java.lang.AssertionError: Expected exception message 'Access Denied: Cannot create schema invalid_catalog.test' to match 'Catalog does not exist: invalid_catalog' for query: CREATE SCHEMA invalid_catalog.test
	at org.testng.Assert.fail(Assert.java:98)
	...
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
Caused by: java.lang.RuntimeException: Access Denied: Cannot create schema invalid_catalog.test
	at com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema(AccessDeniedException.java:67)
	at com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema(AccessDeniedException.java:62)
	at com.facebook.presto.testing.TestingAccessControlManager.checkCanCreateSchema(TestingAccessControlManager.java:166)
	at com.facebook.presto.execution.CreateSchemaTask.execute(CreateSchemaTask.java:62)
```
## Impact
NA

## Test Plan
Added unit test to verify fix.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure CREATE SCHEMA validates the target catalog before performing access control checks to surface the correct error when the catalog is invalid.

Bug Fixes:
- Fix CREATE SCHEMA to report an invalid catalog error instead of an access denied error when the catalog does not exist.

Tests:
- Add an integration test covering catalog validation precedence over access control for CREATE SCHEMA.