### PR TITLE
fix(analyzer): Prevent incorrect materialized view query rewrite when base query lacks GROUP BY

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -539,7 +539,7 @@ public class MaterializedViewQueryOptimizer
                                     throw new IllegalStateException("GROUP BY ordinal references non-single-column select item");
                                 }
                             }
-                            if (!groupByOfMaterializedView.get().contains(resolved) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(resolved)) {
+                            if (!isExpressionInMvGroupBy(resolved, groupByOfMaterializedView.get()) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(resolved)) {
                                 throw new IllegalStateException(format("Grouping element %s is not present in materialized view groupBy field", element));
                             }
                             // Store the resolved expression so visitSingleColumn can match against it
@@ -619,7 +619,7 @@ public class MaterializedViewQueryOptimizer
             Optional<Set<Expression>> groupByOfMaterializedView = materializedViewInfo.getGroupBy();
             // TODO: Replace this logic with rule-based validation framework.
             if (groupByOfMaterializedView.isPresent() &&
-                    validateExpressionForGroupBy(groupByOfMaterializedView.get(), expression) &&
+                    !isRewritableWithMvGroupBy(groupByOfMaterializedView.get(), expression) &&
                     (!expressionsInGroupBy.isPresent() || !expressionsInGroupBy.get().contains(expression))) {
                 throw new IllegalStateException("Query a column presents in materialized view group by: " + expression.toString());
             }
@@ -925,21 +925,47 @@ public class MaterializedViewQueryOptimizer
             return rewritten.build();
         }
 
-        private boolean validateExpressionForGroupBy(Set<Expression> groupByOfMaterializedView, Expression expression)
+        private boolean isRewritableWithMvGroupBy(Set<Expression> mvGroupBy, Expression expression)
         {
-            boolean canRewrite = expression instanceof FunctionCall
+            // Dimension column — MV collapses rows on this column, not rewritable
+            // without matching GROUP BY in the base query
+            if (isExpressionInMvGroupBy(expression, mvGroupBy)) {
+                return false;
+            }
+
+            // Rewritable aggregate (SUM, COUNT, MIN, MAX, AVG) — rollup is always safe
+            if (expression instanceof FunctionCall
                     && (ASSOCIATIVE_REWRITE_FUNCTIONS.contains(((FunctionCall) expression).getName())
-                    || MaterializedViewUtils.validateNonAssociativeFunctionRewrite((FunctionCall) expression, materializedViewInfo.getBaseToViewColumnMap()));
+                    || MaterializedViewUtils.validateNonAssociativeFunctionRewrite(
+                            (FunctionCall) expression, materializedViewInfo.getBaseToViewColumnMap()))) {
+                return true;
+            }
 
-            // Scalar expressions (IF, CASE, COALESCE, scalar functions like CONCAT/ABS/JSON_EXTRACT)
-            // are valid in SELECT — the rewriter handles them by rewriting leaf identifiers.
-            // Only known built-in scalar functions qualify; unknown/plugin functions are not assumed scalar.
-            boolean isScalar = !(expression instanceof Identifier)
-                    && (!(expression instanceof FunctionCall) || isScalarFunction((FunctionCall) expression));
+            // Non-dimension column mapped in MV — safe to rewrite
+            if (materializedViewInfo.getBaseToViewColumnMap().containsKey(expression)) {
+                return true;
+            }
 
-            // If a selected column is not present in GROUP BY node of the query.
-            // It must be 1) be selected in the materialized view and 2) not present in GROUP BY node of the materialized view
-            return groupByOfMaterializedView.contains(expression) || !(materializedViewInfo.getBaseToViewColumnMap().containsKey(expression) || canRewrite || isScalar);
+            // Scalar expression (IF, CAST, ABS, arithmetic, etc.) — safe only when
+            // the base query has GROUP BY. Without GROUP BY, the MV collapses rows
+            // and these expressions would silently lose duplicates.
+            if (expressionsInGroupBy.isPresent()
+                    && !(expression instanceof Identifier)
+                    && (!(expression instanceof FunctionCall) || isScalarFunction((FunctionCall) expression))) {
+                return true;
+            }
+
+            // Unrecognized expression — not rewritable
+            return false;
+        }
+
+        private boolean isExpressionInMvGroupBy(Expression expression, Set<Expression> mvGroupBy)
+        {
+            if (mvGroupBy.contains(expression)) {
+                return true;
+            }
+            Identifier viewColumn = materializedViewInfo.getBaseToViewColumnMap().get(expression);
+            return viewColumn != null && mvGroupBy.contains(viewColumn);
         }
 
         private boolean isScalarFunction(FunctionCall functionCall)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -800,6 +800,145 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testBaseQueryWithoutGroupByNotRewrittenToMVWithGroupByAlias()
+    {
+        // MV uses aliases in GROUP BY — base query without GROUP BY must NOT be rewritten
+        String originalViewSql = format("SELECT a as mv_a, count(b) as cb, c as mv_c FROM %s GROUP BY mv_a, mv_c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, c FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Same scenario with a single aliased GROUP BY column
+        originalViewSql = format("SELECT a as mv_a, b FROM %s GROUP BY mv_a, b", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testBaseQueryWithoutGroupByScalarExpressionsNotRewritten()
+    {
+        // Scalar expressions wrapping GROUP BY columns must NOT be rewritten when base query has no GROUP BY.
+        // The MV collapses rows via GROUP BY, so reading scalar expressions of those columns loses duplicates.
+        String originalViewSql = format("SELECT a, b, SUM(c) AS total FROM %s GROUP BY a, b", BASE_TABLE_1);
+
+        // REJECT: arithmetic on GROUP BY columns
+        String baseQuerySql = format("SELECT a + b FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: CAST of a GROUP BY column
+        baseQuerySql = format("SELECT CAST(a AS VARCHAR) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: IF expression wrapping GROUP BY columns
+        baseQuerySql = format("SELECT IF(a > 0, b, 0) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: scalar function on GROUP BY column
+        baseQuerySql = format("SELECT ABS(a) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: COALESCE on GROUP BY columns
+        baseQuerySql = format("SELECT COALESCE(a, b) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: CASE expression on GROUP BY columns
+        baseQuerySql = format("SELECT CASE WHEN a > 0 THEN b ELSE 0 END FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: NULLIF on GROUP BY column
+        baseQuerySql = format("SELECT NULLIF(a, 0) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: nested scalar (ABS(a + b))
+        baseQuerySql = format("SELECT ABS(a + b) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: comparison expression on GROUP BY columns
+        baseQuerySql = format("SELECT a > b FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: NOT expression on GROUP BY column
+        baseQuerySql = format("SELECT NOT (a > 0) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: IS NULL on GROUP BY column
+        baseQuerySql = format("SELECT a IS NULL FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: IN predicate on GROUP BY column
+        baseQuerySql = format("SELECT a IN (1, 2, 3) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Valid: aggregate without GROUP BY is still a valid rollup
+        baseQuerySql = format("SELECT SUM(c) FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(total) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Valid: COUNT rollup without GROUP BY
+        String originalViewSqlCount = format("SELECT a, COUNT(b) AS cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(cnt) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSqlCount, BASE_TABLE_1, VIEW_1);
+
+        // Valid: scalar expression with GROUP BY in base query is fine
+        baseQuerySql = format("SELECT a + b, SUM(c) FROM %s GROUP BY a, b", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a + b, SUM(total) FROM %s GROUP BY a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByAliasedMVColumns()
+    {
+        // MV uses aliases in GROUP BY — base query with GROUP BY should still rewrite via rollup
+        String originalViewSql = format("SELECT a as mv_a, c as mv_c, SUM(b) as total FROM %s GROUP BY mv_a, mv_c", BASE_TABLE_1);
+
+        // Exact same GROUP BY as MV
+        String baseQuerySql = format("SELECT a, c, SUM(b) FROM %s GROUP BY a, c", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT mv_a as a, mv_c as c, SUM(total) FROM %s GROUP BY mv_a, mv_c", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Rollup: query groups by subset of MV GROUP BY
+        baseQuerySql = format("SELECT a, SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a as a, SUM(total) FROM %s GROUP BY mv_a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Aggregate-only rollup (no GROUP BY in query)
+        baseQuerySql = format("SELECT SUM(b) FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(total) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: bare GROUP BY columns without GROUP BY — MV collapses rows
+        baseQuerySql = format("SELECT a, c FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: single aliased GROUP BY column without GROUP BY
+        baseQuerySql = format("SELECT a FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: scalar expression on aliased GROUP BY column without GROUP BY
+        baseQuerySql = format("SELECT a + c FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: CAST of aliased GROUP BY column without GROUP BY
+        baseQuerySql = format("SELECT CAST(a AS VARCHAR) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: query groups by column NOT in MV GROUP BY
+        baseQuerySql = format("SELECT SUM(b), d FROM %s GROUP BY d", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: query selects column not in MV
+        baseQuerySql = format("SELECT a, d FROM %s GROUP BY a, d", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: aggregate not pre-computed in MV
+        baseQuerySql = format("SELECT MAX(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: IF expression on aliased GROUP BY column without GROUP BY
+        baseQuerySql = format("SELECT IF(a > 0, c, 0) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithGroupByCube()
     {
         String originalViewSql = format("SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);


### PR DESCRIPTION
Summary:
Fixes three data correctness bugs in MaterializedViewQueryOptimizer where queries could be incorrectly rewritten to read from materialized views that collapse rows via GROUP BY:

1. **Alias mismatch**: When the MV definition uses aliases in GROUP BY (e.g., GROUP BY mv_a instead of GROUP BY a), the validation compared base column names against alias names. The contains() check always failed, allowing the rewrite to proceed unchecked.

2. **Scalar expression bypass**: Scalar expressions wrapping GROUP BY columns (arithmetic, CAST, IF, CASE, COALESCE, ABS, etc.) were unconditionally exempted from the GROUP BY guard via the isScalar flag. When the base query had no GROUP BY, these expressions would silently read collapsed data from the MV, losing duplicate rows.

3. **Missed optimization (line 542)**: The GROUP BY element validation in visitQuerySpecification had the same alias mismatch, falsely rejecting valid rollup rewrites when the MV used column aliases.

Changes:
- Renamed validateExpressionForGroupBy to isRewritableWithMvGroupBy with positive return semantics (true = safe to rewrite) and early-return structure for readability
- Extracted isExpressionInMvGroupBy helper for alias-aware GROUP BY membership check, used in both visitQuerySpecification and isRewritableWithMvGroupBy
- Gated the isScalar exemption on expressionsInGroupBy.isPresent() so scalar expressions are only allowed through when the base query has GROUP BY

Differential Revision: D104480220

```
== RELEASE NOTES ==

General Changes
* Fix data correctness bugs in ``MaterializedViewQueryOptimizer`` where queries without ``GROUP BY`` could be incorrectly rewritten to use materialized views with ``GROUP BY``, producing fewer rows than expected. Alias mismatches and scalar expression bypasses allowed invalid rewrites that silently collapsed duplicate rows.

```


