### PR TITLE
chore(deps): Upgrade jjwt dependencies from 0.11.5 to 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
         <dep.datasketches-memory.version>2.2.0</dep.datasketches-memory.version>
         <dep.datasketches-java.version>5.0.1</dep.datasketches-java.version>
         <dep.io.opentelemetry.version>1.58.0</dep.io.opentelemetry.version>
+        <dep.jjwt.version>0.13.0</dep.jjwt.version>
 
         <release.autoPublish>true</release.autoPublish>
     </properties>
@@ -1645,18 +1646,18 @@
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>
-                <version>0.11.5</version>
+                <version>${dep.jjwt.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-impl</artifactId>
-                <version>0.11.5</version>
+                <version>${dep.jjwt.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
-                <version>0.11.5</version>
+                <version>${dep.jjwt.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -156,9 +156,9 @@ public class IcebergRestCatalogFactory
                             "version", nodeVersion.toString());
 
                     String jwt = Jwts.builder()
-                            .setSubject(session.getUser())
-                            .setIssuer(nodeVersion.toString())
-                            .setIssuedAt(new Date())
+                            .subject(session.getUser())
+                            .issuer(nodeVersion.toString())
+                            .issuedAt(new Date())
                             .claim("user", session.getUser())
                             .claim("source", session.getSource().orElse(""))
                             .compact();

--- a/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
+++ b/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
@@ -187,7 +187,7 @@ public class IcebergRestCatalogServlet
     protected Claims getTokenClaims(String token)
     {
         token = token.replaceAll("Bearer token-exchange-token:sub=", "");
-        return Jwts.parserBuilder().build().parseClaimsJwt(token).getBody();
+        return Jwts.parser().build().parseUnsecuredClaims(token).getPayload();
     }
 
     protected boolean isRestUserSessionToken(String token)

--- a/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
+++ b/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
@@ -22,9 +22,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
+
+import javax.crypto.SecretKey;
 
 import java.security.Principal;
 import java.time.ZonedDateTime;
@@ -42,7 +44,7 @@ public class InternalAuthenticationManager
     private static final Logger log = Logger.get(InternalAuthenticationManager.class);
 
     private final boolean internalJwtEnabled;
-    private final byte[] hmac;
+    private final SecretKey hmacKey;
     private final String nodeId;
     private final Optional<String> sharedSecret;
 
@@ -58,10 +60,11 @@ public class InternalAuthenticationManager
         requireNonNull(nodeId, "nodeId is null");
         this.internalJwtEnabled = internalJwtEnabled;
         if (internalJwtEnabled) {
-            this.hmac = Hashing.sha256().hashString(sharedSecret.get(), UTF_8).asBytes();
+            byte[] hmac = Hashing.sha256().hashString(sharedSecret.get(), UTF_8).asBytes();
+            this.hmacKey = Keys.hmacShaKeyFor(hmac);
         }
         else {
-            this.hmac = null;
+            this.hmacKey = null;
         }
         this.nodeId = nodeId;
     }
@@ -74,18 +77,19 @@ public class InternalAuthenticationManager
     private String generateJwt()
     {
         return Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, hmac)
-                .setSubject(nodeId)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .subject(nodeId)
+                .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .signWith(hmacKey)
                 .compact();
     }
 
     private String parseJwt(String jwt)
     {
         return Jwts.parser()
-                .setSigningKey(hmac)
-                .parseClaimsJws(jwt)
-                .getBody()
+                .verifyWith(hmacKey)
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload()
                 .getSubject();
     }
 

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
@@ -21,10 +21,12 @@ import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import javax.crypto.SecretKey;
 
 import java.io.File;
 import java.net.URL;
@@ -34,7 +36,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -43,7 +44,6 @@ import static com.facebook.presto.jdbc.TestPrestoDriver.closeQuietly;
 import static com.facebook.presto.jdbc.TestPrestoDriver.waitForNodeRefresh;
 import static com.google.common.io.Files.asCharSource;
 import static com.google.common.io.Resources.getResource;
-import static io.jsonwebtoken.JwsHeader.KEY_ID;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Base64.getMimeDecoder;
@@ -102,9 +102,10 @@ public class TestPrestoDriverAuth
     public void testSuccessDefaultKey()
             throws Exception
     {
+        SecretKey key = Keys.hmacShaKeyFor(defaultKey);
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .signWith(SignatureAlgorithm.HS512, defaultKey)
+                .subject("test")
+                .signWith(key, Jwts.SIG.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -122,10 +123,11 @@ public class TestPrestoDriverAuth
     public void testSuccessHmac()
             throws Exception
     {
+        SecretKey key = Keys.hmacShaKeyFor(hmac222);
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .setHeaderParam(KEY_ID, "222")
-                .signWith(SignatureAlgorithm.HS512, hmac222)
+                .subject("test")
+                .header().keyId("222").and()
+                .signWith(key, Jwts.SIG.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -144,9 +146,9 @@ public class TestPrestoDriverAuth
             throws Exception
     {
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .setHeaderParam(KEY_ID, "33")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .subject("test")
+                .header().keyId("33").and()
+                .signWith(privateKey33, Jwts.SIG.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -176,7 +178,7 @@ public class TestPrestoDriverAuth
             throws Exception
     {
         String accessToken = Jwts.builder()
-                .setSubject("test")
+                .subject("test")
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -191,9 +193,10 @@ public class TestPrestoDriverAuth
             throws Exception
     {
         String badKey = "iPqFfWmGvClP953xU9110Q48qB4F5dcJ7QQel3O1k0xU52mlR6fT51SMa2f4KzhFRqqpwGUOud8Eo12pK9EW5H4N";
+        SecretKey key = Keys.hmacShaKeyFor(badKey.getBytes(US_ASCII));
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .signWith(SignatureAlgorithm.HS512, Base64.getEncoder().encodeToString(badKey.getBytes(US_ASCII)))
+                .subject("test")
+                .signWith(key, Jwts.SIG.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -208,9 +211,9 @@ public class TestPrestoDriverAuth
             throws Exception
     {
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .setHeaderParam(KEY_ID, "42")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .subject("test")
+                .header().keyId("42").and()
+                .signWith(privateKey33, Jwts.SIG.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -225,9 +228,9 @@ public class TestPrestoDriverAuth
             throws Exception
     {
         String accessToken = Jwts.builder()
-                .setSubject("test")
-                .setHeaderParam(KEY_ID, "unknown")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .subject("test")
+                .header().keyId("unknown").and()
+                .signWith(privateKey33, Jwts.SIG.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/JsonWebTokenAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/JsonWebTokenAuthenticator.java
@@ -25,12 +25,11 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.SigningKeyResolver;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -64,7 +63,7 @@ public class JsonWebTokenAuthenticator
     private static final String KEY_ID_VARIABLE = "${KID}";
 
     private final JwtParser jwtParser;
-    private final Function<JwsHeader<?>, Key> keyLoader;
+    private final Function<JwsHeader, Key> keyLoader;
 
     @Inject
     public JsonWebTokenAuthenticator(JsonWebTokenConfig config)
@@ -78,34 +77,17 @@ public class JsonWebTokenAuthenticator
             keyLoader = new StaticKeyLoader(config.getKeyFile());
         }
 
-        JwtParser jwtParser = Jwts.parserBuilder()
-                .deserializeJsonWith(new JacksonDeserializer<>(ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class)))
-                .setSigningKeyResolver(new SigningKeyResolver()
-                {
-                    // interface uses raw types and this can not be fixed here
-                    @SuppressWarnings("rawtypes")
-                    @Override
-                    public Key resolveSigningKey(JwsHeader header, Claims claims)
-                    {
-                        return keyLoader.apply(header);
-                    }
-
-                    @SuppressWarnings("rawtypes")
-                    @Override
-                    public Key resolveSigningKey(JwsHeader header, String plaintext)
-                    {
-                        return keyLoader.apply(header);
-                    }
-                })
-                .build();
+        JwtParserBuilder builder = Jwts.parser()
+                .json(new JacksonDeserializer<>(ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class)))
+                .keyLocator(header -> keyLoader.apply((JwsHeader) header));
 
         if (config.getRequiredIssuer() != null) {
-            jwtParser.requireIssuer(config.getRequiredIssuer());
+            builder.requireIssuer(config.getRequiredIssuer());
         }
         if (config.getRequiredAudience() != null) {
-            jwtParser.requireAudience(config.getRequiredAudience());
+            builder.requireAudience(config.getRequiredAudience());
         }
-        this.jwtParser = jwtParser;
+        this.jwtParser = builder.build();
     }
 
     @Override
@@ -124,7 +106,7 @@ public class JsonWebTokenAuthenticator
         }
 
         try {
-            Jws<Claims> claimsJws = jwtParser.parseClaimsJws(token);
+            Jws<Claims> claimsJws = jwtParser.parseSignedClaims(token);
 
             AuthorizedIdentity authorizedIdentity = claimsJws.getBody().get(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class);
             if (authorizedIdentity != null) {
@@ -148,7 +130,7 @@ public class JsonWebTokenAuthenticator
     }
 
     private static class StaticKeyLoader
-            implements Function<JwsHeader<?>, Key>
+            implements Function<JwsHeader, Key>
     {
         private final LoadedKey key;
 
@@ -160,15 +142,14 @@ public class JsonWebTokenAuthenticator
         }
 
         @Override
-        public Key apply(JwsHeader<?> header)
+        public Key apply(JwsHeader header)
         {
-            SignatureAlgorithm algorithm = SignatureAlgorithm.forName(header.getAlgorithm());
-            return key.getKey(algorithm);
+            return key.getKey(header.getAlgorithm());
         }
     }
 
     private static class DynamicKeyLoader
-            implements Function<JwsHeader<?>, Key>
+            implements Function<JwsHeader, Key>
     {
         private final String keyFile;
         private final ConcurrentMap<String, LoadedKey> keys = new ConcurrentHashMap<>();
@@ -181,14 +162,13 @@ public class JsonWebTokenAuthenticator
         }
 
         @Override
-        public Key apply(JwsHeader<?> header)
+        public Key apply(JwsHeader header)
         {
             String keyId = getKeyId(header);
-            SignatureAlgorithm algorithm = SignatureAlgorithm.forName(header.getAlgorithm());
-            return keys.computeIfAbsent(keyId, this::loadKey).getKey(algorithm);
+            return keys.computeIfAbsent(keyId, this::loadKey).getKey(header.getAlgorithm());
         }
 
-        private static String getKeyId(JwsHeader<?> header)
+        private static String getKeyId(JwsHeader header)
         {
             String keyId = header.getKeyId();
             if (keyId == null) {
@@ -247,13 +227,14 @@ public class JsonWebTokenAuthenticator
             this.publicKey = null;
         }
 
-        public Key getKey(SignatureAlgorithm algorithm)
+        public Key getKey(String algorithm)
         {
-            if (algorithm.isHmac()) {
+            // HMAC algorithms: HS256, HS384, HS512
+            if (algorithm.startsWith("HS")) {
                 if (hmacKey == null) {
                     throw new UnsupportedJwtException(format("JWT is signed with %s, but no HMAC key is configured", algorithm));
                 }
-                return new SecretKeySpec(hmacKey, algorithm.getJcaName());
+                return new SecretKeySpec(hmacKey, "Hmac" + algorithm.substring(2));
             }
 
             if (publicKey == null) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JweTokenSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JweTokenSerializer.java
@@ -156,10 +156,10 @@ public class JweTokenSerializer
         }
 
         JwtBuilder jwt = newJwtBuilder()
-                .setExpiration(Date.from(clock.instant().plusMillis(tokenExpiration.toMillis())))
+                .expiration(Date.from(clock.instant().plusMillis(tokenExpiration.toMillis())))
                 .claim(principalField, claimsMap.get(principalField).toString())
-                .setAudience(audience)
-                .setIssuer(issuer)
+                .audience().add(audience).and()
+                .issuer(issuer)
                 .claim(ACCESS_TOKEN_KEY, tokenPair.getAccessToken())
                 .claim(EXPIRATION_TIME_KEY, tokenPair.getExpiration())
                 .claim(REFRESH_TOKEN_KEY, tokenPair.getRefreshToken().orElseThrow(JweTokenSerializer::throwExceptionForNonExistingRefreshToken))

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JwtUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JwtUtil.java
@@ -34,12 +34,12 @@ public final class JwtUtil
     public static JwtBuilder newJwtBuilder()
     {
         return Jwts.builder()
-                .serializeToJsonWith(JWT_SERIALIZER);
+                .json(JWT_SERIALIZER);
     }
 
     public static JwtParserBuilder newJwtParserBuilder()
     {
-        return Jwts.parserBuilder()
-                .deserializeJsonWith(JWT_DESERIALIZER);
+        return Jwts.parser()
+                .json(JWT_DESERIALIZER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.net.URI;
-import java.security.Key;
+import javax.crypto.SecretKey;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
@@ -70,7 +70,7 @@ public class OAuth2Service
     private final String failureHtml;
 
     private final TemporalAmount challengeTimeout;
-    private final Key stateHmac;
+    private final SecretKey stateHmac;
     private final JwtParser jwtParser;
 
     private final OAuth2TokenHandler tokenHandler;
@@ -96,7 +96,7 @@ public class OAuth2Service
                 .map(key -> sha256().hashString(key, UTF_8).asBytes())
                 .orElseGet(() -> secureRandomBytes(32)));
         this.jwtParser = newJwtParserBuilder()
-                .setSigningKey(stateHmac)
+                .verifyWith(stateHmac)
                 .requireAudience(STATE_AUDIENCE_UI)
                 .build();
 
@@ -111,9 +111,9 @@ public class OAuth2Service
         Instant challengeExpiration = now().plus(challengeTimeout);
         String state = newJwtBuilder()
                 .signWith(stateHmac)
-                .setAudience(STATE_AUDIENCE_UI)
+                .audience().add(STATE_AUDIENCE_UI).and()
                 .claim(HANDLER_STATE_CLAIM, handlerState.orElse(null))
-                .setExpiration(Date.from(challengeExpiration))
+                .expiration(Date.from(challengeExpiration))
                 .compact();
 
         OAuth2Client.Request request = client.createAuthorizationRequest(state, callbackUri);
@@ -145,9 +145,9 @@ public class OAuth2Service
         Instant challengeExpiration = now().plus(challengeTimeout);
         String state = newJwtBuilder()
                 .signWith(stateHmac)
-                .setAudience(STATE_AUDIENCE_UI)
+                .audience().add(STATE_AUDIENCE_UI).and()
                 .claim(HANDLER_STATE_CLAIM, handlerState.orElse(null))
-                .setExpiration(Date.from(challengeExpiration))
+                .expiration(Date.from(challengeExpiration))
                 .compact();
 
         return client.createAuthorizationRequest(state, callbackUri);
@@ -241,8 +241,8 @@ public class OAuth2Service
     {
         try {
             return jwtParser
-                    .parseClaimsJws(state)
-                    .getBody();
+                    .parseSignedClaims(state)
+                    .getPayload();
         }
         catch (RuntimeException e) {
             throw new ChallengeFailedException("State validation failed", e);

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/ZstdCodec.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/ZstdCodec.java
@@ -18,6 +18,11 @@ import io.airlift.compress.zstd.ZstdDecompressor;
 import io.jsonwebtoken.CompressionCodec;
 import io.jsonwebtoken.CompressionException;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.copyOfRange;
 
@@ -25,6 +30,12 @@ public class ZstdCodec
         implements CompressionCodec
 {
     public static final String CODEC_NAME = "ZSTD";
+
+    @Override
+    public String getId()
+    {
+        return CODEC_NAME;
+    }
 
     @Override
     public String getAlgorithmName()
@@ -43,11 +54,31 @@ public class ZstdCodec
     }
 
     @Override
+    public OutputStream compress(OutputStream outputStream)
+            throws CompressionException
+    {
+        throw new UnsupportedOperationException("Stream compression not supported");
+    }
+
+    @Override
     public byte[] decompress(byte[] bytes)
             throws CompressionException
     {
         byte[] output = new byte[toIntExact(ZstdDecompressor.getDecompressedSize(bytes, 0, bytes.length))];
         new ZstdDecompressor().decompress(bytes, 0, bytes.length, output, 0, output.length);
         return output;
+    }
+
+    @Override
+    public InputStream decompress(InputStream inputStream)
+            throws CompressionException
+    {
+        try {
+            byte[] bytes = inputStream.readAllBytes();
+            return new ByteArrayInputStream(decompress(bytes));
+        }
+        catch (IOException e) {
+            throw new CompressionException("Failed to decompress input stream", e);
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
@@ -19,7 +19,8 @@ import com.facebook.presto.server.TaskResource;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.hash.Hashing;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+
+import javax.crypto.SecretKey;
 import jakarta.ws.rs.container.ResourceInfo;
 import org.testng.annotations.Test;
 
@@ -83,10 +84,11 @@ public class TestInternalAuthenticationFilter
         InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
         InternalAuthenticationFilter internalAuthenticationFilter =
                 new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+        SecretKey key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(Hashing.sha256().hashString("secret", UTF_8).asBytes());
         String jwtToken = Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
-                .setSubject(principalString)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .subject(principalString)
+                .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .signWith(key)
                 .compact();
 
         MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken));
@@ -108,10 +110,11 @@ public class TestInternalAuthenticationFilter
         InternalAuthenticationManager internalAuthenticationManager = new InternalAuthenticationManager(Optional.of(sharedSecret), "nodeId", internalJwtEnabled);
         InternalAuthenticationFilter internalAuthenticationFilter =
                 new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
+        SecretKey key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(Hashing.sha256().hashString("secret", UTF_8).asBytes());
         String jwtToken = Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
-                .setSubject(principalString)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .subject(principalString)
+                .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .signWith(key)
                 .compact();
 
         MockContainerRequestContext containerRequestContext = new MockContainerRequestContext(ImmutableListMultimap.of(PRESTO_INTERNAL_BEARER, jwtToken));

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestJsonWebTokenAuthenticator.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestJsonWebTokenAuthenticator.java
@@ -37,8 +37,9 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static io.jsonwebtoken.JwsHeader.KEY_ID;
-import static io.jsonwebtoken.SignatureAlgorithm.HS256;
 import static io.jsonwebtoken.security.Keys.secretKeyFor;
+
+import javax.crypto.SecretKey;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Base64.getMimeDecoder;
 import static java.util.Base64.getMimeEncoder;
@@ -89,11 +90,12 @@ public class TestJsonWebTokenAuthenticator
     private static String createJsonWebToken(Path keyFile, String principal, AuthorizedIdentity authorizedIdentity)
             throws IOException
     {
-        byte[] key = getMimeDecoder().decode(readAllBytes(keyFile.toAbsolutePath()));
+        byte[] keyBytes = getMimeDecoder().decode(readAllBytes(keyFile.toAbsolutePath()));
+        SecretKey key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(keyBytes);
         return Jwts.builder()
-                .signWith(HS256, key)
-                .setHeaderParam(KEY_ID, KEY_ID_FOO)
-                .setSubject(principal)
+                .signWith(key, Jwts.SIG.HS256)
+                .header().keyId(KEY_ID_FOO).and()
+                .subject(principal)
                 .claim(AUTHORIZED_IDENTITY_ATTRIBUTE, authorizedIdentity)
                 .compact();
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
@@ -189,10 +189,12 @@ public abstract class BaseOAuth2AuthenticationFilterTest
         keyGenerator.initialize(4096);
         long now = Instant.now().getEpochSecond();
         String token = newJwtBuilder()
-                .setHeaderParam("alg", "RS256")
-                .setHeaderParam("kid", "public:f467aa08-1c1b-4cde-ba45-84b0ef5d2ba8")
-                .setHeaderParam("typ", "JWT")
-                .setClaims(
+                .header()
+                    .add("alg", "RS256")
+                    .add("kid", "public:f467aa08-1c1b-4cde-ba45-84b0ef5d2ba8")
+                    .add("typ", "JWT")
+                    .and()
+                .claims(
                         new DefaultClaims(
                                 ImmutableMap.<String, Object>builder()
                                         .put("aud", ImmutableList.of())

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestJweTokenSerializer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestJweTokenSerializer.java
@@ -211,7 +211,8 @@ public class TestJweTokenSerializer
             implements OAuth2Client
     {
         private final Map<String, Object> claims = Jwts.claims()
-                .setSubject("user");
+                .subject("user")
+                .build();
 
         @Override
         public void load()

--- a/presto-proxy/src/main/java/com/facebook/presto/proxy/JsonWebTokenHandler.java
+++ b/presto-proxy/src/main/java/com/facebook/presto/proxy/JsonWebTokenHandler.java
@@ -16,7 +16,7 @@ package com.facebook.presto.proxy;
 import com.facebook.airlift.security.pem.PemReader;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.inject.Inject;
 
 import java.io.File;
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.jsonwebtoken.JwsHeader.KEY_ID;
 import static java.nio.file.Files.readAllBytes;
 
 public class JsonWebTokenHandler
@@ -60,13 +59,13 @@ public class JsonWebTokenHandler
         checkState(jwtSigner.isPresent(), "not configured");
 
         JwtBuilder jwt = Jwts.builder()
-                .setSubject(subject)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
+                .subject(subject)
+                .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
 
         jwtSigner.get().accept(jwt);
-        jwtKeyId.ifPresent(keyId -> jwt.setHeaderParam(KEY_ID, keyId));
-        jwtIssuer.ifPresent(jwt::setIssuer);
-        jwtAudience.ifPresent(jwt::setAudience);
+        jwtKeyId.ifPresent(keyId -> jwt.header().keyId(keyId).and());
+        jwtIssuer.ifPresent(jwt::issuer);
+        jwtAudience.ifPresent(aud -> jwt.audience().add(aud).and());
 
         return jwt.compact();
     }
@@ -82,7 +81,7 @@ public class JsonWebTokenHandler
             if (!(key instanceof RSAPrivateKey)) {
                 throw new IOException("Only RSA private keys are supported");
             }
-            return Optional.of(jwt -> jwt.signWith(SignatureAlgorithm.RS256, key));
+            return Optional.of(jwt -> jwt.signWith(key, Jwts.SIG.RS256));
         }
         catch (IOException e) {
             throw new RuntimeException("Failed to load key file: " + file, e);
@@ -93,7 +92,7 @@ public class JsonWebTokenHandler
         try {
             byte[] base64Key = readAllBytes(file.toPath());
             byte[] key = Base64.getMimeDecoder().decode(base64Key);
-            return Optional.of(jwt -> jwt.signWith(SignatureAlgorithm.HS256, key));
+            return Optional.of(jwt -> jwt.signWith(Keys.hmacShaKeyFor(key), Jwts.SIG.HS256));
         }
         catch (IOException | IllegalArgumentException e) {
             throw new RuntimeException("Failed to load key file: " + file, e);


### PR DESCRIPTION
## Description

- Updated io.jsonwebtoken:jjwt-api, jjwt-impl, and jjwt-jackson from 0.11.5 to 0.13.0
- Centralized version management using dep.jjwt.version property
- Updated all code to use jjwt 0.13.0 API

## Motivation and Context

Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade JSON Web Token handling to the jjwt 0.13.0 API across server, proxy, JDBC, and OAuth2 components, including dependency and configuration updates.

Enhancements:
- Refactor JWT creation, parsing, and key resolution to use the new jjwt 0.13.0 builder and parser APIs, including typed key handling and updated claims/header APIs.
- Extend the Zstd OAuth2 codec to support stream-based compression/decompression interfaces and expose a codec identifier.
- Centralize jjwt dependency version management via a shared Maven property and apply it to all jjwt artifacts.

Tests:
- Update authentication, OAuth2, and Iceberg REST tests to construct and parse JWTs using the jjwt 0.13.0 APIs, ensuring compatibility with the upgraded library.