### PR TITLE
fix(deps): Bump presto-spark-classloader-spark3 parent version to 0.298-SNAPSHOT

### DIFF
--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>presto-root</artifactId>
     <groupId>com.facebook.presto</groupId>
-    <version>0.296-SNAPSHOT</version>
+    <version>0.298-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Summary:
## Description

Bump the parent version in `presto-spark-classloader-spark3/pom.xml` from `0.296-SNAPSHOT` to `0.298-SNAPSHOT` so it matches the rest of the reactor (and its sibling `presto-spark-classloader-spark2`).

## Motivation and Context

Building with `-Dspark-version=3` activates the spark3 profile in `presto-spark-classloader-interface`, which adds a dependency on `presto-spark-classloader-spark3` at `${project.version}` (= `0.298-SNAPSHOT`). The spark3 module's own parent is pinned at `0.296-SNAPSHOT`, so it builds itself as `0.296-SNAPSHOT`. Maven reactor resolution matches by GAV, so the interface module cannot resolve the dependency from the reactor and falls through to nexus, where `0.298-SNAPSHOT` does not exist:

```
[ERROR] Failed to execute goal on project presto-spark-classloader-interface: Could not resolve dependencies for project com.facebook.presto:presto-spark-classloader-interface:jar:0.298-SNAPSHOT: Could not find artifact com.facebook.presto:presto-spark-classloader-spark3:jar:0.298-SNAPSHOT in nexus
```

This breaks any spark3 build of the reactor. The spark2 sibling does not have this problem because its parent reference was kept current during prior release rev-bumps.

The root cause — that release tooling skips profile-gated modules during version bumps — will be addressed in a follow-up change.

## Impact

None to spark2 builds (default profile is unchanged). spark3 builds now resolve the classloader-spark3 module from the reactor at the expected version.

## Test Plan

Built `//datainfra/presto/server/spark:presto.spark` with `-Dspark-version=3` (via the daily-release Buck flow) and confirmed the spark3 reactor build completes past `presto-spark-classloader-interface`.

## Contributor checklist

- [x] Read [The Presto Code of Conduct](https://github.com/prestodb/presto/blob/master/CODE_OF_CONDUCT.md) and adhere to the principles outlined.
- [x] Mentioned the Github issue this PR is intended to fix.
- [x] Provided sufficient unit tests and tested the changes locally.
- [x] Provided sufficient PR description.
- [x] Reviewed the conventions in the [contribution guidelines](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md).

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D104270940


