### PR TITLE
feat(native-pos): MaterializedOutput: support replicateNullsAndAny

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -44,6 +44,7 @@ folly::dynamic MaterializedOutputNode::serialize() const {
   obj["numPartitions"] = numPartitions_;
   obj["keys"] = ISerializable::serialize(keys_);
   obj["partitionFunctionSpec"] = partitionFunctionSpec_->serialize();
+  obj["replicateNullsAndAny"] = replicateNullsAndAny_;
   obj["outputType"] = outputType_->serialize();
   obj["sources"] = ISerializable::serialize(sources_);
   return obj;
@@ -71,6 +72,12 @@ core::PlanNodePtr MaterializedOutputNode::create(
 
   auto outputType = ISerializable::deserialize<RowType>(obj["outputType"]);
 
+  // replicateNullsAndAny defaults to false for backward compatibility with
+  // serialized plans produced before the field existed.
+  const bool replicateNullsAndAny = obj.count("replicateNullsAndAny") != 0
+      ? obj["replicateNullsAndAny"].asBool()
+      : false;
+
   // Buffer cannot be deserialized — it is set externally by the plan
   // converter.
   return std::make_shared<MaterializedOutputNode>(
@@ -79,6 +86,7 @@ core::PlanNodePtr MaterializedOutputNode::create(
       static_cast<int>(obj["numPartitions"].asInt()),
       std::move(outputType),
       std::move(partitionFunctionSpec),
+      replicateNullsAndAny,
       std::move(source),
       std::shared_ptr<MaterializedOutputBuffer>{});
 }
@@ -98,11 +106,14 @@ MaterializedOutput::MaterializedOutput(
           planNode->sources()[0]->outputType(),
           planNode->outputType(),
           planNode->outputType())),
+      keyChannels_(
+          toChannels(planNode->sources()[0]->outputType(), planNode->keys())),
       partitionFunction_(
           numDestinations_ == 1 ? nullptr
                                 : planNode->partitionFunctionSpec()->create(
                                       numDestinations_,
                                       /*localExchange=*/false)),
+      replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
       buffer_(planNode->buffer()),
       targetSizeInBytes_(
           std::clamp(
@@ -254,6 +265,93 @@ void MaterializedOutput::serializeRows(
   }
 }
 
+void MaterializedOutput::collectNullRows(
+    const RowVector& rawInput,
+    int32_t numRows) {
+  rows_.resize(numRows);
+  rows_.setAll();
+
+  nullRows_.resize(numRows);
+  nullRows_.clearAll();
+
+  decodedVectors_.resize(keyChannels_.size());
+
+  for (size_t keyIdx = 0; keyIdx < keyChannels_.size(); ++keyIdx) {
+    const auto keyChannel = keyChannels_[keyIdx];
+    if (keyChannel == kConstantChannel) {
+      continue;
+    }
+    const auto& keyVector = rawInput.childAt(keyChannel);
+    if (keyVector->mayHaveNulls()) {
+      auto& decoded = decodedVectors_[keyIdx];
+      decoded.decode(*keyVector, rows_);
+      if (auto* rawNulls = decoded.nulls(&rows_)) {
+        velox::bits::orWithNegatedBits(
+            nullRows_.asMutableRange().bits(), rawNulls, 0, numRows);
+      }
+    }
+  }
+  nullRows_.updateBounds();
+}
+
+std::vector<int32_t> MaterializedOutput::selectRowsToReplicate(
+    int32_t numInputRows) {
+  // Replicate semantics (mirrors Velox PartitionedOutput): the very first
+  // input row across the operator's lifetime ("any") is broadcast to all
+  // partitions, plus every row whose key columns contain a null.
+  std::vector<int32_t> rowsToExpand;
+  int32_t loopStart = 0;
+  if (!replicatedAny_) {
+    rowsToExpand.push_back(0);
+    replicatedAny_ = true;
+    loopStart = 1;
+  }
+  for (int32_t i = loopStart; i < numInputRows; ++i) {
+    if (nullRows_.isValid(i)) {
+      rowsToExpand.push_back(i);
+    }
+  }
+  return rowsToExpand;
+}
+
+void MaterializedOutput::appendReplicaEntries(
+    int32_t serializeStartRow,
+    const std::vector<int32_t>& rowsToExpand) {
+  // For each replicate row, we keep the existing single-partition entry and
+  // append N-1 additional entries that point to the same flat-buffer slice —
+  // flushBatch's per-partition grouping does the rest.
+  const auto extra =
+      static_cast<size_t>(numDestinations_ - 1) * rowsToExpand.size();
+  rowOffsets_.reserve(rowOffsets_.size() + extra);
+  rowSizes_.reserve(rowSizes_.size() + extra);
+  rowPartitions_.reserve(rowPartitions_.size() + extra);
+
+  for (int32_t i : rowsToExpand) {
+    const int32_t rowIdx = serializeStartRow + i;
+    const int64_t offset = rowOffsets_[rowIdx];
+    const int32_t size = rowSizes_[rowIdx];
+    // Force the existing entry to partition 0 so the appended 1..N-1 give
+    // exactly one entry per destination — no duplicate sends.
+    rowPartitions_[rowIdx] = 0;
+    for (uint32_t p = 1; p < static_cast<uint32_t>(numDestinations_); ++p) {
+      rowOffsets_.push_back(offset);
+      rowSizes_.push_back(size);
+      rowPartitions_.push_back(p);
+      ++rowCount_;
+    }
+  }
+}
+
+void MaterializedOutput::expandReplicateRows(
+    int32_t serializeStartRow,
+    int32_t numInputRows) {
+  const auto rowsToExpand = selectRowsToReplicate(numInputRows);
+  if (rowsToExpand.empty()) {
+    return;
+  }
+  appendReplicaEntries(serializeStartRow, rowsToExpand);
+}
+
 void MaterializedOutput::addInput(RowVectorPtr input) {
   // Save a reference to the raw input before initializeInput() projects it.
   // The partition function's key channels are set up relative to inputType
@@ -271,8 +369,19 @@ void MaterializedOutput::addInput(RowVectorPtr input) {
 
   computePartitions(*rawInput, numRows);
 
+  // Collect null-key rows BEFORE serialization so the replicate-expansion
+  // step can read them.
+  if (shouldReplicate()) {
+    collectNullRows(*rawInput, numRows);
+  }
+
+  const int32_t serializeStartRow = rowCount_;
   row::CompactRow compactRow(output_);
   serializeRows(compactRow, numRows);
+
+  if (shouldReplicate()) {
+    expandReplicateRows(serializeStartRow, numRows);
+  }
 
   output_.reset();
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -18,6 +18,8 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 #include "velox/row/CompactRow.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::presto::operators {
 
@@ -30,6 +32,7 @@ class MaterializedOutputNode : public velox::core::PlanNode {
       velox::RowTypePtr outputType,
       std::shared_ptr<const velox::core::PartitionFunctionSpec>
           partitionFunctionSpec,
+      bool replicateNullsAndAny,
       velox::core::PlanNodePtr source,
       std::shared_ptr<MaterializedOutputBuffer> buffer)
       : velox::core::PlanNode(id),
@@ -37,6 +40,7 @@ class MaterializedOutputNode : public velox::core::PlanNode {
         keys_(std::move(keys)),
         outputType_(std::move(outputType)),
         partitionFunctionSpec_(std::move(partitionFunctionSpec)),
+        replicateNullsAndAny_(replicateNullsAndAny),
         sources_{std::move(source)},
         buffer_(std::move(buffer)) {}
 
@@ -58,6 +62,10 @@ class MaterializedOutputNode : public velox::core::PlanNode {
 
   const auto& partitionFunctionSpec() const {
     return partitionFunctionSpec_;
+  }
+
+  bool isReplicateNullsAndAny() const {
+    return replicateNullsAndAny_;
   }
 
   const velox::RowTypePtr& outputType() const override {
@@ -84,6 +92,7 @@ class MaterializedOutputNode : public velox::core::PlanNode {
   const velox::RowTypePtr outputType_;
   const std::shared_ptr<const velox::core::PartitionFunctionSpec>
       partitionFunctionSpec_;
+  const bool replicateNullsAndAny_;
   const std::vector<velox::core::PlanNodePtr> sources_;
   const std::shared_ptr<MaterializedOutputBuffer> buffer_;
 };
@@ -150,10 +159,36 @@ class MaterializedOutput : public velox::exec::Operator {
   std::unique_ptr<folly::IOBuf> buildRowGroup(
       const std::vector<int32_t>& rowIndices);
 
+  // True when the plan requested replicateNullsAndAny AND broadcasting
+  // would actually produce extra entries (i.e., more than one destination).
+  bool shouldReplicate() const {
+    return replicateNullsAndAny_ && numDestinations_ > 1;
+  }
+
+  // Mark rows whose key columns contain a null. Used by
+  // expandReplicateRows() when shouldReplicate() is true.
+  void collectNullRows(const velox::RowVector& rawInput, int32_t numRows);
+
+  // Pick which input rows need to be broadcast: the very first row of the
+  // operator's lifetime (the "any" sentinel) plus every null-keyed row.
+  std::vector<int32_t> selectRowsToReplicate(int32_t numInputRows);
+
+  // For each row in rowsToExpand, append (numDestinations_ - 1) extra
+  // (offset, size, partition) entries pointing to the same flat-buffer
+  // slice — the row ends up at every destination.
+  void appendReplicaEntries(
+      int32_t serializeStartRow,
+      const std::vector<int32_t>& rowsToExpand);
+
+  // Orchestrates selectRowsToReplicate + appendReplicaEntries.
+  void expandReplicateRows(int32_t serializeStartRow, int32_t numInputRows);
+
   // Immutable config — declaration order must match constructor init order.
   const int32_t numDestinations_;
   const std::vector<velox::column_index_t> outputChannels_;
+  const std::vector<velox::column_index_t> keyChannels_;
   std::unique_ptr<velox::core::PartitionFunction> partitionFunction_;
+  const bool replicateNullsAndAny_;
   MaterializedOutputBuffer* const buffer_;
 
   // Flush threshold: clamp(numPartitions * kDefaultAvgRowSize, 1MB, 10MB).
@@ -171,6 +206,15 @@ class MaterializedOutput : public velox::exec::Operator {
   // Reusable per-batch buffers.
   velox::RowVectorPtr output_;
   std::vector<uint32_t> partitions_;
+
+  // Replicate-nulls-and-any state. Mirrors Velox PartitionedOutput.
+  // Tracks rows whose key columns contain NULLs (which must be broadcast
+  // to all partitions) and whether the "any" sentinel row has already been
+  // broadcast across the operator's lifetime.
+  velox::SelectivityVector rows_;
+  velox::SelectivityVector nullRows_;
+  std::vector<velox::DecodedVector> decodedVectors_;
+  bool replicatedAny_{false};
 
   // Flat buffer model — rows are serialized into a pool-tracked
   // contiguous buffer with parallel arrays tracking offsets, sizes,

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -162,7 +162,8 @@ class MaterializedExchangeTest : public exec::test::OperatorTestBase {
   std::vector<RowVectorPtr> runExchangeWrite(
       const std::vector<RowVectorPtr>& data,
       int numPartitions,
-      int numDrivers) {
+      int numDrivers,
+      bool replicateNullsAndAny = false) {
     auto dataType = asRowType(data[0]->type());
     auto writeInfoStr =
         localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
@@ -208,6 +209,7 @@ class MaterializedExchangeTest : public exec::test::OperatorTestBase {
         numPartitions,
         dataType,
         partitionFunctionSpec,
+        replicateNullsAndAny,
         valuesNode,
         buffer);
 
@@ -432,6 +434,88 @@ TEST_F(MaterializedExchangeTest, bufferMemoryTracking) {
 
   buffer->abort();
   cleanupDirectory(shuffleDir->getPath());
+}
+
+// Verifies replicateNullsAndAny: rows whose key columns are NULL must be
+// broadcast to every partition (plus the very first row of each operator
+// instance — the "any" sentinel). Without this, queries like full outer
+// joins produce wrong results.
+TEST_F(MaterializedExchangeTest, replicateNullsAndAny) {
+  // Input: 6 rows, key column has nulls at rows 2 and 4.
+  // With numPartitions=4 and replicate=true:
+  //   - Row 0 ("any") → broadcast to all 4 partitions
+  //   - Rows 2, 4 (null keys) → broadcast to all 4 partitions
+  //   - Rows 1, 3, 5 → routed by hash to one partition each
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt, 4, std::nullopt, 6}),
+      makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+  });
+
+  const int numPartitions = 4;
+  const int numDrivers = 1;
+
+  // Run with replicate=true.
+  runExchangeWrite(
+      {data}, numPartitions, numDrivers, /*replicateNullsAndAny=*/true);
+  auto actual = runExchangeRead(numPartitions, asRowType(data->type()));
+
+  // Flatten actual into a single per-row count keyed by the data column.
+  // Each input row should appear:
+  //   - Replicated rows (row 0 + null-keyed rows 2, 4): numPartitions times
+  //   - Non-replicated rows (rows 1, 3, 5): exactly 1 time
+  std::map<std::string, int> dataValueCounts;
+  for (const auto& vec : actual) {
+    auto* dataVector = vec->childAt(1)->as<SimpleVector<StringView>>();
+    for (vector_size_t i = 0; i < vec->size(); ++i) {
+      ++dataValueCounts[std::string(dataVector->valueAt(i).getString())];
+    }
+  }
+
+  // Replicated: "a" (row 0, "any"), "c" (null key), "e" (null key)
+  EXPECT_EQ(dataValueCounts["a"], numPartitions)
+      << "Row 0 (the 'any' sentinel) must be broadcast to all partitions";
+  EXPECT_EQ(dataValueCounts["c"], numPartitions)
+      << "Row 2 (null key) must be broadcast to all partitions";
+  EXPECT_EQ(dataValueCounts["e"], numPartitions)
+      << "Row 4 (null key) must be broadcast to all partitions";
+  // Non-replicated: hash-routed to one partition each.
+  EXPECT_EQ(dataValueCounts["b"], 1) << "Row 1 must go to one partition";
+  EXPECT_EQ(dataValueCounts["d"], 1) << "Row 3 must go to one partition";
+  EXPECT_EQ(dataValueCounts["f"], 1) << "Row 5 must go to one partition";
+
+  cleanupDirectory(tempDir_->getPath());
+}
+
+// Negative control for the test above: same input, replicate=false. Each
+// row should appear exactly once across all partitions (no broadcast).
+TEST_F(MaterializedExchangeTest, replicateNullsAndAnyDisabled) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt, 4, std::nullopt, 6}),
+      makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+  });
+
+  const int numPartitions = 4;
+  const int numDrivers = 1;
+
+  runExchangeWrite(
+      {data}, numPartitions, numDrivers, /*replicateNullsAndAny=*/false);
+  auto actual = runExchangeRead(numPartitions, asRowType(data->type()));
+
+  std::map<std::string, int> dataValueCounts;
+  for (const auto& vec : actual) {
+    auto* dataVector = vec->childAt(1)->as<SimpleVector<StringView>>();
+    for (vector_size_t i = 0; i < vec->size(); ++i) {
+      ++dataValueCounts[std::string(dataVector->valueAt(i).getString())];
+    }
+  }
+
+  for (const std::string& v : {"a", "b", "c", "d", "e", "f"}) {
+    EXPECT_EQ(dataValueCounts[v], 1)
+        << "Row '" << v
+        << "' should not be replicated when replicateNullsAndAny=false";
+  }
+
+  cleanupDirectory(tempDir_->getPath());
 }
 
 } // namespace facebook::presto::operators::test

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2668,6 +2668,7 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
             partitionedOutputNode->numPartitions(),
             partitionedOutputNode->outputType(),
             partitionedOutputNode->partitionFunctionSpecPtr(),
+            partitionedOutputNode->isReplicateNullsAndAny(),
             partitionedOutputNode->sources()[0],
             std::move(buffer));
 


### PR DESCRIPTION
Summary:
`MaterializedOutput` was silently dropping the `replicateNullsAndAny` partitioning flag, producing incorrect results for any query whose plan requires null-keyed (or "any" sentinel) rows to reach every partition — e.g. full outer joins, anti-joins, and certain semi-joins.

Three changes plug the gap:

1. `MaterializedOutputNode` now carries a `replicateNullsAndAny` field (constructor arg + accessor + serialize/deserialize). Backward-compatible: deserialize defaults the field to false when missing from a serialized plan.

2. `PrestoToVeloxQueryPlan.cpp` passes `partitionedOutputNode->isReplicateNullsAndAny()` through when constructing the matex plan node from a Presto `PartitionedOutputNode`.

3. `MaterializedOutput::addInput` now mirrors Velox's `PartitionedOutput` replicate logic: after serialization, null-keyed rows (and the very first row of the operator's lifetime — the "any" sentinel) get additional partition entries appended, so each such row ends up at every destination. The flat buffer slice is unchanged — only `rowOffsets_/rowSizes_/rowPartitions_` grow. `flushBatch`'s per-partition grouping does the rest.

Constructor arg ordering for `replicateNullsAndAny` is positioned to mirror Velox's `PartitionedOutputNode` (between partitionFunctionSpec and source). Required, no default — callers must explicitly state intent.

NOTE: This is the github/presto_cpp half of the change. The internal callers in `fb_sapphire_cpp/shuffle/tests/` are updated in a follow-up diff stacked on this one.

Reviewed By: han-yan01

Differential Revision: D104343923

```
== NO RELEASE NOTE ==
```
