### PR TITLE
fix(security): Upgrade Netty to 4.2.13.Final to address CVE-2026-42584

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
         <dep.protobuf-java.version>4.30.2</dep.protobuf-java.version>
         <dep.jetty.version>12.0.29</dep.jetty.version>
-        <dep.netty.version>4.2.12.Final</dep.netty.version>
+        <dep.netty.version>4.2.13.Final</dep.netty.version>
         <dep.reactor-netty.version>1.3.3</dep.reactor-netty.version>
         <dep.snakeyaml.version>2.5</dep.snakeyaml.version>
         <dep.gson.version>2.12.1</dep.gson.version>


### PR DESCRIPTION
## Description
Upgrade Netty to 4.2.13.Final to address below CVEs.

CVE-2026-41417
CVE-2026-44248
CVE-2026-42577
CVE-2026-42578
CVE-2026-42579
CVE-2026-42580
CVE-2026-42581
CVE-2026-42582
CVE-2026-42583
CVE-2026-42584
CVE-2026-42585
CVE-2026-42586
CVE-2026-42587


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

== RELEASE NOTES ==

Security Changes
* Upgrade Netty to 4.2.13.Final in response to `CVE-2026-41417  <https://github.com/advisories/GHSA-fghv-69vj-qj49>` , `CVE-2026-44248  <https://github.com/advisories/GHSA-jfg9-48mv-9qgx>` , `CVE-2026-42577  <https://github.com/advisories/GHSA-rwm7-x88c-3g2p>` , `CVE-2026-42578  <https://github.com/advisories/GHSA-45q3-82m4-75jr>` , `CVE-2026-42579  <https://github.com/advisories/GHSA-cm33-6792-r9fm>` , `CVE-2026-42580  <https://github.com/advisories/GHSA-m4cv-j2px-7723>`, `CVE-2026-42581  <https://github.com/advisories/GHSA-xxqh-mfjm-7mv9>` , `CVE-2026-42582  <https://github.com/advisories/GHSA-2c5c-chwr-9hqw>` , `CVE-2026-42583  <https://github.com/advisories/GHSA-mj4r-2hfc-f8p6>` , `CVE-2026-42584  <https://github.com/advisories/GHSA-57rv-r2g8-2cj3>` , `CVE-2026-42585  <https://github.com/advisories/GHSA-38f8-5428-x5cv>` , `CVE-2026-42586  <https://github.com/advisories/GHSA-rgrr-p7gp-5xj7>` and `CVE-2026-42587  <https://github.com/advisories/GHSA-f6hv-jmp6-3vwv>`_.
```
