### PR TITLE
build: Move presto-spark-classloader-spark3 to always-active modules so release tooling bumps it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,8 @@
         <module>presto-expressions</module>
         <module>presto-benchmark-runner</module>
         <module>presto-spark-classloader-interface</module>
+        <module>presto-spark-classloader-spark2</module>
+        <module>presto-spark-classloader-spark3</module>
         <module>presto-spark-base</module>
         <module>presto-spark-common</module>
         <module>presto-spark</module>
@@ -3236,10 +3238,6 @@
                 <dep.spark.version>2.0.2-6</dep.spark.version>
             </properties>
 
-            <modules>
-                <module>presto-spark-classloader-spark2</module>
-            </modules>
-
             <build>
                 <pluginManagement>
                     <plugins>
@@ -3307,10 +3305,6 @@
             <properties>
                 <dep.spark.version>3.4.1-1</dep.spark.version>
             </properties>
-
-            <modules>
-                <module>presto-spark-classloader-spark3</module>
-            </modules>
 
             <build>
                 <pluginManagement>

--- a/presto-spark-classloader-spark2/pom.xml
+++ b/presto-spark-classloader-spark2/pom.xml
@@ -19,6 +19,7 @@
     <dependency>
       <groupId>com.facebook.presto.spark</groupId>
       <artifactId>spark-core</artifactId>
+      <version>2.0.2-6</version>
       <scope>provided</scope>
     </dependency>
 

--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -24,8 +24,8 @@
     <dependency>
       <groupId>com.facebook.presto.spark</groupId>
       <artifactId>spark-core</artifactId>
-      <version>3.4.1-1</version>
-      <scope>compile</scope>
+      <version>3.4.1-2</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Summary:
## Description

Move the `<module>presto-spark-classloader-spark3</module>` declaration out of the `spark3` Maven profile and into the always-active `<modules>` list at the top of the root `pom.xml`, alongside the other `presto-spark-*` modules.

The `spark3` profile retains its `<properties>` (`dep.spark.version=3.4.1-1`) and `<build>/<pluginManagement>` blocks — those still need to differ between spark2 and spark3 builds.

## Motivation and Context

The `spark2` and `spark3` profiles are mutually exclusive at activation time — `spark2` is `activeByDefault` and uses `<name>!spark-version</name>`, while `spark3` activates on `<name>spark-version</name>=3`. As a result, only one of the two `presto-spark-classloader-*` modules is in the reactor at any given time, depending on whether `-Dspark-version=3` is set.

This bites release tooling. `mvn versions:set` and `mvn release:prepare` walk only the active reactor and rewrite `<parent><version>` only in modules they see. The OSS release workflow at `.github/workflows/presto-release-prepare.yml` invokes both without `-Dspark-version=3`, so the `spark3` profile is never active during a release cut. Result: the `spark2` classloader's parent version is kept in sync with the rest of the reactor on every release, but the `spark3` classloader is silently skipped. Over multiple cycles the spark3 module froze at `0.296-SNAPSHOT` while the rest of the project advanced to `0.298-SNAPSHOT`, breaking any spark3 build of the reactor (the immediate symptom is a `Could not find artifact ...presto-spark-classloader-spark3:jar:0.298-SNAPSHOT in nexus` failure resolving the dependency declared in `presto-spark-classloader-interface`).

`maven-release-plugin` has no `-DprocessAllModules`-style flag, so a tooling-only fix would have to invoke `release:prepare` per profile and reconcile tags — fragile. Moving the module to the always-active list eliminates the bug class entirely: every Maven tool (versions plugin, release plugin, IDE imports, dependency analyzers) sees the module unconditionally.

The `presto-spark-classloader-spark3` pom is self-contained — its dependencies hardcode `spark-core 3.4.1-1` and do not reference `${dep.spark.version}` — so it compiles in a default-profile reactor without the `spark3` profile being active. Verified by running `mvn -pl presto-spark-classloader-spark3 -am compile` from the project root with no profile flags; build succeeded and produced the expected `presto-spark-classloader-spark3-0.298-SNAPSHOT.jar`.

## Impact

- Default `mvn` builds now include `presto-spark-classloader-spark3` in the reactor and compile it. Output artifact is unused (the `presto-spark-classloader-interface` profile-gated dependency declaration controls which classloader actually gets pulled into the assembled distribution), so this is a small extra compile step in default builds, not a runtime change.
- spark3 builds (`-Dspark-version=3`) are unchanged in behavior. The module is now in the reactor unconditionally rather than via the profile, but the dependency wiring in `presto-spark-classloader-interface` is unchanged.
- spark2 module remains in its profile (this change is the minimum needed to fix the immediate bug); a future cleanup could symmetrically move it to the always-active list, eliminating the asymmetry.
- Release tooling (`versions:set`, `release:prepare`) now bumps the spark3 module's parent version on every release cut without any workflow change.

## Test Plan

Built `mvn -pl presto-spark-classloader-spark3 -am compile -DskipTests` from the presto-trunk project root with no profile flags and confirmed the module compiles cleanly and produces the `0.298-SNAPSHOT` jar in the default reactor.

## Contributor checklist

- [x] Read [The Presto Code of Conduct](https://github.com/prestodb/presto/blob/master/CODE_OF_CONDUCT.md) and adhere to the principles outlined.
- [x] Mentioned the Github issue this PR is intended to fix.
- [x] Provided sufficient unit tests and tested the changes locally.
- [x] Provided sufficient PR description.
- [x] Reviewed the conventions in the [contribution guidelines](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md).

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D104275057


