### PR TITLE
fix(plugin-iceberg): Handle deprecated Iceberg write.object-storage.path property

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -441,7 +441,8 @@ public class HiveTableOperations
     public LocationProvider locationProvider()
     {
         TableMetadata metadata = current();
-        return LocationProviders.locationsFor(metadata.location(), metadata.properties());
+        Map<String, String> sanitizedProperties = IcebergUtil.sanitizeProperties(metadata.properties(), database + "." + tableName);
+        return LocationProviders.locationsFor(metadata.location(), sanitizedProperties);
     }
 
     private Table getTable()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -512,13 +512,34 @@ public final class IcebergUtil
                 .anyMatch(snapshot -> snapshot.snapshotId() == id);
     }
 
+    /**
+     * Sanitizes table properties by converting deprecated properties that cause errors in Iceberg 1.9.0+.
+     *
+     * @param properties the original properties map
+     * @param tableName the table name for logging purposes
+     * @return a new map with deprecated properties converted to their new equivalents
+     */
+    public static Map<String, String> sanitizeProperties(Map<String, String> properties, String tableName)
+    {
+        Map<String, String> sanitized = new HashMap<>(properties);
+        if (sanitized.containsKey(OBJECT_STORE_PATH)) {
+            log.warn("Table %s uses deprecated property '%s'. Converting to '%s' for Iceberg library compatibility.", tableName, OBJECT_STORE_PATH, WRITE_DATA_LOCATION);
+            if (!sanitized.containsKey(WRITE_DATA_LOCATION)) {
+                sanitized.put(WRITE_DATA_LOCATION, sanitized.get(OBJECT_STORE_PATH));
+            }
+            sanitized.remove(OBJECT_STORE_PATH);
+        }
+        return sanitized;
+    }
+
     public static LocationProvider getLocationProvider(SchemaTableName schemaTableName, String tableLocation, Map<String, String> storageProperties)
     {
         if (storageProperties.containsKey(WRITE_LOCATION_PROVIDER_IMPL)) {
             throw new PrestoException(NOT_SUPPORTED, "Table " + schemaTableName + " specifies " + storageProperties.get(WRITE_LOCATION_PROVIDER_IMPL) +
                     " as a location provider. Writing to Iceberg tables with custom location provider is not supported.");
         }
-        return locationsFor(tableLocation, storageProperties);
+        Map<String, String> sanitizedProperties = sanitizeProperties(storageProperties, schemaTableName.toString());
+        return locationsFor(tableLocation, sanitizedProperties);
     }
 
     public static TableScan buildTableScan(Table icebergTable, MetadataTableType metadataTableType, RuntimeStats runtimeStats)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -5113,4 +5113,31 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("DROP TABLE IF EXISTS " + tableName);
         }
     }
+
+    @Test
+    public void testDeprecatedObjectStoragePathProperty()
+            throws IOException
+    {
+        String tableName = "test_deprecated_property";
+        String dataWriteLocation = createTempDirectory(tableName).toAbsolutePath().toString();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR)");
+            assertUpdate("CALL system.set_table_property('" + getSession().getSchema().get() + "', '" + tableName + "', 'write.object-storage.enabled', 'true')");
+            assertUpdate("CALL system.set_table_property('" + getSession().getSchema().get() + "', '" + tableName + "', 'write.object-storage.path', '" + dataWriteLocation + "')");
+            Table icebergTable = loadTable(tableName);
+            assertTrue(icebergTable.properties().containsKey("write.object-storage.enabled"));
+            assertTrue(icebergTable.properties().containsKey("write.object-storage.path"));
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'test')", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'test')");
+            assertQuery("SELECT COUNT(*) FROM " + tableName, "VALUES (1)");
+        }
+        finally {
+            try {
+                assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+            catch (Exception e) {
+                // ignored for hive catalog compatibility
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where Presto fails to insert data into Iceberg tables created by Apache Flink, Spark, etc. The failure occurs because other engines create tables using the deprecated Iceberg property `write.object-storage.path`, but the Apache Iceberg library (version 1.9.0+) throws an IllegalArgumentException when encountering this deprecated property [here](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/core/src/main/java/org/apache/iceberg/LocationProviders.java#L87).

The fix implements property sanitization that automatically converts deprecated Iceberg properties to their modern equivalents before passing them to the Iceberg library, ensuring backward compatibility with tables created by other systems like Flink, Spark, etc.

**Error before fix:**

```
java.lang.IllegalArgumentException: Property 'write.object-storage.path' has been deprecated 
and will be removed in 2.0, use 'write.data.path' instead.
```

## Motivation and Context
Other engines may add the deprecated write.object-storage.path property when creating Iceberg tables. Apache Iceberg library (1.9.0+) rejects this deprecated property with an exception, and currently Presto is using an upgraded version of Iceberg, which would throw an error for deprecated Iceberg properties listed [here](https://github.com/apache/iceberg/blob/apache-iceberg-1.9.0/core/src/main/java/org/apache/iceberg/LocationProviders.java#L80).

## Impact
Presto can now successfully read and write to Iceberg tables created by other engines and maintains backward compatibility.

## Test Plan
Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Sanitize deprecated Iceberg table properties to maintain compatibility with newer Iceberg versions and external engines using legacy settings.

Bug Fixes:
- Prevent write failures when handling tables that use the deprecated write.object-storage.path property by converting it to the supported write.data.path property before invoking Iceberg APIs.

Enhancements:
- Centralize Iceberg table property sanitization and reuse it in both generic location provider creation and Hive table operations for safer location resolution.

Tests:
- Add an integration test verifying that tables with the deprecated write.object-storage.* properties can still be written to and queried successfully.