### PR TITLE
feat: Register NimbleWriterFactory at server startup (#27782)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -18,6 +18,9 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <glog/logging.h>
 #include <proxygen/lib/http/HTTPHeaders.h>
+#ifdef PRESTO_ENABLE_NIMBLE
+#include "fb_velox/dwio/nimble/writer/NimbleWriter.h"
+#endif
 #include "presto_cpp/main/Announcer.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicMemoryChecker.h"
@@ -1598,6 +1601,9 @@ void PrestoServer::registerMemoryArbitrators() {
 void PrestoServer::registerFileReadersAndWriters() {
   velox::dwrf::registerDwrfReaderFactory();
   velox::dwrf::registerDwrfWriterFactory();
+#ifdef PRESTO_ENABLE_NIMBLE
+  velox::nimble::registerNimbleWriterFactory();
+#endif
   velox::orc::registerOrcReaderFactory();
   velox::parquet::registerParquetReaderFactory();
   velox::parquet::registerParquetWriterFactory();
@@ -1612,6 +1618,9 @@ void PrestoServer::registerFileReadersAndWriters() {
 void PrestoServer::unregisterFileReadersAndWriters() {
   velox::dwrf::unregisterDwrfReaderFactory();
   velox::dwrf::unregisterDwrfWriterFactory();
+#ifdef PRESTO_ENABLE_NIMBLE
+  velox::nimble::unregisterNimbleWriterFactory();
+#endif
   velox::parquet::unregisterParquetReaderFactory();
   velox::parquet::unregisterParquetWriterFactory();
   if (SystemConfig::instance()->textWriterEnabled()) {


### PR DESCRIPTION
Summary:

Registers the existing `fb_velox` `NimbleWriterFactory` in
`PrestoServer::registerFileReadersAndWriters()`, alongside the existing
DWRF and Parquet writer factories, with a matching unregister in
`unregisterFileReadersAndWriters()`. Adds the
`//fb_velox/dwio/nimble/writer:writer` BUCK dep to `presto_server_lib`.

## Why

Without this registration, the dwio writer-factory lookup for
`FileFormat::NIMBLE` returns null at INSERT time on a native worker,
even when the Velox Iceberg `DataSink` accepts NIMBLE (see stacked Velox
adapter diff). The `NimbleWriterFactory` itself already exists at
`fb_velox/dwio/nimble/writer/NimbleWriter.h:15-32` and is registered
today only by the Prism connector -- never by `presto_cpp`'s main
bootstrap.

## What this does

- Adds `#include "fb_velox/dwio/nimble/writer/NimbleWriter.h"` near the
  existing dwrf/parquet writer includes (alphabetically sorted).
- Adds `velox::nimble::registerNimbleWriterFactory()` call alongside
  `velox::dwrf::registerDwrfWriterFactory()` and
  `velox::parquet::registerParquetWriterFactory()`.
- Adds the matching `unregisterNimbleWriterFactory()` to the teardown.
- Adds the BUCK dep on `//fb_velox/dwio/nimble/writer:writer`.

## What this does NOT do

- Does not change DWRF, Parquet, ORC, or text reader/writer
  registration.
- Does not register a NIMBLE reader (the Nimble reader factory is
  already registered transitively via the connector's reader path that
  uses the on-disk magic-byte sniff).
- Does not modify any catalog or session-property defaults.

## Pairing requirement

The Velox `NimbleWriterOptionsAdapter` diff in the parent of this stack
MUST land first, or INSERT into a NIMBLE Iceberg table will still fail
at the `IcebergDataSink` ctor (`Unsupported file format`) before ever
reaching the writer-factory lookup. Both diffs together are required
for end-to-end NIMBLE Iceberg writes.

=== NO RELEASE NOTES ===

Reviewed By: xiaoxmeng, srsuryadev

Differential Revision: D104838168


