### PR TITLE
build: Enforce Java 8 API floor on presto-spark module closure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2899,6 +2899,33 @@
                     <version>0.5.1</version>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.24</version>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java18</artifactId>
+                            <version>1.0</version>
+                        </signature>
+                        <ignores>
+                            <!-- MethodHandle.invoke / invokeExact are polymorphic-signature
+                                 methods that animal-sniffer cannot statically resolve. -->
+                            <ignore>java.lang.invoke.MethodHandle</ignore>
+                        </ignores>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-java8-api</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 

--- a/presto-analyzer/pom.xml
+++ b/presto-analyzer/pom.xml
@@ -62,4 +62,13 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -93,6 +93,10 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -187,6 +187,10 @@
                     </ignoredNonTestScopedDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -140,4 +140,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -57,4 +57,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -117,6 +117,10 @@
                     </ignoredResourcePatterns>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-internal-communication/pom.xml
+++ b/presto-internal-communication/pom.xml
@@ -121,4 +121,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -527,6 +527,10 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
                 <configuration>

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -137,7 +137,7 @@ public final class TimestampOperators
             long millis = date + chronology.getZone().getOffset(date);
             return TimeUnit.MILLISECONDS.toDays(millis);
         }
-        return floorDiv(value, MILLISECONDS_PER_DAY);
+        return floorDiv(value, (long) MILLISECONDS_PER_DAY);
     }
 
     @ScalarOperator(CAST)

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -49,4 +49,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -60,4 +60,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -92,6 +92,10 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -126,4 +126,13 @@
             <artifactId>security</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -469,6 +469,10 @@
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -79,4 +79,13 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/presto-spark-classloader-spark2/pom.xml
+++ b/presto-spark-classloader-spark2/pom.xml
@@ -29,4 +29,13 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -48,4 +48,13 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -136,6 +136,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -69,6 +69,10 @@
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -159,4 +159,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Summary:
## Description

Adds `animal-sniffer-maven-plugin` to `presto-spark` and the modules it transitively depends on, configured against the Java 8 signature DB. The plugin scans bytecode at the `process-classes` phase and fails the build on references to JDK APIs that do not exist in Java 8.

Also fixes one pre-existing leak surfaced by the new check: `TimestampOperators.java:140` was calling `Math.floorDiv(long, int)` (added in Java 9). Cast the second argument to `long` to use the Java 8 `(long, long)` overload.

## Motivation and Context

`presto-spark` is consumed by Apache Spark 2.x deployments, which require Java 8. There is no compile-time enforcement of this floor today: `<project.build.targetJdk>8</project.build.targetJdk>` in the affected modules is a hint read by maven-pmd-plugin, not by `javac`, and `<air.check.skip-modernizer>true</air.check.skip-modernizer>` disables the only existing related check. As a result, contributors can introduce Java 9+ APIs (e.g. `Optional.or(Supplier)`, `Math.floorDiv(long, int)`, `Stream.toList()`) that compile and pass tests on the Java 17 CI matrix but throw `NoSuchMethodError` at runtime on a Java 8 driver/executor.

## Impact

- No public API changes.
- New `process-classes` check fails the build on Java 9+ API references in opted-in modules.
- Polymorphic-signature `MethodHandle.invoke`/`invokeExact` calls are globally ignored — animal-sniffer cannot statically resolve them, and they are not real violations.

Differential Revision: D104913960

## Release Notes

```
== NO RELEASE NOTE ==
```