### PR TITLE
fix(native): Possible segv in system data source creation

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
@@ -113,7 +113,7 @@ SystemDataSource::SystemDataSource(
         handle,
         "ColumnHandle must be an instance of SystemColumnHandle "
         "for '{}' on table '{}'",
-        handle->name(),
+        it->second->name(),
         systemTableHandle->tableName());
 
     auto columnIndex = taskSchema->getChildIdxIfExists(handle->name());


### PR DESCRIPTION
If the handle is null it is accessed to provide data to print the error message. This results in invalid memory access and a possible segv.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Prevent possible segmentation fault by avoiding access to a potentially null column handle when formatting validation error messages in the system connector.

## Summary by Sourcery

Bug Fixes:
- Avoid potential segmentation fault by using the validated column handle from the map instead of the possibly null handle when formatting error messages in system data source creation.