### PR TITLE
feat(presto): Register Nimble reader session properties in Java coordinator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -57,6 +57,8 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_DEBUG_MEMORY_POOL_NAME_REGEX = "native_debug_memory_pool_name_regex";
     public static final String NATIVE_DEBUG_MEMORY_POOL_WARN_THRESHOLD_BYTES = "native_debug_memory_pool_warn_threshold_bytes";
     public static final String NATIVE_SELECTIVE_NIMBLE_READER_ENABLED = "native_selective_nimble_reader_enabled";
+    public static final String NATIVE_NIMBLE_STRING_DECODER_ZERO_COPY = "native_nimble_string_decoder_zero_copy";
+    public static final String NATIVE_NIMBLE_PRESERVE_DICTIONARY_ENCODING = "native_nimble_preserve_dictionary_encoding";
     public static final String NATIVE_ROW_SIZE_TRACKING_ENABLED = "row_size_tracking_enabled";
     public static final String NATIVE_PREFERRED_OUTPUT_BATCH_BYTES = "preferred_output_batch_bytes";
     public static final String NATIVE_PREFERRED_OUTPUT_BATCH_ROWS = "preferred_output_batch_rows";
@@ -264,6 +266,18 @@ public class NativeWorkerSessionPropertyProvider
                         "Temporary flag to control whether selective Nimble reader should be " +
                                 "used in this query or not.  Will be removed after the selective Nimble " +
                                 "reader is fully rolled out.",
+                        false,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_NIMBLE_STRING_DECODER_ZERO_COPY,
+                        "Enable zero-copy string decoding in the Nimble selective reader, " +
+                                "using the non-legacy encoding path.",
+                        false,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_NIMBLE_PRESERVE_DICTIONARY_ENCODING,
+                        "Preserve dictionary encoding for Nimble string column reads, " +
+                                "returning DictionaryVector instead of FlatVector.",
                         false,
                         !nativeExecution),
                 booleanProperty(

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesIncludingInvalidProperties.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesIncludingInvalidProperties.java
@@ -58,4 +58,30 @@ public class TestSetWorkerSessionPropertiesIncludingInvalidProperties
                         "setSessionProperties={distinct_aggregation_spill_enabled=false}, " +
                         "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}, clearTransactionId=false}");
     }
+
+    @Test
+    public void testSetSessionNimbleStringDecoderZeroCopy()
+    {
+        @Language("SQL") String setSession = "SET SESSION native_nimble_string_decoder_zero_copy=true";
+        MaterializedResult setSessionResult = computeActual(setSession);
+        assertEquals(
+                setSessionResult.toString(),
+                "MaterializedResult{rows=[[true]], " +
+                        "types=[boolean], " +
+                        "setSessionProperties={native_nimble_string_decoder_zero_copy=true}, " +
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}, clearTransactionId=false}");
+    }
+
+    @Test
+    public void testSetSessionPreserveDictionaryEncoding()
+    {
+        @Language("SQL") String setSession = "SET SESSION native_nimble_preserve_dictionary_encoding=true";
+        MaterializedResult setSessionResult = computeActual(setSession);
+        assertEquals(
+                setSessionResult.toString(),
+                "MaterializedResult{rows=[[true]], " +
+                        "types=[boolean], " +
+                        "setSessionProperties={native_nimble_preserve_dictionary_encoding=true}, " +
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}, clearTransactionId=false}");
+    }
 }


### PR DESCRIPTION
Summary:
Register two new session properties in NativeWorkerSessionPropertyProvider:
- pass_string_buffers_from_decoder: Enable non-legacy Nimble encoding path
- preserve_dictionary_encoding: Enable dictionary vector preservation

These Java-side registrations are required for the verifier to pass these
properties via -tsp to the native C++ workers.

Reviewed By: xiaoxmeng

Differential Revision: D102489359


