### PR TITLE
fix(planner): Fix ConstantExpression type mismatch in PropertyDerivations.visitProject

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -848,7 +848,7 @@ public class PropertyDerivations
                 if (value instanceof VariableReferenceExpression) {
                     ConstantExpression existingConstantValue = constants.get(value);
                     if (existingConstantValue != null) {
-                        constants.put(output, new ConstantExpression(((VariableReferenceExpression) value).getSourceLocation(), value, expression.getType()));
+                        constants.put(output, existingConstantValue);
                     }
                 }
                 else if (!(value instanceof RowExpression)) {


### PR DESCRIPTION
## Description
In `PropertyDerivations.visitProject`, when `RowExpressionInterpreter.optimize()` reduces a complex expression to a `VariableReferenceExpression` that is already known to be constant, the code was constructing a new `ConstantExpression` with the `VariableReferenceExpression` object itself as the value instead of using the existing constant's actual value. This caused `ConstantExpression`'s constructor type check to fail with `IllegalArgumentException: Object 'sum_1080' does not match type long`, since a `VariableReferenceExpression` is not a valid `Long` value for a `BIGINT` column.

The fix reuses the existing `ConstantExpression` directly from the constants map, which already holds the correct value and type.

## Motivation and Context
When the optimizer encounters a projection where a complex expression simplifies to a variable reference that is already known to be constant, it should propagate that constant value. The previous code incorrectly passed the `VariableReferenceExpression` object as the constant value, causing a type mismatch exception.

## Impact
Bug fix in the query optimizer. No public API changes. Fixes a query failure (`IllegalArgumentException`) that can occur during optimization when constant propagation encounters certain expression patterns.

## Test Plan
- Unit tests pass
- Verified the fix addresses the type mismatch scenario described above

## Contributor checklist
- [x] Make sure your changes are compliant with our style guide
- [x] Make sure you've read and comply with the contributing guide
- [x] Make sure your commit is a single logical change
- [x] Make sure you run tests with your changes

== NO RELEASE NOTE ==

## Summary by Sourcery

Bug Fixes:
- Correct constant propagation by reusing existing ConstantExpression instances instead of constructing new ones with incorrect values.