### PR TITLE
feat(native): Implement read support for Iceberg row lineage

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -882,7 +882,7 @@ See the `Iceberg spec — Row Lineage <https://iceberg.apache.org/spec/#row-line
    Presto supports **reading** row lineage columns only.  Writing
    row lineage metadata (assigning ``_row_id`` and
    ``_last_updated_sequence_number`` when inserting or updating rows) is not
-   yet supported.
+   supported.
 
 ``_row_id`` column
 ~~~~~~~~~~~~~~~~~~

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -866,6 +866,83 @@ When this column is used, deleted rows will not be filtered out of the results.
      file:/path/to/table/data/delete_file_d8510b3e-510a-4fc2-b2b2-e59ead7fd386.parquet |         0
      NULL                                                                              |         1
 
+Row Lineage Columns
+^^^^^^^^^^^^^^^^^^^
+
+Iceberg format version 3 introduces row lineage: two metadata columns that allow
+you to trace the origin of every row back to a specific file and snapshot.
+These columns are ``NULL`` for tables that use format version 1 or 2.  When an
+existing V1/V2 table is upgraded to V3, Iceberg automatically backfills the
+``firstRowId`` metadata on all existing data files so that the columns become
+non-``NULL`` for every row, including rows written before the upgrade.
+See the `Iceberg spec — Row Lineage <https://iceberg.apache.org/spec/#row-lineage>`_ for the full specification.
+
+.. note::
+
+   Presto currently supports **reading** row lineage columns only.  Writing
+   row lineage metadata (assigning ``_row_id`` and
+   ``_last_updated_sequence_number`` when inserting or updating rows) is not
+   yet supported.
+
+``_row_id`` column
+~~~~~~~~~~~~~~~~~~
+A globally unique, monotonically increasing ``BIGINT`` identifier for each row.
+The value is derived from the data file's ``firstRowId`` (stored in the Iceberg
+manifest) plus the row's ordinal position within that file
+(``firstRowId + position_in_file``).  Row IDs are stable across reads and are
+unique within the table at any given point in time.
+
+.. code-block:: sql
+
+    SELECT _row_id, id, value FROM my_v3_table ORDER BY _row_id;
+
+.. code-block:: text
+
+     _row_id | id | value
+    ---------+----+-------
+           0 |  1 | one
+           1 |  2 | two
+
+For V1/V2 tables, the column returns ``NULL``:
+
+.. code-block:: sql
+
+    SELECT _row_id FROM my_v2_table ORDER BY id;
+
+.. code-block:: text
+
+     _row_id
+    ---------
+     NULL
+     NULL
+
+``_last_updated_sequence_number`` column
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Iceberg data sequence number of the snapshot in which this row was last
+written (inserted or updated).  All rows written in the same ``APPEND`` or
+``OVERWRITE`` commit share the same sequence number.  Later commits produce
+higher sequence numbers, so you can use this column to determine the relative
+write order of rows across snapshots.
+
+.. code-block:: sql
+
+    SELECT _last_updated_sequence_number, id, value
+    FROM my_v3_table
+    ORDER BY _row_id;
+
+.. code-block:: text
+
+     _last_updated_sequence_number | id | value
+    -------------------------------+----+-------
+                                 1 |  1 | one
+                                 2 |  2 | two
+
+The example above shows two rows written in separate commits: ``id = 1`` was
+committed first (sequence number 1) and ``id = 2`` was committed next (sequence
+number 2).
+
+For V1/V2 tables, the column returns ``NULL``.
+
 Presto C++ Support
 ^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -879,7 +879,7 @@ See the `Iceberg spec — Row Lineage <https://iceberg.apache.org/spec/#row-line
 
 .. note::
 
-   Presto currently supports **reading** row lineage columns only.  Writing
+   Presto supports **reading** row lineage columns only.  Writing
    row lineage metadata (assigning ``_row_id`` and
    ``_last_updated_sequence_number`` when inserting or updating rows) is not
    yet supported.

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
@@ -17,13 +17,11 @@ import com.facebook.presto.execution.QueryStats;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
-import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tests.ResultWithQueryId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
@@ -35,7 +33,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
-import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DataWriter;
@@ -48,32 +45,18 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-/**
- * Tests that row lineage values (_row_id and _last_updated_sequence_number) are consistent
- * between the Iceberg API (used by Spark internally to create and read Iceberg V3 tables)
- * and Presto (which reads the row lineage hidden columns).
- *
- * <p>This test creates V3 tables and writes data using the same Iceberg API that Spark uses
- * under the hood (HadoopCatalog, GenericRecord, GenericParquetWriter), then verifies that
- * Presto returns identical row lineage values to those derived from the Iceberg file metadata.
- */
 public class TestIcebergRowLineage
-        extends AbstractTestQueryFramework
+        extends TestIcebergRowLineageBase
 {
-    private static final String TEST_SCHEMA = "tpch";
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -87,169 +70,13 @@ public class TestIcebergRowLineage
                 .build().getQueryRunner();
     }
 
-    @Test
-    public void testSparkCreatedV3TableRowLineageMatchesPresto()
-            throws Exception
+    @Override
+    protected File getCatalogDirectory()
     {
-        String tableName = "test_spark_row_lineage";
-        Catalog catalog = loadCatalog();
-        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
-
-        try {
-            // Create V3 table using the Iceberg Catalog API (same API Spark's SparkCatalog uses)
-            Schema schema = new Schema(
-                    Types.NestedField.required(1, "id", Types.IntegerType.get()),
-                    Types.NestedField.optional(2, "value", Types.StringType.get()));
-            Table table = catalog.createTable(tableId, schema,
-                    org.apache.iceberg.PartitionSpec.unpartitioned(),
-                    ImmutableMap.of("format-version", "3"));
-
-            // First commit: write one row using Iceberg's data writer (same API Spark uses internally)
-            writeRecords(table, schema, GenericRecord.create(schema).copy("id", 1, "value", "one"));
-
-            // Second commit: write another row in a separate commit
-            table.refresh();
-            writeRecords(table, schema, GenericRecord.create(schema).copy("id", 2, "value", "two"));
-
-            // Read expected row lineage values from Iceberg DataFile metadata
-            // This is the ground truth that both Spark and Presto should agree on
-            table.refresh();
-            List<long[]> expectedPairs = new ArrayList<>();
-            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-                for (FileScanTask task : tasks) {
-                    DataFile dataFile = task.file();
-                    Long firstRowId = dataFile.firstRowId();
-                    long seqNum = task.file().dataSequenceNumber();
-
-                    // Verify that V3 metadata was written correctly
-                    assertNotNull(firstRowId,
-                            "Iceberg should set firstRowId for V3 tables (same behavior as Spark)");
-
-                    for (long pos = 0; pos < dataFile.recordCount(); pos++) {
-                        expectedPairs.add(new long[] {firstRowId + pos, seqNum});
-                    }
-                }
-            }
-            expectedPairs.sort((a, b) -> Long.compare(a[0], b[0]));
-
-            // Read row lineage from Presto
-            MaterializedResult prestoResult = computeActual(
-                    "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " + tableName +
-                            " ORDER BY \"_row_id\"");
-            List<MaterializedRow> prestoRows = prestoResult.getMaterializedRows();
-
-            // Assert same number of rows
-            assertEquals(prestoRows.size(), expectedPairs.size(),
-                    "Presto and Iceberg API should return the same number of rows");
-
-            // Assert row lineage values match between Iceberg API (Spark path) and Presto
-            for (int i = 0; i < prestoRows.size(); i++) {
-                Long prestoRowId = (Long) prestoRows.get(i).getField(0);
-                Long prestoSeqNum = (Long) prestoRows.get(i).getField(1);
-
-                assertNotNull(prestoRowId, "Presto _row_id should not be null for V3 table");
-                assertNotNull(prestoSeqNum, "Presto _last_updated_sequence_number should not be null");
-
-                assertEquals(prestoRowId.longValue(), expectedPairs.get(i)[0],
-                        "Presto _row_id should match expected value from Iceberg metadata");
-                assertEquals(prestoSeqNum.longValue(), expectedPairs.get(i)[1],
-                        "Presto _last_updated_sequence_number should match Iceberg metadata");
-            }
-
-            // Verify _row_id uniqueness
-            long distinctRowIds = (Long) computeActual(
-                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
-            assertEquals(distinctRowIds, 2L, "Row IDs must be unique across all rows");
-
-            // Verify sequence numbers differ between commits
-            long distinctSeqNums = (Long) computeActual(
-                    "SELECT count(DISTINCT \"_last_updated_sequence_number\") FROM " + tableName).getOnlyValue();
-            assertEquals(distinctSeqNums, 2L, "Sequence numbers should differ between commits");
-
-            // Verify ordering: earlier commits have smaller sequence numbers
-            Long seqForFirst = (Long) computeActual(
-                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
-                            " WHERE id = 1").getOnlyValue();
-            Long seqForSecond = (Long) computeActual(
-                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
-                            " WHERE id = 2").getOnlyValue();
-            assertTrue(seqForFirst < seqForSecond,
-                    "_last_updated_sequence_number should be smaller for earlier commits");
-        }
-        finally {
-            catalog.dropTable(tableId, true);
-        }
-    }
-
-    @Test
-    public void testSparkCreatedV3TableRowLineageWithMultipleRowsPerCommit()
-            throws Exception
-    {
-        String tableName = "test_spark_row_lineage_multi";
-        Catalog catalog = loadCatalog();
-        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
-
-        try {
-            // Create V3 table
-            Schema schema = new Schema(
-                    Types.NestedField.required(1, "id", Types.IntegerType.get()),
-                    Types.NestedField.optional(2, "value", Types.StringType.get()));
-            Table table = catalog.createTable(tableId, schema,
-                    org.apache.iceberg.PartitionSpec.unpartitioned(),
-                    ImmutableMap.of("format-version", "3"));
-
-            // Write multiple rows in a single commit (same as Spark INSERT with multiple values)
-            writeRecords(table, schema,
-                    GenericRecord.create(schema).copy("id", 1, "value", "one"),
-                    GenericRecord.create(schema).copy("id", 2, "value", "two"),
-                    GenericRecord.create(schema).copy("id", 3, "value", "three"));
-
-            // Read file metadata from Iceberg API
-            table.refresh();
-            List<long[]> expectedPairs = new ArrayList<>();
-            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-                for (FileScanTask task : tasks) {
-                    DataFile dataFile = task.file();
-                    Long firstRowId = dataFile.firstRowId();
-                    long seqNum = task.file().dataSequenceNumber();
-                    assertNotNull(firstRowId, "firstRowId should be set for V3 tables");
-                    for (long pos = 0; pos < dataFile.recordCount(); pos++) {
-                        expectedPairs.add(new long[] {firstRowId + pos, seqNum});
-                    }
-                }
-            }
-            expectedPairs.sort((a, b) -> Long.compare(a[0], b[0]));
-
-            // Read from Presto
-            MaterializedResult prestoResult = computeActual(
-                    "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " +
-                            tableName + " ORDER BY \"_row_id\"");
-            List<MaterializedRow> prestoRows = prestoResult.getMaterializedRows();
-
-            assertEquals(prestoRows.size(), expectedPairs.size());
-
-            // All rows from the same commit should have the same sequence number
-            long firstSeqNum = expectedPairs.get(0)[1];
-            for (int i = 0; i < prestoRows.size(); i++) {
-                Long prestoRowId = (Long) prestoRows.get(i).getField(0);
-                Long prestoSeqNum = (Long) prestoRows.get(i).getField(1);
-
-                assertEquals(prestoRowId.longValue(), expectedPairs.get(i)[0],
-                        "Row ID should match expected value from Iceberg metadata");
-                assertEquals(prestoSeqNum.longValue(), expectedPairs.get(i)[1],
-                        "Sequence number should match expected value from Iceberg metadata");
-                assertEquals(prestoSeqNum.longValue(), firstSeqNum,
-                        "All rows in the same commit should have the same sequence number");
-            }
-
-            // Verify all row IDs are unique
-            long distinctRowIds = (Long) computeActual(
-                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
-            assertEquals(distinctRowIds, 3L);
-        }
-        finally {
-            catalog.dropTable(tableId, true);
-        }
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(
+                dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
     }
 
     @Test
@@ -538,56 +365,5 @@ public class TestIcebergRowLineage
                 .getFullQueryInfo(result.getQueryId())
                 .getQueryStats();
         return stats.getCompletedSplits();
-    }
-
-    private void writeRecords(Table table, Schema schema, Record... records)
-            throws Exception
-    {
-        String filename = "data-" + UUID.randomUUID() + ".parquet";
-        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
-                table.location(), "data/" + filename);
-        Configuration conf = new Configuration();
-
-        DataWriter<Record> writer = Parquet.writeData(
-                        HadoopOutputFile.fromPath(filePath, conf))
-                .forTable(table)
-                .createWriterFunc(GenericParquetWriter::create)
-                .overwrite()
-                .build();
-        try {
-            for (Record record : records) {
-                writer.write(record);
-            }
-        }
-        finally {
-            writer.close();
-        }
-
-        table.newAppend()
-                .appendFile(writer.toDataFile())
-                .commit();
-    }
-
-    private Catalog loadCatalog()
-    {
-        return CatalogUtil.loadCatalog(
-                HadoopCatalog.class.getName(), ICEBERG_CATALOG,
-                getProperties(), new Configuration());
-    }
-
-    private Map<String, String> getProperties()
-    {
-        File metastoreDir = getCatalogDirectory();
-        return ImmutableMap.of("warehouse", metastoreDir.toURI().toString());
-    }
-
-    private File getCatalogDirectory()
-    {
-        Path dataDirectory = getDistributedQueryRunner()
-                .getCoordinator().getDataDirectory();
-        Path catalogDirectory = getIcebergDataDirectoryPath(
-                dataDirectory, HADOOP.name(),
-                new IcebergConfig().getFileFormat(), false);
-        return catalogDirectory.toFile();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineageBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineageBase.java
@@ -11,16 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.nativetests.iceberg;
+package com.facebook.presto.iceberg;
 
-import com.facebook.presto.iceberg.CatalogType;
-import com.facebook.presto.iceberg.IcebergConfig;
-import com.facebook.presto.iceberg.IcebergQueryRunner;
-import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
-import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
@@ -43,59 +37,33 @@ import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-public class TestPrestoNativeIcebergV3Queries
+public abstract class TestIcebergRowLineageBase
         extends AbstractTestQueryFramework
 {
-    private static final String TEST_SCHEMA = "tpch";
+    protected static final String TEST_SCHEMA = "tpch";
 
-    // Unique suffix per test-class instantiation.
-    private static final String RUN_ID =
-            UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
-                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
-                .setCatalogType(CatalogType.HADOOP)
-                .setAddStorageFormatToPath(true)
-                .build();
-    }
-
-    @Override
-    protected ExpectedQueryRunner createExpectedQueryRunner()
-            throws Exception
-    {
-        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
-                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
-                .setCatalogType(CatalogType.HADOOP)
-                .setAddStorageFormatToPath(true)
-                .build();
-    }
+    protected abstract File getCatalogDirectory();
 
     @Test
     public void testV3TableRowLineageMatchesIcebergMetadata()
             throws Exception
     {
-        String tableName = "test_native_row_lineage_" + RUN_ID;
+        String tableName = "test_row_lineage";
         Catalog catalog = loadCatalog();
         TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
-
         try {
-            Schema schema = createTestSchema();
             Table table = createTestTable(catalog, tableId, "3");
+            Schema schema = table.schema();
 
             writeRecords(table, GenericRecord.create(schema).copy("id", 1, "value", "one"));
             table.refresh();
@@ -104,7 +72,6 @@ public class TestPrestoNativeIcebergV3Queries
             table.refresh();
             List<long[]> expectedPairs = buildExpectedPairs(table, "Iceberg should set firstRowId for V3 tables");
 
-            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
             assertPrestoRowLineageMatchesExpected(tableName, expectedPairs);
 
             long distinctRowIds = (Long) computeActual(
@@ -116,11 +83,9 @@ public class TestPrestoNativeIcebergV3Queries
             assertEquals(distinctSeqNums, 2L, "Sequence numbers should differ between commits");
 
             Long seqForFirst = (Long) computeActual(
-                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
-                            " WHERE id = 1").getOnlyValue();
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName + " WHERE id = 1").getOnlyValue();
             Long seqForSecond = (Long) computeActual(
-                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
-                            " WHERE id = 2").getOnlyValue();
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName + " WHERE id = 2").getOnlyValue();
             assertTrue(seqForFirst < seqForSecond,
                     "_last_updated_sequence_number should be smaller for earlier commits");
         }
@@ -137,13 +102,12 @@ public class TestPrestoNativeIcebergV3Queries
     public void testV3TableRowLineageWithMultipleRowsPerCommit()
             throws Exception
     {
-        String tableName = "test_native_row_lineage_multi_" + RUN_ID;
+        String tableName = "test_row_lineage_multi";
         Catalog catalog = loadCatalog();
         TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
-
         try {
-            Schema schema = createTestSchema();
             Table table = createTestTable(catalog, tableId, "3");
+            Schema schema = table.schema();
 
             writeRecords(table,
                     GenericRecord.create(schema).copy("id", 1, "value", "one"),
@@ -153,7 +117,6 @@ public class TestPrestoNativeIcebergV3Queries
             table.refresh();
             List<long[]> expectedPairs = buildExpectedPairs(table, "firstRowId should be set for V3 tables");
 
-            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
             assertPrestoRowLineageMatchesExpected(tableName, expectedPairs);
 
             long sharedSeqNum = expectedPairs.get(0)[1];
@@ -179,40 +142,30 @@ public class TestPrestoNativeIcebergV3Queries
     public void testRowLineageBackfilledOnV2ToV3Upgrade()
             throws Exception
     {
-        String tableName = "test_native_row_lineage_v2_" + RUN_ID;
+        String tableName = "test_row_lineage_v2_to_v3";
         Catalog catalog = loadCatalog();
         TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
-
         try {
-            Schema schema = createTestSchema();
             Table table = createTestTable(catalog, tableId, "2");
+            Schema schema = table.schema();
 
             writeRecords(table,
                     GenericRecord.create(schema).copy("id", 1, "value", "one"),
                     GenericRecord.create(schema).copy("id", 2, "value", "two"));
             table.refresh();
-            writeRecords(table,
-                    GenericRecord.create(schema).copy("id", 3, "value", "three"));
+            writeRecords(table, GenericRecord.create(schema).copy("id", 3, "value", "three"));
 
-            // V1/V2 tables have no row lineage; both columns are null.
+            // V2 tables have no row lineage; both columns are null.
             assertEquals(computeActual("SELECT \"_row_id\", * FROM " + tableName).getRowCount(), 3);
-            assertQuery("SELECT \"_row_id\" FROM " + tableName + " ORDER BY id");
-            assertQuery("SELECT \"_last_updated_sequence_number\" FROM " + tableName + " ORDER BY id");
-
-            // Explicitly validate that lineage columns are null for all rows before upgrading to V3.
             assertEquals(
                     computeActual("SELECT count(*) FROM " + tableName + " WHERE \"_row_id\" IS NOT NULL").getOnlyValue(),
-                    0L,
-                    "_row_id should be null for all rows before upgrading from V2");
+                    0L, "_row_id should be null for all rows in a V2 table");
             assertEquals(
                     computeActual("SELECT count(*) FROM " + tableName + " WHERE \"_last_updated_sequence_number\" IS NOT NULL").getOnlyValue(),
-                    0L,
-                    "_last_updated_sequence_number should be null for all rows before upgrading from V2");
+                    0L, "_last_updated_sequence_number should be null for all rows in a V2 table");
 
             table.refresh();
-            table.updateProperties()
-                    .set("format-version", "3")
-                    .commit();
+            table.updateProperties().set("format-version", "3").commit();
             table.refresh();
 
             writeRecords(table,
@@ -220,10 +173,6 @@ public class TestPrestoNativeIcebergV3Queries
                     GenericRecord.create(schema).copy("id", 5, "value", "five"));
             table.refresh();
 
-            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
-
-            // V2→V3 upgrade backfills firstRowId on existing manifest entries, so all rows
-            // (including the 3 pre-upgrade ones) now have non-null row lineage.
             assertEquals(computeActual("SELECT count(*) FROM " + tableName +
                             " WHERE \"_row_id\" IS NULL").getOnlyValue(), 0L,
                     "All rows should have non-null _row_id after V3 upgrade");
@@ -236,7 +185,8 @@ public class TestPrestoNativeIcebergV3Queries
             assertEquals(distinctRowIds, 5L, "Row IDs must be unique across all 5 rows after upgrade");
 
             table.refresh();
-            List<long[]> allExpectedPairs = buildExpectedPairs(table, "All files should have firstRowId set after V3 upgrade");
+            List<long[]> allExpectedPairs = buildExpectedPairs(table,
+                    "All files should have firstRowId set after V3 upgrade");
             assertPrestoRowLineageMatchesExpected(tableName, allExpectedPairs);
         }
         finally {
@@ -248,7 +198,7 @@ public class TestPrestoNativeIcebergV3Queries
         }
     }
 
-    private void assertPrestoRowLineageMatchesExpected(String tableName, List<long[]> expectedPairs)
+    protected void assertPrestoRowLineageMatchesExpected(String tableName, List<long[]> expectedPairs)
     {
         MaterializedResult result = computeActual(
                 "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " + tableName +
@@ -268,7 +218,7 @@ public class TestPrestoNativeIcebergV3Queries
         }
     }
 
-    private static List<long[]> buildExpectedPairs(Table table, String firstRowIdMessage)
+    protected static List<long[]> buildExpectedPairs(Table table, String firstRowIdMessage)
             throws Exception
     {
         List<long[]> pairs = new ArrayList<>();
@@ -288,23 +238,19 @@ public class TestPrestoNativeIcebergV3Queries
         return pairs;
     }
 
-    private static Schema createTestSchema()
+    protected static Table createTestTable(Catalog catalog, TableIdentifier tableId, String formatVersion)
     {
-        return new Schema(
+        Schema schema = new Schema(
                 Types.NestedField.required(1, "id", Types.IntegerType.get()),
                 Types.NestedField.optional(2, "value", Types.StringType.get()));
-    }
-
-    private static Table createTestTable(Catalog catalog, TableIdentifier tableId, String formatVersion)
-    {
         return catalog.createTable(
                 tableId,
-                createTestSchema(),
+                schema,
                 org.apache.iceberg.PartitionSpec.unpartitioned(),
                 ImmutableMap.of("format-version", formatVersion));
     }
 
-    private void writeRecords(Table table, Record... records)
+    protected void writeRecords(Table table, Record... records)
             throws Exception
     {
         String filename = "data-" + UUID.randomUUID() + ".parquet";
@@ -312,8 +258,7 @@ public class TestPrestoNativeIcebergV3Queries
                 table.location(), "data/" + filename);
         Configuration conf = new Configuration();
 
-        DataWriter<Record> writer = Parquet.writeData(
-                        HadoopOutputFile.fromPath(filePath, conf))
+        DataWriter<Record> writer = Parquet.writeData(HadoopOutputFile.fromPath(filePath, conf))
                 .forTable(table)
                 .createWriterFunc(GenericParquetWriter::create)
                 .overwrite()
@@ -327,31 +272,18 @@ public class TestPrestoNativeIcebergV3Queries
             writer.close();
         }
 
-        table.newAppend()
-                .appendFile(writer.toDataFile())
-                .commit();
+        table.newAppend().appendFile(writer.toDataFile()).commit();
     }
 
-    private Catalog loadCatalog()
+    protected Catalog loadCatalog()
     {
         return CatalogUtil.loadCatalog(
-                HadoopCatalog.class.getName(), IcebergQueryRunner.ICEBERG_CATALOG,
+                HadoopCatalog.class.getName(), ICEBERG_CATALOG,
                 getProperties(), new Configuration());
     }
 
     private Map<String, String> getProperties()
     {
-        File metastoreDir = getCatalogDirectory();
-        return ImmutableMap.of("warehouse", metastoreDir.toURI().toString());
-    }
-
-    private File getCatalogDirectory()
-    {
-        Path dataDirectory = getDistributedQueryRunner()
-                .getCoordinator().getDataDirectory();
-        Path catalogDirectory = IcebergQueryRunner.getIcebergDataDirectoryPath(
-                dataDirectory, CatalogType.HADOOP.name(),
-                new IcebergConfig().getFileFormat(), true);
-        return catalogDirectory.toFile();
+        return ImmutableMap.of("warehouse", getCatalogDirectory().toURI().toString());
     }
 }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -15,14 +15,27 @@
 #include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 
+#include <algorithm>
+#include <unordered_set>
+
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::presto {
 
 namespace {
+
+// Row-lineage columns are not included in a table's dataColumns but may exist
+// physically in written files. Centralizing the names here means adding a new
+// lineage column only requires updating this one set.
+const std::unordered_set<std::string> kRowLineageColumnNames = {
+    velox::connector::hive::iceberg::IcebergMetadataColumn::kRowIdColumnName,
+    velox::connector::hive::iceberg::IcebergMetadataColumn::
+        kLastUpdatedSequenceNumberColumnName,
+};
 
 velox::connector::hive::iceberg::FileContent toVeloxFileContent(
     const presto::protocol::iceberg::FileContent content) {
@@ -93,6 +106,20 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
       types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
           fieldNamesToLowerCase, parsedType->kind(), parsedType));
     }
+
+    // Row-lineage columns are not included in the table's dataColumns but may
+    // exist physically in the written files (e.g. after MERGE/UPDATE). Add any
+    // requested lineage columns to finalDataColumns so the reader can match
+    // them with the Parquet schema.
+    for (const auto& handle : columnHandles) {
+      if (kRowLineageColumnNames.count(handle->name()) &&
+          std::find(names.begin(), names.end(), handle->name()) ==
+              names.end()) {
+        names.emplace_back(handle->name());
+        types.push_back(handle->dataType());
+      }
+    }
+
     finalDataColumns = ROW(std::move(names), std::move(types));
   }
 
@@ -211,9 +238,15 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   }
 
   std::unordered_map<std::string, std::string> infoColumns = {
-      {"$data_sequence_number",
-       std::to_string(icebergSplit->dataSequenceNumber)},
-      {"$path", icebergSplit->path}};
+      {"$path", icebergSplit->path},
+      {velox::connector::hive::iceberg::IcebergMetadataColumn::
+           kDataSequenceNumberInfoColumn,
+       std::to_string(icebergSplit->dataSequenceNumber)}};
+  if (icebergSplit->firstRowId >= 0) {
+    infoColumns[velox::connector::hive::iceberg::IcebergMetadataColumn::
+                    kFirstRowIdInfoColumn] =
+        std::to_string(icebergSplit->firstRowId);
+  }
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -238,6 +238,58 @@
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-iceberg</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-iceberg</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-api</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-core</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-parquet</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>${dep.parquet.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -238,18 +238,6 @@
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-iceberg</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-iceberg</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3RowLineage.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3RowLineage.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests.iceberg;
+
+import com.facebook.presto.iceberg.CatalogType;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.TestIcebergRowLineageBase;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+
+public class TestIcebergV3RowLineage
+        extends TestIcebergRowLineageBase
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Override
+    protected File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = IcebergQueryRunner.getIcebergDataDirectoryPath(
+                dataDirectory, CatalogType.HADOOP.name(),
+                new IcebergConfig().getFileFormat(), true);
+        return catalogDirectory.toFile();
+    }
+}

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestPrestoNativeIcebergV3Queries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestPrestoNativeIcebergV3Queries.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests.iceberg;
+
+import com.facebook.presto.iceberg.CatalogType;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrestoNativeIcebergV3Queries
+        extends AbstractTestQueryFramework
+{
+    private static final String TEST_SCHEMA = "tpch";
+
+    // Unique suffix per test-class instantiation.
+    private static final String RUN_ID =
+            UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testV3TableRowLineageMatchesIcebergMetadata()
+            throws Exception
+    {
+        String tableName = "test_native_row_lineage_" + RUN_ID;
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+
+        try {
+            Schema schema = createTestSchema();
+            Table table = createTestTable(catalog, tableId, "3");
+
+            writeRecords(table, GenericRecord.create(schema).copy("id", 1, "value", "one"));
+            table.refresh();
+            writeRecords(table, GenericRecord.create(schema).copy("id", 2, "value", "two"));
+
+            table.refresh();
+            List<long[]> expectedPairs = buildExpectedPairs(table, "Iceberg should set firstRowId for V3 tables");
+
+            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
+            assertPrestoRowLineageMatchesExpected(tableName, expectedPairs);
+
+            long distinctRowIds = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctRowIds, 2L, "Row IDs must be unique across all rows");
+
+            long distinctSeqNums = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_last_updated_sequence_number\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctSeqNums, 2L, "Sequence numbers should differ between commits");
+
+            Long seqForFirst = (Long) computeActual(
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
+                            " WHERE id = 1").getOnlyValue();
+            Long seqForSecond = (Long) computeActual(
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
+                            " WHERE id = 2").getOnlyValue();
+            assertTrue(seqForFirst < seqForSecond,
+                    "_last_updated_sequence_number should be smaller for earlier commits");
+        }
+        finally {
+            try {
+                catalog.dropTable(tableId, true);
+            }
+            catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testV3TableRowLineageWithMultipleRowsPerCommit()
+            throws Exception
+    {
+        String tableName = "test_native_row_lineage_multi_" + RUN_ID;
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+
+        try {
+            Schema schema = createTestSchema();
+            Table table = createTestTable(catalog, tableId, "3");
+
+            writeRecords(table,
+                    GenericRecord.create(schema).copy("id", 1, "value", "one"),
+                    GenericRecord.create(schema).copy("id", 2, "value", "two"),
+                    GenericRecord.create(schema).copy("id", 3, "value", "three"));
+
+            table.refresh();
+            List<long[]> expectedPairs = buildExpectedPairs(table, "firstRowId should be set for V3 tables");
+
+            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
+            assertPrestoRowLineageMatchesExpected(tableName, expectedPairs);
+
+            long sharedSeqNum = expectedPairs.get(0)[1];
+            for (long[] pair : expectedPairs) {
+                assertEquals(pair[1], sharedSeqNum,
+                        "All rows in a single commit should have the same sequence number");
+            }
+
+            long distinctRowIds = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctRowIds, 3L, "Row IDs must be unique across all rows");
+        }
+        finally {
+            try {
+                catalog.dropTable(tableId, true);
+            }
+            catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testRowLineageBackfilledOnV2ToV3Upgrade()
+            throws Exception
+    {
+        String tableName = "test_native_row_lineage_v2_" + RUN_ID;
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+
+        try {
+            Schema schema = createTestSchema();
+            Table table = createTestTable(catalog, tableId, "2");
+
+            writeRecords(table,
+                    GenericRecord.create(schema).copy("id", 1, "value", "one"),
+                    GenericRecord.create(schema).copy("id", 2, "value", "two"));
+            table.refresh();
+            writeRecords(table,
+                    GenericRecord.create(schema).copy("id", 3, "value", "three"));
+
+            // V1/V2 tables have no row lineage; both columns are null.
+            assertEquals(computeActual("SELECT \"_row_id\", * FROM " + tableName).getRowCount(), 3);
+            assertQuery("SELECT \"_row_id\" FROM " + tableName + " ORDER BY id");
+            assertQuery("SELECT \"_last_updated_sequence_number\" FROM " + tableName + " ORDER BY id");
+
+            // Explicitly validate that lineage columns are null for all rows before upgrading to V3.
+            assertEquals(
+                    computeActual("SELECT count(*) FROM " + tableName + " WHERE \"_row_id\" IS NOT NULL").getOnlyValue(),
+                    0L,
+                    "_row_id should be null for all rows before upgrading from V2");
+            assertEquals(
+                    computeActual("SELECT count(*) FROM " + tableName + " WHERE \"_last_updated_sequence_number\" IS NOT NULL").getOnlyValue(),
+                    0L,
+                    "_last_updated_sequence_number should be null for all rows before upgrading from V2");
+
+            table.refresh();
+            table.updateProperties()
+                    .set("format-version", "3")
+                    .commit();
+            table.refresh();
+
+            writeRecords(table,
+                    GenericRecord.create(schema).copy("id", 4, "value", "four"),
+                    GenericRecord.create(schema).copy("id", 5, "value", "five"));
+            table.refresh();
+
+            assertQuery("SELECT \"_row_id\", \"_last_updated_sequence_number\", * FROM " + tableName);
+
+            // V2→V3 upgrade backfills firstRowId on existing manifest entries, so all rows
+            // (including the 3 pre-upgrade ones) now have non-null row lineage.
+            assertEquals(computeActual("SELECT count(*) FROM " + tableName +
+                            " WHERE \"_row_id\" IS NULL").getOnlyValue(), 0L,
+                    "All rows should have non-null _row_id after V3 upgrade");
+            assertEquals(computeActual("SELECT count(*) FROM " + tableName +
+                            " WHERE \"_last_updated_sequence_number\" IS NULL").getOnlyValue(), 0L,
+                    "All rows should have non-null _last_updated_sequence_number after V3 upgrade");
+
+            long distinctRowIds = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctRowIds, 5L, "Row IDs must be unique across all 5 rows after upgrade");
+
+            table.refresh();
+            List<long[]> allExpectedPairs = buildExpectedPairs(table, "All files should have firstRowId set after V3 upgrade");
+            assertPrestoRowLineageMatchesExpected(tableName, allExpectedPairs);
+        }
+        finally {
+            try {
+                catalog.dropTable(tableId, true);
+            }
+            catch (Exception ignored) {
+            }
+        }
+    }
+
+    private void assertPrestoRowLineageMatchesExpected(String tableName, List<long[]> expectedPairs)
+    {
+        MaterializedResult result = computeActual(
+                "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " + tableName +
+                        " ORDER BY \"_row_id\"");
+        List<MaterializedRow> rows = result.getMaterializedRows();
+        assertEquals(rows.size(), expectedPairs.size(),
+                "Presto and Iceberg API should return the same number of rows");
+        for (int i = 0; i < rows.size(); i++) {
+            Long rowId = (Long) rows.get(i).getField(0);
+            Long seqNum = (Long) rows.get(i).getField(1);
+            assertNotNull(rowId, "Presto _row_id should not be null for V3 table");
+            assertNotNull(seqNum, "Presto _last_updated_sequence_number should not be null");
+            assertEquals(rowId.longValue(), expectedPairs.get(i)[0],
+                    "_row_id should match Iceberg metadata");
+            assertEquals(seqNum.longValue(), expectedPairs.get(i)[1],
+                    "_last_updated_sequence_number should match Iceberg metadata");
+        }
+    }
+
+    private static List<long[]> buildExpectedPairs(Table table, String firstRowIdMessage)
+            throws Exception
+    {
+        List<long[]> pairs = new ArrayList<>();
+        try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+            for (FileScanTask task : tasks) {
+                DataFile dataFile = task.file();
+                Long firstRowId = dataFile.firstRowId();
+                assertNotNull(firstRowId, firstRowIdMessage);
+                assertTrue(firstRowId >= 0, "firstRowId should be non-negative: " + firstRowId);
+                long seqNum = dataFile.dataSequenceNumber();
+                for (long pos = 0; pos < dataFile.recordCount(); pos++) {
+                    pairs.add(new long[] {firstRowId + pos, seqNum});
+                }
+            }
+        }
+        pairs.sort((a, b) -> Long.compare(a[0], b[0]));
+        return pairs;
+    }
+
+    private static Schema createTestSchema()
+    {
+        return new Schema(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "value", Types.StringType.get()));
+    }
+
+    private static Table createTestTable(Catalog catalog, TableIdentifier tableId, String formatVersion)
+    {
+        return catalog.createTable(
+                tableId,
+                createTestSchema(),
+                org.apache.iceberg.PartitionSpec.unpartitioned(),
+                ImmutableMap.of("format-version", formatVersion));
+    }
+
+    private void writeRecords(Table table, Record... records)
+            throws Exception
+    {
+        String filename = "data-" + UUID.randomUUID() + ".parquet";
+        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
+                table.location(), "data/" + filename);
+        Configuration conf = new Configuration();
+
+        DataWriter<Record> writer = Parquet.writeData(
+                        HadoopOutputFile.fromPath(filePath, conf))
+                .forTable(table)
+                .createWriterFunc(GenericParquetWriter::create)
+                .overwrite()
+                .build();
+        try {
+            for (Record record : records) {
+                writer.write(record);
+            }
+        }
+        finally {
+            writer.close();
+        }
+
+        table.newAppend()
+                .appendFile(writer.toDataFile())
+                .commit();
+    }
+
+    private Catalog loadCatalog()
+    {
+        return CatalogUtil.loadCatalog(
+                HadoopCatalog.class.getName(), IcebergQueryRunner.ICEBERG_CATALOG,
+                getProperties(), new Configuration());
+    }
+
+    private Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toURI().toString());
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner()
+                .getCoordinator().getDataDirectory();
+        Path catalogDirectory = IcebergQueryRunner.getIcebergDataDirectoryPath(
+                dataDirectory, CatalogType.HADOOP.name(),
+                new IcebergConfig().getFileFormat(), true);
+        return catalogDirectory.toFile();
+    }
+}


### PR DESCRIPTION
## Description
Adds end-to-end read support for the Iceberg V3 row lineage hidden metadata columns `_row_id` and `_last_updated_sequence_number` in the Presto native execution engine.

## Motivation and Context
Fixes
- https://github.com/prestodb/presto/issues/27197

## Impact
Adds Iceberg v3 row lineage read support in native engine.

## Test Plan
Tests added in this PR

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Adds read support of row lineage columns as per Iceberg V3 spec.
```

## Summary by Sourcery

Add native Iceberg row lineage read support by propagating lineage metadata columns into Velox splits and table handles and validating behavior end-to-end against Iceberg metadata.

New Features:
- Support reading Iceberg V3 row lineage metadata columns in the Presto native execution engine.

Enhancements:
- Include row lineage metadata columns in native Iceberg table handle data columns so they can be resolved from file schemas.
- Propagate Iceberg row lineage-related info columns, including data sequence number and first row ID, into Velox Iceberg splits.

Build:
- Add Iceberg, Hadoop, Hive, and Parquet test dependencies to the native test module to enable Iceberg integration tests.

Tests:
- Add native Iceberg V3 query tests that verify row lineage columns match Iceberg metadata, including multi-row commits and V2-to-V3 upgrade backfill behavior.