### PR TITLE
feat(plugin-native-sidecar): Add support for adding plugin loaded types in sidecar plugin

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
@@ -50,13 +50,7 @@ public interface TypeManager
      */
     boolean hasType(TypeSignature signature);
 
-    default void addType(Type type)
-    {
-        throw new UnsupportedOperationException();
-    }
+    void addType(Type type);
 
-    default void addParametricType(ParametricType parametricType)
-    {
-        throw new UnsupportedOperationException();
-    }
+    void addParametricType(ParametricType parametricType);
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
@@ -49,4 +49,14 @@ public interface TypeManager
      * Checks for the existence of this type.
      */
     boolean hasType(TypeSignature signature);
+
+    default void addType(Type type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void addParametricType(ParametricType parametricType)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestingTypeManager.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestingTypeManager.java
@@ -65,4 +65,16 @@ public class TestingTypeManager
     {
         return getType(signature) != null;
     }
+
+    @Override
+    public void addType(Type type)
+    {
+        throw new UnsupportedOperationException("Adding a type is not supported ");
+    }
+
+    @Override
+    public void addParametricType(ParametricType parametricType)
+    {
+        throw new UnsupportedOperationException("Adding a parametric type is not supported ");
+    }
 }

--- a/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingTypeManager.java
+++ b/presto-hudi/src/test/java/com/facebook/presto/hudi/TestingTypeManager.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.hudi;
 
+import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
@@ -68,5 +69,17 @@ public class TestingTypeManager
     public boolean hasType(TypeSignature signature)
     {
         return getType(signature) != null;
+    }
+
+    @Override
+    public void addType(Type type)
+    {
+        throw new UnsupportedOperationException("Adding a type is not supported ");
+    }
+
+    @Override
+    public void addParametricType(ParametricType parametricType)
+    {
+        throw new UnsupportedOperationException("Adding a parametric type is not supported ");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -19,6 +19,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
@@ -194,6 +195,18 @@ public class TestIcebergFileWriter
         public boolean hasType(TypeSignature signature)
         {
             return getType(signature) != null;
+        }
+
+        @Override
+        public void addType(Type type)
+        {
+            throw new UnsupportedOperationException("Adding a type is not supported ");
+        }
+
+        @Override
+        public void addParametricType(ParametricType parametricType)
+        {
+            throw new UnsupportedOperationException("Adding a parametric type is not supported ");
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -554,6 +554,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
     {
         this(blockEncodingSerde, functionsConfig, types, functionAndTypeManager, true);
     }
+
     public BuiltInTypeAndFunctionNamespaceManager(
             BlockEncodingSerde blockEncodingSerde,
             FunctionsConfig functionsConfig,
@@ -1312,6 +1313,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         return ImmutableList.copyOf(types.values());
     }
 
+    @Override
     public void addType(Type type)
     {
         requireNonNull(type, "type is null");
@@ -1319,6 +1321,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         checkState(existingType == null || existingType.equals(type), "Type %s is already registered", type);
     }
 
+    @Override
     public void addParametricType(ParametricType parametricType)
     {
         String name = parametricType.getName().toLowerCase(Locale.ENGLISH);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -89,6 +89,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -655,14 +656,14 @@ public class FunctionAndTypeManager
     {
         TypeSignatureBase typeSignatureBase = type.getTypeSignature().getTypeSignatureBase();
         checkArgument(typeSignatureBase.hasStandardType(), "Expect standard types");
-        builtInTypeAndFunctionNamespaceManager.addType(type);
+        servingTypeManager.get().addType(type);
     }
 
     public void addParametricType(ParametricType parametricType)
     {
         TypeSignatureBase typeSignatureBase = parametricType.getTypeSignatureBase();
         checkArgument(typeSignatureBase.hasStandardType(), "Expect standard types");
-        builtInTypeAndFunctionNamespaceManager.addParametricType(parametricType);
+        servingTypeManager.get().addParametricType(parametricType);
     }
 
     @VisibleForTesting
@@ -1069,8 +1070,9 @@ public class FunctionAndTypeManager
 
     private Map<String, ParametricType> getServingTypeManagerParametricTypes()
     {
+        // While loading the parametric types, the name is in lowercase.
         return servingTypeManager.get().getParametricTypes().stream()
-                .collect(toImmutableMap(ParametricType::getName, parametricType -> parametricType));
+                .collect(toImmutableMap(parametricType -> parametricType.getName().toLowerCase(Locale.ENGLISH), parametricType -> parametricType));
     }
 
     private Collection<? extends SqlFunction> getFunctions(

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -305,6 +305,18 @@ public class FunctionAndTypeManager
             }
 
             @Override
+            public void addType(Type type)
+            {
+                FunctionAndTypeManager.this.addType(type);
+            }
+
+            @Override
+            public void addParametricType(ParametricType parametricType)
+            {
+                FunctionAndTypeManager.this.addParametricType(parametricType);
+            }
+
+            @Override
             public Collection<SqlFunction> listBuiltInFunctions()
             {
                 return FunctionAndTypeManager.this.listBuiltInFunctions();
@@ -652,6 +664,7 @@ public class FunctionAndTypeManager
         return resolveFunctionInternal(transactionId, functionName, parameterTypes);
     }
 
+    @Override
     public void addType(Type type)
     {
         TypeSignatureBase typeSignatureBase = type.getTypeSignature().getTypeSignatureBase();
@@ -659,6 +672,7 @@ public class FunctionAndTypeManager
         servingTypeManager.get().addType(type);
     }
 
+    @Override
     public void addParametricType(ParametricType parametricType)
     {
         TypeSignatureBase typeSignatureBase = parametricType.getTypeSignatureBase();

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -290,6 +290,20 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-mongodb</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-ml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
@@ -194,6 +194,22 @@ public class NativeTypeManager
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void addType(Type type)
+    {
+        requireNonNull(type, "type is null");
+        Type existingType = types.putIfAbsent(type.getTypeSignature(), type);
+        checkState(existingType == null || existingType.equals(type), "Type %s is already registered", type);
+    }
+
+    @Override
+    public void addParametricType(ParametricType parametricType)
+    {
+        String name = parametricType.getName().toLowerCase(Locale.ENGLISH);
+        checkArgument(!parametricTypes.containsKey(name), "Parametric type already registered: %s", name);
+        parametricTypes.putIfAbsent(name, parametricType);
+    }
+
     private void addAllTypes(List<Type> typesList, List<ParametricType> parametricTypesList)
     {
         typesList.forEach(this::addType);
@@ -203,20 +219,6 @@ public class NativeTypeManager
     private Type instantiateParametricType(ExactTypeSignature exactTypeSignature)
     {
         return typeManager.instantiateParametricType(exactTypeSignature.getTypeSignature());
-    }
-
-    private void addType(Type type)
-    {
-        requireNonNull(type, "type is null");
-        Type existingType = types.putIfAbsent(type.getTypeSignature(), type);
-        checkState(existingType == null || existingType.equals(type), "Type %s is already registered", type);
-    }
-
-    private void addParametricType(ParametricType parametricType)
-    {
-        String name = parametricType.getName().toLowerCase(Locale.ENGLISH);
-        checkArgument(!parametricTypes.containsKey(name), "Parametric type already registered: %s", name);
-        parametricTypes.putIfAbsent(name, parametricType);
     }
 
     private static <T> List<T> filterSupportedTypes(

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarWithPluginLoadedTypes.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarWithPluginLoadedTypes.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.ml.MLPlugin;
+import com.facebook.presto.ml.type.ClassifierParametricType;
+import com.facebook.presto.mongodb.MongoPlugin;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.mongodb.ObjectIdType.OBJECT_ID;
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static org.testng.Assert.assertTrue;
+
+public class TestNativeSidecarWithPluginLoadedTypes
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setCoordinatorSidecarEnabled(true)
+                .build();
+        setupNativeSidecarPlugin(queryRunner);
+        queryRunner.installPlugin(new MongoPlugin());
+        queryRunner.installPlugin(new MLPlugin());
+        return queryRunner;
+    }
+
+    @Test
+    public void testTypesLoaded()
+    {
+        FunctionAndTypeManager functionAndTypeManager = getQueryRunner().getMetadata().getFunctionAndTypeManager();
+        assertTrue(functionAndTypeManager.hasType(OBJECT_ID.getTypeSignature()));
+        // parametric type
+        TypeSignature classifierSignature = new TypeSignature(
+                ClassifierParametricType.NAME,
+                TypeSignatureParameter.of(BIGINT.getTypeSignature()));
+        assertTrue(functionAndTypeManager.hasType(classifierSignature));
+    }
+}


### PR DESCRIPTION
## Description
This PR enables the Native Sidecar plugin to support plugin-loaded custom types by extending the `TypeManager` interface with type registration capabilities and ensuring proper delegation to the serving type manager.

## Motivation and Context
Previously, the Native Sidecar plugin's `NativeTypeManager` could only work with built-in Presto types. When plugins (like MongoDB or ML plugins) registered custom types, these types were not available, causing compatibility issues and limiting functionality.

## Impact
Plugin provided types are now available in `NativeTypeManager`.

## Test Plan
Unit tests, CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Native sidecar Plugin Changes
* Add support for adding plugin loaded types in sidecar plugin
```

## Summary by Sourcery

Allow the native sidecar type manager and serving type manager to register types defined by plugins and ensure consistent plugin loading order across bundles.

New Features:
- Enable TypeManager implementations to register concrete and parametric types via new addType and addParametricType hooks.
- Support native sidecar type manager in recognizing and registering plugin-provided types, including parametric types.

Bug Fixes:
- Ensure coordinator and standard plugins are loaded in a deterministic cross-bundle order and that classloaders are safely closed on failures.

Enhancements:
- Adjust FunctionAndTypeManager to delegate type registration to the active serving type manager and normalize parametric type names to lowercase for lookups.

Build:
- Add MongoDB and ML plugin modules as test-scoped dependencies for the native sidecar plugin module.

Tests:
- Add an integration test validating that native sidecar setups can use types provided by MongoDB and ML plugins, including parametric classifier types.

## Summary by Sourcery

Enable native sidecar to register and use plugin-defined types by extending type registration capabilities and delegating them through the active serving type manager.

New Features:
- Allow TypeManager implementations, including the native sidecar type manager, to register concrete and parametric types via new addType and addParametricType hooks.

Enhancements:
- Ensure FunctionAndTypeManager delegates type registration to the current serving TypeManager and normalizes parametric type names for lookups.

Build:
- Add MongoDB and ML plugins as test-scoped dependencies of the native sidecar plugin module.

Tests:
- Add an integration test verifying that native sidecar setups can resolve MongoDB ObjectId and ML classifier parametric types registered by plugins.