### PR TITLE
fix(plugin-singlestore): Fix type mapping for SingleStore JDBC client 1.2.11

### DIFF
--- a/presto-singlestore/src/main/java/com/facebook/presto/plugin/singlestore/SingleStoreClient.java
+++ b/presto-singlestore/src/main/java/com/facebook/presto/plugin/singlestore/SingleStoreClient.java
@@ -76,6 +76,7 @@ public class SingleStoreClient
         Properties connectionProperties = DriverConnectionFactory.basicConnectionProperties(config);
         String connectionAttributes = String.format("_connector_name:%s", "SingleStore Presto Connector");
         connectionProperties.setProperty("connectionAttributes", connectionAttributes);
+        connectionProperties.setProperty("tinyInt1isBit", "false");
         return connectionProperties;
     }
 
@@ -150,18 +151,12 @@ public class SingleStoreClient
                 return "longtext";
             }
             if (varcharType.getLengthSafe() <= 21844) {
-                // 21844 is the maximum length a singlestore varchar supports.
                 return super.toSqlType(type);
             }
-            if (varcharType.getLengthSafe() <= 5592405) { // 16MB
+            if (varcharType.getLengthSafe() <= 16777215) {
                 return "mediumtext";
             }
-            if (varcharType.getLengthSafe() <= 1431655765) { // 100MB to 1GB
-                return "longtext"; // max = 1431655765
-            }
-            else {
-                throw new PrestoException(NOT_SUPPORTED, "Unsupported column width: " + varcharType.getLengthSafe());
-            }
+            return "longtext";
         }
 
         return super.toSqlType(type);

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreTypeMapping.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreTypeMapping.java
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.tests.datatype.DataType.bigintDataType;
 import static com.facebook.presto.tests.datatype.DataType.charDataType;
@@ -98,9 +99,9 @@ public class TestSingleStoreTypeMapping
                 .addRoundTrip(stringDataType("varchar(10)", createVarcharType(10)), "text_a")//utf-8
                 .addRoundTrip(stringDataType("varchar(255)", createVarcharType(255)), "text_b")
                 .addRoundTrip(stringDataType("varchar(21844)", createVarcharType(21844)), "text_c")
-                .addRoundTrip(stringDataType("varchar(21846)", createVarcharType(5592405)), "text_d")
-                .addRoundTrip(stringDataType("varchar(65536)", createVarcharType(5592405)), "text_e")
-                .addRoundTrip(stringDataType("varchar(16777215)", createVarcharType(1431655765)), "text_f")
+                .addRoundTrip(stringDataType("varchar(21846)", createVarcharType(16777215)), "text_d")
+                .addRoundTrip(stringDataType("varchar(65536)", createVarcharType(16777215)), "text_e")
+                .addRoundTrip(stringDataType("varchar(16777215)", createVarcharType(16777215)), "text_f")
                 .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
     }
 
@@ -108,10 +109,10 @@ public class TestSingleStoreTypeMapping
     public void testSingleStoreCreatedParameterizedVarchar()
     {
         DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext", createVarcharType(255 / 3)), "a")//utf-8
-                .addRoundTrip(stringDataType("text", createVarcharType(65535 / 3)), "b")
-                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215 / 3)), "c")
-                .addRoundTrip(stringDataType("longtext", createVarcharType((int) (4294967295L / 3))), "d")
+                .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), "a")
+                .addRoundTrip(stringDataType("text", createVarcharType(65535)), "b")
+                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), "c")
+                .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
                 .addRoundTrip(varcharDataType(32), "e")
                 .addRoundTrip(varcharDataType(15000), "f")
                 .execute(getQueryRunner(), singleStoreCreateAndInsert("tpch.singlestore_test_parameterized_varchar"));
@@ -122,10 +123,10 @@ public class TestSingleStoreTypeMapping
     {
         String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
         DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext", createVarcharType(255 / 3)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("text", createVarcharType(65535 / 3)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215 / 3)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("longtext", createVarcharType((int) (4294967295L / 3))), sampleUnicodeText)
+                .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("text", createVarcharType(65535)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), sampleUnicodeText)
+                .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), sampleUnicodeText)
                 .addRoundTrip(varcharDataType(sampleUnicodeText.length()), sampleUnicodeText)
                 .addRoundTrip(varcharDataType(32), sampleUnicodeText)
                 .addRoundTrip(varcharDataType(20000), sampleUnicodeText)


### PR DESCRIPTION
Summary:
The SingleStore JDBC client upgrade from 1.1.9 to 1.2.11 (D104667036) changed two driver behaviors that broke type mapping tests:

1. TINYINT columns are now reported as Types.BIT, causing Presto to map them to BOOLEAN instead of TINYINT. Fixed by setting `tinyInt1isBit=false` in connection properties, matching the MySQL connector's approach.

2. TEXT type COLUMN_SIZE is now reported as byte length instead of character length (e.g., TINYTEXT reports 255 instead of 85=255/3). Fixed by updating toSqlType thresholds from character-based (5592405, 1431655765) to byte-based (16777215) for round-trip consistency, and updating test expectations accordingly.

Differential Revision: D104908865

## Summary by Sourcery

Adjust SingleStore connector type mappings and connection properties to restore correct behavior with the upgraded JDBC driver.

Bug Fixes:
- Preserve TINYINT semantics by disabling tinyInt1isBit in SingleStore JDBC connection properties so TINYINT is not mapped to BOOLEAN.
- Align varchar/TEXT type mapping thresholds with JDBC-reported byte lengths to ensure consistent round-trip behavior for large text columns.

Enhancements:
- Simplify SingleStore varchar-to-TEXT mapping logic by collapsing multiple size thresholds into mediumtext and longtext tiers based on byte lengths.

Tests:
- Update SingleStore type mapping tests to use byte-based varchar lengths and unbounded varchar for LONGTEXT to match new driver behavior.

```
== RELEASE NOTES ==

Singlestore Connector Changes
* Fix TINYINT type mapping to preserve TINYINT semantics instead of incorrectly mapping to BOOLEAN after JDBC driver upgrade.
* Fix varchar type mapping for TEXT types to use byte-based thresholds matching the JDBC driver's COLUMN_SIZE reporting.

```