### PR TITLE
fix(native-pos): Fix PartitionAndSerialize ROUND_ROBIN sending all rows to partition 0

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -301,7 +301,15 @@ class PartitionAndSerializeOperator : public Operator {
     if (numPartitions_ == 1) {
       std::fill(partitions_.begin(), partitions_.end(), 0);
     } else {
-      partitionFunction_->partition(*input_, partitions_);
+      // partition() may either populate partitions_ directly (e.g. hash), or
+      // return a single partition for the entire batch without writing to
+      // partitions_ (e.g. round-robin). Handle both cases.
+      auto singlePartition =
+          partitionFunction_->partition(*input_, partitions_);
+      if (singlePartition.has_value()) {
+        std::fill(
+            partitions_.begin(), partitions_.end(), singlePartition.value());
+      }
     }
 
     // TODO Avoid copy.

--- a/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
@@ -30,6 +30,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/ExchangeClient.h"
+#include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -1162,6 +1163,49 @@ TEST_F(ShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
                   .planNode();
 
   testPartitionAndSerialize(plan, data);
+}
+
+TEST_F(ShuffleTest, partitionAndSerializeRoundRobin) {
+  const int32_t numPartitions = 4;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
+  });
+
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data, data, data}, false)
+          .addNode(
+              [numPartitions](
+                  core::PlanNodeId nodeId,
+                  core::PlanNodePtr source) -> core::PlanNodePtr {
+                return std::make_shared<PartitionAndSerializeNode>(
+                    nodeId,
+                    std::vector<core::TypedExprPtr>{},
+                    numPartitions,
+                    source->outputType(),
+                    std::move(source),
+                    false,
+                    std::make_shared<exec::RoundRobinPartitionFunctionSpec>());
+              })
+          .planNode();
+
+  auto results = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+  ASSERT_EQ(results->size(), 3 * 1'000);
+
+  auto partitions = results->childAt(0)->as<SimpleVector<int32_t>>();
+  std::set<int32_t> uniquePartitions;
+  for (auto i = 0; i < results->size(); ++i) {
+    auto p = partitions->valueAt(i);
+    ASSERT_GE(p, 0);
+    ASSERT_LT(p, numPartitions);
+    uniquePartitions.insert(p);
+  }
+
+  // With 3 input batches and 4 partitions, round-robin must assign to more
+  // than one partition. Before the fix, all rows went to partition 0.
+  ASSERT_GT(uniquePartitions.size(), 1)
+      << "Round-robin should distribute across multiple partitions";
 }
 
 TEST_F(ShuffleTest, partitionAndSerializeEndToEnd) {


### PR DESCRIPTION
PartitionAndSerialize::computePartitions() discarded the std::optional<uint32_t> return from partitionFunction_->partition(). For RoundRobinPartitionFunction, this return value is the partition assignment for the entire batch, and the partitions vector is never populated — so the zero-initialized vector was memcpy'd through, sending all rows to partition 0.

Fix: capture the optional return and fill the partitions vector when has_value(), matching the pattern in PartitionedOutput.cpp.

Added partitionAndSerializeRoundRobin unit test.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure PartitionAndSerialize correctly handles round-robin partition assignments instead of sending all rows to partition 0.

Bug Fixes:
- Fix PartitionAndSerialize to respect the single-partition result returned by RoundRobinPartitionFunction instead of leaving all rows assigned to partition 0.

Tests:
- Add a ShuffleTest case to verify round-robin partitioning distributes rows across multiple partitions.