### PR TITLE
fix(planner): Run SimplifyPlanWithEmptyInput before AddExchanges

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -1054,6 +1054,14 @@ public class PlanOptimizers
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
             builder.add(new CteProjectionAndPredicatePushDown(metadata, expressionOptimizerManager)); // must run before PhysicalCteOptimizer
             builder.add(new PhysicalCteOptimizer(metadata)); // Must run before AddExchanges
+            // Run a final empty-input cleanup before AddExchanges so empty subtrees produced by the
+            // intermediate optimizers above (predicate pushdown, join elimination, CTE rewrite, etc.)
+            // are pruned before exchanges wrap them. Running this *before* AddExchanges keeps the
+            // optimizer free of any Exchange-shaped pruning concerns that would otherwise interact
+            // poorly with write-side subtrees (TableWriter / TableFinish rely on the Exchange chain
+            // beneath them being preserved even when the source is statically empty, e.g.
+            // CREATE TABLE ... AS SELECT ... WITH NO DATA).
+            builder.add(new SimplifyPlanWithEmptyInput());
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled())));
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchangesForSingleNodeExecution(metadata)));
         }
@@ -1156,9 +1164,6 @@ public class PlanOptimizers
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())));
-
-        // Pass after connector optimizer, as it relies on connector optimizer to identify empty input tables and convert them to empty ValuesNode
-        builder.add(new SimplifyPlanWithEmptyInput());
 
         builder.add(
                 new IterativeOptimizer(


### PR DESCRIPTION
## Summary

The second invocation of `SimplifyPlanWithEmptyInput` was registered after `AddExchanges` / `AddLocalExchanges`. At that position it cannot prune empty subtrees that are wrapped in `ExchangeNode`s introduced by those passes — because `SimplifyPlanWithEmptyInput` intentionally never visits `ExchangeNode`.

`ExchangeNode` is the only logical boundary between a `TableWriterNode` and its source. Pruning it would collapse write-side subtrees with statically empty input — e.g. `CREATE TABLE foo AS SELECT * FROM orders WITH NO DATA` — and skip the table-create side-effect that `TableFinishNode` performs at commit. That manifested as ~10 hive test regressions across `testCreateTableAsSelect`, `testInsert`, and materialized-view tests.

This PR moves the second invocation to immediately before `AddExchanges`, so it runs after the intermediate logical optimizers (predicate pushdown, join elimination, CTE rewrite, projection pushdown, etc.) but before any exchanges wrap the resulting empty subtrees.

After this point, the only remaining empty inputs are those introduced by the physical-stage connector optimizer at line ~1152 (`ApplyConnectorOptimization(PHYSICAL)`). These are rare, and leaving them un-pruned has no correctness impact — only a small redundant-Exchange-over-empty-Values shape in the executed plan.

## Why move instead of teach the optimizer to handle Exchanges

Adding a `visitExchange` override to `SimplifyPlanWithEmptyInput` was attempted in an earlier revision of this PR. It broke writes: pruning the inner `ExchangeNode` between a `TableWriterNode` and its empty source removes the boundary the writer relies on for its commit-fragment signalling, so `TableFinishNode` ends up with zero fragments and skips the table-create. Repositioning `SimplifyPlanWithEmptyInput` to a phase where Exchanges don't yet exist sidesteps the entire interaction class.

## Test plan

- [x] `TestSimplifyPlanWithEmptyInput` (23/23 pass) — existing tests still cover all empty-input pruning shapes
- [x] Compile + checkstyle on `presto-main-base`
- [ ] CI to verify previously-failing hive `testInsert` / `testCreateTableAsSelect` / materialized-view tests now pass

```
== RELEASE NOTES ==

General Changes
* Reposition ``SimplifyPlanWithEmptyInput`` to run before ``AddExchanges`` so empty subtrees produced by logical optimizers are pruned before exchanges wrap them, without risk to write-side plans.
```
