### PR TITLE
Upgrade hudi version to 1.2.0 in presto version 0.293

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>0.15.0</dep.hudi.version>
+        <dep.hudi.version>1.1.1</dep.hudi.version>
         <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
         <dep.docker-java.version>3.4.1</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2705,9 +2705,14 @@
                             <ignoredClassPattern>META-INF.versions.11.module-info</ignoredClassPattern>
                             <!-- Ignore duplicate classes related to lucene-core and ranger-apache -->
                             <ignoredClassPattern>META-INF.versions.9.org.apache.lucene.*</ignoredClassPattern>
+                            <!-- hudi-presto-bundle shades io.airlift.compress.* classes (different version
+                                 than our direct aircompressor dep), producing expected duplicate-class conflicts. -->
+                            <ignoredClassPattern>io.airlift.compress.*</ignoredClassPattern>
                         </ignoredClassPatterns>
                         <ignoredResourcePatterns combine.children="append">
                             <ignoredResourcePattern>git.properties</ignoredResourcePattern>
+                            <!-- Duplicated between hive-apache and hudi-presto-bundle (content is equal). -->
+                            <ignoredResourcePattern>logicalType.avsc</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>0.14.0</dep.hudi.version>
+        <dep.hudi.version>0.15.0</dep.hudi.version>
         <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
         <dep.docker-java.version>3.4.1</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-        <dep.hudi.version>1.1.1</dep.hudi.version>
+        <dep.hudi.version>1.2.0-rc1</dep.hudi.version>
         <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
         <dep.docker-java.version>3.4.1</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
@@ -2603,6 +2603,20 @@
 
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+    	<!-- TODO: remove once Hudi 1.2.0 is voted through and synced to Maven Central -->
+    	<repository>
+            <releases>
+            	<enabled>true</enabled>
+            </releases>
+            <snapshots>
+            	<enabled>false</enabled>
+            </snapshots>
+            <id>apache-hudi-staging</id>
+            <url>https://repository.apache.org/content/repositories/orgapachehudi-1176</url>
+    	</repository>
+    </repositories>
 
     <build>
         <pluginManagement>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -518,6 +518,10 @@
                     <ignoredDependencies>
                         <ignoredDependency>org.glassfish.jersey.core:jersey-common:jar</ignoredDependency>
                         <ignoredDependency>org.eclipse.jetty:jetty-server:jar</ignoredDependency>
+                        <ignoredDependency>org.apache.httpcomponents:httpclient</ignoredDependency>
+                        <!-- hudi-presto-bundle shades io.airlift.compress.* classes, so the analyzer
+                             attributes aircompressor usage to the bundle and flags this direct declaration as unused. -->
+                        <ignoredDependency>io.airlift:aircompressor</ignoredDependency>
                     </ignoredDependencies>
                 </configuration>
             </plugin>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
@@ -97,11 +97,11 @@ public class HudiDirectoryLister
                 .filterCompletedInstants()
                 .filter(instant -> MERGE_ON_READ.equals(metaClient.getTableType()) && instant.getAction().equals(HoodieTimeline.COMPACTION_ACTION))
                 .lastInstant()
-                .map(HoodieInstant::getTimestamp).orElseGet(() -> metaClient.getActiveTimeline()
+                .map(HoodieInstant::requestedTime).orElseGet(() -> metaClient.getActiveTimeline()
                         .getCommitsTimeline()
                         .filterCompletedInstants()
                         .lastInstant()
-                        .map(HoodieInstant::getTimestamp).orElseThrow(() -> new RuntimeException("No active instant found")));
+                        .map(HoodieInstant::requestedTime).orElseThrow(() -> new RuntimeException("No active instant found")));
         HoodieEngineContext engineContext = new HoodieLocalEngineContext(storageConf);
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
                 .enable(metadataEnabled)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
@@ -40,10 +40,16 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.hive.HiveFileInfo.createHiveFileInfo;
@@ -51,6 +57,10 @@ import static com.facebook.presto.hive.HiveSessionProperties.getHudiTablesUseMer
 import static com.facebook.presto.hive.HiveSessionProperties.isHudiMetadataEnabled;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DEFAULT_PORT;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToHadoopFileStatus;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePathInfo;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConfWithCopy;
 
 public class HudiDirectoryLister
         implements DirectoryLister
@@ -77,8 +87,9 @@ public class HudiDirectoryLister
         if (actualConfig instanceof CopyOnFirstWriteConfiguration) {
             actualConfig = ((CopyOnFirstWriteConfiguration) actualConfig).getConfig();
         }
+        StorageConfiguration<Configuration> storageConf = getStorageConfWithCopy(actualConfig);
         this.metaClient = HoodieTableMetaClient.builder()
-                .setConf(actualConfig)
+                .setConf(storageConf)
                 .setBasePath(table.getStorage().getLocation())
                 .build();
         this.latestInstant = metaClient.getActiveTimeline()
@@ -91,7 +102,7 @@ public class HudiDirectoryLister
                         .filterCompletedInstants()
                         .lastInstant()
                         .map(HoodieInstant::getTimestamp).orElseThrow(() -> new RuntimeException("No active instant found")));
-        HoodieEngineContext engineContext = new HoodieLocalEngineContext(actualConfig);
+        HoodieEngineContext engineContext = new HoodieLocalEngineContext(storageConf);
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
                 .enable(metadataEnabled)
                 .build();
@@ -142,9 +153,12 @@ public class HudiDirectoryLister
                 String latestInstant,
                 boolean shouldUseMergedView)
         {
-            String partition = FSUtils.getRelativePartitionPath(new Path(tablePath), directory);
+            String partition = FSUtils.getRelativePartitionPath(new StoragePath(tablePath), convertToStoragePath(directory));
             if (fileStatuses.isPresent()) {
-                fileSystemView.addFilesToView(fileStatuses.get());
+                List<StoragePathInfo> pathInfos = Arrays.stream(fileStatuses.get())
+                        .map(fs -> convertToStoragePathInfo(fs))
+                        .collect(Collectors.toList());
+                fileSystemView.addFilesToView(pathInfos);
                 this.hoodieBaseFileIterator = fileSystemView.fetchLatestBaseFiles(partition).iterator();
             }
             else {
@@ -170,7 +184,7 @@ public class HudiDirectoryLister
         public HiveFileInfo next()
                 throws IOException
         {
-            FileStatus fileStatus = hoodieBaseFileIterator.next().getFileStatus();
+            FileStatus fileStatus = convertToHadoopFileStatus(hoodieBaseFileIterator.next().getPathInfo());
             String[] name = {"localhost:" + DFS_DATANODE_DEFAULT_PORT};
             String[] host = {"localhost"};
             LocatedFileStatus hoodieFileStatus = new LocatedFileStatus(fileStatus,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeBootstrapBaseFileSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeBootstrapBaseFileSplitConverter.java
@@ -71,7 +71,7 @@ public class HudiRealtimeBootstrapBaseFileSplitConverter
         if (!isNullOrEmpty(customFileSplitClass) && HoodieRealtimeBootstrapBaseFileSplit.class.getName().equals(customFileSplitClass)) {
             String deltaFilePaths = customSplitInfo.get(DELTA_FILE_PATHS_KEY);
             List<String> deltaLogPaths = isNullOrEmpty(deltaFilePaths) ? Collections.emptyList() : Arrays.asList(deltaFilePaths.split(","));
-            List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(p -> new HoodieLogFile(new Path(p))).collect(Collectors.toList());
+            List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(HoodieLogFile::new).collect(Collectors.toList());
             FileSplit bootstrapFileSplit = new FileSplit(
                     new Path(customSplitInfo.get(BOOTSTRAP_FILE_SPLIT_PATH)),
                     parseLong(customSplitInfo.get(BOOTSTRAP_FILE_SPLIT_START)),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeSplitConverter.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.util;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.util.Option;
@@ -67,7 +66,7 @@ public class HudiRealtimeSplitConverter
         if (HoodieRealtimeFileSplit.class.getName().equals(customSplitClass)) {
             requireNonNull(customSplitInfo.get(HUDI_DELTA_FILEPATHS_KEY), "HUDI_DELTA_FILEPATHS_KEY is missing");
             List<String> deltaLogPaths = SPLITTER.splitToList(customSplitInfo.get(HUDI_DELTA_FILEPATHS_KEY));
-            List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(p -> new HoodieLogFile(new Path(p))).collect(Collectors.toList());
+            List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(HoodieLogFile::new).collect(Collectors.toList());
             return Optional.of(new HoodieRealtimeFileSplit(
                     split,
                     requireNonNull(customSplitInfo.get(HUDI_BASEPATH_KEY), "HUDI_BASEPATH_KEY is missing"),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestCustomSplitConversionUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestCustomSplitConversionUtils.java
@@ -44,7 +44,7 @@ public class TestCustomSplitConversionUtils
             throws IOException
     {
         List<String> deltaLogPaths = Arrays.asList("test1", "test2", "test3");
-        List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(p -> new HoodieLogFile(new Path(p))).collect(Collectors.toList());
+        List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(HoodieLogFile::new).collect(Collectors.toList());
         String expectedMaxCommitTime = "max_commit_time";
 
         FileSplit baseSplit = new FileSplit(FILE_PATH, SPLIT_START_POS, SPLIT_LENGTH, SPLIT_HOSTS);
@@ -125,7 +125,7 @@ public class TestCustomSplitConversionUtils
             throws IOException
     {
         List<String> deltaLogPaths = Arrays.asList("test1", "test2", "test3");
-        List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(p -> new HoodieLogFile(new Path(p))).collect(Collectors.toList());
+        List<HoodieLogFile> deltaLogFiles = deltaLogPaths.stream().map(HoodieLogFile::new).collect(Collectors.toList());
         String maxCommitTime = "max_commit_time";
 
         Path bootstrapSourceFilePath = new Path("/test/source/test.parquet");

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -121,7 +121,7 @@ public class HudiSplitManager
         StorageConfiguration<Configuration> storageConf = getStorageConfWithCopy(conf);
         HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(storageConf).setBasePath(table.getPath()).build();
         HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-        String timestamp = timeline.lastInstant().map(HoodieInstant::getTimestamp).orElse(null);
+        String timestamp = timeline.lastInstant().map(HoodieInstant::requestedTime).orElse(null);
         if (timestamp == null) {
             // no completed instant for current table
             return new FixedSplitSource(ImmutableList.of());

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplitManager.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.storage.StorageConfiguration;
 
 import javax.inject.Inject;
 
@@ -63,6 +64,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMemoryFileSystemViewWithTimeline;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConfWithCopy;
 
 public class HudiSplitManager
         implements ConnectorSplitManager
@@ -116,14 +118,15 @@ public class HudiSplitManager
         ExtendedFileSystem fs = getFileSystem(session, table);
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(isHudiMetadataTableEnabled(session)).build();
         Configuration conf = fs.getConf();
-        HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(conf).setBasePath(table.getPath()).build();
+        StorageConfiguration<Configuration> storageConf = getStorageConfWithCopy(conf);
+        HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(storageConf).setBasePath(table.getPath()).build();
         HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
         String timestamp = timeline.lastInstant().map(HoodieInstant::getTimestamp).orElse(null);
         if (timestamp == null) {
             // no completed instant for current table
             return new FixedSplitSource(ImmutableList.of());
         }
-        HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(conf);
+        HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(storageConf);
         HoodieTableFileSystemView fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
 
         return new HudiSplitSource(

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
@@ -29,11 +29,11 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.storage.StoragePath;
 
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +62,7 @@ public class HudiPartitionSplitGenerator
     private final MetastoreContext metastoreContext;
     private final HudiTableLayoutHandle layout;
     private final HudiTableHandle table;
-    private final Path tablePath;
+    private final StoragePath tablePath;
     private final HoodieTableFileSystemView fsView;
     private final AsyncQueue<ConnectorSplit> asyncQueue;
     private final Queue<String> concurrentPartitionQueue;
@@ -82,7 +82,7 @@ public class HudiPartitionSplitGenerator
         this.metastoreContext = toMetastoreContext(requireNonNull(session, "session is null"));
         this.layout = requireNonNull(layout, "layout is null");
         this.table = layout.getTable();
-        this.tablePath = new Path(table.getPath());
+        this.tablePath = new StoragePath(table.getPath());
         this.fsView = requireNonNull(fsView, "fsView is null");
         this.asyncQueue = requireNonNull(asyncQueue, "asyncQueue is null");
         this.concurrentPartitionQueue = requireNonNull(concurrentPartitionQueue, "concurrentPartitionQueue is null");
@@ -106,7 +106,7 @@ public class HudiPartitionSplitGenerator
     private void generateSplitsFromPartition(String partitionName)
     {
         HudiPartition hudiPartition = getHudiPartition(metastore, metastoreContext, layout, partitionName);
-        Path partitionPath = new Path(hudiPartition.getStorage().getLocation());
+        StoragePath partitionPath = new StoragePath(hudiPartition.getStorage().getLocation());
         String relativePartitionPath = FSUtils.getRelativePartitionPath(tablePath, partitionPath);
         Stream<FileSlice> fileSlices = HudiTableType.MOR.equals(table.getTableType()) ?
                 fsView.getLatestMergedFileSlicesBeforeOrOn(relativePartitionPath, latestInstant) :

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/split/HudiPartitionSplitGenerator.java
@@ -124,7 +124,7 @@ public class HudiPartitionSplitGenerator
             HudiPartition partition,
             HudiSplitWeightProvider splitWeightProvider)
     {
-        HudiFile baseFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileLen())).orElse(null);
+        HudiFile baseFile = slice.getBaseFile().map(f -> new HudiFile(f.getPath(), 0, f.getFileSize())).orElse(null);
         if (null == baseFile && table.getTableType() == HudiTableType.COW) {
             return Optional.empty();
         }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade the Hudi dependency and adapt the Presto Hudi connector to Hudi 1.2.0 storage and timeline APIs, including related build and shading configuration updates.

Enhancements:
- Update Hudi directory listing, split management, and partition split generation to use Hudi 1.2.0 StorageConfiguration/StoragePath APIs and requestedTime-based timelines.

Build:
- Bump the Hudi dependency from 0.14.0 to 1.2.0-rc1 and add a temporary Apache Hudi staging repository for artifact resolution.
- Extend shading and dependency-analysis ignore patterns to account for classes and resources bundled by the new hudi-presto-bundle artifact.

Tests:
- Adjust Hudi split-conversion tests to use the updated HoodieLogFile constructors compatible with Hudi 1.2.0.

Chores:
- Simplify Hudi log file construction in runtime and utility code to align with the newer Hudi API and silence analyzer false positives for shaded dependencies.