### PR TITLE
feat: V3 DeleteFile fields end-to-end through Java + protocol + bridge (#27789)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.iceberg.FileContent.fromIcebergFileContent;
 import static com.facebook.presto.iceberg.FileFormat.fromIcebergFileFormat;
+import static com.facebook.presto.iceberg.IcebergUtil.getDataSequenceNumber;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -42,6 +43,10 @@ public final class DeleteFile
     private final List<Integer> equalityFieldIds;
     private final Map<Integer, byte[]> lowerBounds;
     private final Map<Integer, byte[]> upperBounds;
+    private final long dataSequenceNumber;
+    private final String referencedDataFile;
+    private final long contentOffset;
+    private final long contentSize;
 
     public static DeleteFile fromIceberg(org.apache.iceberg.DeleteFile deleteFile)
     {
@@ -50,6 +55,8 @@ public final class DeleteFile
         Map<Integer, byte[]> upperBounds = firstNonNull(deleteFile.upperBounds(), ImmutableMap.<Integer, ByteBuffer>of())
                 .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
 
+        Long offset = deleteFile.contentOffset();
+        Long size = deleteFile.contentSizeInBytes();
         return new DeleteFile(
                 fromIcebergFileContent(deleteFile.content()),
                 deleteFile.path().toString(),
@@ -58,7 +65,11 @@ public final class DeleteFile
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
                 lowerBounds,
-                upperBounds);
+                upperBounds,
+                getDataSequenceNumber(deleteFile),
+                deleteFile.referencedDataFile() == null ? "" : deleteFile.referencedDataFile(),
+                offset == null ? 0L : offset,
+                size == null ? 0L : size);
     }
 
     @JsonCreator
@@ -70,7 +81,11 @@ public final class DeleteFile
             @JsonProperty("fileSizeInBytes") long fileSizeInBytes,
             @JsonProperty("equalityFieldIds") List<Integer> equalityFieldIds,
             @JsonProperty("lowerBounds") Map<Integer, byte[]> lowerBounds,
-            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds)
+            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds,
+            @JsonProperty("dataSequenceNumber") long dataSequenceNumber,
+            @JsonProperty("referencedDataFile") String referencedDataFile,
+            @JsonProperty("contentOffset") long contentOffset,
+            @JsonProperty("contentSize") long contentSize)
     {
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
@@ -80,6 +95,10 @@ public final class DeleteFile
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
         this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
         this.upperBounds = ImmutableMap.copyOf(requireNonNull(upperBounds, "upperBounds is null"));
+        this.dataSequenceNumber = dataSequenceNumber;
+        this.referencedDataFile = referencedDataFile == null ? "" : referencedDataFile;
+        this.contentOffset = contentOffset;
+        this.contentSize = contentSize;
     }
 
     @JsonProperty
@@ -128,6 +147,30 @@ public final class DeleteFile
     public Map<Integer, byte[]> getUpperBounds()
     {
         return upperBounds;
+    }
+
+    @JsonProperty
+    public long dataSequenceNumber()
+    {
+        return dataSequenceNumber;
+    }
+
+    @JsonProperty
+    public String referencedDataFile()
+    {
+        return referencedDataFile;
+    }
+
+    @JsonProperty
+    public long contentOffset()
+    {
+        return contentOffset;
+    }
+
+    @JsonProperty
+    public long contentSize()
+    {
+        return contentSize;
     }
 
     @Override

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -16,7 +16,9 @@
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
+
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
@@ -171,13 +173,14 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
     const protocol::ConnectorId& catalogId,
     const protocol::ConnectorSplit* connectorSplit,
     const protocol::SplitContext* splitContext) const {
-  auto icebergSplit =
+  const auto* icebergSplitPtr =
       dynamic_cast<const protocol::iceberg::IcebergSplit*>(connectorSplit);
   VELOX_CHECK_NOT_NULL(
-      icebergSplit, "Unexpected split type {}", connectorSplit->_type);
+      icebergSplitPtr, "Unexpected split type {}", connectorSplit->_type);
+  const protocol::iceberg::IcebergSplit& icebergSplit = *icebergSplitPtr;
 
   std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-  for (const auto& entry : icebergSplit->partitionKeys) {
+  for (const auto& entry : icebergSplit.partitionKeys) {
     partitionKeys.emplace(
         entry.second.name,
         entry.second.value == nullptr
@@ -189,8 +192,8 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   customSplitInfo["table_format"] = "hive-iceberg";
 
   std::vector<velox::connector::hive::iceberg::IcebergDeleteFile> deletes;
-  deletes.reserve(icebergSplit->deletes.size());
-  for (const auto& deleteFile : icebergSplit->deletes) {
+  deletes.reserve(icebergSplit.deletes.size());
+  for (const auto& deleteFile : icebergSplit.deletes) {
     std::unordered_map<int32_t, std::string> lowerBounds(
         deleteFile.lowerBounds.begin(), deleteFile.lowerBounds.end());
 
@@ -205,29 +208,48 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
         deleteFile.fileSizeInBytes,
         std::vector(deleteFile.equalityFieldIds),
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        deleteFile.dataSequenceNumber,
+        deleteFile.contentOffset,
+        deleteFile.contentSize,
+        deleteFile.referencedDataFile);
 
     deletes.emplace_back(icebergDeleteFile);
   }
 
   std::unordered_map<std::string, std::string> infoColumns = {
-      {"$data_sequence_number",
-       std::to_string(icebergSplit->dataSequenceNumber)},
-      {"$path", icebergSplit->path}};
+      {velox::connector::hive::iceberg::IcebergMetadataColumn::
+           kDataSequenceNumberInfoColumn,
+       fmt::to_string(icebergSplit.dataSequenceNumber)},
+      {"$path", icebergSplit.path}};
+  // Only emit `$first_row_id` when the coordinator assigned a non-negative
+  // value. `firstRowId == -1` is the protocol's "unset" sentinel for V1/V2
+  // splits and for V3 splits where row lineage was not assigned. The Velox
+  // reader VELOX_CHECK_GE-asserts non-negativity if the key is present, so
+  // emitting -1 would crash every V1/V2 read. Mirrors the Java guard in
+  // `IcebergPageSourceProvider.java`.
+  if (icebergSplit.firstRowId >= 0) {
+    infoColumns.emplace(
+        velox::connector::hive::iceberg::IcebergMetadataColumn::
+            kFirstRowIdInfoColumn,
+        fmt::to_string(icebergSplit.firstRowId));
+  }
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,
-      icebergSplit->path,
-      toVeloxFileFormat(icebergSplit->fileFormat),
-      icebergSplit->start,
-      icebergSplit->length,
+      icebergSplit.path,
+      toVeloxFileFormat(icebergSplit.fileFormat),
+      icebergSplit.start,
+      icebergSplit.length,
       partitionKeys,
       std::nullopt,
       customSplitInfo,
       nullptr,
       splitContext->cacheable,
       deletes,
-      infoColumns);
+      infoColumns,
+      std::nullopt,
+      icebergSplit.dataSequenceNumber);
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -386,6 +386,29 @@ void to_json(json& j, const DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  to_json_key(
+      j,
+      "dataSequenceNumber",
+      p.dataSequenceNumber,
+      "DeleteFile",
+      "int64_t",
+      "dataSequenceNumber");
+  to_json_key(
+      j,
+      "referencedDataFile",
+      p.referencedDataFile,
+      "DeleteFile",
+      "String",
+      "referencedDataFile");
+  to_json_key(
+      j,
+      "contentOffset",
+      p.contentOffset,
+      "DeleteFile",
+      "int64_t",
+      "contentOffset");
+  to_json_key(
+      j, "contentSize", p.contentSize, "DeleteFile", "int64_t", "contentSize");
 }
 
 void from_json(const json& j, DeleteFile& p) {
@@ -423,6 +446,42 @@ void from_json(const json& j, DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  if (j.count("dataSequenceNumber")) {
+    from_json_key(
+        j,
+        "dataSequenceNumber",
+        p.dataSequenceNumber,
+        "DeleteFile",
+        "int64_t",
+        "dataSequenceNumber");
+  }
+  if (j.count("referencedDataFile")) {
+    from_json_key(
+        j,
+        "referencedDataFile",
+        p.referencedDataFile,
+        "DeleteFile",
+        "String",
+        "referencedDataFile");
+  }
+  if (j.count("contentOffset")) {
+    from_json_key(
+        j,
+        "contentOffset",
+        p.contentOffset,
+        "DeleteFile",
+        "int64_t",
+        "contentOffset");
+  }
+  if (j.count("contentSize")) {
+    from_json_key(
+        j,
+        "contentSize",
+        p.contentSize,
+        "DeleteFile",
+        "int64_t",
+        "contentSize");
+  }
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -98,6 +98,10 @@ struct DeleteFile {
   List<Integer> equalityFieldIds = {};
   Map<Integer, String> lowerBounds = {};
   Map<Integer, String> upperBounds = {};
+  int64_t dataSequenceNumber = {};
+  String referencedDataFile = {};
+  int64_t contentOffset = {};
+  int64_t contentSize = {};
 };
 void to_json(json& j, const DeleteFile& p);
 void from_json(const json& j, DeleteFile& p);


### PR DESCRIPTION
Summary:

Stacked on D104959593 (which added V3 typed fields to
`velox::IcebergDeleteFile` and the `dataSequenceNumber` parameter on
the production `HiveIcebergSplit` constructor).  This diff plumbs all
of those fields through the Java side and the Prestissimo bridge so
the typed Velox structs are populated end-to-end.

Adds:
- `dataSequenceNumber`, `referencedDataFile`, `contentOffset`,
  `contentSize` on `presto-iceberg/.../delete/DeleteFile.java`
- The same four fields on the C++ protocol struct
  `presto::protocol::iceberg::DeleteFile`
- All bridge wiring in
  `presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp`:
  - Forwards the four DeleteFile fields into the Velox
    `IcebergDeleteFile` struct (fields added in D104959593)
  - Forwards `protocol::iceberg::IcebergSplit::dataSequenceNumber`
    into the Velox `HiveIcebergSplit` ctor (parameter added in
    D104959593)
  - Populates `infoColumns[$first_row_id]` from
    `icebergSplit->firstRowId` alongside the existing
    `$data_sequence_number` entry, so the V3 `_row_id` system
    column finally returns non-NULL values in production
  - Uses the constants from `IcebergMetadataColumns.h` instead of
    raw string literals (no behavior change beyond removing
    duplication)
  - Uses `folly::to<std::string>` in place of `std::to_string`
    (Android-portable per Meta C++ convention)
  - Routes the protocol pointer through a const-reference local
    after the VELOX_CHECK_NOT_NULL so clang-tidy
    bugprone-unchecked-pointer-access can prove null-safety

## Why these are needed

- Equality-delete conflict resolution (V2+ spec): without the typed
  `dataSequenceNumber` plumbed all the way from manifest -> protocol
  -> bridge -> Velox struct, `shouldSkipBySequenceNumber()` always
  evaluates against 0 and the filter never fires -- equality deletes
  can over-apply to rows from later snapshots that share the same
  equality key.

- V3 `_row_id` system column: without `$first_row_id` in
  `infoColumns`, `IcebergSplitReader::firstRowId_` stays `nullopt`
  and `_row_id` returns NULL for every row instead of the per-row
  file-position-based ID.

- DV blob location: the existing `lowerBounds[100]` /
  `upperBounds[101]` smuggling kept the C++ reader functional but
  meant the Velox struct couldn't be reasoned about by anyone who
  didn't know about the secret field IDs.  Typed fields make DV
  blob location a first-class concern.

- `referencedDataFile` filter: not strictly required while the
  coordinator filters per-split, but adds protection against
  pre-V3-spec compliance bugs in the planner.

## Pairing requirement

D104959593 MUST land first, or the Prestissimo bridge will fail to
compile when it tries to pass `contentOffset` / `contentLength` /
`referencedDataFile` (and the trailing `dataSequenceNumber` ctor
arg) into Velox structs that don't yet declare them.

Reviewed By: srsuryadev

Differential Revision: D104959645


