### PR TITLE
chore(deps): Bump Apache Lucene 8.11.3 to 9.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dep.joda.version>2.14.0</dep.joda.version>
         <dep.tempto.version>1.55</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
-        <dep.lucene.version>9.12.0</dep.lucene.version>
+        <dep.lucene.version>9.12.3</dep.lucene.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.parquet.version>1.16.0</dep.parquet.version>
         <dep.iceberg.version>1.10.1</dep.iceberg.version>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -16,7 +16,6 @@
         <dep.elasticsearch.version>7.17.27</dep.elasticsearch.version>
         <dep.log4j.version>2.25.4</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
-        <dep.lucene.version>8.11.3</dep.lucene.version>
     </properties>
 
     <dependencies>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -15,7 +15,6 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
-        <dep.lucene.version>8.11.3</dep.lucene.version>
     </properties>
 
     <dependencies>
@@ -333,7 +332,7 @@
 
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
             <version>${dep.lucene.version}</version>
         </dependency>
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/WordStemFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/WordStemFunction.java
@@ -20,7 +20,7 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
-import org.tartarus.snowball.SnowballProgram;
+import org.tartarus.snowball.SnowballStemmer;
 import org.tartarus.snowball.ext.ArmenianStemmer;
 import org.tartarus.snowball.ext.BasqueStemmer;
 import org.tartarus.snowball.ext.CatalanStemmer;
@@ -52,7 +52,7 @@ public final class WordStemFunction
 {
     private WordStemFunction() {}
 
-    private static final Map<Slice, Supplier<SnowballProgram>> STEMMERS = ImmutableMap.<Slice, Supplier<SnowballProgram>>builder()
+    private static final Map<Slice, Supplier<SnowballStemmer>> STEMMERS = ImmutableMap.<Slice, Supplier<SnowballStemmer>>builder()
             .put(utf8Slice("ca"), CatalanStemmer::new)
             .put(utf8Slice("da"), DanishStemmer::new)
             .put(utf8Slice("de"), German2Stemmer::new)
@@ -90,14 +90,14 @@ public final class WordStemFunction
     @SqlType("varchar(x)")
     public static Slice wordStem(@SqlType("varchar(x)") Slice slice, @SqlType("varchar(2)") Slice language)
     {
-        Supplier<SnowballProgram> stemmer = STEMMERS.get(language);
+        Supplier<SnowballStemmer> stemmer = STEMMERS.get(language);
         if (stemmer == null) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Unknown stemmer language: " + language.toStringUtf8());
         }
         return wordStem(slice, stemmer.get());
     }
 
-    private static Slice wordStem(Slice slice, SnowballProgram stemmer)
+    private static Slice wordStem(Slice slice, SnowballStemmer stemmer)
     {
         stemmer.setCurrent(slice.toStringUtf8());
         return stemmer.stem() ? utf8Slice(stemmer.getCurrent()) : slice;


### PR DESCRIPTION
## Description

This is part of upgrading the dependencies to avoid vulnerabilities.

Upgraded Lucene from `8.11.3` to `9.12.3`, including the artifact rename from `lucene-analyzers-common` to `lucene-analysis-common`. Updated Snowball stemming API usage by replacing `SnowballProgram` with `SnowballStemmer` and adjusted related imports/types in `WordStemFunction.java`

**Background:**

**In Lucene 8.x:**

`SnowballProgram` directly exposed the `stem()` API
language stemmers extended `SnowballProgram`

**In Lucene 9.x:**

Lucene introduced an intermediate abstraction `SnowballStemmer`
`stem()` was moved from `SnowballProgram` to `SnowballStemmer`

This is primarily an API refactor/cleanup in Lucene and not a stemming algorithm change, so no functional impact is expected. 
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade Lucene dependencies and align stemming integration with the Lucene 9.x API.

Enhancements:
- Update Lucene version to 9.12.3 across root, main, and Elasticsearch modules to pick up the latest fixes and security updates.
- Switch Lucene analyzer dependency from lucene-analyzers-common to lucene-analysis-common to match the new artifact layout.
- Adjust WordStemFunction to use the SnowballStemmer API instead of SnowballProgram for compatibility with Lucene 9.x.