### PR TITLE
perf(native-pos): Fix OOM due to excessive memory usage in BroadcastFileReader 

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -291,6 +291,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kAggregationSpillEnabled, true),
           BOOL_PROP(kOrderBySpillEnabled, true),
           NUM_PROP(kMaxSpillBytes, 100UL << 30), // 100GB
+          NUM_PROP(kBroadcastExchangeSourceReadBufferBytes, 1 << 20), // 1MB
           BOOL_PROP(kBroadcastJoinTableCachingEnabled, false),
           BOOL_PROP(kExchangeLazyFetchingEnabled, false),
           NUM_PROP(kRequestDataSizesMaxWaitSec, 10),
@@ -460,6 +461,11 @@ bool SystemConfig::aggregationSpillEnabled() const {
 
 bool SystemConfig::orderBySpillEnabled() const {
   return optionalProperty<bool>(kOrderBySpillEnabled).value();
+}
+
+uint64_t SystemConfig::broadcastExchangeSourceReadBufferBytes() const {
+  return optionalProperty<uint64_t>(kBroadcastExchangeSourceReadBufferBytes)
+      .value();
 }
 
 bool SystemConfig::broadcastJoinTableCachingEnabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -902,6 +902,12 @@ class SystemConfig : public ConfigBase {
       "order-by-spill-enabled"};
   static constexpr std::string_view kMaxSpillBytes{"max-spill-bytes"};
 
+  /// Input stream buffer size in bytes for reading broadcast files. Controls
+  /// per-source memory footprint when many broadcast sources are active.
+  /// Default: 1MB.
+  static constexpr std::string_view kBroadcastExchangeSourceReadBufferBytes{
+      "broadcast-exchange-source-read-buffer-bytes"};
+
   /// When enabled, hash tables built for broadcast joins are cached and reused
   /// across tasks within the same query and stage.
   static constexpr std::string_view kBroadcastJoinTableCachingEnabled{
@@ -1303,6 +1309,8 @@ class SystemConfig : public ConfigBase {
   bool aggregationSpillEnabled() const;
 
   bool orderBySpillEnabled() const;
+
+  uint64_t broadcastExchangeSourceReadBufferBytes() const;
 
   bool broadcastJoinTableCachingEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include <fmt/format.h>
+#include <folly/ScopeGuard.h>
 #include <folly/Uri.h>
 
 #include "presto_cpp/main/operators/BroadcastExchangeSource.h"
@@ -41,6 +42,10 @@ BroadcastExchangeSource::request(
   }
 
   return folly::makeTryWith([&]() -> Response {
+    SCOPE_EXIT {
+      checkFinish();
+    };
+
     int64_t totalBytes = 0;
     std::vector<std::unique_ptr<velox::exec::SerializedPageBase>> pages;
 
@@ -82,6 +87,10 @@ BroadcastExchangeSource::requestDataSizes(
     std::chrono::microseconds /*maxWait*/) {
   // Deferred execution to avoid blocking the caller thread.
   return folly::makeSemiFuture().deferValue([this](auto&&) -> Response {
+    SCOPE_EXIT {
+      checkFinish();
+    };
+
     auto remainingPageSizes = reader_->remainingPageSizes();
 
     // If the source is empty from the start, signal completion to ExchangeQueue

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
@@ -30,7 +30,9 @@ class BroadcastExchangeSource : public velox::exec::ExchangeSource {
       const std::shared_ptr<velox::exec::ExchangeQueue>& queue,
       const std::shared_ptr<BroadcastFileReader>& reader,
       velox::memory::MemoryPool* pool)
-      : ExchangeSource(taskId, destination, queue, pool), reader_(reader) {}
+      : ExchangeSource(taskId, destination, queue, pool), reader_(reader) {
+    VELOX_CHECK_NOT_NULL(reader_);
+  }
 
   bool shouldRequestLocked() override {
     return !atEnd_;
@@ -43,7 +45,9 @@ class BroadcastExchangeSource : public velox::exec::ExchangeSource {
   folly::SemiFuture<Response> requestDataSizes(
       std::chrono::microseconds maxWait) override;
 
-  void close() override {}
+  void close() override {
+    finish();
+  }
 
   bool supportsMetrics() const override {
     return true;
@@ -63,6 +67,16 @@ class BroadcastExchangeSource : public velox::exec::ExchangeSource {
       velox::memory::MemoryPool* pool);
 
  private:
+  void checkFinish() {
+    if (atEnd_) {
+      finish();
+    }
+  }
+
+  void finish() {
+    reader_->close();
+  }
+
   const std::shared_ptr<BroadcastFileReader> reader_;
 };
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFile.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFile.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/operators/BroadcastFile.h"
 #include "presto_cpp/external/json/nlohmann/json.hpp"
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/thrift/ThriftIO.h"
 #include "presto_cpp/main/thrift/gen-cpp2/presto_native_types.h"
@@ -256,8 +257,14 @@ velox::BufferPtr BroadcastFileReader::next() {
   return pageBuffer;
 }
 
+void BroadcastFileReader::close() {
+  inputStream_.reset();
+  closed_ = true;
+}
+
 void BroadcastFileReader::ensureFooterRead() {
-  // Read the footer on first access
+  VELOX_CHECK(
+      !closed_, "BroadcastFileReader is closed; cannot read after close()");
   if (inputStream_ != nullptr) {
     return;
   }
@@ -271,7 +278,9 @@ void BroadcastFileReader::ensureFooterRead() {
 
   // Create the input stream for sequential reads
   inputStream_ = std::make_unique<velox::common::FileInputStream>(
-      std::move(readFile), 8 * 1024 * 1024, pool_); // 8MB buffer
+      std::move(readFile),
+      SystemConfig::instance()->broadcastExchangeSourceReadBufferBytes(),
+      pool_);
 }
 
 std::vector<int64_t> BroadcastFileReader::remainingPageSizes() {

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
@@ -94,6 +94,9 @@ class BroadcastFileReader {
 
   ~BroadcastFileReader() = default;
 
+  /// Releases the input stream to free memory before destruction.
+  void close();
+
   /// Return true if more data is available.
   bool hasNext();
 
@@ -119,6 +122,7 @@ class BroadcastFileReader {
   const std::shared_ptr<velox::filesystems::FileSystem> fileSystem_;
 
   std::unique_ptr<velox::common::FileInputStream> inputStream_;
+  bool closed_{false};
   int64_t numBytes_{0};
   uint32_t numPagesRead_{0};
   std::vector<int64_t> pageSizes_;


### PR DESCRIPTION
Summary:

Fix OOM on large broadcast tables.

When size of each file was greater than default (8mb), each exchange source would create and hold 8mb buffer until end of task execution, well after sources are drained.

This resulted in excessive memory consumption leading to OOMs.

This was  close() was a no-op and BroadcastFileReader had no close() method at all — the input stream buffer was only ref count destructed, which meant that it would hold buffer memory until end of task execution.

**Changes**:

1. BroadcastFileReader: input stream buffer size is now configurable via the `broadcast-exchange-source-read-buffer-bytes` system config property (default 1MB, previously hardcoded 8MB). This lowers per-source memory footprint when many broadcast sources are active.
2. BroadcastExchangeSource: close() now properly closes the underlying input stream via BroadcastFileReader::close(). Additionally, both request() and requestDataSizes() now eagerly close the reader as soon as the source is drained (atEnd), rather than holding the buffer until task teardown. Since ExchangeClient only calls ExchangeSource::close() in its own close() (not per-source when drained), this eager release is necessary to avoid accumulating dead buffers across many broadcast sources.
3. BroadcastFileReader::close() is idempotent — the eager close on drain and the later close at task teardown are both safe.

Differential Revision: D104499584

```
== NO RELEASE NOTE ==
```


