### PR TITLE
Update google bigquery storage sdk from v1beta1 to v1

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -174,7 +174,7 @@
 
         <dependency>
             <groupId>com.google.api.grpc</groupId>
-            <artifactId>proto-google-cloud-bigquerystorage-v1beta1</artifactId>
+            <artifactId>proto-google-cloud-bigquerystorage-v1</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryConnectorModule.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryConnectorModule.java
@@ -49,7 +49,7 @@ public class BigQueryConnectorModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(BigQueryStorageClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(BigQueryReadClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryConnector.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);
         binder.bind(BigQuerySplitManager.class).in(Scopes.SINGLETON);

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -34,13 +34,13 @@ public class BigQueryPageSourceProvider
         implements ConnectorPageSourceProvider
 {
     private static final Logger log = Logger.get(BigQueryPageSourceProvider.class);
-    private final BigQueryStorageClientFactory bigQueryStorageClientFactory;
+    private final BigQueryReadClientFactory bigQueryReadClientFactory;
     private final int maxReadRowsRetries;
 
     @Inject
-    public BigQueryPageSourceProvider(BigQueryStorageClientFactory bigQueryStorageClientFactory, BigQueryConfig config)
+    public BigQueryPageSourceProvider(BigQueryReadClientFactory bigQueryReadClientFactory, BigQueryConfig config)
     {
-        this.bigQueryStorageClientFactory = bigQueryStorageClientFactory;
+        this.bigQueryReadClientFactory = bigQueryReadClientFactory;
         this.maxReadRowsRetries = config.getMaxReadRowsRetries();
     }
 
@@ -66,6 +66,6 @@ public class BigQueryPageSourceProvider
                 .map(BigQueryColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        return new BigQueryResultPageSource(bigQueryStorageClientFactory, maxReadRowsRetries, bigQuerySplit, bigQueryColumnHandles);
+        return new BigQueryResultPageSource(bigQueryReadClientFactory, maxReadRowsRetries, bigQuerySplit, bigQueryColumnHandles);
     }
 }

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
@@ -95,7 +95,7 @@ public class BigQueryResultPageSource
             BigQuerySplit split,
             ImmutableList<BigQueryColumnHandle> columns)
     {
-        this.bigQueryReadClient = bigQueryReadClientFactory.createBigQueryStorageClient();
+        this.bigQueryReadClient = bigQueryReadClientFactory.createBigQueryReadClient();
         this.split = split;
         requireNonNull(columns, "columns is null");
         this.columnNames = columns.stream()

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
@@ -29,7 +29,7 @@ import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorPageSource;
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.common.collect.ImmutableList;
@@ -79,7 +79,7 @@ public class BigQueryResultPageSource
 {
     static final AvroDecimalConverter DECIMAL_CONVERTER = new AvroDecimalConverter();
     private static final Logger log = Logger.get(BigQueryResultPageSource.class);
-    private final BigQueryStorageClient bigQueryStorageClient;
+    private final BigQueryReadClient bigQueryReadClient;
     private final BigQuerySplit split;
     private final List<String> columnNames;
     private final ImmutableList<Type> columnTypes;
@@ -90,12 +90,12 @@ public class BigQueryResultPageSource
     private long completedPositions;
 
     public BigQueryResultPageSource(
-            BigQueryStorageClientFactory bigQueryStorageClientFactory,
+            BigQueryReadClientFactory bigQueryReadClientFactory,
             int maxReadRowsRetries,
             BigQuerySplit split,
             ImmutableList<BigQueryColumnHandle> columns)
     {
-        this.bigQueryStorageClient = bigQueryStorageClientFactory.createBigQueryStorageClient();
+        this.bigQueryReadClient = bigQueryReadClientFactory.createBigQueryStorageClient();
         this.split = split;
         requireNonNull(columns, "columns is null");
         this.columnNames = columns.stream()
@@ -110,7 +110,7 @@ public class BigQueryResultPageSource
         log.debug("Starting to read from %s", split.getStreamName());
         ReadRowsRequest.Builder readRowsRequest = ReadRowsRequest.newBuilder()
                 .setReadStream(split.getStreamName());
-        responses = new ReadRowsHelper(bigQueryStorageClient, readRowsRequest, maxReadRowsRetries).readRows();
+        responses = new ReadRowsHelper(bigQueryReadClient, readRowsRequest, maxReadRowsRetries).readRows();
         closed = false;
     }
 
@@ -276,7 +276,7 @@ public class BigQueryResultPageSource
     public void close()
             throws IOException
     {
-        bigQueryStorageClient.close();
+        bigQueryReadClient.close();
         closed = true;
     }
 

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryResultPageSource.java
@@ -29,8 +29,9 @@ import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorPageSource;
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1beta1.Storage;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -84,7 +85,7 @@ public class BigQueryResultPageSource
     private final ImmutableList<Type> columnTypes;
     private final AtomicLong readBytes;
     private final PageBuilder pageBuilder;
-    private Iterator<Storage.ReadRowsResponse> responses;
+    private Iterator<ReadRowsResponse> responses;
     private boolean closed;
     private long completedPositions;
 
@@ -107,10 +108,8 @@ public class BigQueryResultPageSource
         this.pageBuilder = new PageBuilder(columnTypes);
 
         log.debug("Starting to read from %s", split.getStreamName());
-        Storage.ReadRowsRequest.Builder readRowsRequest = Storage.ReadRowsRequest.newBuilder()
-                .setReadPosition(Storage.StreamPosition.newBuilder()
-                        .setStream(Storage.Stream.newBuilder()
-                                .setName(split.getStreamName())));
+        ReadRowsRequest.Builder readRowsRequest = ReadRowsRequest.newBuilder()
+                .setReadStream(split.getStreamName());
         responses = new ReadRowsHelper(bigQueryStorageClient, readRowsRequest, maxReadRowsRetries).readRows();
         closed = false;
     }
@@ -143,7 +142,7 @@ public class BigQueryResultPageSource
     public Page getNextPage()
     {
         checkState(pageBuilder.isEmpty(), "PageBuilder is not empty at the beginning of a new page");
-        Storage.ReadRowsResponse response = responses.next();
+        ReadRowsResponse response = responses.next();
         Iterable<GenericRecord> records = parse(response);
         for (GenericRecord record : records) {
             pageBuilder.declarePosition();
@@ -281,7 +280,7 @@ public class BigQueryResultPageSource
         closed = true;
     }
 
-    Iterable<GenericRecord> parse(Storage.ReadRowsResponse response)
+    Iterable<GenericRecord> parse(ReadRowsResponse response)
     {
         byte[] buffer = response.getAvroRows().getSerializedBinaryRows().toByteArray();
         readBytes.addAndGet(buffer.length);
@@ -290,7 +289,7 @@ public class BigQueryResultPageSource
         return () -> new AvroBinaryIterator(avroSchema, buffer);
     }
 
-    Stream<GenericRecord> toRecords(Storage.ReadRowsResponse response)
+    Stream<GenericRecord> toRecords(ReadRowsResponse response)
     {
         byte[] buffer = response.getAvroRows().getSerializedBinaryRows().toByteArray();
         readBytes.addAndGet(buffer.length);

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
@@ -34,7 +35,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
-import static com.google.cloud.bigquery.storage.v1.ReadSession;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -46,7 +46,7 @@ public class BigQuerySplitManager
     private static final Logger log = Logger.get(BigQuerySplitManager.class);
 
     private final BigQueryClient bigQueryClient;
-    private final BigQueryStorageClientFactory bigQueryStorageClientFactory;
+    private final BigQueryReadClientFactory bigQueryReadClientFactory;
     private final OptionalInt parallelism;
     private final ReadSessionCreatorConfig readSessionCreatorConfig;
     private final NodeManager nodeManager;
@@ -55,13 +55,13 @@ public class BigQuerySplitManager
     public BigQuerySplitManager(
             BigQueryConfig config,
             BigQueryClient bigQueryClient,
-            BigQueryStorageClientFactory bigQueryStorageClientFactory,
+            BigQueryReadClientFactory bigQueryReadClientFactory,
             NodeManager nodeManager)
     {
         requireNonNull(config, "config cannot be null");
 
         this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient cannot be null");
-        this.bigQueryStorageClientFactory = requireNonNull(bigQueryStorageClientFactory, "bigQueryStorageClientFactory cannot be null");
+        this.bigQueryReadClientFactory = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory cannot be null");
         this.parallelism = config.getParallelism();
         this.readSessionCreatorConfig = config.createReadSessionCreatorConfig();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager cannot be null");
@@ -98,7 +98,7 @@ public class BigQuerySplitManager
                 .map(column -> ((BigQueryColumnHandle) column).getName())
                 .collect(toImmutableList());
 
-        ReadSession readSession = new ReadSessionCreator(readSessionCreatorConfig, bigQueryClient, bigQueryStorageClientFactory)
+        ReadSession readSession = new ReadSessionCreator(readSessionCreatorConfig, bigQueryClient, bigQueryReadClientFactory)
                 .create(tableId, projectedColumnsNames, filter, actualParallelism);
 
         return readSession.getStreamsList().stream()

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
@@ -34,7 +35,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
-import com.google.cloud.bigquery.storage.v1.ReadSession;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
-import static com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
-import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
@@ -35,6 +34,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
+import static com.google.cloud.bigquery.storage.v1.ReadSession;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -46,7 +46,7 @@ public class BigQuerySplitManager
     private static final Logger log = Logger.get(BigQuerySplitManager.class);
 
     private final BigQueryClient bigQueryClient;
-    private final BigQueryStorageClientFactory bigQueryStorageClientFactory;
+    private final BigQueryReadClientFactory bigQueryReadClientFactory;
     private final OptionalInt parallelism;
     private final ReadSessionCreatorConfig readSessionCreatorConfig;
     private final NodeManager nodeManager;
@@ -55,13 +55,13 @@ public class BigQuerySplitManager
     public BigQuerySplitManager(
             BigQueryConfig config,
             BigQueryClient bigQueryClient,
-            BigQueryStorageClientFactory bigQueryStorageClientFactory,
+            BigQueryReadClientFactory bigQueryReadClientFactory,
             NodeManager nodeManager)
     {
         requireNonNull(config, "config cannot be null");
 
         this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient cannot be null");
-        this.bigQueryStorageClientFactory = requireNonNull(bigQueryStorageClientFactory, "bigQueryStorageClientFactory cannot be null");
+        this.bigQueryReadClientFactory = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory cannot be null");
         this.parallelism = config.getParallelism();
         this.readSessionCreatorConfig = config.createReadSessionCreatorConfig();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager cannot be null");
@@ -98,7 +98,7 @@ public class BigQuerySplitManager
                 .map(column -> ((BigQueryColumnHandle) column).getName())
                 .collect(toImmutableList());
 
-        ReadSession readSession = new ReadSessionCreator(readSessionCreatorConfig, bigQueryClient, bigQueryStorageClientFactory)
+        ReadSession readSession = new ReadSessionCreator(readSessionCreatorConfig, bigQueryClient, bigQueryReadClientFactory)
                 .create(tableId, projectedColumnsNames, filter, actualParallelism);
 
         return readSession.getStreamsList().stream()

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
@@ -16,8 +16,8 @@ package com.facebook.presto.plugin.bigquery;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.auth.Credentials;
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageSettings;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import jakarta.inject.Inject;
 
 import java.io.IOException;
@@ -29,32 +29,32 @@ import java.util.Optional;
  * https://github.com/google/guice/wiki/Avoid-Injecting-Closable-Resources), this factory creates
  * short lived clients that can be closed independently.
  */
-public class BigQueryStorageClientFactory
+public class BigQueryReadClientFactory
 {
     private final Optional<Credentials> credentials;
     private final HeaderProvider headerProvider;
 
     @Inject
-    public BigQueryStorageClientFactory(BigQueryCredentialsSupplier bigQueryCredentialsSupplier, HeaderProvider headerProvider)
+    public BigQueryReadClientFactory(BigQueryCredentialsSupplier bigQueryCredentialsSupplier, HeaderProvider headerProvider)
     {
         this.credentials = bigQueryCredentialsSupplier.getCredentials();
         this.headerProvider = headerProvider;
     }
 
-    BigQueryStorageClient createBigQueryStorageClient()
+    BigQueryReadClient createBigQueryStorageClient()
     {
         try {
-            BigQueryStorageSettings.Builder clientSettings = BigQueryStorageSettings.newBuilder()
+            BigQueryReadSettings.Builder clientSettings = BigQueryReadSettings.newBuilder()
                     .setTransportChannelProvider(
-                            BigQueryStorageSettings.defaultGrpcTransportProviderBuilder()
+                            BigQueryReadSettings.defaultGrpcTransportProviderBuilder()
                                     .setHeaderProvider(headerProvider)
                                     .build());
             credentials.ifPresent(credentials ->
                     clientSettings.setCredentialsProvider(FixedCredentialsProvider.create(credentials)));
-            return BigQueryStorageClient.create(clientSettings.build());
+            return BigQueryReadClient.create(clientSettings.build());
         }
         catch (IOException e) {
-            throw new UncheckedIOException("Error creating BigQueryStorageClient", e);
+            throw new UncheckedIOException("Error creating BigQueryReadClient", e);
         }
     }
 }

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
@@ -16,8 +16,8 @@ package com.facebook.presto.plugin.bigquery;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.auth.Credentials;
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageSettings;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageSettings;
 import jakarta.inject.Inject;
 
 import java.io.IOException;

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryStorageClientFactory.java
@@ -41,7 +41,7 @@ public class BigQueryReadClientFactory
         this.headerProvider = headerProvider;
     }
 
-    BigQueryReadClient createBigQueryStorageClient()
+    BigQueryReadClient createBigQueryReadClient()
     {
         try {
             BigQueryReadSettings.Builder clientSettings = BigQueryReadSettings.newBuilder()

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
@@ -13,9 +13,9 @@
  */
 package com.facebook.presto.plugin.bigquery;
 
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
-import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -52,7 +52,7 @@ public class ReadRowsHelper
             catch (RuntimeException e) {
                 // if relevant, retry the read, from the last read position
                 if (BigQueryUtil.isRetryable(e) && retries < maxReadRowsRetries) {
-                    request.getReadPositionBuilder().setOffset(readRowsCount);
+                    request.setOffset(readRowsCount);
                     serverResponses = fetchResponses(request);
                     retries++;
                 }

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
@@ -32,7 +32,7 @@ public class ReadRowsHelper
     public ReadRowsHelper(BigQueryReadClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries)
     {
         this.client = requireNonNull(client, "client cannot be null");
-        this.request = requireNonNull(request, "client cannot be null");
+        this.request = requireNonNull(request, "request cannot be null");
         this.maxReadRowsRetries = maxReadRowsRetries;
     }
 

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadRowsHelper.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.plugin.bigquery;
 
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 
@@ -25,11 +25,11 @@ import static java.util.Objects.requireNonNull;
 
 public class ReadRowsHelper
 {
-    private BigQueryStorageClient client;
+    private BigQueryReadClient client;
     private ReadRowsRequest.Builder request;
     private int maxReadRowsRetries;
 
-    public ReadRowsHelper(BigQueryStorageClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries)
+    public ReadRowsHelper(BigQueryReadClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries)
     {
         this.client = requireNonNull(client, "client cannot be null");
         this.request = requireNonNull(request, "client cannot be null");
@@ -58,7 +58,7 @@ public class ReadRowsHelper
                 }
                 else {
                     // to safely close the client
-                    try (BigQueryStorageClient ignored = client) {
+                    try (BigQueryReadClient ignored = client) {
                         throw e;
                     }
                 }

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
@@ -73,7 +73,7 @@ public class ReadSessionCreator
 
         TableInfo actualTable = getActualTable(tableDetails, selectedFields, new String[] {});
 
-        try (BigQueryReadClient bigQueryReadClient = bigQueryReadClientFactory.createBigQueryStorageClient()) {
+        try (BigQueryReadClient bigQueryReadClient = bigQueryReadClientFactory.createBigQueryReadClient()) {
             TableReadOptions.Builder readOptions = TableReadOptions.newBuilder()
                     .addAllSelectedFields(selectedFields);
             filter.ifPresent(readOptions::setRowRestriction);

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
@@ -24,10 +24,11 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1beta1.ReadOptions;
-import com.google.cloud.bigquery.storage.v1beta1.Storage;
-import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -66,42 +67,36 @@ public class ReadSessionCreator
         this.bigQueryStorageClientFactory = bigQueryStorageClientFactory;
     }
 
-    public Storage.ReadSession create(TableId table, ImmutableList<String> selectedFields, Optional<String> filter, int parallelism)
+    public ReadSession create(TableId table, ImmutableList<String> selectedFields, Optional<String> filter, int parallelism)
     {
         TableInfo tableDetails = bigQueryClient.getTable(table);
 
         TableInfo actualTable = getActualTable(tableDetails, selectedFields, new String[] {});
 
         try (BigQueryStorageClient bigQueryStorageClient = bigQueryStorageClientFactory.createBigQueryStorageClient()) {
-            ReadOptions.TableReadOptions.Builder readOptions = ReadOptions.TableReadOptions.newBuilder()
+            TableReadOptions.Builder readOptions = TableReadOptions.newBuilder()
                     .addAllSelectedFields(selectedFields);
             filter.ifPresent(readOptions::setRowRestriction);
 
-            TableReferenceProto.TableReference tableReference = toTableReference(actualTable.getTableId());
+            String tableString = format("projects/%s/datasets/%s/tables/%s",
+                    actualTable.getTableId().getProject(),
+                    actualTable.getTableId().getDataset(),
+                    actualTable.getTableId().getTable());
 
-            Storage.ReadSession readSession = bigQueryStorageClient.createReadSession(
-                    Storage.CreateReadSessionRequest.newBuilder()
+            ReadSession.Builder sessionBuilder = ReadSession.newBuilder()
+                    .setTable(tableString)
+                    .setDataFormat(DataFormat.AVRO)
+                    .setReadOptions(readOptions);
+
+            ReadSession readSession = bigQueryStorageClient.createReadSession(
+                    CreateReadSessionRequest.newBuilder()
                             .setParent("projects/" + bigQueryClient.getProjectId())
-                            .setFormat(Storage.DataFormat.AVRO)
-                            .setRequestedStreams(parallelism)
-                            .setReadOptions(readOptions)
-                            .setTableReference(tableReference)
-                            // The BALANCED sharding strategy causes the server to
-                            // assign roughly the same number of rows to each stream.
-                            .setShardingStrategy(Storage.ShardingStrategy.BALANCED)
+                            .setReadSession(sessionBuilder)
+                            .setMaxStreamCount(parallelism)
                             .build());
 
             return readSession;
         }
-    }
-
-    TableReferenceProto.TableReference toTableReference(TableId tableId)
-    {
-        return TableReferenceProto.TableReference.newBuilder()
-                .setProjectId(tableId.getProject())
-                .setDatasetId(tableId.getDataset())
-                .setTableId(tableId.getTable())
-                .build();
     }
 
     TableInfo getActualTable(

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/ReadSessionCreator.java
@@ -24,7 +24,7 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
@@ -55,16 +55,16 @@ public class ReadSessionCreator
 
     private final ReadSessionCreatorConfig config;
     private final BigQueryClient bigQueryClient;
-    private final BigQueryStorageClientFactory bigQueryStorageClientFactory;
+    private final BigQueryReadClientFactory bigQueryReadClientFactory;
 
     public ReadSessionCreator(
             ReadSessionCreatorConfig config,
             BigQueryClient bigQueryClient,
-            BigQueryStorageClientFactory bigQueryStorageClientFactory)
+            BigQueryReadClientFactory bigQueryReadClientFactory)
     {
         this.config = config;
         this.bigQueryClient = bigQueryClient;
-        this.bigQueryStorageClientFactory = bigQueryStorageClientFactory;
+        this.bigQueryReadClientFactory = bigQueryReadClientFactory;
     }
 
     public ReadSession create(TableId table, ImmutableList<String> selectedFields, Optional<String> filter, int parallelism)
@@ -73,7 +73,7 @@ public class ReadSessionCreator
 
         TableInfo actualTable = getActualTable(tableDetails, selectedFields, new String[] {});
 
-        try (BigQueryStorageClient bigQueryStorageClient = bigQueryStorageClientFactory.createBigQueryStorageClient()) {
+        try (BigQueryReadClient bigQueryReadClient = bigQueryReadClientFactory.createBigQueryStorageClient()) {
             TableReadOptions.Builder readOptions = TableReadOptions.newBuilder()
                     .addAllSelectedFields(selectedFields);
             filter.ifPresent(readOptions::setRowRestriction);
@@ -88,7 +88,7 @@ public class ReadSessionCreator
                     .setDataFormat(DataFormat.AVRO)
                     .setReadOptions(readOptions);
 
-            ReadSession readSession = bigQueryStorageClient.createReadSession(
+            ReadSession readSession = bigQueryReadClient.createReadSession(
                     CreateReadSessionRequest.newBuilder()
                             .setParent("projects/" + bigQueryClient.getProjectId())
                             .setReadSession(sessionBuilder)

--- a/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/MockResponsesBatch.java
+++ b/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/MockResponsesBatch.java
@@ -13,18 +13,18 @@
  */
 package com.facebook.presto.plugin.bigquery;
 
-import com.google.cloud.bigquery.storage.v1beta1.Storage;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 
 public class MockResponsesBatch
-        implements Iterator<Storage.ReadRowsResponse>
+        implements Iterator<ReadRowsResponse>
 {
     private Queue<Object> responses = new LinkedList<>();
 
-    void addResponse(Storage.ReadRowsResponse response)
+    void addResponse(ReadRowsResponse response)
     {
         responses.add(response);
     }
@@ -41,11 +41,11 @@ public class MockResponsesBatch
     }
 
     @Override
-    public Storage.ReadRowsResponse next()
+    public ReadRowsResponse next()
     {
         Object next = responses.poll();
-        if (next instanceof Storage.ReadRowsResponse) {
-            return (Storage.ReadRowsResponse) next;
+        if (next instanceof ReadRowsResponse) {
+            return (ReadRowsResponse) next;
         }
         if (next instanceof RuntimeException) {
             throw (RuntimeException) next;

--- a/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestReadRowsHelper.java
+++ b/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestReadRowsHelper.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.plugin.bigquery;
 
-import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 public class TestReadRowsHelper
 {
     // it is not used, we just need the reference
-    BigQueryStorageClient client = mock(BigQueryStorageClient.class);
+    BigQueryReadClient client = mock(BigQueryReadClient.class);
     private ReadRowsRequest.Builder request = ReadRowsRequest.newBuilder().setReadStream("test");
 
     @Test
@@ -72,7 +72,7 @@ public class TestReadRowsHelper
     {
         Iterator<MockResponsesBatch> responses;
 
-        MockReadRowsHelper(BigQueryStorageClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries, Iterable<MockResponsesBatch> responses)
+        MockReadRowsHelper(BigQueryReadClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries, Iterable<MockResponsesBatch> responses)
         {
             super(client, request, maxReadRowsRetries);
             this.responses = responses.iterator();

--- a/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestReadRowsHelper.java
+++ b/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestReadRowsHelper.java
@@ -13,8 +13,9 @@
  */
 package com.facebook.presto.plugin.bigquery;
 
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
-import com.google.cloud.bigquery.storage.v1beta1.Storage;
+import com.google.cloud.bigquery.storage.v1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -30,42 +31,40 @@ public class TestReadRowsHelper
 {
     // it is not used, we just need the reference
     BigQueryStorageClient client = mock(BigQueryStorageClient.class);
-    private Storage.ReadRowsRequest.Builder request = Storage.ReadRowsRequest.newBuilder().setReadPosition(
-            Storage.StreamPosition.newBuilder().setStream(
-                    Storage.Stream.newBuilder().setName("test")));
+    private ReadRowsRequest.Builder request = ReadRowsRequest.newBuilder().setReadStream("test");
 
     @Test
     void testNoFailures()
     {
         MockResponsesBatch batch1 = new MockResponsesBatch();
-        batch1.addResponse(Storage.ReadRowsResponse.newBuilder().setRowCount(10).build());
-        batch1.addResponse(Storage.ReadRowsResponse.newBuilder().setRowCount(11).build());
+        batch1.addResponse(ReadRowsResponse.newBuilder().setRowCount(10).build());
+        batch1.addResponse(ReadRowsResponse.newBuilder().setRowCount(11).build());
 
         // so we can run multiple tests
-        ImmutableList<Storage.ReadRowsResponse> responses = ImmutableList.copyOf(
+        ImmutableList<ReadRowsResponse> responses = ImmutableList.copyOf(
                 new MockReadRowsHelper(client, request, 3, ImmutableList.of(batch1))
                         .readRows());
 
         assertThat(responses.size()).isEqualTo(2);
-        assertThat(responses.stream().mapToLong(Storage.ReadRowsResponse::getRowCount).sum()).isEqualTo(21);
+        assertThat(responses.stream().mapToLong(ReadRowsResponse::getRowCount).sum()).isEqualTo(21);
     }
 
     @Test
     void testRetryOfSingleFailure()
     {
         MockResponsesBatch batch1 = new MockResponsesBatch();
-        batch1.addResponse(Storage.ReadRowsResponse.newBuilder().setRowCount(10).build());
+        batch1.addResponse(ReadRowsResponse.newBuilder().setRowCount(10).build());
         batch1.addException(new StatusRuntimeException(Status.INTERNAL.withDescription(
                 "Received unexpected EOS on DATA frame from server.")));
         MockResponsesBatch batch2 = new MockResponsesBatch();
-        batch2.addResponse(Storage.ReadRowsResponse.newBuilder().setRowCount(11).build());
+        batch2.addResponse(ReadRowsResponse.newBuilder().setRowCount(11).build());
 
-        ImmutableList<Storage.ReadRowsResponse> responses = ImmutableList.copyOf(
+        ImmutableList<ReadRowsResponse> responses = ImmutableList.copyOf(
                 new MockReadRowsHelper(client, request, 3, ImmutableList.of(batch1, batch2))
                         .readRows());
 
         assertThat(responses.size()).isEqualTo(2);
-        assertThat(responses.stream().mapToLong(Storage.ReadRowsResponse::getRowCount).sum()).isEqualTo(21);
+        assertThat(responses.stream().mapToLong(ReadRowsResponse::getRowCount).sum()).isEqualTo(21);
     }
 
     private static final class MockReadRowsHelper
@@ -73,14 +72,14 @@ public class TestReadRowsHelper
     {
         Iterator<MockResponsesBatch> responses;
 
-        MockReadRowsHelper(BigQueryStorageClient client, Storage.ReadRowsRequest.Builder request, int maxReadRowsRetries, Iterable<MockResponsesBatch> responses)
+        MockReadRowsHelper(BigQueryStorageClient client, ReadRowsRequest.Builder request, int maxReadRowsRetries, Iterable<MockResponsesBatch> responses)
         {
             super(client, request, maxReadRowsRetries);
             this.responses = responses.iterator();
         }
 
         @Override
-        protected Iterator<Storage.ReadRowsResponse> fetchResponses(Storage.ReadRowsRequest.Builder readRowsRequest)
+        protected Iterator<ReadRowsResponse> fetchResponses(ReadRowsRequest.Builder readRowsRequest)
         {
             return responses.next();
         }


### PR DESCRIPTION
## Description
Update Google BigQuery Storage API SDK from v1beta1 to v1.

## Motivation and Context
v1beta1 is a preview API, and v1 is a GA API with better performance and reliability.

## Impact
There should be no visible impact as v1 API is backward compatible (no changes in API activation, IAM permission, quota, billing etc.). V1 API has been GA-ed since 2020 and most of SDK/customers have migrated to v1.

## Test Plan
Updates to unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update Google BigQuery Storage API SDK from v1beta1 to v1. 
```

## Summary by Sourcery

Upgrade BigQuery storage integration from the v1beta1 API to the GA v1 API and align request/response handling accordingly.

Enhancements:
- Update BigQuery Storage read session creation and read-rows helpers to use v1 request/response types and semantics.
- Simplify table reference construction and retry offset handling to match the v1 client API.
- Adjust tests and mock helpers to operate on v1 ReadRowsRequest/ReadRowsResponse types.

Build:
- Switch presto-bigquery module dependency from proto-google-cloud-bigquerystorage-v1beta1 to proto-google-cloud-bigquerystorage-v1.

## Summary by Sourcery

Upgrade the BigQuery connector to use the GA BigQuery Storage v1 Read API instead of the deprecated v1beta1 API for read sessions and row retrieval.

Enhancements:
- Replace usages of BigQueryStorageClient and v1beta1 request/response types with BigQueryReadClient and v1 equivalents across split creation and page source code.
- Simplify table and stream reference construction and offset handling to follow the v1 API model while preserving existing read and retry behavior.

Build:
- Switch the presto-bigquery module dependency from proto-google-cloud-bigquerystorage-v1beta1 to proto-google-cloud-bigquerystorage-v1.

Tests:
- Update BigQuery read-rows unit tests and mocking utilities to operate on v1 ReadRowsRequest/ReadRowsResponse types.