### PR TITLE
DNR-Test PR

### DIFF
--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.9.6</version>
+            <version>0.9.8</version>
             <classifier>all</classifier>
             <exclusions>
                 <exclusion>

--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -19,17 +19,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>ru.yandex.clickhouse</groupId>
+            <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.3.2</version>
+            <version>0.9.6</version>
+            <classifier>all</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -77,6 +82,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseModule.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseModule.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.clickhouse;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import com.facebook.presto.plugin.clickhouse.optimization.ClickHouseQueryGenerator;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.procedure.Procedure;
@@ -22,7 +23,6 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
-import ru.yandex.clickhouse.ClickHouseDriver;
 
 import java.sql.SQLException;
 

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DriverConnectionFactory.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DriverConnectionFactory.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.plugin.clickhouse;
 
-import ru.yandex.clickhouse.ClickHouseDriver;
+import com.clickhouse.jdbc.ClickHouseDriver;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DriverConnectionFactory.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/DriverConnectionFactory.java
@@ -52,11 +52,8 @@ public class DriverConnectionFactory
         if (config.getConnectionPassword() != null) {
             connectionProperties.setProperty("password", config.getConnectionPassword());
         }
-        connectionProperties.setProperty("useInformationSchema", "true");
-        connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
-        connectionProperties.setProperty("useUnicode", "true");
-        connectionProperties.setProperty("characterEncoding", "utf8");
-        connectionProperties.setProperty("tinyInt1isBit", "false");
+        // ClickHouse JDBC driver specific properties
+        connectionProperties.setProperty("client_name", "presto");
         return connectionProperties;
     }
 

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseDistributedQueries.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseDistributedQueries.java
@@ -63,11 +63,23 @@ public class TestClickHouseDistributedQueries
                 TpchTable.getTables());
     }
 
+    @Override
     @AfterClass(alwaysRun = true)
-    public final void destroy()
+    public void close()
+            throws Exception
     {
-        if (clickhouseServer != null) {
-            clickhouseServer.close();
+        try {
+            // Close QueryRunner first via parent's close() method
+            // This ensures all queries and background tasks are stopped
+            super.close();
+        }
+        finally {
+            // Then close the ClickHouse server
+            // This prevents "connection refused" errors during QueryRunner shutdown
+            if (clickhouseServer != null) {
+                clickhouseServer.close();
+                clickhouseServer = null;
+            }
         }
     }
 

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseModule.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseModule.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.plugin.clickhouse;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import ru.yandex.clickhouse.ClickHouseDriver;
 
 import java.util.Map;
 import java.util.Optional;

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
@@ -23,7 +23,7 @@ import java.sql.Statement;
 public class TestingClickHouseServer
         implements Closeable
 {
-    private static final String CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:23.12.2.59";
+    private static final String CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.3.3.102";
     private final ClickHouseContainer dockerContainer;
 
     public TestingClickHouseServer()

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
@@ -23,7 +23,7 @@ import java.sql.Statement;
 public class TestingClickHouseServer
         implements Closeable
 {
-    private static final String CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.3.3.102";
+    private static final String CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:25.3.6.56";
     private final ClickHouseContainer dockerContainer;
 
     public TestingClickHouseServer()

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingDatabase.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingDatabase.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.plugin.clickhouse;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import com.facebook.presto.spi.ConnectorSession;
-import ru.yandex.clickhouse.ClickHouseDriver;
 
 import java.sql.Connection;
 import java.sql.DriverManager;


### PR DESCRIPTION
upgrade ru.yandex.clickhouse:clickhouse-jdbc to com.clickhouse:clickhouse-jdbc jar

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade ClickHouse JDBC dependency and test container image version for the ClickHouse connector.

Enhancements:
- Switch ClickHouse JDBC dependency from ru.yandex.clickhouse:clickhouse-jdbc 0.3.2 to com.clickhouse:clickhouse-jdbc 0.9.6 with updated transitive dependency exclusions.
- Exclude JNA from presto-common and adjust ClickHouse connector dependencies to avoid conflicting native libraries.
- Update the Docker ClickHouse server image used in tests to version 24.3.3.102.

Build:
- Adjust presto-clickhouse module Maven dependencies to use the new ClickHouse JDBC artifact and classifiers.