### PR TITLE
feat(native-pos): Make MaterializedOutputBuffer size configurable with dynamic drain threshold (#27795)

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -237,7 +237,11 @@ SystemConfig::SystemConfig() {
           NUM_PROP(
               kExchangeMaterializationPartitioningRowBatchBufferSize,
               16L << 20),
-          NUM_PROP(kExchangeMaterializationPerPartitionBufferSize, 130L * 1024),
+          NUM_PROP(kExchangeMaterializationOutputBufferMaxBytes, 1L << 30),
+          NUM_PROP(
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes,
+              130L * 1024),
+          BOOL_PROP(kExchangeMaterializationOutputBufferUseSystemMemory, false),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           BOOL_PROP(kHttpEnableAccessLog, false),
@@ -779,10 +783,22 @@ int64_t SystemConfig::exchangeMaterializationPartitioningRowBatchBufferSize()
       .value_or(16L << 20);
 }
 
-int64_t SystemConfig::exchangeMaterializationPerPartitionBufferSize() const {
+int64_t SystemConfig::exchangeMaterializationOutputBufferMaxBytes() const {
+  return optionalProperty<int64_t>(kExchangeMaterializationOutputBufferMaxBytes)
+      .value_or(1L << 30);
+}
+
+int64_t SystemConfig::exchangeMaterializationOutputBufferPerPartitionMaxBytes()
+    const {
   return optionalProperty<int64_t>(
-             kExchangeMaterializationPerPartitionBufferSize)
+             kExchangeMaterializationOutputBufferPerPartitionMaxBytes)
       .value_or(130L * 1024);
+}
+
+bool SystemConfig::exchangeMaterializationOutputBufferUseSystemMemory() const {
+  return optionalProperty<bool>(
+             kExchangeMaterializationOutputBufferUseSystemMemory)
+      .value_or(false);
 }
 
 bool SystemConfig::enableSerializedPageChecksum() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -677,12 +677,29 @@ class SystemConfig : public ConfigBase {
       kExchangeMaterializationPartitioningRowBatchBufferSize{
           "exchange.materialization.partitioning-row-batch-buffer-size"};
 
+  /// MaterializedOutputBuffer total size in bytes. Needed until reclaim is
+  /// implemented; acts as the backpressure cap for the output buffer.
+  /// The per-partition drain threshold is dynamically computed as
+  /// min(output-buffer.per-partition-max-bytes, output-buffer.max-bytes /
+  /// numPartitions). Default: 1GB.
+  static constexpr std::string_view
+      kExchangeMaterializationOutputBufferMaxBytes{
+          "exchange.materialization.output-buffer.max-bytes"};
+
   /// MaterializedOutputBuffer per-partition drain threshold in bytes. When a
   /// partition accumulates this much data, it is drained to the writer.
   /// Default: 130KB.
   static constexpr std::string_view
-      kExchangeMaterializationPerPartitionBufferSize{
-          "exchange.materialization.per-partition-buffer-size"};
+      kExchangeMaterializationOutputBufferPerPartitionMaxBytes{
+          "exchange.materialization.output-buffer.per-partition-max-bytes"};
+
+  /// When true, MaterializedOutputBuffer uses a system memory pool (outside
+  /// the arbitrator). When false, uses an operator pool under the query's
+  /// memory hierarchy (visible to the arbitrator).
+  /// Default: false.
+  static constexpr std::string_view
+      kExchangeMaterializationOutputBufferUseSystemMemory{
+          "exchange.materialization.output-buffer.use-system-memory"};
 
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
@@ -1141,7 +1158,11 @@ class SystemConfig : public ConfigBase {
 
   int64_t exchangeMaterializationPartitioningRowBatchBufferSize() const;
 
-  int64_t exchangeMaterializationPerPartitionBufferSize() const;
+  int64_t exchangeMaterializationOutputBufferMaxBytes() const;
+
+  int64_t exchangeMaterializationOutputBufferPerPartitionMaxBytes() const;
+
+  bool exchangeMaterializationOutputBufferUseSystemMemory() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -14,6 +14,7 @@
 
 #include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
 
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <algorithm>
 #include <cstring>
@@ -115,6 +116,12 @@ bool MaterializedOutputBuffer::maybeApplyBackpressure(
       promises_.push_back(std::move(promise));
       *future = std::move(semiFuture);
       ++backpressureCount_;
+      LOG(INFO) << fmt::format(
+          "MaterializedOutputBuffer backpressure: bufferedBytes={}MB >= "
+          "max={}MB, waitingDrivers={}",
+          bufferedBytes_ >> 20,
+          maxBufferedBytes_ >> 20,
+          promises_.size());
       return true;
     }
   }
@@ -137,14 +144,29 @@ bool MaterializedOutputBuffer::enqueue(
       "enqueue called after finishAndClose when pool is not aborted");
 
   auto rowGroupBytes = static_cast<int64_t>(rowGroup->computeChainDataLength());
-  bufferedBytes_ += rowGroupBytes;
+  auto currentBytes = (bufferedBytes_ += rowGroupBytes);
+  int64_t peak = peakBufferedBytes_;
+  while (currentBytes > peak &&
+         !peakBufferedBytes_.compare_exchange_weak(peak, currentBytes)) {
+  }
 
   auto drainedBytes =
       partitionBuffers_[partition]->enqueue(partition, std::move(rowGroup));
 
   if (drainedBytes > 0) {
     ++drainCount_;
-    totalDrainedBytes_ += drainedBytes;
+    auto totalDrained = (totalDrainedBytes_ += drainedBytes);
+    auto currentGB = totalDrained >> 30;
+    int64_t lastGB = lastLoggedDrainedGB_;
+    if (currentGB > lastGB &&
+        lastLoggedDrainedGB_.compare_exchange_strong(lastGB, currentGB)) {
+      LOG(INFO) << fmt::format(
+          "MaterializedOutputBuffer progress: totalDrained={}GB, "
+          "drainCount={}, bufferedBytes={}MB",
+          currentGB,
+          static_cast<int64_t>(drainCount_),
+          bufferedBytes_ >> 20);
+    }
     auto prevTotal = bufferedBytes_.fetch_sub(drainedBytes);
     if (prevTotal >= continueBufferedBytes_ &&
         (prevTotal - drainedBytes) < continueBufferedBytes_) {
@@ -245,7 +267,8 @@ void MaterializedOutputBuffer::abort() {
   }
   maybeUnblockProducers(promises);
 
-  // Tell the writer to abort.
+  LOG(INFO)
+      << "MaterializedOutputBuffer: calling writer noMoreData(false) [abort]";
   writer_->noMoreData(/*success=*/false);
 }
 
@@ -259,11 +282,20 @@ void MaterializedOutputBuffer::setNumDrivers(uint32_t numDrivers) {
 
 bool MaterializedOutputBuffer::noMoreDrivers() {
   bool isLast = false;
+  uint32_t finished = 0;
+  uint32_t total = 0;
   {
     std::lock_guard<std::mutex> lock(stateMutex_);
     ++numFinishedDrivers_;
-    isLast = numDrivers_ > 0 && numFinishedDrivers_ >= numDrivers_;
+    finished = numFinishedDrivers_;
+    total = numDrivers_;
+    isLast = total > 0 && finished >= total;
   }
+  LOG(INFO) << fmt::format(
+      "MaterializedOutputBuffer noMoreDrivers: {}/{} finished, isLast={}",
+      finished,
+      total,
+      isLast);
   if (isLast) {
     finishAndClose();
   }
@@ -272,6 +304,13 @@ bool MaterializedOutputBuffer::noMoreDrivers() {
 
 void MaterializedOutputBuffer::maybeUnblockProducers(
     std::vector<velox::ContinuePromise>& promises) {
+  if (!promises.empty()) {
+    LOG(INFO) << fmt::format(
+        "MaterializedOutputBuffer resumed: unblocked {} drivers, "
+        "bufferedBytes={}MB",
+        promises.size(),
+        bufferedBytes_ >> 20);
+  }
   for (auto& promise : promises) {
     promise.setValue();
   }
@@ -281,8 +320,28 @@ void MaterializedOutputBuffer::finishAndClose() {
   if (finished_.exchange(true)) {
     return;
   }
+  LOG(INFO) << fmt::format(
+      "MaterializedOutputBuffer finishAndClose: draining, bufferedBytes={}MB",
+      bufferedBytes_ >> 20);
   drainAll();
+  LOG(INFO) << "MaterializedOutputBuffer: calling writer noMoreData(true)";
   writer_->noMoreData(/*success=*/true);
+  int64_t totalCollects = 0;
+  for (int32_t i = 0; i < numPartitions_; ++i) {
+    totalCollects += collectCountPerPartition_[i];
+  }
+  LOG(INFO) << fmt::format(
+      "MaterializedOutputBuffer progress: totalDrained={}GB, "
+      "drainCount={}, bufferedBytes={}MB",
+      totalDrainedBytes_ >> 30,
+      static_cast<int64_t>(drainCount_),
+      bufferedBytes_ >> 20);
+  LOG(INFO) << fmt::format(
+      "MaterializedOutputBuffer closed: "
+      "backpressureCount={}, collectCalls={}, peakBufferedBytes={}MB",
+      static_cast<int64_t>(backpressureCount_),
+      totalCollects,
+      peakBufferedBytes_ >> 20);
 }
 
 folly::F14FastMap<std::string, int64_t> MaterializedOutputBuffer::stats()
@@ -301,6 +360,7 @@ folly::F14FastMap<std::string, int64_t> MaterializedOutputBuffer::stats()
     totalCollects += collectCountPerPartition_[i];
   }
   writerStats[std::string(kTotalCollectCalls)] = totalCollects;
+  writerStats[std::string(kPeakBufferedBytes)] = peakBufferedBytes_;
   return writerStats;
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -61,8 +61,10 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
       maxBufferedBytes_(maxBufferedBytes),
       continueBufferedBytes_(maxBufferedBytes * 9 / 10),
       partitionDrainThreshold_(
-          partitionDrainThreshold > 0 ? partitionDrainThreshold
-                                      : kDefaultDrainThreshold),
+          std::min(
+              partitionDrainThreshold > 0 ? partitionDrainThreshold
+                                          : kDefaultDrainThreshold,
+              maxBufferedBytes / numPartitions)),
       writer_(std::move(writer)),
       pool_(std::move(pool)),
       collectCountPerPartition_(numPartitions) {
@@ -74,6 +76,16 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
   }
   VELOX_CHECK_GT(numPartitions, 0, "Must have at least one partition");
   VELOX_CHECK_NOT_NULL(writer_, "ShuffleWriter must be non-null");
+  LOG(INFO) << fmt::format(
+      "MaterializedOutputBuffer: partitions={}, maxBufferedBytes={}MB, "
+      "effectiveDrainThreshold={}KB (configured={}KB), pool={}",
+      numPartitions_,
+      maxBufferedBytes_ >> 20,
+      partitionDrainThreshold_ >> 10,
+      (partitionDrainThreshold > 0 ? partitionDrainThreshold
+                                   : kDefaultDrainThreshold) >>
+          10,
+      pool_->name());
 }
 
 MaterializedOutputBuffer::~MaterializedOutputBuffer() {

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -56,6 +56,8 @@ class MaterializedOutputBuffer {
       "materializedOutputBuffer.bufferPoolPeakBytes";
   static constexpr std::string_view kTotalCollectCalls =
       "materializedOutputBuffer.totalCollectCalls";
+  static constexpr std::string_view kPeakBufferedBytes =
+      "materializedOutputBuffer.peakBufferedBytes";
 
   MaterializedOutputBuffer(
       int32_t numPartitions,
@@ -199,6 +201,8 @@ class MaterializedOutputBuffer {
   std::atomic<int64_t> totalDrainedBytes_{0};
   std::atomic<int64_t> drainCount_{0};
   std::atomic<int64_t> backpressureCount_{0};
+  std::atomic<int64_t> peakBufferedBytes_{0};
+  std::atomic<int64_t> lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;
 };
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2644,21 +2644,29 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         shuffleFactory,
         "ShuffleInterface factory '{}' not registered",
         shuffleName_);
-    auto shuffleWriterPool = velox::memory::memoryManager()->addLeafPool(
-        fmt::format("_sys.exchange_writer.{}", taskId));
+    const auto useSystemMemory =
+        SystemConfig::instance()
+            ->exchangeMaterializationOutputBufferUseSystemMemory();
+    auto shuffleWriterPool = useSystemMemory
+        ? velox::memory::memoryManager()->addLeafPool(
+              fmt::format("_sys.exchange_writer.{}", taskId))
+        : queryCtx_->pool()->addLeafChild(
+              fmt::format("exchange_writer.{}", taskId));
     auto shuffleWriter = shuffleFactory->createWriter(
         *serializedShuffleWriteInfo_, shuffleWriterPool.get());
 
     auto sharedWriter =
         std::shared_ptr<operators::ShuffleWriter>(std::move(shuffleWriter));
+    const auto maxBufferedBytes =
+        SystemConfig::instance()->exchangeMaterializationOutputBufferMaxBytes();
     const auto drainThreshold =
         SystemConfig::instance()
-            ->exchangeMaterializationPerPartitionBufferSize();
+            ->exchangeMaterializationOutputBufferPerPartitionMaxBytes();
     auto buffer = std::make_shared<operators::MaterializedOutputBuffer>(
         partitionedOutputNode->numPartitions(),
         std::move(sharedWriter),
         std::move(shuffleWriterPool),
-        /*maxBufferedBytes=*/640UL * 1024 * 1024,
+        maxBufferedBytes,
         drainThreshold);
 
     auto materializedOutputNode =


### PR DESCRIPTION
### Summary

Add 3 new system configs for MaterializedOutputBuffer:
- exchange.materialization.output-buffer.max-bytes (default 1GB): total buffer size cap
- exchange.materialization.output-buffer.per-partition-max-bytes (default 130KB): per-partition drain threshold
- exchange.materialization.output-buffer.use-system-memory (default false): use system memory pool instead of operator pool

The per-partition drain threshold is dynamically capped to min(per-partition-max-bytes, max-bytes / numPartitions). This prevents backpressure deadlock at high partition counts where P × drainThreshold >= maxBufferedBytes (previously possible at P >= 5042 with hardcoded 640MB max and 130KB threshold).

Operator memory by default gives the arbitrator visibility into buffer usage. System memory pool available via config toggle for workloads that need to bypass arbitration.
Adds construction log showing effective vs configured drain threshold.

Dynamic drain threshold: min(configuredPerPartition, outputBufferSize / P).
This prevents backpressure deadlock at high partition counts where
P × drainThreshold >= maxBufferedBytes (previously possible at P >= 5042
with hardcoded 640MB max and 130KB threshold).

Operator memory by default gives the arbitrator visibility into buffer
usage. System memory pool available via config toggle.

Adds construction log showing effective vs configured drain threshold.

Differential Revision: D105012411

```
== NO RELEASE NOTE ==
```


