### PR TITLE
feat(plugin-iceberg): Add `ALTER MATERIALIZED VIEW SET PROPERTIES`

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2864,35 +2864,52 @@ Property Name                                          Description              
                                                        view falls back to a full recompute.
 ====================================================== ============================================================= ========================
 
-Table Properties
-^^^^^^^^^^^^^^^^
+.. _iceberg-alter-materialized-view:
 
-The following table properties can be specified when creating a materialized view:
+Materialized View Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-========================================================== ============================================================================
-Property Name                                              Description
-========================================================== ============================================================================
-``storage_schema``                                         Schema name for the storage table. Defaults to the materialized view's
-                                                           schema.
+The following table properties can be specified when creating a materialized view.
+Properties marked **Yes** in the *Alterable* column can be changed after creation
+by using :doc:`/sql/alter-materialized-view`; properties not specified in the
+``SET PROPERTIES`` clause keep their current value, and setting these properties to
+``NULL`` is not supported.
 
-``storage_table``                                          Custom name for the storage table. Defaults to the prefix plus the
-                                                           materialized view name.
+.. list-table::
+   :widths: 25 60 15
+   :header-rows: 1
 
-``stale_read_behavior``                                    Behavior when reading from a materialized view that is stale beyond the
-                                                           staleness window. Valid values: ``FAIL`` (throw an error),
-                                                           ``USE_VIEW_QUERY`` (query base tables instead).
-
-``staleness_window``                                       Duration window for staleness tolerance (e.g., ``1h``, ``30m``, ``0s``).
-                                                           Defaults to ``0s`` if only ``stale_read_behavior`` is set. When set to
-                                                           ``0s``, any staleness triggers the configured behavior.
-
-``refresh_type``                                           Refresh strategy for the materialized view. Valid values: ``FULL``
-                                                           (always recompute entire view), ``INCREMENTAL`` (recompute only stale
-                                                           partitions when possible, fall back to full otherwise). When not set,
-                                                           uses the ``materialized_view_default_refresh_type`` session property.
-========================================================== ============================================================================
+   * - Property Name
+     - Description
+     - Alterable
+   * - ``storage_schema``
+     - Schema name for the storage table. Defaults to the materialized view's schema.
+     - No
+   * - ``storage_table``
+     - Custom name for the storage table. Defaults to the prefix plus the materialized view name.
+     - No
+   * - ``stale_read_behavior``
+     - Behavior when reading from a materialized view that is stale beyond the staleness window.
+       Valid values: ``FAIL`` (throw an error), ``USE_VIEW_QUERY`` (query base tables instead).
+     - Yes
+   * - ``staleness_window``
+     - Duration window for staleness tolerance (e.g., ``1h``, ``30m``, ``0s``).
+       Defaults to ``0s`` if only ``stale_read_behavior`` is set.
+       When set to ``0s``, any staleness triggers the configured behavior.
+     - Yes
+   * - ``refresh_type``
+     - Refresh strategy for the materialized view. Valid values: ``FULL``
+       (always recompute entire view), ``INCREMENTAL`` (recompute only stale
+       partitions when possible, fall back to full otherwise). When not set,
+       uses the ``materialized_view_default_refresh_type`` session property.
+     - Yes
 
 The storage table inherits standard Iceberg table properties for partitioning, sorting, and file format.
+
+Example::
+
+    ALTER MATERIALIZED VIEW hourly_sales
+    SET PROPERTIES (staleness_window = '30m', refresh_type = 'INCREMENTAL');
 
 Freshness and Refresh
 ^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -8,6 +8,7 @@ This chapter describes the SQL syntax used in Presto.
     :maxdepth: 1
 
     sql/alter-function
+    sql/alter-materialized-view
     sql/alter-schema
     sql/alter-table
     sql/alter-view

--- a/presto-docs/src/main/sphinx/sql/alter-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-materialized-view.rst
@@ -1,0 +1,52 @@
+=======================
+ALTER MATERIALIZED VIEW
+=======================
+
+.. warning::
+
+    Materialized views are experimental. The SPI and behavior may change in future releases.
+
+    To enable, set :ref:`admin/properties:\`\`experimental.legacy-materialized-views\`\`` = ``false``
+    in configuration properties. ``ALTER MATERIALIZED VIEW ... SET PROPERTIES`` is not supported
+    when ``legacy_materialized_views=true``.
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    ALTER MATERIALIZED VIEW [ IF EXISTS ] name SET PROPERTIES (property_name = value [, ...])
+
+Description
+-----------
+
+Change properties on an existing materialized view. The set of properties that can be changed
+is connector-specific; some properties (typically those that determine the physical identity of
+the storage) are fixed at creation time. See :doc:`/connector` for the
+authoritative list of updatable properties.
+
+The optional ``IF EXISTS`` clause causes the error to be suppressed if the materialized view
+does not exist.
+
+Setting a property to ``NULL`` is not supported. To change a property, the new value must be
+non-null. Properties not mentioned in the ``SET PROPERTIES`` clause are left unchanged.
+
+Examples
+--------
+
+Change a property on a materialized view::
+
+    ALTER MATERIALIZED VIEW users SET PROPERTIES (x = 'y');
+
+Use ``IF EXISTS`` to suppress an error when the view may not exist::
+
+    ALTER MATERIALIZED VIEW IF EXISTS users SET PROPERTIES (x = 'y');
+
+For connector-specific examples, see :doc:`/connector`.
+
+See Also
+--------
+
+:doc:`create-materialized-view`, :doc:`drop-materialized-view`,
+:doc:`refresh-materialized-view`, :doc:`show-create-materialized-view`,
+:doc:`/admin/materialized-views`

--- a/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
@@ -109,5 +109,6 @@ Create a materialized view with connector properties::
 See Also
 --------
 
-:doc:`drop-materialized-view`, :doc:`refresh-materialized-view`,
-:doc:`show-create-materialized-view`, :doc:`/admin/materialized-views`
+:doc:`alter-materialized-view`, :doc:`drop-materialized-view`,
+:doc:`refresh-materialized-view`, :doc:`show-create-materialized-view`,
+:doc:`/admin/materialized-views`

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -196,6 +196,7 @@ import static com.facebook.presto.iceberg.IcebergMaterializedViewProperties.getS
 import static com.facebook.presto.iceberg.IcebergMaterializedViewProperties.getStalenessWindow;
 import static com.facebook.presto.iceberg.IcebergMaterializedViewProperties.getStorageSchema;
 import static com.facebook.presto.iceberg.IcebergMaterializedViewProperties.getStorageTable;
+import static com.facebook.presto.iceberg.IcebergMaterializedViewProperties.serializeForUpdate;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NUMBER;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DELETE_FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.FILE_PATH;
@@ -2064,6 +2065,22 @@ public abstract class IcebergAbstractMetadata
                 dropTable(session, storageTableHandle);
             }
         }
+    }
+
+    @Override
+    public void setMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, Map<String, Object> properties)
+    {
+        if (!getMaterializedView(session, viewName).isPresent()) {
+            throw new PrestoException(NOT_FOUND, "Materialized view does not exist: " + viewName);
+        }
+
+        ImmutableMap.Builder<String, String> updates = ImmutableMap.builder();
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            Map.Entry<String, String> serialized = serializeForUpdate(entry.getKey(), entry.getValue());
+            updates.put(serialized.getKey(), serialized.getValue());
+        }
+
+        updateIcebergViewProperties(session, viewName, updates.build());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMaterializedViewProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMaterializedViewProperties.java
@@ -16,17 +16,28 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STALENESS_WINDOW;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STALE_READ_BEHAVIOR;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STORAGE_SCHEMA;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STORAGE_TABLE_NAME;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_MATERIALIZED_VIEW_PROPERTY;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.session.PropertyMetadata.durationProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
+import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -44,6 +55,57 @@ public class IcebergMaterializedViewProperties
     public static final String STALENESS_WINDOW = "staleness_window";
     public static final String REFRESH_TYPE = "refresh_type";
 
+    private static final List<MaterializedViewProperty> MV_ONLY_PROPERTIES = ImmutableList.of(
+            creationOnly(
+                    stringProperty(
+                            STORAGE_SCHEMA,
+                            "Schema for the materialized view storage table (defaults to same schema as the materialized view)",
+                            null,
+                            true),
+                    PRESTO_MATERIALIZED_VIEW_STORAGE_SCHEMA),
+            creationOnly(
+                    stringProperty(
+                            STORAGE_TABLE,
+                            "Custom name for the materialized view storage table (defaults to generated name)",
+                            null,
+                            true),
+                    PRESTO_MATERIALIZED_VIEW_STORAGE_TABLE_NAME),
+            updatable(
+                    new PropertyMetadata<>(
+                            STALE_READ_BEHAVIOR,
+                            "Behavior when reading from a stale materialized view (FAIL or USE_VIEW_QUERY)",
+                            createUnboundedVarcharType(),
+                            MaterializedViewStaleReadBehavior.class,
+                            null,
+                            true,
+                            value -> value == null ? null : MaterializedViewStaleReadBehavior.valueOf(((String) value).toUpperCase(ENGLISH)),
+                            value -> value == null ? null : ((MaterializedViewStaleReadBehavior) value).name()),
+                    PRESTO_MATERIALIZED_VIEW_STALE_READ_BEHAVIOR,
+                    value -> ((MaterializedViewStaleReadBehavior) value).name()),
+            updatable(
+                    durationProperty(
+                            STALENESS_WINDOW,
+                            "Staleness window for materialized view (e.g., '1h', '30m', '0s')",
+                            null,
+                            true),
+                    PRESTO_MATERIALIZED_VIEW_STALENESS_WINDOW,
+                    value -> ((Duration) value).toString()),
+            updatable(
+                    new PropertyMetadata<>(
+                            REFRESH_TYPE,
+                            "Refresh type for materialized view (FULL or INCREMENTAL)",
+                            createUnboundedVarcharType(),
+                            MaterializedViewRefreshType.class,
+                            null,
+                            true,
+                            value -> value == null ? null : MaterializedViewRefreshType.valueOf(((String) value).toUpperCase(ENGLISH)),
+                            value -> value == null ? null : ((MaterializedViewRefreshType) value).name()),
+                    PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE,
+                    value -> ((MaterializedViewRefreshType) value).name()));
+
+    private static final Map<String, MaterializedViewProperty> MV_ONLY_PROPERTIES_BY_NAME =
+            Maps.uniqueIndex(MV_ONLY_PROPERTIES, property -> property.metadata().getName());
+
     private final List<PropertyMetadata<?>> materializedViewProperties;
 
     @Inject
@@ -51,53 +113,74 @@ public class IcebergMaterializedViewProperties
     {
         requireNonNull(tableProperties, "tableProperties is null");
 
-        // MV-specific properties
-        List<PropertyMetadata<?>> mvOnlyProperties = ImmutableList.<PropertyMetadata<?>>builder()
-                .add(stringProperty(
-                        STORAGE_SCHEMA,
-                        "Schema for the materialized view storage table (defaults to same schema as the materialized view)",
-                        null,
-                        true))
-                .add(stringProperty(
-                        STORAGE_TABLE,
-                        "Custom name for the materialized view storage table (defaults to generated name)",
-                        null,
-                        true))
-                .add(new PropertyMetadata<>(
-                        STALE_READ_BEHAVIOR,
-                        "Behavior when reading from a stale materialized view (FAIL or USE_VIEW_QUERY)",
-                        createUnboundedVarcharType(),
-                        MaterializedViewStaleReadBehavior.class,
-                        null,
-                        true,
-                        value -> value == null ? null : MaterializedViewStaleReadBehavior.valueOf(((String) value).toUpperCase(ENGLISH)),
-                        value -> value == null ? null : ((MaterializedViewStaleReadBehavior) value).name()))
-                .add(durationProperty(
-                        STALENESS_WINDOW,
-                        "Staleness window for materialized view (e.g., '1h', '30m', '0s')",
-                        null,
-                        true))
-                .add(new PropertyMetadata<>(
-                        REFRESH_TYPE,
-                        "Refresh type for materialized view (FULL or INCREMENTAL)",
-                        createUnboundedVarcharType(),
-                        MaterializedViewRefreshType.class,
-                        null,
-                        true,
-                        value -> value == null ? null : MaterializedViewRefreshType.valueOf(((String) value).toUpperCase(ENGLISH)),
-                        value -> value == null ? null : ((MaterializedViewRefreshType) value).name()))
-                .build();
-
         // Combine table properties (for storage table) with MV-specific properties
         materializedViewProperties = ImmutableList.<PropertyMetadata<?>>builder()
                 .addAll(tableProperties.getTableProperties())
-                .addAll(mvOnlyProperties)
+                .addAll(MV_ONLY_PROPERTIES.stream().map(MaterializedViewProperty::metadata).iterator())
                 .build();
     }
 
     public List<PropertyMetadata<?>> getMaterializedViewProperties()
     {
         return materializedViewProperties;
+    }
+
+    public static Map.Entry<String, String> serializeForUpdate(String name, Object value)
+    {
+        MaterializedViewProperty property = MV_ONLY_PROPERTIES_BY_NAME.get(name);
+        if (property == null || !property.updatable()) {
+            throw new PrestoException(INVALID_MATERIALIZED_VIEW_PROPERTY,
+                    format("Materialized view property is not updatable: %s", name));
+        }
+        if (value == null) {
+            throw new PrestoException(NOT_SUPPORTED,
+                    format("Clearing materialized view property %s is not supported", name));
+        }
+        return Map.entry(property.storageKey(), property.serializer().apply(value));
+    }
+
+    private static MaterializedViewProperty creationOnly(PropertyMetadata<?> metadata, String storageKey)
+    {
+        return new MaterializedViewProperty(metadata, storageKey, null);
+    }
+
+    private static MaterializedViewProperty updatable(PropertyMetadata<?> metadata, String storageKey, Function<Object, String> serializer)
+    {
+        return new MaterializedViewProperty(metadata, storageKey, requireNonNull(serializer, "serializer is null"));
+    }
+
+    private static final class MaterializedViewProperty
+    {
+        private final PropertyMetadata<?> metadata;
+        private final String storageKey;
+        private final Function<Object, String> serializer;
+
+        MaterializedViewProperty(PropertyMetadata<?> metadata, String storageKey, Function<Object, String> serializer)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.storageKey = requireNonNull(storageKey, "storageKey is null");
+            this.serializer = serializer;
+        }
+
+        PropertyMetadata<?> metadata()
+        {
+            return metadata;
+        }
+
+        String storageKey()
+        {
+            return storageKey;
+        }
+
+        Function<Object, String> serializer()
+        {
+            return serializer;
+        }
+
+        boolean updatable()
+        {
+            return serializer != null;
+        }
     }
 
     public static Optional<String> getStorageSchema(Map<String, Object> properties)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
@@ -762,6 +762,104 @@ public class TestIcebergMaterializedViewMetadata
     }
 
     @Test
+    public void testAlterMaterializedViewSetProperties()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_alter_mv_props_base (id BIGINT, value BIGINT)");
+        assertUpdate("INSERT INTO test_alter_mv_props_base VALUES (1, 100)", 1);
+
+        assertUpdate("CREATE MATERIALIZED VIEW test_alter_mv_props_mv " +
+                "WITH (stale_read_behavior = 'FAIL', staleness_window = '1h', refresh_type = 'FULL') " +
+                "AS SELECT id, value FROM test_alter_mv_props_base");
+
+        RESTCatalog catalog = new RESTCatalog();
+        Map<String, String> catalogProps = new HashMap<>();
+        catalogProps.put("uri", serverUri);
+        catalogProps.put("warehouse", warehouseLocation.getAbsolutePath());
+        catalog.initialize("test_catalog", catalogProps);
+
+        try {
+            TableIdentifier viewId = TableIdentifier.of(Namespace.of("test_schema"), "test_alter_mv_props_mv");
+
+            assertUpdate("ALTER MATERIALIZED VIEW test_alter_mv_props_mv " +
+                    "SET PROPERTIES (staleness_window = '5m', refresh_type = 'INCREMENTAL')");
+
+            Map<String, String> properties = catalog.loadView(viewId).properties();
+            assertEquals(properties.get("presto.materialized_view.stale_read_behavior"), "FAIL",
+                    "stale_read_behavior should remain unchanged");
+            assertEquals(properties.get("presto.materialized_view.staleness_window"), "5.00m",
+                    "staleness_window should be updated");
+            assertEquals(properties.get("presto.materialized_view.refresh_type"), "INCREMENTAL",
+                    "refresh_type should be updated");
+
+            // Updates can be applied incrementally; unspecified properties stay put.
+            assertUpdate("ALTER MATERIALIZED VIEW test_alter_mv_props_mv " +
+                    "SET PROPERTIES (stale_read_behavior = 'USE_VIEW_QUERY')");
+            properties = catalog.loadView(viewId).properties();
+            assertEquals(properties.get("presto.materialized_view.stale_read_behavior"), "USE_VIEW_QUERY");
+            assertEquals(properties.get("presto.materialized_view.refresh_type"), "INCREMENTAL");
+        }
+        finally {
+            catalog.close();
+        }
+
+        assertUpdate("DROP MATERIALIZED VIEW test_alter_mv_props_mv");
+        assertUpdate("DROP TABLE test_alter_mv_props_base");
+    }
+
+    @Test
+    public void testAlterMaterializedViewSetPropertiesRejectsStorageProperties()
+    {
+        assertUpdate("CREATE TABLE test_alter_mv_storage_base (id BIGINT)");
+        try {
+            assertUpdate("CREATE MATERIALIZED VIEW test_alter_mv_storage_mv " +
+                    "AS SELECT id FROM test_alter_mv_storage_base");
+            assertQueryFails(
+                    "ALTER MATERIALIZED VIEW test_alter_mv_storage_mv SET PROPERTIES (storage_schema = 'other')",
+                    ".*Materialized view property is not updatable: storage_schema.*");
+            assertQueryFails(
+                    "ALTER MATERIALIZED VIEW test_alter_mv_storage_mv SET PROPERTIES (storage_table = 'other_table')",
+                    ".*Materialized view property is not updatable: storage_table.*");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_alter_mv_storage_mv");
+            assertUpdate("DROP TABLE test_alter_mv_storage_base");
+        }
+    }
+
+    @Test
+    public void testAlterMaterializedViewSetPropertiesRejectsLegacy()
+    {
+        assertUpdate("CREATE TABLE test_alter_mv_legacy_base (id BIGINT)");
+        try {
+            assertUpdate("CREATE MATERIALIZED VIEW test_alter_mv_legacy_mv " +
+                    "AS SELECT id FROM test_alter_mv_legacy_base");
+
+            Session legacySession = Session.builder(getSession())
+                    .setSystemProperty("legacy_materialized_views", "true")
+                    .build();
+            assertQueryFails(
+                    legacySession,
+                    "ALTER MATERIALIZED VIEW test_alter_mv_legacy_mv SET PROPERTIES (staleness_window = '5m')",
+                    ".*ALTER MATERIALIZED VIEW \\.\\.\\. SET PROPERTIES is not supported when legacy_materialized_views=true.*");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_alter_mv_legacy_mv");
+            assertUpdate("DROP TABLE test_alter_mv_legacy_base");
+        }
+    }
+
+    @Test
+    public void testAlterMaterializedViewSetPropertiesMissingView()
+    {
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW test_alter_mv_missing SET PROPERTIES (staleness_window = '5m')",
+                ".*Materialized view does not exist:.*test_alter_mv_missing.*");
+        // IF EXISTS is a no-op.
+        assertUpdate("ALTER MATERIALIZED VIEW IF EXISTS test_alter_mv_missing SET PROPERTIES (staleness_window = '5m')");
+    }
+
+    @Test
     public void testNoOrphanStorageTableOnValidationFailure()
             throws Exception
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
@@ -828,6 +828,40 @@ public class TestIcebergMaterializedViewMetadata
     }
 
     @Test
+    public void testAlterMaterializedViewSetPropertiesRejectsUnknownProperty()
+    {
+        assertUpdate("CREATE TABLE test_alter_mv_unknown_base (id BIGINT)");
+        try {
+            assertUpdate("CREATE MATERIALIZED VIEW test_alter_mv_unknown_mv " +
+                    "AS SELECT id FROM test_alter_mv_unknown_base");
+            assertQueryFails(
+                    "ALTER MATERIALIZED VIEW test_alter_mv_unknown_mv SET PROPERTIES (nonexistent_property = 'foo')",
+                    ".*does not support materialized view property 'nonexistent_property'.*");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_alter_mv_unknown_mv");
+            assertUpdate("DROP TABLE test_alter_mv_unknown_base");
+        }
+    }
+
+    @Test
+    public void testAlterMaterializedViewSetPropertiesRejectsNullValue()
+    {
+        assertUpdate("CREATE TABLE test_alter_mv_null_base (id BIGINT)");
+        try {
+            assertUpdate("CREATE MATERIALIZED VIEW test_alter_mv_null_mv " +
+                    "AS SELECT id FROM test_alter_mv_null_base");
+            assertQueryFails(
+                    "ALTER MATERIALIZED VIEW test_alter_mv_null_mv SET PROPERTIES (staleness_window = NULL)",
+                    ".*Invalid null value for materialized view property.*");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_alter_mv_null_mv");
+            assertUpdate("DROP TABLE test_alter_mv_null_base");
+        }
+    }
+
+    @Test
     public void testAlterMaterializedViewSetPropertiesRejectsLegacy()
     {
         assertUpdate("CREATE TABLE test_alter_mv_legacy_base (id BIGINT)");

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SetPropertiesTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SetPropertiesTask.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataUtil;
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
+import static com.facebook.presto.sql.tree.SetProperties.Type.MATERIALIZED_VIEW;
 import static com.facebook.presto.sql.tree.SetProperties.Type.TABLE;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.String.format;
@@ -64,6 +66,19 @@ public class SetPropertiesTask
                     parameterExtractor(statement, parameters)).build();
             setTableProperties(statement, tableName, metadata, accessControl, session, properties);
         }
+        else if (statement.getType() == MATERIALIZED_VIEW) {
+            if (SystemSessionProperties.isLegacyMaterializedViews(session)) {
+                throw new PrestoException(NOT_SUPPORTED, "ALTER MATERIALIZED VIEW ... SET PROPERTIES is not supported when legacy_materialized_views=true");
+            }
+            Map<String, Object> properties = metadata.getMaterializedViewPropertyManager().getUserSpecifiedProperties(
+                    getConnectorIdOrThrow(session, metadata, tableName.getCatalogName()),
+                    tableName.getCatalogName(),
+                    sqlProperties,
+                    session,
+                    metadata,
+                    parameterExtractor(statement, parameters)).build();
+            setMaterializedViewProperties(statement, tableName, metadata, accessControl, session, properties);
+        }
         else {
             throw new PrestoException(NOT_SUPPORTED, format("Unsupported target type: %s", statement.getType()));
         }
@@ -91,5 +106,18 @@ public class SetPropertiesTask
 
         accessControl.checkCanSetTableProperties(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName, properties);
         metadata.setTableProperties(session, tableHandle.get(), properties);
+    }
+
+    private void setMaterializedViewProperties(SetProperties statement, QualifiedObjectName viewName, Metadata metadata, AccessControl accessControl, Session session, Map<String, Object> properties)
+    {
+        if (!metadata.getMetadataResolver(session).getMaterializedView(viewName).isPresent()) {
+            if (!statement.isTableExists()) {
+                throw new PrestoException(NOT_FOUND, format("Materialized view does not exist: %s", viewName));
+            }
+            return;
+        }
+
+        accessControl.checkCanSetTableProperties(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), viewName, properties);
+        metadata.setMaterializedViewProperties(session, viewName, properties);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -550,6 +550,12 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Object> properties)
+    {
+        delegate.setMaterializedViewProperties(session, viewName, properties);
+    }
+
+    @Override
     public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
     {
         return delegate.beginRefreshMaterializedView(session, tableHandle);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -465,6 +465,11 @@ public interface Metadata
     void dropMaterializedView(Session session, QualifiedObjectName viewName);
 
     /**
+     * Set properties on the specified materialized view.
+     */
+    void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Object> properties);
+
+    /**
      * List materialized views in the specified schema prefix.
      */
     List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1278,6 +1278,19 @@ public class MetadataManager
     }
 
     @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Object> properties)
+    {
+        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, viewName.getCatalogName());
+        ConnectorId connectorId = catalogMetadata.getConnectorId();
+        ConnectorMetadata metadata = catalogMetadata.getMetadata();
+
+        metadata.setMaterializedViewProperties(
+                session.toConnectorSession(connectorId),
+                toSchemaTableName(viewName.getSchemaName(), viewName.getObjectName()),
+                properties);
+    }
+
+    @Override
     public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -617,6 +617,18 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Object> properties)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.setMaterializedViewProperties(session, viewName, properties);
+        }
+        finally {
+            stats.recordSetTablePropertiesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
     public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
     {
         long startTime = System.nanoTime();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -586,6 +586,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public void setMaterializedViewProperties(Session session, QualifiedObjectName viewName, Map<String, Object> properties)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -97,6 +97,8 @@ statement
         viewSecurity?
         (WITH properties)? AS (query | '('query')')                    #createMaterializedView
     | DROP MATERIALIZED VIEW (IF EXISTS)? qualifiedName                #dropMaterializedView
+    | ALTER MATERIALIZED VIEW (IF EXISTS)? qualifiedName
+        SET PROPERTIES properties                                      #setMaterializedViewProperties
     | REFRESH MATERIALIZED VIEW qualifiedName
         (WHERE where=booleanExpression)?                               #refreshMaterializedView
     | CREATE (OR REPLACE)? TEMPORARY? FUNCTION functionName=qualifiedName

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1042,7 +1042,16 @@ public final class SqlFormatter
 
         protected Void visitSetProperties(SetProperties node, Integer context)
         {
-            builder.append("ALTER TABLE ");
+            switch (node.getType()) {
+                case TABLE:
+                    builder.append("ALTER TABLE ");
+                    break;
+                case MATERIALIZED_VIEW:
+                    builder.append("ALTER MATERIALIZED VIEW ");
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported SetProperties type: " + node.getType());
+            }
             if (node.isTableExists()) {
                 builder.append("IF EXISTS ");
             }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -232,6 +232,7 @@ import static com.facebook.presto.sql.tree.RoutineCharacteristics.Determinism.NO
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.sql.tree.SetProperties.Type.MATERIALIZED_VIEW;
 import static com.facebook.presto.sql.tree.SetProperties.Type.TABLE;
 import static com.facebook.presto.sql.tree.TableFunctionDescriptorArgument.descriptorArgument;
 import static com.facebook.presto.sql.tree.TableFunctionDescriptorArgument.nullDescriptorArgument;
@@ -580,6 +581,21 @@ class AstBuilder
         return new SetProperties(getLocation(context),
                 TABLE,
                 getQualifiedName(context.tableName),
+                properties,
+                context.EXISTS() != null);
+    }
+
+    @Override
+    public Node visitSetMaterializedViewProperties(SqlBaseParser.SetMaterializedViewPropertiesContext context)
+    {
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().property(), Property.class);
+        }
+
+        return new SetProperties(getLocation(context),
+                MATERIALIZED_VIEW,
+                getQualifiedName(context.qualifiedName()),
                 properties,
                 context.EXISTS() != null);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetProperties.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetProperties.java
@@ -27,7 +27,8 @@ public class SetProperties
 {
     public enum Type
     {
-        TABLE
+        TABLE,
+        MATERIALIZED_VIEW,
     }
 
     private final Type type;

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1897,6 +1897,11 @@ public class TestSqlParser
         assertInvalidStatement("ALTER TABLE a SET PROPERTIES ()", "mismatched input '\\)'. Expecting: <identifier>");
         assertStatement("ALTER TABLE IF EXISTS b SET PROPERTIES (foo=12345)", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("b"), ImmutableList.of(new Property(new Identifier("foo"), new LongLiteral("12345"))), true));
         assertInvalidStatement("ALTER TABLE IF EXISTS b SET PROPERTIES ()", "mismatched input '\\)'. Expecting: <identifier>");
+
+        assertStatement("ALTER MATERIALIZED VIEW a SET PROPERTIES (staleness_window='1h')", new SetProperties(SetProperties.Type.MATERIALIZED_VIEW, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("staleness_window"), new StringLiteral("1h"))), false));
+        assertStatement("ALTER MATERIALIZED VIEW a SET PROPERTIES (staleness_window='1h', refresh_type='FULL')", new SetProperties(SetProperties.Type.MATERIALIZED_VIEW, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("staleness_window"), new StringLiteral("1h")), new Property(new Identifier("refresh_type"), new StringLiteral("FULL"))), false));
+        assertStatement("ALTER MATERIALIZED VIEW IF EXISTS b SET PROPERTIES (max_snapshots_per_refresh=5)", new SetProperties(SetProperties.Type.MATERIALIZED_VIEW, QualifiedName.of("b"), ImmutableList.of(new Property(new Identifier("max_snapshots_per_refresh"), new LongLiteral("5"))), true));
+        assertInvalidStatement("ALTER MATERIALIZED VIEW a SET PROPERTIES ()", "mismatched input '\\)'. Expecting: <identifier>");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -792,6 +792,14 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Set properties on the specified materialized view.
+     */
+    default void setMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, Map<String, Object> properties)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support setting materialized view properties");
+    }
+
+    /**
      * Get the materialized view status to inform the engine how much data has been materialized in the view
      *
      * @param baseQueryDomain The domain from which to consider missing partitions. For example, a query that

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -605,6 +605,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void setMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, Map<String, Object> properties)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.setMaterializedViewProperties(session, viewName, properties);
+        }
+    }
+
+    @Override
     public MaterializedViewStatus getMaterializedViewStatus(ConnectorSession session, SchemaTableName materializedViewName, TupleDomain<String> baseQueryDomain)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description

Adds a new SQL statement, `ALTER MATERIALIZED VIEW <name> SET PROPERTIES (...)`, and implements it for the Iceberg connector. Lets users update `stale_read_behavior`, `staleness_window`, and `refresh_type` on existing Iceberg materialized views. `storage_schema` and `storage_table` remain creation-only since they identify the physical storage table. `NULL` values are rejected (no clearing).

The statement is gated at the engine on `legacy_materialized_views=false`; legacy mode is rejected before any connector dispatch, preserving prior behavior.

## Motivation and Context

Today an Iceberg materialized view's freshness/refresh policy is fixed at creation. Changing it requires dropping and recreating the MV — which also drops the storage table and any cached data. This PR makes those policy properties tunable in place.

## Impact

New SQL surface: `ALTER MATERIALIZED VIEW name SET PROPERTIES (...)`.

Connector SPI gains `ConnectorMetadata.setMaterializedViewProperties(ConnectorSession, SchemaTableName, Map<String, Object>)` with a default that throws `NOT_SUPPORTED`. Existing connectors are unaffected.

Plumbing mirrors `ALTER TABLE ... SET PROPERTIES`: `SetProperties.Type` gains `MATERIALIZED_VIEW`, and the engine `Metadata` facade / `MetadataManager` / its wrappers expose the new method. Access control reuses `checkCanSetTableProperties` against the MV name.

## Test Plan

- `TestSqlParser#testSetProperties` covers parsing of the new statement (positive and `IF EXISTS` cases).
- `TestIcebergMaterializedViewMetadata` adds four integration tests: golden-path update, rejection of `storage_schema`/`storage_table`, legacy-mode rejection, and missing-MV behavior with/without `IF EXISTS`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add ``ALTER MATERIALIZED VIEW <name> SET PROPERTIES (...)`` SQL statement to update materialized view properties after creation. :pr:`27806`

Iceberg Changes
* Allow updating ``stale_read_behavior``, ``staleness_window``, and ``refresh_type`` on existing materialized views via ``ALTER MATERIALIZED VIEW ... SET PROPERTIES`` (requires ``legacy_materialized_views=false``). :pr:`27806`
```

## Summary by Sourcery

Introduce ALTER MATERIALIZED VIEW ... SET PROPERTIES support and plumb materialized view property updates through the engine and Iceberg connector.

New Features:
- Add SQL support for ALTER MATERIALIZED VIEW ... SET PROPERTIES, including IF EXISTS and formatter output.
- Allow Iceberg materialized views to update staleness and refresh policy properties in place via the new statement.

Enhancements:
- Extend metadata APIs and connector SPI to support setting materialized view properties with access control and stats recording.
- Refine Iceberg materialized view property handling to distinguish creation-only and updatable properties and centralize serialization for storage.

Tests:
- Add parser tests for ALTER MATERIALIZED VIEW ... SET PROPERTIES syntax and validation.
- Add Iceberg integration tests covering property updates, rejection of storage properties, legacy mode behavior, and missing-view handling.