### PR TITLE
fix(analyzer): Relax stale view validation for compatible string types

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -25,6 +25,7 @@ import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RealType;
@@ -4545,12 +4546,29 @@ class StatementAnalyzer
                 ViewDefinition.ViewColumn column = columns.get(i);
                 Field field = fieldList.get(i);
                 if (!column.getName().equalsIgnoreCase(field.getName().orElse(null)) ||
-                        !functionAndTypeResolver.canCoerce(field.getType(), column.getType())) {
+                        !areViewColumnTypesCompatible(column.getType(), field.getType())) {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        private boolean areViewColumnTypesCompatible(Type storedType, Type analyzedType)
+        {
+            return functionAndTypeResolver.canCoerce(analyzedType, storedType) ||
+                    functionAndTypeResolver.canCoerce(storedType, analyzedType) ||
+                    isCharacterStringCompatibility(storedType, analyzedType);
+        }
+
+        private boolean isCharacterStringCompatibility(Type first, Type second)
+        {
+            return isCharacterStringType(first) && isCharacterStringType(second);
+        }
+
+        private boolean isCharacterStringType(Type type)
+        {
+            return type instanceof CharType || type instanceof VarcharType;
         }
 
         private ExpressionAnalysis analyzeExpression(Expression expression, Scope scope)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
@@ -426,6 +427,48 @@ public class AbstractAnalyzerTest
                 new SchemaTableName("s1", "v2"),
                 ImmutableList.of(ColumnMetadata.builder().setName("a").setType(VARCHAR).build()));
         inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadata2, viewData2, false));
+
+        // valid view with symmetric type coercion between stored and analyzed types
+        String viewDataSymmetricCoercion = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
+                new ViewDefinition(
+                        "select CAST(a AS INTEGER) a from t1",
+                        Optional.of(TPCH_CATALOG),
+                        Optional.of("s1"),
+                        ImmutableList.of(new ViewDefinition.ViewColumn("a", BIGINT)),
+                        Optional.of("user"),
+                        false));
+        ConnectorTableMetadata viewMetadataSymmetricCoercion = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v_symmetric_coercion"),
+                ImmutableList.of(ColumnMetadata.builder().setName("a").setType(BIGINT).build()));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadataSymmetricCoercion, viewDataSymmetricCoercion, false));
+
+        // issue-shaped view: stored char(3), analyzed char(20); should be valid with symmetric coercion
+        String viewDataCharSymmetricCoercion = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
+                new ViewDefinition(
+                        "select CAST('abc' AS CHAR(20)) a",
+                        Optional.of(TPCH_CATALOG),
+                        Optional.of("s1"),
+                        ImmutableList.of(new ViewDefinition.ViewColumn("a", CharType.createCharType(3))),
+                        Optional.of("user"),
+                        false));
+        ConnectorTableMetadata viewMetadataCharSymmetricCoercion = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v_char_symmetric_coercion"),
+                ImmutableList.of(ColumnMetadata.builder().setName("a").setType(CharType.createCharType(3)).build()));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadataCharSymmetricCoercion, viewDataCharSymmetricCoercion, false));
+
+        // issue-shaped view: stored char(3), analyzed varchar; should remain stale under default coercion rules
+        String viewDataCharVarcharStale = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
+                new ViewDefinition(
+                        "select b from t6",
+                        Optional.of(TPCH_CATALOG),
+                        Optional.of("s1"),
+                        ImmutableList.of(new ViewDefinition.ViewColumn("b", CharType.createCharType(3))),
+                        Optional.of("user"),
+                        false));
+        ConnectorTableMetadata viewMetadataCharVarcharStale = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v_char_varchar_stale"),
+                ImmutableList.of(ColumnMetadata.builder().setName("b").setType(CharType.createCharType(3)).build()));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadataCharVarcharStale, viewDataCharVarcharStale, false));
 
         // view referencing table in different schema from itself and session
         String viewData3 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1540,6 +1540,24 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testViewWithSymmetricTypeCoercionIsNotStale()
+    {
+        analyze("SELECT * FROM v_symmetric_coercion");
+    }
+
+    @Test
+    public void testViewWithSymmetricCharTypeCoercionIsNotStale()
+    {
+        analyze("SELECT * FROM v_char_symmetric_coercion");
+    }
+
+    @Test
+    public void testViewWithCharAndVarcharTypeMismatchIsNotStale()
+    {
+        analyze("SELECT * FROM v_char_varchar_stale");
+    }
+
+    @Test
     public void testStoredViewAnalysisScoping()
     {
         // the view must not be analyzed using the query context


### PR DESCRIPTION
## Description
Relax stale view validation in the analyzer for compatible view column types.

This change updates `StatementAnalyzer.isViewStale()` to treat view columns as compatible when:

- The analyzed type can be coerced to the stored type, or
- The stored type can be coerced to the analyzed type, or
- Both types belong to the string family (CHAR / VARCHAR)

## Motivation and Context
Connector-backed views can store column metadata derived from the source system, while Presto re-analyzes the stored view SQL using its own type inference rules during query planning. When the source system and Presto derive different but compatible result types for the same expression, Presto can incorrectly mark the view as stale.

This change makes stale-view validation more tolerant of compatible type differences by:

- Allowing symmetric coercion between stored and analyzed column types, and
- Treating CHAR / VARCHAR mismatches as compatible for stale-view checking

## Impact
Connector-backed views with compatible string-type differences are less likely to fail with: `View <name> is stale; it must be re-created
`
## Test Plan
Added/updated analyzer tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Relax view staleness detection to treat compatible column type differences as valid for connector-backed views.

Bug Fixes:
- Prevent connector-backed views from being incorrectly marked as stale when stored and analyzed column types are mutually coercible or compatible string types.

Enhancements:
- Introduce a compatibility check for view column types that allows symmetric type coercion and treats CHAR/VARCHAR combinations as compatible in stale-view validation.

Tests:
- Add analyzer tests and setup views to cover symmetric type coercion, CHAR-to-CHAR coercion, and CHAR/VARCHAR mismatch behavior in stale-view detection.