### PR TITLE
fix: Populate session fields when query fails before Session is authenticated

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -54,7 +54,6 @@ import java.util.concurrent.Executor;
 
 import static com.facebook.presto.Session.SessionBuilder;
 import static com.facebook.presto.SystemSessionProperties.getAnalyzerType;
-import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static com.facebook.presto.util.AnalyzerUtil.createAnalyzerOptions;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -329,11 +328,7 @@ public class DispatchManager
         catch (Throwable throwable) {
             // creation must never fail, so register a failed query in this case
             if (session == null) {
-                session = Session.builder(createTestingSessionPropertyManager())
-                        .setQueryId(queryId)
-                        .setIdentity(sessionContext.getIdentity())
-                        .setSource(sessionContext.getSource())
-                        .build();
+                session = sessionSupplier.createSessionForFailedQuery(queryId, sessionContext, warningCollectorFactory);
             }
             DispatchQuery failedDispatchQuery = failedDispatchQueryFactory.createFailedDispatchQuery(session, query, Optional.empty(), throwable);
             queryCreated(failedDispatchQuery);

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
@@ -26,6 +27,12 @@ public class NoOpSessionSupplier
 {
     @Override
     public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Session createSessionForFailedQuery(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -77,7 +77,24 @@ public class QuerySessionSupplier
     {
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
                 .setQueryId(queryId)
-                .setIdentity(authenticateIdentity(queryId, context))
+                .setIdentity(authenticateIdentity(queryId, context));
+        populateSessionBuilder(sessionBuilder, context, warningCollectorFactory, false);
+        return sessionBuilder;
+    }
+
+    @Override
+    public Session createSessionForFailedQuery(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    {
+        SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
+                .setQueryId(queryId)
+                .setIdentity(context.getIdentity());
+        populateSessionBuilder(sessionBuilder, context, warningCollectorFactory, true);
+        return sessionBuilder.build();
+    }
+
+    private void populateSessionBuilder(SessionBuilder sessionBuilder, SessionContext context, WarningCollectorFactory warningCollectorFactory, boolean ignoreFailures)
+    {
+        sessionBuilder
                 .setSource(context.getSource())
                 .setCatalog(context.getCatalog())
                 .setSchema(context.getSchema())
@@ -94,25 +111,25 @@ public class QuerySessionSupplier
             sessionBuilder.setTimeZoneKey(forcedSessionTimeZone.get());
         }
         else if (context.getTimeZoneId() != null) {
-            sessionBuilder.setTimeZoneKey(getTimeZoneKey(context.getTimeZoneId()));
+            applyAction(ignoreFailures, () -> sessionBuilder.setTimeZoneKey(getTimeZoneKey(context.getTimeZoneId())));
         }
 
         if (context.getLanguage() != null) {
-            sessionBuilder.setLocale(Locale.forLanguageTag(context.getLanguage()));
+            applyAction(ignoreFailures, () -> sessionBuilder.setLocale(Locale.forLanguageTag(context.getLanguage())));
         }
 
         for (Entry<String, String> entry : context.getSystemProperties().entrySet()) {
-            sessionBuilder.setSystemProperty(entry.getKey(), entry.getValue());
+            applyAction(ignoreFailures, () -> sessionBuilder.setSystemProperty(entry.getKey(), entry.getValue()));
         }
         for (Entry<String, Map<String, String>> catalogProperties : context.getCatalogSessionProperties().entrySet()) {
             String catalog = catalogProperties.getKey();
             for (Entry<String, String> entry : catalogProperties.getValue().entrySet()) {
-                sessionBuilder.setCatalogSessionProperty(catalog, entry.getKey(), entry.getValue());
+                applyAction(ignoreFailures, () -> sessionBuilder.setCatalogSessionProperty(catalog, entry.getKey(), entry.getValue()));
             }
         }
 
         for (Entry<String, String> preparedStatement : context.getPreparedStatements().entrySet()) {
-            sessionBuilder.addPreparedStatement(preparedStatement.getKey(), preparedStatement.getValue());
+            applyAction(ignoreFailures, () -> sessionBuilder.addPreparedStatement(preparedStatement.getKey(), preparedStatement.getValue()));
         }
 
         if (context.supportClientTransaction()) {
@@ -120,14 +137,27 @@ public class QuerySessionSupplier
         }
 
         for (Entry<SqlFunctionId, SqlInvokedFunction> entry : context.getSessionFunctions().entrySet()) {
-            sessionBuilder.addSessionFunction(entry.getKey(), entry.getValue());
+            applyAction(ignoreFailures, () -> sessionBuilder.addSessionFunction(entry.getKey(), entry.getValue()));
         }
 
         // Put after setSystemProperty are called
-        WarningCollector warningCollector = warningCollectorFactory.create(sessionBuilder.getSystemProperty(WARNING_HANDLING, WarningHandlingLevel.class));
-        sessionBuilder.setWarningCollector(warningCollector);
+        applyAction(ignoreFailures, () -> {
+            WarningCollector warningCollector = warningCollectorFactory.create(sessionBuilder.getSystemProperty(WARNING_HANDLING, WarningHandlingLevel.class));
+            sessionBuilder.setWarningCollector(warningCollector);
+        });
+    }
 
-        return sessionBuilder;
+    private void applyAction(boolean ignoreFailures, Runnable action)
+    {
+        try {
+            action.run();
+        }
+        catch (RuntimeException e) {
+            if (!ignoreFailures) {
+                throw e;
+            }
+            log.warn(e, "Skipping exception while building failed query session: ", e);
+        }
     }
 
     private Identity authenticateIdentity(QueryId queryId, SessionContext context)

--- a/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
@@ -21,4 +22,7 @@ import static com.facebook.presto.Session.SessionBuilder;
 public interface SessionSupplier
 {
     SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
+
+    // Build a Session for a query whose normal session construction failed during dispatch
+    Session createSessionForFailedQuery(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -133,6 +133,84 @@ public class TestQuerySessionSupplier
     }
 
     @Test
+    public void testCreateSessionForFailedQuery()
+    {
+        HttpRequestSessionContext context = new HttpRequestSessionContext(TEST_REQUEST, new SqlParserOptions());
+        QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
+                createTestTransactionManager(),
+                new AllowAllAccessControl(),
+                createTestingSessionPropertyManager(),
+                new SqlEnvironmentConfig(),
+                new SecurityConfig());
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        Session session = sessionSupplier.createSessionForFailedQuery(new QueryId("test_query_id"), context, warningCollectorFactory);
+
+        // All session fields populated by createSessionBuilder must also be populated here so
+        // QueryCompletedEvent payloads carry the same fields when authorization fails early.
+        assertEquals(session.getQueryId(), new QueryId("test_query_id"));
+        assertEquals(session.getUser(), "testUser");
+        assertEquals(session.getSource().get(), "testSource");
+        assertEquals(session.getCatalog().get(), "testCatalog");
+        assertEquals(session.getSchema().get(), "testSchema");
+        assertEquals(session.getLocale(), Locale.TAIWAN);
+        assertEquals(session.getTimeZoneKey(), getTimeZoneKey("Asia/Taipei"));
+        assertEquals(session.getRemoteUserAddress().get(), "testRemote");
+        assertEquals(session.getClientInfo().get(), "client-info");
+        assertEquals(session.getClientTags(), ImmutableSet.of("tag1", "tag2", "tag3"));
+        assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()
+                .put(QUERY_MAX_MEMORY, "1GB")
+                .put(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .put(HASH_PARTITION_COUNT, "43")
+                .build());
+        assertEquals(session.getPreparedStatements(), ImmutableMap.<String, String>builder()
+                .put("query1", "select * from foo")
+                .put("query2", "select * from bar")
+                .build());
+        assertEquals(session.getSessionFunctions(), ImmutableMap.of(SQL_FUNCTION_ID_ADD, SQL_FUNCTION_ADD));
+    }
+
+    @Test
+    public void testCreateSessionForFailedQueryToleratesInvalidTimeZone()
+    {
+        // Inverse of testInvalidTimeZone: the failure path must not throw on bad input,
+        // since it is the "must never fail" fallback used to register failed queries.
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .put(PRESTO_TIME_ZONE, "unknown_timezone")
+                        .put(PRESTO_CATALOG, "testCatalog")
+                        .build(),
+                "testRemote",
+                ImmutableMap.of());
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
+                createTestTransactionManager(),
+                new AllowAllAccessControl(),
+                createTestingSessionPropertyManager(),
+                new SqlEnvironmentConfig(),
+                new SecurityConfig());
+        WarningCollectorFactory warningCollectorFactory = new WarningCollectorFactory()
+        {
+            @Override
+            public WarningCollector create(WarningHandlingLevel warningHandlingLevel)
+            {
+                return WarningCollector.NOOP;
+            }
+        };
+        Session session = sessionSupplier.createSessionForFailedQuery(new QueryId("test_query_id"), context, warningCollectorFactory);
+
+        assertEquals(session.getUser(), "testUser");
+        assertEquals(session.getCatalog().get(), "testCatalog");
+    }
+
+    @Test
     public void testEmptyClientTags()
     {
         HttpServletRequest request1 = new MockHttpServletRequest(


### PR DESCRIPTION
Summary:
## Description
When `QuerySessionSupplier.createSessionBuilder` throws before producing a `Session` (most commonly because authorization in `selectAuthorizedIdentity` denies the query), `DispatchManager.createQueryInternal` falls back to building a stripped-down `Session` containing only `queryId`, `identity`, and `source`. As a result, every other session-derived field (`catalog`, `schema`, `clientInfo`, `clientTags`, `userAgent`, `remoteUserAddress`, `resourceEstimates`, `traceToken`, `timeZoneKey`, `locale`, system properties, catalog session properties, prepared statements, session functions) is null in the `QueryCompletedEvent` payload that downstream `EventListener` plugins receive — even though every one of those values is already present on `SessionContext`, populated from the request headers before authorization runs.

This change introduces a new method on the `SessionSupplier` interface, `createSessionForFailedQuery`, that mirrors the field set populated by `createSessionBuilder` but skips authorization and tolerates malformed input. `QuerySessionSupplier` shares its field-population logic between the normal path and the failure path via an extracted private helper, so adding a new session field automatically propagates to both paths and the two implementations cannot drift. `DispatchManager`'s catch block now delegates to the new method instead of inlining a near-empty `Session.builder` call.

## Motivation and Context
Failed-query events from authorization-denied queries are nearly opaque to event listeners and observability pipelines today: the user and source columns are populated but every other session-derived column is empty. Operators investigating denied queries (whether to triage permission misconfigurations, identify abusive clients, or analyze access-control rollouts) lose the ability to filter by catalog, schema, client tags, client info, or any session property.

## Impact
- Adds one method to the `SessionSupplier` interface (`com.facebook.presto.server.SessionSupplier`). Both in-tree implementations (`QuerySessionSupplier`, `NoOpSessionSupplier`) are updated. `SessionSupplier` is an internal engine interface, not part of the public plugin SPI, so external connectors and plugins are unaffected.
- No behavior change for queries that successfully construct a `Session`. The new code path runs only when the existing fallback (`session == null` in the catch block) would have run.
- `QueryCompletedEvent` payloads for early-failed queries now carry the same session fields they would have carried on success, making event-listener output consistent across success and failure cases.

## Test Plan
- Added `testCreateSessionForFailedQuery` in `TestQuerySessionSupplier`, asserting that all fields populated by the existing `testCreateSession` are also populated when going through `createSessionForFailedQuery` (queryId, user, source, catalog, schema, locale, time zone, remote user address, client info, client tags, system properties, prepared statements, session functions).
- Added `testCreateSessionForFailedQueryToleratesInvalidTimeZone` as the inverse of the existing `testInvalidTimeZone` test, confirming that the failure path swallows malformed input rather than re-throwing (the fallback must satisfy the existing "creation must never fail" contract in `DispatchManager`).
- Built and ran the existing `TestQuerySessionSupplier` suite locally to confirm no regression on the strict path.

## Contributor checklist
- [x] Read [Contribution guidelines for this project](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md).
- [x] All commits have been signed-off via the DCO.
- [x] Formatted my code with `mvn javadoc:javadoc spotless:apply` (no formatting changes required by `arc f`).
- [x] Added or updated unit tests as appropriate.
- [x] Verified that this change does not break existing functionality.

## Release Notes
```
== NO RELEASE NOTE ==

```

Differential Revision: D104299459

## Summary by Sourcery

Populate full session metadata in failed-query sessions and route dispatcher fallback through a new failure-aware session construction path.

New Features:
- Add SessionSupplier.createSessionForFailedQuery to construct sessions for queries whose normal session creation fails while mirroring standard session metadata population.

Bug Fixes:
- Ensure QueryCompletedEvent for queries that fail before authorization includes catalog, schema, client info, client tags, time zone, locale, system properties, prepared statements, and session functions instead of leaving them empty.
- Make failed-query session creation tolerate malformed inputs such as invalid time zones without throwing, preserving the dispatcher’s "creation must never fail" guarantee.

Enhancements:
- Refactor QuerySessionSupplier to share session field population logic between normal and failure paths via a helper that supports strict and lenient modes.
- Update NoOpSessionSupplier to implement the new failure-session method for consistency with the SessionSupplier interface.

Tests:
- Add tests verifying createSessionForFailedQuery populates the same session fields as the normal path and tolerates invalid time zones without errors.