### PR TITLE
feat(plugin-iceberg): Push down `_last_updated_sequence_number` predicates

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -114,15 +114,20 @@ public class IcebergSplitManager
             return new EqualityDeletesSplitSource(session, icebergTable, deleteFiles);
         }
         else {
-            TableScan tableScan = icebergTable.newScan()
+            // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
+            //      propagate it at split level so the parquet pushdown can leverage it.
+            TupleDomain<IcebergColumnHandle> metadataColumnConstraints = getMetadataColumnConstraints(layoutHandle.getValidPredicate());
+
+            TableScan baseScan = icebergTable.newScan()
                     .metricsReporter(new RuntimeStatsMetricsReporter(session.getRuntimeStats()))
                     .filter(toIcebergExpression(predicate))
                     .useSnapshot(table.getIcebergTableName().getSnapshotId().get())
                     .planWith(executor);
+            // Iceberg's planFiles() strips column stats unless includeColumnStats() is requested.
+            final TableScan tableScan = hasLastUpdatedSequenceNumberConstraint(metadataColumnConstraints)
+                    ? baseScan.includeColumnStats()
+                    : baseScan;
 
-            // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
-            //      propagate it at split level so the parquet pushdown can leverage it.
-            TupleDomain<IcebergColumnHandle> metadataColumnConstraints = getMetadataColumnConstraints(layoutHandle.getValidPredicate());
             return procedureContext
                     .flatMap(context -> context.customizeSplitSource(session, tableScan, metadataColumnConstraints))
                     .orElseGet(() -> new IcebergSplitSource(
@@ -130,6 +135,13 @@ public class IcebergSplitManager
                             tableScan,
                             metadataColumnConstraints));
         }
+    }
+
+    private static boolean hasLastUpdatedSequenceNumberConstraint(TupleDomain<IcebergColumnHandle> metadataColumnConstraints)
+    {
+        return metadataColumnConstraints.getDomains()
+                .map(domains -> domains.keySet().stream().anyMatch(IcebergColumnHandle::isLastUpdatedSequenceNumberColumn))
+                .orElse(false);
     }
 
     @Managed

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 
@@ -43,6 +44,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getAffinitySc
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getNodeSelectionStrategy;
 import static com.facebook.presto.iceberg.FileFormat.fromIcebergFileFormat;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
+import static com.facebook.presto.iceberg.IcebergUtil.buildLastUpdatedSequenceNumberEvaluator;
 import static com.facebook.presto.iceberg.IcebergUtil.getDataSequenceNumber;
 import static com.facebook.presto.iceberg.IcebergUtil.getFirstRowId;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeys;
@@ -68,6 +70,7 @@ public class IcebergSplitSource
     private final long affinitySchedulingFileSectionSize;
 
     private final TupleDomain<IcebergColumnHandle> metadataColumnConstraints;
+    private final InclusiveMetricsEvaluator lineageEvaluator;
 
     public IcebergSplitSource(
             ConnectorSession session,
@@ -85,6 +88,7 @@ public class IcebergSplitSource
     {
         requireNonNull(session, "session is null");
         this.metadataColumnConstraints = requireNonNull(metadataColumnConstraints, "metadataColumnConstraints is null");
+        this.lineageEvaluator = buildLastUpdatedSequenceNumberEvaluator(metadataColumnConstraints);
         this.targetSplitSize = targetSplitSize;
         this.minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
         this.nodeSelectionStrategy = getNodeSelectionStrategy(session);
@@ -105,7 +109,12 @@ public class IcebergSplitSource
         while (iterator.hasNext()) {
             FileScanTask task = iterator.next();
             IcebergSplit icebergSplit = (IcebergSplit) toIcebergSplit(task);
-            if (metadataColumnsMatchPredicates(metadataColumnConstraints, icebergSplit.getPath(), icebergSplit.getDataSequenceNumber())) {
+            if (metadataColumnsMatchPredicates(
+                    metadataColumnConstraints,
+                    icebergSplit.getPath(),
+                    icebergSplit.getDataSequenceNumber(),
+                    task.file(),
+                    lineageEvaluator)) {
                 splits.add(icebergSplit);
             }
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -79,6 +79,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.io.CloseableIterable;
@@ -141,6 +142,7 @@ import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpressio
 import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
 import static com.facebook.presto.iceberg.FileContent.fromIcebergFileContent;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
@@ -192,6 +194,7 @@ import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES;
 import static org.apache.iceberg.LocationProviders.locationsFor;
+import static org.apache.iceberg.MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER;
 import static org.apache.iceberg.MetadataTableUtils.createMetadataTableInstance;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
@@ -218,6 +221,7 @@ import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_FOLDER_STORAGE_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
 import static org.apache.iceberg.TableProperties.WRITE_METADATA_LOCATION;
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.types.Type.TypeID.BINARY;
 import static org.apache.iceberg.types.Type.TypeID.FIXED;
 
@@ -241,6 +245,10 @@ public final class IcebergUtil
     protected static final String VIEW_OWNER = "view_owner";
 
     public static final int DEFAULT_MIN_INPUT_FILES = 5;
+
+    private static final Schema LINEAGE_ONLY_SCHEMA = new Schema(LAST_UPDATED_SEQUENCE_NUMBER);
+    private static final InclusiveMetricsEvaluator MATCH_ALL_LINEAGE_EVALUATOR =
+            new InclusiveMetricsEvaluator(LINEAGE_ONLY_SCHEMA, alwaysTrue());
 
     private IcebergUtil() {}
 
@@ -645,9 +653,8 @@ public final class IcebergUtil
         return partitionValue == null ? NullableValue.asNull(prestoType) : NullableValue.of(prestoType, partitionValue);
     }
 
-    // Strip the constraints on metadata columns like "$path", "$data_sequence_number" from the list.
-    // Also strips row lineage columns (_row_id, _last_updated_sequence_number) which cannot be
-    // pushed to Iceberg's manifest filter because they are not part of the physical table schema.
+    // Row-lineage columns are stripped because Iceberg's Binder rejects field ids absent from
+    // the table schema; they are evaluated at the split level instead.
     public static <U> TupleDomain<IcebergColumnHandle> getNonMetadataColumnConstraints(TupleDomain<U> allConstraints)
     {
         return allConstraints.transform(c -> {
@@ -661,10 +668,21 @@ public final class IcebergUtil
 
     public static <U> TupleDomain<IcebergColumnHandle> getMetadataColumnConstraints(TupleDomain<U> allConstraints)
     {
-        return allConstraints.transform(c -> isMetadataColumnId(((IcebergColumnHandle) c).getId()) ? (IcebergColumnHandle) c : null);
+        return allConstraints.transform(c -> {
+            IcebergColumnHandle handle = (IcebergColumnHandle) c;
+            if (isMetadataColumnId(handle.getId()) || handle.isLastUpdatedSequenceNumberColumn()) {
+                return handle;
+            }
+            return null;
+        });
     }
 
-    public static boolean metadataColumnsMatchPredicates(TupleDomain<IcebergColumnHandle> constraints, String path, long dataSequenceNumber)
+    public static boolean metadataColumnsMatchPredicates(
+            TupleDomain<IcebergColumnHandle> constraints,
+            String path,
+            long dataSequenceNumber,
+            ContentFile<?> file,
+            InclusiveMetricsEvaluator lineageEvaluator)
     {
         if (constraints.isAll()) {
             return true;
@@ -673,16 +691,57 @@ public final class IcebergUtil
         boolean matches = true;
         if (constraints.getDomains().isPresent()) {
             for (Map.Entry<IcebergColumnHandle, Domain> constraint : constraints.getDomains().get().entrySet()) {
-                if (constraint.getKey() == PATH_COLUMN_HANDLE) {
-                    matches &= constraint.getValue().includesNullableValue(utf8Slice(path));
+                IcebergColumnHandle handle = constraint.getKey();
+                Domain domain = constraint.getValue();
+                if (handle == PATH_COLUMN_HANDLE) {
+                    matches &= domain.includesNullableValue(utf8Slice(path));
                 }
-                else if (constraint.getKey() == DATA_SEQUENCE_NUMBER_COLUMN_HANDLE) {
-                    matches &= constraint.getValue().includesNullableValue(dataSequenceNumber);
+                else if (handle == DATA_SEQUENCE_NUMBER_COLUMN_HANDLE) {
+                    matches &= domain.includesNullableValue(dataSequenceNumber);
+                }
+                else if (handle.isLastUpdatedSequenceNumberColumn()) {
+                    matches &= lastUpdatedSequenceNumberMatches(domain, dataSequenceNumber, file, lineageEvaluator);
                 }
             }
         }
 
         return matches;
+    }
+
+    // The fallback branches handle cases where InclusiveMetricsEvaluator would over-include:
+    // V2/no-row-lineage files (column always null) and V3 pre-compaction (effective value =
+    // dataSequenceNumber per Iceberg's LastUpdatedSeqReader).
+    private static boolean lastUpdatedSequenceNumberMatches(
+            Domain domain,
+            long dataSequenceNumber,
+            ContentFile<?> file,
+            InclusiveMetricsEvaluator evaluator)
+    {
+        int fieldId = LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
+        Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
+        Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
+        if (lowerBounds != null && lowerBounds.containsKey(fieldId)
+                && upperBounds != null && upperBounds.containsKey(fieldId)) {
+            return evaluator.eval(file);
+        }
+        if (file instanceof DataFile && ((DataFile) file).firstRowId() == null) {
+            return domain.isNullAllowed();
+        }
+        return domain.includesNullableValue(dataSequenceNumber);
+    }
+
+    public static InclusiveMetricsEvaluator buildLastUpdatedSequenceNumberEvaluator(TupleDomain<IcebergColumnHandle> metadataColumnConstraints)
+    {
+        if (metadataColumnConstraints.getDomains().isEmpty()) {
+            return MATCH_ALL_LINEAGE_EVALUATOR;
+        }
+        Domain domain = metadataColumnConstraints.getDomains().get().get(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE);
+        if (domain == null) {
+            return MATCH_ALL_LINEAGE_EVALUATOR;
+        }
+        Expression expression = toIcebergExpression(TupleDomain.withColumnDomains(
+                ImmutableMap.of(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE, domain)));
+        return new InclusiveMetricsEvaluator(LINEAGE_ONLY_SCHEMA, expression);
     }
 
     public static PartitionSet getPartitions(

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
@@ -412,6 +412,48 @@ public class TestIcebergRowLineage
         }
     }
 
+    @Test
+    public void testDisjointOrRangesPruneMiddleFile()
+            throws Exception
+    {
+        String tableName = "test_lineage_disjoint_or";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+        try {
+            Table table = catalog.createTable(tableId, PUSHDOWN_TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            appendOneRow(table, 1, "one");
+            appendOneRow(table, 2, "two");
+            appendOneRow(table, 3, "three");
+
+            List<long[]> idAndSeq = readIdAndSequenceNumber(tableName);
+            long seq1 = sequenceNumberForId(idAndSeq, 1);
+            long seq2 = sequenceNumberForId(idAndSeq, 2);
+            long seq3 = sequenceNumberForId(idAndSeq, 3);
+            assertTrue(seq1 < seq2 && seq2 < seq3, "sequence numbers must increase per commit");
+
+            String disjointPredicate = " WHERE \"_last_updated_sequence_number\" <= " + seq1
+                    + " OR \"_last_updated_sequence_number\" >= " + seq3;
+
+            int splitsAll = completedSplitsFor("SELECT id FROM " + tableName);
+            int splitsDisjoint = completedSplitsFor("SELECT id FROM " + tableName + disjointPredicate);
+            assertTrue(splitsAll > splitsDisjoint,
+                    "expected disjoint OR to prune middle file but unrestricted=" + splitsAll
+                            + " disjoint=" + splitsDisjoint);
+
+            MaterializedResult result = computeActual("SELECT id FROM " + tableName + disjointPredicate + " ORDER BY id");
+            List<Integer> ids = new ArrayList<>();
+            for (MaterializedRow row : result.getMaterializedRows()) {
+                ids.add((Integer) row.getField(0));
+            }
+            assertEquals(ids, ImmutableList.of(1, 3));
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
     private static final Schema PUSHDOWN_TABLE_SCHEMA = new Schema(
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
             Types.NestedField.optional(2, "value", Types.StringType.get()));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
@@ -13,15 +13,21 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.execution.QueryStats;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.ResultWithQueryId;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
@@ -40,9 +46,11 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
@@ -242,6 +250,252 @@ public class TestIcebergRowLineage
         finally {
             catalog.dropTable(tableId, true);
         }
+    }
+
+    @Test
+    public void testPredicatePushdownPreCompaction()
+            throws Exception
+    {
+        String tableName = "test_lineage_pushdown_pre";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+        try {
+            Table table = catalog.createTable(tableId, PUSHDOWN_TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            appendOneRow(table, 1, "one");
+            appendOneRow(table, 2, "two");
+            appendOneRow(table, 3, "three");
+
+            List<long[]> idAndSeq = readIdAndSequenceNumber(tableName);
+            assertEquals(idAndSeq.size(), 3);
+            long seq1 = sequenceNumberForId(idAndSeq, 1);
+            long seq2 = sequenceNumberForId(idAndSeq, 2);
+            long seq3 = sequenceNumberForId(idAndSeq, 3);
+            assertTrue(seq1 < seq2 && seq2 < seq3, "sequence numbers must increase per commit");
+
+            assertIdsForPredicate(tableName, "<= " + seq1, ImmutableList.of(1));
+            assertIdsForPredicate(tableName, "<= " + seq2, ImmutableList.of(1, 2));
+            assertIdsForPredicate(tableName, "<= " + seq3, ImmutableList.of(1, 2, 3));
+            assertIdsForPredicate(tableName, "< " + seq1, ImmutableList.of());
+            assertIdsForPredicate(tableName, "BETWEEN " + seq2 + " AND " + seq3, ImmutableList.of(2, 3));
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    @Test
+    public void testPredicatePushdownPostCompaction()
+            throws Exception
+    {
+        String tableName = "test_lineage_pushdown_post";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+        try {
+            Table table = catalog.createTable(tableId, PUSHDOWN_TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            appendOneRow(table, 1, "one");
+            appendOneRow(table, 2, "two");
+            table.refresh();
+            long preSeq1 = sequenceNumberForId(readIdAndSequenceNumber(tableName), 1);
+            long preSeq2 = sequenceNumberForId(readIdAndSequenceNumber(tableName), 2);
+            assertTrue(preSeq1 < preSeq2);
+
+            Set<DataFile> preCompactionFiles = new HashSet<>();
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    preCompactionFiles.add(task.file());
+                }
+            }
+            assertEquals(preCompactionFiles.size(), 2);
+
+            Schema lineageAugmentedSchema = MetadataColumns.schemaWithRowLineage(table.schema());
+            Record row1 = GenericRecord.create(lineageAugmentedSchema);
+            row1.setField("id", 1);
+            row1.setField("value", "one");
+            row1.setField(MetadataColumns.ROW_ID.name(), 0L);
+            row1.setField(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(), preSeq1);
+            Record row2 = GenericRecord.create(lineageAugmentedSchema);
+            row2.setField("id", 2);
+            row2.setField("value", "two");
+            row2.setField(MetadataColumns.ROW_ID.name(), 1L);
+            row2.setField(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(), preSeq2);
+            DataFile compactedFile = writeFileWithSchema(table, lineageAugmentedSchema, row1, row2);
+
+            Set<DataFile> compactedFiles = new HashSet<>();
+            compactedFiles.add(compactedFile);
+            table.newRewrite()
+                    .rewriteFiles(preCompactionFiles, compactedFiles)
+                    .commit();
+
+            List<long[]> postIdAndSeq = readIdAndSequenceNumber(tableName);
+            assertEquals(postIdAndSeq.size(), 2);
+            assertEquals(sequenceNumberForId(postIdAndSeq, 1), preSeq1);
+            assertEquals(sequenceNumberForId(postIdAndSeq, 2), preSeq2);
+
+            int lineageFieldId = MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
+            table.refresh();
+            DataFile committedFile = null;
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles()) {
+                for (FileScanTask t : tasks) {
+                    committedFile = t.file();
+                }
+            }
+            assertTrue(committedFile != null
+                            && committedFile.lowerBounds() != null
+                            && committedFile.lowerBounds().containsKey(lineageFieldId),
+                    "compaction file is missing lineage column lower bound stats");
+
+            assertIdsForPredicate(tableName, "<= " + preSeq1, ImmutableList.of(1));
+            assertIdsForPredicate(tableName, "<= " + preSeq2, ImmutableList.of(1, 2));
+            assertIdsForPredicate(tableName, "< " + preSeq1, ImmutableList.of());
+            assertIdsForPredicate(tableName, "> " + preSeq2, ImmutableList.of());
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    @Test
+    public void testV2TableLineagePredicates()
+            throws Exception
+    {
+        String tableName = "test_lineage_pushdown_v2";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+        try {
+            Table table = catalog.createTable(tableId, PUSHDOWN_TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "2"));
+            appendOneRow(table, 1, "one");
+            appendOneRow(table, 2, "two");
+
+            assertIdsForPredicate(tableName, "<= 100", ImmutableList.of());
+            assertIdsForPredicate(tableName, "> 0", ImmutableList.of());
+            assertIdsForPredicate(tableName, "IS NOT NULL", ImmutableList.of());
+            assertIdsForPredicate(tableName, "IS NULL", ImmutableList.of(1, 2));
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    @Test
+    public void testPredicateActuallyPrunesSplits()
+            throws Exception
+    {
+        String tableName = "test_lineage_pushdown_split_count";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+        try {
+            Table table = catalog.createTable(tableId, PUSHDOWN_TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            appendOneRow(table, 1, "one");
+            appendOneRow(table, 2, "two");
+            appendOneRow(table, 3, "three");
+
+            long minSeq = sequenceNumberForId(readIdAndSequenceNumber(tableName), 1);
+
+            int splitsAll = completedSplitsFor("SELECT id FROM " + tableName);
+            int splitsPruned = completedSplitsFor(
+                    "SELECT id FROM " + tableName +
+                            " WHERE \"_last_updated_sequence_number\" < " + minSeq);
+
+            assertTrue(splitsAll > splitsPruned,
+                    "expected predicate to prune splits but unrestricted=" + splitsAll
+                            + " pruned=" + splitsPruned);
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    private static final Schema PUSHDOWN_TABLE_SCHEMA = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "value", Types.StringType.get()));
+
+    private void assertIdsForPredicate(String tableName, String predicate, List<Integer> expectedIds)
+    {
+        MaterializedResult result = computeActual(
+                "SELECT id FROM " + tableName +
+                        " WHERE \"_last_updated_sequence_number\" " + predicate +
+                        " ORDER BY id");
+        List<Integer> actualIds = new ArrayList<>();
+        for (MaterializedRow row : result.getMaterializedRows()) {
+            actualIds.add((Integer) row.getField(0));
+        }
+        assertEquals(actualIds, expectedIds, "rows for predicate \"" + predicate + "\"");
+    }
+
+    private List<long[]> readIdAndSequenceNumber(String tableName)
+    {
+        MaterializedResult result = computeActual(
+                "SELECT id, \"_last_updated_sequence_number\" FROM " + tableName + " ORDER BY id");
+        List<long[]> rows = new ArrayList<>();
+        for (MaterializedRow row : result.getMaterializedRows()) {
+            rows.add(new long[] {(Integer) row.getField(0), (Long) row.getField(1)});
+        }
+        return rows;
+    }
+
+    private static long sequenceNumberForId(List<long[]> rows, int id)
+    {
+        for (long[] row : rows) {
+            if (row[0] == id) {
+                return row[1];
+            }
+        }
+        throw new AssertionError("id not found: " + id);
+    }
+
+    private void appendOneRow(Table table, int id, String value)
+            throws Exception
+    {
+        Record record = GenericRecord.create(table.schema());
+        record.setField("id", id);
+        record.setField("value", value);
+        DataFile dataFile = writeFileWithSchema(table, table.schema(), record);
+        table.newAppend().appendFile(dataFile).commit();
+        table.refresh();
+    }
+
+    private DataFile writeFileWithSchema(Table table, Schema writeSchema, Record... records)
+            throws Exception
+    {
+        String filename = "data-" + UUID.randomUUID() + ".parquet";
+        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
+                table.location(), "data/" + filename);
+        Configuration conf = new Configuration();
+
+        DataWriter<Record> writer = Parquet.writeData(HadoopOutputFile.fromPath(filePath, conf))
+                .schema(writeSchema)
+                .withSpec(table.spec())
+                .createWriterFunc(GenericParquetWriter::create)
+                .metricsConfig(org.apache.iceberg.MetricsConfig.forTable(table))
+                .overwrite()
+                .build();
+        try {
+            for (Record record : records) {
+                writer.write(record);
+            }
+        }
+        finally {
+            writer.close();
+        }
+        return writer.toDataFile();
+    }
+
+    private int completedSplitsFor(String sql)
+    {
+        DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(getSession(), sql);
+        QueryStats stats = runner.getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(result.getQueryId())
+                .getQueryStats();
+        return stats.getCompletedSplits();
     }
 
     private void writeRecords(Table table, Schema schema, Record... records)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.hive.HiveCompressionCodec;
 import com.facebook.presto.hive.HiveStorageFormat;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.metastore.Column;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -40,6 +45,7 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_NEGATIVE_INFINITE;
 import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_NEGATIVE_ZERO;
 import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_POSITIVE_INFINITE;
@@ -49,6 +55,8 @@ import static com.facebook.presto.iceberg.IcebergUtil.REAL_NEGATIVE_ZERO;
 import static com.facebook.presto.iceberg.IcebergUtil.REAL_POSITIVE_INFINITE;
 import static com.facebook.presto.iceberg.IcebergUtil.REAL_POSITIVE_ZERO;
 import static com.facebook.presto.iceberg.IcebergUtil.getAdjacentValue;
+import static com.facebook.presto.iceberg.IcebergUtil.getMetadataColumnConstraints;
+import static com.facebook.presto.iceberg.IcebergUtil.getNonMetadataColumnConstraints;
 import static com.facebook.presto.iceberg.IcebergUtil.getTargetSplitSize;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.intBitsToFloat;
@@ -421,6 +429,20 @@ public class TestIcebergUtil
 
         assertThat(HiveCompressionCodec.LZ4.getParquetCompressionCodec()).isNotNull();
         assertThat(HiveCompressionCodec.ZSTD.getParquetCompressionCodec()).isNotNull();
+    }
+
+    @Test
+    public void testRoutesLastUpdatedSequenceNumberToMetadataConstraints()
+    {
+        Domain leSeqTen = Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 10L)), false);
+        TupleDomain<IcebergColumnHandle> all = TupleDomain.withColumnDomains(
+                ImmutableMap.of(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE, leSeqTen));
+
+        TupleDomain<IcebergColumnHandle> nonMetadata = getNonMetadataColumnConstraints(all);
+        TupleDomain<IcebergColumnHandle> metadata = getMetadataColumnConstraints(all);
+
+        assertThat(nonMetadata.getDomains().get()).doesNotContainKey(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE);
+        assertThat(metadata.getDomains().get()).containsEntry(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE, leSeqTen);
     }
 
     @Test


### PR DESCRIPTION
Prune Iceberg files at the split source using materialized lineage stats (post-compaction) or the file's dataSequenceNumber (pre-compaction).

## Description
Push down predicates on the V3 row-lineage column `_last_updated_sequence_number` to the split source. Files are pruned via Iceberg's `InclusiveMetricsEvaluator` when materialized stats are present (post-compaction) and via the file's `dataSequenceNumber` otherwise (pre-compaction). V2 files match iff the predicate accepts null.

## Motivation and Context
Prerequisite for compaction-safe incremental scans (e.g., bounded MV refresh). `$data_sequence_number` is unsafe across compaction; the row-lineage column carries per-row values through rewrites.

## Impact
Lineage predicates now prune files at planning time instead of full-scan-then-filter. No semantic change.

## Test Plan
Tests in `TestIcebergRowLineage` cover pre-compaction pruning, post-compaction pruning (synthetic compacted file via `RewriteFiles`), V2 null semantics, and observable split-count reduction.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add predicate push down on ``_last_updated_sequence_number`` for file-level pruning. 
```

## Summary by Sourcery

Push down Iceberg row-lineage `_last_updated_sequence_number` predicates to the split source for file-level pruning, including both pre- and post-compaction scenarios and V2 semantics.

New Features:
- Enable split-level pruning based on `_last_updated_sequence_number` using either materialized lineage stats or file data sequence numbers.

Enhancements:
- Route `_last_updated_sequence_number` constraints through Iceberg metadata constraint handling and build an InclusiveMetricsEvaluator for lineage-based pruning in the split source.

Tests:
- Add Iceberg row-lineage tests covering predicate pushdown before and after compaction, V2 null semantics, and observable split-count reduction.
- Add a utility test to ensure `_last_updated_sequence_number` constraints are routed to metadata column constraints.