### PR TITLE
docs: Fix errors in doc build

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2903,7 +2903,7 @@ See :doc:`/admin/materialized-views` for general information on refresh behavior
 .. _iceberg-incremental-refresh:
 
 Incremental Refresh
-"""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^
 
 The Iceberg connector supports incremental refresh, which atomically replaces only stale
 partitions rather than recomputing the entire result set. See :ref:`admin/materialized-views:Incremental Refresh`

--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -108,7 +108,7 @@ default is ``10000``.
     write path.
 
 ``lance.index-cache-size``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Size of the Lance index cache per worker node. The index cache stores
 scalar and vector index data to speed up filtered queries. The default is

--- a/presto-docs/src/main/sphinx/security/password-file.rst
+++ b/presto-docs/src/main/sphinx/security/password-file.rst
@@ -316,7 +316,7 @@ Import the Presto coordinator's certificate into client's truststore. See :ref:`
 Also make sure to include ``--truststore-*`` properties when running Presto CLI as suggested in :ref:`cli_execution`.
 
 javax.net.ssl.SSLPeerUnverifiedException: Hostname <some_host_name> not verified
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This error implies the Common Name in the imported coordinator's certificate in the client's truststore does not match the hostname
 provided with ``--server`` flag. Modify the ``--server`` option to use the same hostname that is mentioned as the Common Name


### PR DESCRIPTION
## Description
Edits in various documentation files to correct the following errors currently appearing in doc builds. 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/security/password-file.rst:319: WARNING: Title underline too short.

javax.net.ssl.SSLPeerUnverifiedException: Hostname <some_host_name> not verified
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/security/password-file.rst:319: WARNING: Title underline too short.

javax.net.ssl.SSLPeerUnverifiedException: Hostname <some_host_name> not verified
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/lance.rst:111: WARNING: Title underline too short.

``lance.index-cache-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/lance.rst:111: WARNING: Title underline too short.

``lance.index-cache-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/iceberg.rst:2905: CRITICAL: Title level inconsistent:

Incremental Refresh
""""""""""""""""""" [docutils]

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties-session.rst:864: WARNING: Failed to create a cross reference. A title or caption not found: 'iceberg-incremental-refresh' [ref.ref]
```

## Motivation and Context
In the case of a couple of these, a misformatted heading led to the failure of that heading to display on the compiled page, as well as the failure of a link from another page to that heading. For the rest of them, excess warnings slow down doc builds and make it harder to diagnose and correct problems when creating new documentation. 

## Impact
Documentation, as described in **Motivation and Context**.

## Test Plan
Local doc builds. 

Before: 
The errors shown in **Description** appeared during a local doc build and in the compiled documentation. 

Total: `build succeeded, 60 warnings.`

After:
The errors shown in **Description** appeared during a local doc build and in the compiled documentation. 

Total: `build succeeded, 54 warnings.`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix documentation build issues by correcting misformatted headings and references in Sphinx docs.

Documentation:
- Correct Sphinx heading underlines and title levels in security and connector documentation to eliminate build warnings and ensure all headings render correctly.
- Fix broken cross-reference to the Iceberg incremental refresh section so linked documentation anchors resolve properly.