### PR TITLE
fix: Report native worker cache and query memory separately in /v1/status

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -41,7 +41,15 @@ public class NodeStatus
     private final long heapUsed;
     private final long heapAvailable;
     private final long nonHeapUsed;
+    // Native-worker (Prestissimo) memory breakdown; both are 0 on JVM workers.
+    // In-memory AsyncDataCache footprint. This memory is evictable/reclaimable
+    // and does not, on its own, represent out-of-memory pressure.
     private final long asyncDataCacheBytes;
+    // Sum of per-pool reserved bytes (non-evictable query memory). Reservations
+    // are rounded up to Velox's quantized reservation size, so this slightly
+    // over-reports live usage. It excludes the evictable AsyncDataCache
+    // (reported separately in asyncDataCacheBytes) but may include memory that
+    // is spillable under pressure.
     private final long queryMemoryBytes;
 
     @ThriftConstructor

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -41,6 +41,8 @@ public class NodeStatus
     private final long heapUsed;
     private final long heapAvailable;
     private final long nonHeapUsed;
+    private final long asyncDataCacheBytes;
+    private final long queryMemoryBytes;
 
     @ThriftConstructor
     @JsonCreator
@@ -58,7 +60,9 @@ public class NodeStatus
             @JsonProperty("systemCpuLoad") double systemCpuLoad,
             @JsonProperty("heapUsed") long heapUsed,
             @JsonProperty("heapAvailable") long heapAvailable,
-            @JsonProperty("nonHeapUsed") long nonHeapUsed)
+            @JsonProperty("nonHeapUsed") long nonHeapUsed,
+            @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
+            @JsonProperty("queryMemoryBytes") long queryMemoryBytes)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -74,6 +78,8 @@ public class NodeStatus
         this.heapUsed = heapUsed;
         this.heapAvailable = heapAvailable;
         this.nonHeapUsed = nonHeapUsed;
+        this.asyncDataCacheBytes = asyncDataCacheBytes;
+        this.queryMemoryBytes = queryMemoryBytes;
     }
 
     @ThriftField(1)
@@ -172,5 +178,19 @@ public class NodeStatus
     public long getNonHeapUsed()
     {
         return nonHeapUsed;
+    }
+
+    @ThriftField(15)
+    @JsonProperty
+    public long getAsyncDataCacheBytes()
+    {
+        return asyncDataCacheBytes;
+    }
+
+    @ThriftField(16)
+    @JsonProperty
+    public long getQueryMemoryBytes()
+    {
+        return queryMemoryBytes;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -627,7 +627,9 @@ public class TestResourceManagerClusterStateProvider
                 2.0,
                 1,
                 2,
-                3);
+                3,
+                0,
+                0);
     }
 
     private NodeStatus createCoordinatorNodeStatus(String nodeId)
@@ -646,7 +648,9 @@ public class TestResourceManagerClusterStateProvider
                 2.0,
                 1,
                 2,
-                3);
+                3,
+                0,
+                0);
     }
 
     private MemoryPoolInfo createMemoryPoolInfo(int maxBytes, int reservedBytes, int reservedRevocableBytes)

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
@@ -54,9 +54,9 @@ public class TestNodeStatus
     @Test
     public void testJsonRoundTrip()
     {
-        // Use the native-worker shape: nonHeapUsed = -1 (not applicable) and
-        // distinct, non-zero values for the two native memory fields so the
-        // round-trip would catch a swapped or dropped field.
+        // Distinct values for the three long fields, including a negative one,
+        // so the round-trip would catch a swapped, dropped, or sign-mangled
+        // field.
         NodeStatus expected = nodeStatus(-1L, 111L, 222L);
 
         NodeStatus actual = CODEC.fromJson(CODEC.toJson(expected));

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.units.DataSize;
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.memory.MemoryInfo;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+
+public class TestNodeStatus
+{
+    private static final JsonCodec<NodeStatus> CODEC = jsonCodec(NodeStatus.class);
+
+    private static NodeStatus nodeStatus(long nonHeapUsed, long asyncDataCacheBytes, long queryMemoryBytes)
+    {
+        return new NodeStatus(
+                "test-node",
+                new NodeVersion("1"),
+                "test-environment",
+                false,
+                new Duration(1, SECONDS),
+                "http://externalAddress",
+                "http://internalAddress",
+                new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
+                8,
+                0.25,
+                0.5,
+                1024,
+                8192,
+                nonHeapUsed,
+                asyncDataCacheBytes,
+                queryMemoryBytes);
+    }
+
+    @Test
+    public void testJsonRoundTrip()
+    {
+        // Use the native-worker shape: nonHeapUsed = -1 (not applicable) and
+        // distinct, non-zero values for the two native memory fields so the
+        // round-trip would catch a swapped or dropped field.
+        NodeStatus expected = nodeStatus(-1L, 111L, 222L);
+
+        NodeStatus actual = CODEC.fromJson(CODEC.toJson(expected));
+
+        assertEquals(actual.getNonHeapUsed(), -1L);
+        assertEquals(actual.getAsyncDataCacheBytes(), 111L);
+        assertEquals(actual.getQueryMemoryBytes(), 222L);
+        assertEquals(actual.getHeapUsed(), expected.getHeapUsed());
+        assertEquals(actual.getHeapAvailable(), expected.getHeapAvailable());
+        assertEquals(actual.getNodeId(), expected.getNodeId());
+    }
+
+    @Test
+    public void testDeserializeLegacyStatusWithoutNativeFields()
+    {
+        // A pre-upgrade worker never emits the native memory fields. The new
+        // coordinator must still deserialize its status, defaulting the
+        // missing fields to 0 (mirrors the native from_json presence guard).
+        String legacyJson = "{" +
+                "\"nodeId\":\"test-node\"," +
+                "\"nodeVersion\":{\"version\":\"1\"}," +
+                "\"environment\":\"test-environment\"," +
+                "\"coordinator\":false," +
+                "\"uptime\":\"1.00s\"," +
+                "\"externalAddress\":\"http://externalAddress\"," +
+                "\"internalAddress\":\"http://internalAddress\"," +
+                "\"memoryInfo\":{\"totalNodeMemory\":\"1MB\",\"pools\":{}}," +
+                "\"processors\":8," +
+                "\"processCpuLoad\":0.25," +
+                "\"systemCpuLoad\":0.5," +
+                "\"heapUsed\":1024," +
+                "\"heapAvailable\":8192," +
+                "\"nonHeapUsed\":42}";
+
+        NodeStatus actual = CODEC.fromJson(legacyJson);
+
+        assertEquals(actual.getNonHeapUsed(), 42L);
+        assertEquals(actual.getAsyncDataCacheBytes(), 0L);
+        assertEquals(actual.getQueryMemoryBytes(), 0L);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -90,6 +90,8 @@ public class StatusResource
                 operatingSystemMXBean == null ? 0 : operatingSystemMXBean.getSystemCpuLoad(),
                 memoryMXBean.getHeapMemoryUsage().getUsed(),
                 memoryMXBean.getHeapMemoryUsage().getMax(),
-                memoryMXBean.getNonHeapMemoryUsage().getUsed());
+                memoryMXBean.getNonHeapMemoryUsage().getUsed(),
+                0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
+                0L); // queryMemoryBytes: native-only; JVM query memory is on-heap
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -312,6 +312,8 @@ public class TestHttpResourceManagerClient
                 1,
                 1,
                 1,
-                1);
+                1,
+                0,
+                0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -57,7 +57,9 @@ public class TestResourceManagerClusterStatusSender
             2.0,
             1,
             2,
-            3);
+            3,
+            0,
+            0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;
     private static final int TARGET_HEARTBEATS = SLEEP_DURATION / HEARTBEAT_INTERVAL;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1);
+                1, 1, 1, 1, 1, 1, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1939,8 +1939,11 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
 
   const double cpuLoadPct{cpuMon_.getCPULoadPct()};
 
-  // 'nonHeapUsed' is a JVM/GC concept and does not apply to native workers.
-  const int64_t nonHeapUsed = -1;
+  // 'nonHeapUsed' is a JVM/GC concept that does not apply to native workers.
+  // Kept at 0 to avoid breaking existing tooling that consumes this field; it
+  // could be changed to a not-applicable value (e.g. -1) in the future. Native
+  // memory is reported via the dedicated fields below.
+  const int64_t nonHeapUsed = 0;
 
   // In-memory AsyncDataCache footprint (evictable/reclaimable). SSD-resident
   // bytes are excluded as they do not contribute to RAM pressure.

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1721,6 +1721,19 @@ void PrestoServer::populateMemAndCPUInfo() {
   cpuMon_.update();
   checkOverload();
   **memoryInfo_.wlock() = std::move(memoryInfo);
+
+  // In-memory AsyncDataCache footprint (evictable/reclaimable); SSD-resident
+  // bytes are excluded as they do not contribute to RAM pressure. Computed here
+  // (this task runs periodically) rather than in fetchNodeStatus(), because
+  // refreshStats() walks the cache shards and fetchNodeStatus() serves every
+  // /v1/status poll on every worker. 0 when no cache instance exists.
+  int64_t asyncDataCacheBytes = 0;
+  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
+    const auto cacheStats = cache->refreshStats();
+    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
+        cacheStats.tinyPadding + cacheStats.largePadding;
+  }
+  asyncDataCacheBytes_.store(asyncDataCacheBytes, std::memory_order_relaxed);
 }
 
 void PrestoServer::checkOverload() {
@@ -1945,14 +1958,11 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // memory is reported via the dedicated fields below.
   const int64_t nonHeapUsed = 0;
 
-  // In-memory AsyncDataCache footprint (evictable/reclaimable). SSD-resident
-  // bytes are excluded as they do not contribute to RAM pressure.
-  int64_t asyncDataCacheBytes = 0;
-  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
-    const auto cacheStats = cache->refreshStats();
-    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
-        cacheStats.tinyPadding + cacheStats.largePadding;
-  }
+  // In-memory AsyncDataCache footprint (evictable/reclaimable), sampled off the
+  // serving path by populateMemAndCPUInfo() — read the cached value here so the
+  // refreshStats() cache-shard walk never runs on the /v1/status poll path.
+  const int64_t asyncDataCacheBytes =
+      asyncDataCacheBytes_.load(std::memory_order_relaxed);
 
   // Query memory (non-evictable): sum of per-query pool reservations, already
   // aggregated per memory pool in populateMemAndCPUInfo(). Reservations are

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1952,7 +1952,10 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   }
 
   // Query memory (non-evictable): sum of per-query pool reservations, already
-  // aggregated per memory pool in populateMemAndCPUInfo().
+  // aggregated per memory pool in populateMemAndCPUInfo(). Reservations are
+  // rounded up to Velox's quantized reservation size, so this slightly
+  // over-reports live usage, and may include memory that is spillable under
+  // pressure. It excludes the evictable AsyncDataCache reported above.
   const auto memoryInfo = **memoryInfo_.rlock();
   int64_t queryMemoryBytes = 0;
   for (const auto& pool : memoryInfo.pools) {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1939,8 +1939,9 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
 
   const double cpuLoadPct{cpuMon_.getCPULoadPct()};
 
-  // TODO(spershin): As 'nonHeapUsed' we could export the cache memory.
-  const int64_t nonHeapUsed{0};
+  // Reports Velox allocator total (queries + cache) as nonHeapUsed
+  // for coordinator visibility.
+  const int64_t nonHeapUsed = velox::memory::memoryManager()->getTotalBytes();
 
   protocol::NodeStatus nodeStatus{
       nodeId_,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1939,9 +1939,25 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
 
   const double cpuLoadPct{cpuMon_.getCPULoadPct()};
 
-  // Reports Velox allocator total (queries + cache) as nonHeapUsed
-  // for coordinator visibility.
-  const int64_t nonHeapUsed = velox::memory::memoryManager()->getTotalBytes();
+  // 'nonHeapUsed' is a JVM/GC concept and does not apply to native workers.
+  const int64_t nonHeapUsed = -1;
+
+  // In-memory AsyncDataCache footprint (evictable/reclaimable). SSD-resident
+  // bytes are excluded as they do not contribute to RAM pressure.
+  int64_t asyncDataCacheBytes = 0;
+  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
+    const auto cacheStats = cache->refreshStats();
+    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
+        cacheStats.tinyPadding + cacheStats.largePadding;
+  }
+
+  // Query memory (non-evictable): sum of per-query pool reservations, already
+  // aggregated per memory pool in populateMemAndCPUInfo().
+  const auto memoryInfo = **memoryInfo_.rlock();
+  int64_t queryMemoryBytes = 0;
+  for (const auto& pool : memoryInfo.pools) {
+    queryMemoryBytes += pool.second.reservedBytes;
+  }
 
   protocol::NodeStatus nodeStatus{
       nodeId_,
@@ -1951,13 +1967,15 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       getUptime(start_),
       address_,
       address_,
-      **memoryInfo_.rlock(),
+      memoryInfo,
       (int)folly::available_concurrency(),
       cpuLoadPct,
       cpuLoadPct,
       pool_ ? pool_->usedBytes() : 0,
       nodeMemoryGb * 1024 * 1024 * 1024,
-      nonHeapUsed};
+      nonHeapUsed,
+      asyncDataCacheBytes,
+      queryMemoryBytes};
 
   return nodeStatus;
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <atomic>
+
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -351,6 +353,12 @@ class PrestoServer {
   // We update these members asynchronously and return in http requests w/o
   // delay.
   folly::Synchronized<std::unique_ptr<protocol::MemoryInfo>> memoryInfo_;
+  // AsyncDataCache footprint (evictable). Refreshed off the serving path by
+  // populateMemAndCPUInfo() and read by fetchNodeStatus(), so the cache-shard
+  // walk in AsyncDataCache::refreshStats() stays off the /v1/status poll path
+  // (its cost otherwise scales with shards × workers × poll frequency). 0 until
+  // the first sample and when no cache instance exists (classic JVM behaviour).
+  std::atomic<int64_t> asyncDataCacheBytes_{0};
   CPUMon cpuMon_;
 
   std::string environment_;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8286,6 +8286,20 @@ void to_json(json& j, const NodeStatus& p) {
       "heapAvailable");
   to_json_key(
       j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+  to_json_key(
+      j,
+      "asyncDataCacheBytes",
+      p.asyncDataCacheBytes,
+      "NodeStatus",
+      "int64_t",
+      "asyncDataCacheBytes");
+  to_json_key(
+      j,
+      "queryMemoryBytes",
+      p.queryMemoryBytes,
+      "NodeStatus",
+      "int64_t",
+      "queryMemoryBytes");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8344,6 +8358,20 @@ void from_json(const json& j, NodeStatus& p) {
       "heapAvailable");
   from_json_key(
       j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+  from_json_key(
+      j,
+      "asyncDataCacheBytes",
+      p.asyncDataCacheBytes,
+      "NodeStatus",
+      "int64_t",
+      "asyncDataCacheBytes");
+  from_json_key(
+      j,
+      "queryMemoryBytes",
+      p.queryMemoryBytes,
+      "NodeStatus",
+      "int64_t",
+      "queryMemoryBytes");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8358,20 +8358,24 @@ void from_json(const json& j, NodeStatus& p) {
       "heapAvailable");
   from_json_key(
       j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
-  from_json_key(
-      j,
-      "asyncDataCacheBytes",
-      p.asyncDataCacheBytes,
-      "NodeStatus",
-      "int64_t",
-      "asyncDataCacheBytes");
-  from_json_key(
-      j,
-      "queryMemoryBytes",
-      p.queryMemoryBytes,
-      "NodeStatus",
-      "int64_t",
-      "queryMemoryBytes");
+  if (j.count("asyncDataCacheBytes")) {
+    from_json_key(
+        j,
+        "asyncDataCacheBytes",
+        p.asyncDataCacheBytes,
+        "NodeStatus",
+        "int64_t",
+        "asyncDataCacheBytes");
+  }
+  if (j.count("queryMemoryBytes")) {
+    from_json_key(
+        j,
+        "queryMemoryBytes",
+        p.queryMemoryBytes,
+        "NodeStatus",
+        "int64_t",
+        "queryMemoryBytes");
+  }
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2012,6 +2012,8 @@ struct NodeStatus {
   int64_t heapUsed = {};
   int64_t heapAvailable = {};
   int64_t nonHeapUsed = {};
+  int64_t asyncDataCacheBytes = {};
+  int64_t queryMemoryBytes = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);


### PR DESCRIPTION
 ## Description
Prestissimo workers previously reported `nonHeapUsed: 0` in `/v1/status` (a `TODO(spershin)` placeholder). Rather than expose the combined Velox allocator total, this reports the two components that matter for memory pressure as separate `NodeStatus` fields, and sets `nonHeapUsed = -1` (a JVM/GC concept that does not apply to native workers):

- `asyncDataCacheBytes` — in-memory AsyncDataCache footprint, from `AsyncDataCache::refreshStats()` (tiny + large sizes + padding; SSD excluded). **Evictable.**
- `queryMemoryBytes` — sum of per-pool `reservedBytes` (query-context pool usage). **Non-evictable.**

## Motivation and Context
The combined allocator total (`getTotalBytes()`) conflates two things that behave very differently under memory pressure:

- **AsyncDataCache is evictable/reclaimable** — Velox shrinks it before OOM.
- **Query memory is non-evictable** — it is the real OOM risk.

A single combined number cannot distinguish "90% but mostly evictable cache → fine" from "90% query memory → real OOM risk". Reporting them separately lets any memory-pressure consumer (monitoring, capacity planning, autoscaling) reason about actual OOM headroom.

`reservedBytes` alone was insufficient as a pod-pressure signal: it reads 0 whenever no query is active, is scoped under `memoryInfo.pools.general`, and excludes cache entirely.

## Impact
- `nonHeapUsed` for Prestissimo workers changes from `0` to `-1`  (not-applicable sentinel). No coordinator logic reads `nonHeapUsed`  for scheduling, so this is backwards-compatible; consumers should treat `-1` as "not reported" for native workers.
- Two new `NodeStatus` fields (`asyncDataCacheBytes`, `queryMemoryBytes` added in both Java (`NodeStatus.java`) and the C++ protocol (`presto_protocol_core.h/.cpp`). Classic (JVM) Presto reports `0` for  both — native-only fields.
- No new dependencies or includes.

## Test Plan
- Prestissimo builds successfully (CI).
- Deploy worker and confirm `/v1/status` returns `nonHeapUsed: -1`, a non-zero `queryMemoryBytes` under active queries, and `asyncDataCacheBytes` reflecting cache warmth.
- Cross-check `asyncDataCacheBytes` against Velox cache metrics.

## Release Notes
```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add ``asyncDataCacheBytes`` and ``queryMemoryBytes`` to the native worker ``/v1/status`` endpoint to report async data cache memory and query memory separately. 
```