### PR TITLE
feat: Add property to disable JDBC view analysis

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -57,6 +57,7 @@ public class BaseJdbcConfig
     private boolean caseSensitiveNameMatchingEnabled;
     @Min(1)
     private int fetchSize = 20000;
+    private boolean prestoManagedViewsEnabled = true;
 
     @NotNull
     public String getConnectionUrl()
@@ -205,6 +206,22 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setFetchSize(int fetchSize)
     {
         this.fetchSize = fetchSize;
+        return this;
+    }
+
+    public boolean isPrestoManagedViewsEnabled()
+    {
+        return prestoManagedViewsEnabled;
+    }
+
+    @Config("jdbc.presto-view-analysis-enabled")
+    @ConfigDescription("Enable Presto-managed handling for connector views. " +
+            "When enabled, Presto analyzes and processes underlying view SQL. " +
+            "When disabled, connector views are treated as datasource-managed " +
+            "and executed directly by the remote datasource without Presto view analysis.")
+    public BaseJdbcConfig setPrestoManagedViewsEnabled(boolean prestoManagedViewsEnabled)
+    {
+        this.prestoManagedViewsEnabled = prestoManagedViewsEnabled;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -22,14 +22,17 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nullable;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -104,4 +107,13 @@ public interface JdbcClient
     TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, List<JdbcColumnHandle> columnHandles, TupleDomain<ColumnHandle> tupleDomain);
 
     String normalizeIdentifier(ConnectorSession session, String identifier);
+
+    /**
+     * Returns view definitions for the specified views.
+     * Connectors that support views should override this method.
+     */
+    default Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> tableNames)
+    {
+        return ImmutableMap.of();
+    }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorTableLayout;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
@@ -55,14 +56,16 @@ public class JdbcMetadata
     private final JdbcMetadataCache jdbcMetadataCache;
     private final JdbcClient jdbcClient;
     private final boolean allowDropTable;
+    private final boolean prestoManagedViewsEnabled;
     private final String url;
     private final AtomicReference<Runnable> rollbackAction = new AtomicReference<>();
 
-    public JdbcMetadata(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, boolean allowDropTable, TableLocationProvider tableLocationProvider)
+    public JdbcMetadata(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, boolean allowDropTable, TableLocationProvider tableLocationProvider, boolean prestoManagedViewsEnabled)
     {
         this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
         this.jdbcClient = requireNonNull(jdbcClient, "client is null");
         this.allowDropTable = allowDropTable;
+        this.prestoManagedViewsEnabled = prestoManagedViewsEnabled;
         this.url = requireNonNull(tableLocationProvider, "tableLocationProvider is null").getTableLocation();
     }
 
@@ -283,5 +286,23 @@ public class JdbcMetadata
     public Optional<Object> getInfo(ConnectorTableLayoutHandle tableHandle)
     {
         return Optional.of(new JdbcInputInfo(url));
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        // Skip view analysis, resolve via normal table flow.
+        if (!prestoManagedViewsEnabled) {
+            return ImmutableMap.of();
+        }
+
+        List<SchemaTableName> tableNames;
+        if (prefix.getTableName() != null) {
+            tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else {
+            tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
+        }
+        return jdbcClient.getViews(session, tableNames);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
@@ -22,20 +22,22 @@ public class JdbcMetadataFactory
     private final JdbcMetadataCache jdbcMetadataCache;
     private final JdbcClient jdbcClient;
     private final boolean allowDropTable;
+    private final boolean prestoManagedViewsEnabled;
     private final TableLocationProvider tableLocationProvider;
 
     @Inject
-    public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config, TableLocationProvider tableLocationProvider)
+    public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config, BaseJdbcConfig baseJdbcConfig, TableLocationProvider tableLocationProvider)
     {
         this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         requireNonNull(config, "config is null");
         this.allowDropTable = config.isAllowDropTable();
+        this.prestoManagedViewsEnabled = baseJdbcConfig.isPrestoManagedViewsEnabled();
         this.tableLocationProvider = requireNonNull(tableLocationProvider, "tableLocationProvider is null");
     }
 
     public JdbcMetadata create()
     {
-        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable, tableLocationProvider);
+        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable, tableLocationProvider, prestoManagedViewsEnabled);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 public class TestBaseJdbcConfig
@@ -41,7 +43,8 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setlistSchemasIgnoredSchemas("information_schema")
                 .setCaseSensitiveNameMatching(false)
-                .setFetchSize(20000));
+                .setFetchSize(20000)
+                .setPrestoManagedViewsEnabled(true));
     }
 
     @Test
@@ -58,6 +61,7 @@ public class TestBaseJdbcConfig
                 .put("list-schemas-ignored-schemas", "test,test2")
                 .put("case-sensitive-name-matching", "true")
                 .put("jdbc-fetch-size", "5000")
+                .put("enable-presto-managed-views", "false")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
@@ -70,7 +74,8 @@ public class TestBaseJdbcConfig
                 .setlistSchemasIgnoredSchemas("test,test2")
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
                 .setCaseSensitiveNameMatching(true)
-                .setFetchSize(5000);
+                .setFetchSize(5000)
+                .setPrestoManagedViewsEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }
@@ -137,6 +142,22 @@ public class TestBaseJdbcConfig
         config.setCaseSensitiveNameMatching(true);
 
         // Should not throw any exception
+        config.validateConfig();
+    }
+
+    @Test
+    public void testPrestoManagedViewProperty()
+    {
+        BaseJdbcConfig config = new BaseJdbcConfig();
+        config.setConnectionUrl("jdbc:mysql://localhost:3306/test");
+        assertTrue(config.isPrestoManagedViewsEnabled());
+
+        config.setPrestoManagedViewsEnabled(false);
+        assertFalse(config.isPrestoManagedViewsEnabled());
+
+        config.setPrestoManagedViewsEnabled(true);
+        assertTrue(config.isPrestoManagedViewsEnabled());
+
         config.validateConfig();
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.plugin.jdbc;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
@@ -71,7 +72,7 @@ public class TestJdbcMetadata
         BaseJdbcConfig baseConfig = new BaseJdbcConfig();
         baseConfig.setConnectionUrl("jdbc:h2:mem:test");
 
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(baseConfig));
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(baseConfig), true);
         tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
     }
 
@@ -269,7 +270,7 @@ public class TestJdbcMetadata
         // Create BaseJdbcConfig with connection URL for drop table test
         BaseJdbcConfig dropConfig = new BaseJdbcConfig();
         dropConfig.setConnectionUrl("jdbc:h2:mem:test");
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), true, new DefaultTableLocationProvider(dropConfig));
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), true, new DefaultTableLocationProvider(dropConfig), true);
         metadata.dropTable(SESSION, tableHandle);
 
         try {
@@ -295,7 +296,7 @@ public class TestJdbcMetadata
         };
 
         // Create JdbcMetadata with the custom provider
-        JdbcMetadata customMetadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, customProvider);
+        JdbcMetadata customMetadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, customProvider, true);
 
         // Verify that the metadata can be created and basic operations work
         JdbcTableHandle customTableHandle = customMetadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
@@ -321,5 +322,52 @@ public class TestJdbcMetadata
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
+    }
+
+    @Test
+    public void testGetViewsWithPrestoManagedViewFalse()
+    {
+        // Create metadata with prestoManagedViewsEnabled=false
+        BaseJdbcConfig config = new BaseJdbcConfig();
+        config.setConnectionUrl("jdbc:h2:mem:test");
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(config), false);
+
+        // When prestoManagedViewsEnabled=false, getViews should delegate to jdbcMetadata.getViews() and returns empty result
+        Map<SchemaTableName, ConnectorViewDefinition> views = metadata.getViews(SESSION, new SchemaTablePrefix("example"));
+        assertEquals(views, ImmutableMap.of());
+
+        // Verify with specific table prefix
+        Map<SchemaTableName, ConnectorViewDefinition> specificView = metadata.getViews(SESSION, new SchemaTablePrefix("example", "view"));
+        assertEquals(specificView, ImmutableMap.of());
+    }
+
+    @Test
+    public void testGetViewsWithPrestoManagedViewTrue()
+    {
+        // metadata is already created with prestoManagedViewsEnabled=true in setUp()
+        // When prestoManagedViewsEnabled=true, should delegate to jdbcClient.getViews().
+        // BaseJdbcClient returns empty by default; connectors override to return actual views
+        Map<SchemaTableName, ConnectorViewDefinition> views = metadata.getViews(SESSION, new SchemaTablePrefix("example"));
+        assertEquals(views, ImmutableMap.of());
+
+        Map<SchemaTableName, ConnectorViewDefinition> specificView = metadata.getViews(SESSION, new SchemaTablePrefix("example", "view"));
+        assertEquals(specificView, ImmutableMap.of());
+    }
+
+    @Test
+    public void testPrestoManagedViewFlagInConstructor()
+    {
+        BaseJdbcConfig config = new BaseJdbcConfig();
+        config.setConnectionUrl("jdbc:h2:mem:test");
+
+        // flag=false: views are datasource-managed, returns empty directly
+        JdbcMetadata metadataFalse = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(config), false);
+        Map<SchemaTableName, ConnectorViewDefinition> viewsFalse = metadataFalse.getViews(SESSION, new SchemaTablePrefix("example"));
+        assertEquals(viewsFalse, ImmutableMap.of());
+
+        // flag=true: delegates to jdbcClient — BaseJdbcClient returns empty by default
+        JdbcMetadata metadataTrue = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(config), true);
+        Map<SchemaTableName, ConnectorViewDefinition> viewsTrue = metadataTrue.getViews(SESSION, new SchemaTablePrefix("example"));
+        assertEquals(viewsTrue, ImmutableMap.of());
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestSimpleJdbcConnectorCompatibility.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestSimpleJdbcConnectorCompatibility.java
@@ -64,7 +64,7 @@ public class TestSimpleJdbcConnectorCompatibility
         SimpleTestTableLocationProvider locationProvider = new SimpleTestTableLocationProvider(simpleConfig);
 
         // Create JdbcMetadata with the simple provider (not using BaseJdbcConfig)
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, locationProvider);
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, locationProvider, true);
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
## Description
Adds a new configuration property ``jdbc.presto-view-analysis-enabled `` to ``BaseJdbcConfig`` and a gatekeeper in ``JdbcMetadata.getViews()`` that controls whether Presto fetches and re-analyzes view SQL from the remote database in JDBC connectors.

When a JDBC connector implements ``JdbcClient.getViews()`` to expose remote database views, Presto currently re-analyzes the raw view SQL through ``StatementAnalyzer.analyzeView()`` as if it were native Presto SQL. This fails for any view containing database-native constructs such as ``SESSION_USER``, database UDFs, or SQL dialect keywords not recognized by Presto's analyzer, even though the same views work correctly from native database clients.

This change introduces ``jdbc.presto-view-analysis-enabled `` as a single gatekeeper in ``JdbcMetadata.getViews()`` that applies uniformly to all JDBC connectors. When set to ``false``, views are surfaced as regular tables via ``getTableHandle()`` and all view resolution is delegated to the remote database. When set to ``true``, the existing Presto-managed view analysis behavior is preserved.

Changes:
- ``BaseJdbcConfig``: add ``jdbc.presto-view-analysis-enabled `` property (default: ``true``)
- ``JdbcClient``: add ``getViews(ConnectorSession, SchemaTablePrefix)`` to interface
- ``JdbcMetadata``: gatekeeper in ``getViews()`` delegates to client or returns
  empty based on flag value
- ``JdbcMetadataFactory``: to create MetadataFactory

## Motivation and Context
https://github.com/prestodb/presto/issues/27814

## Impact
New configuration property for all JDBC connectors in ``catalog.properties``:
| Property | Default | Description |
| --- | --- | --- |
| ``jdbc.presto-view-analysis-enabled `` | ``true`` | When ``true`` (default), Presto fetches view SQL from the remote database and analyzes it as Presto SQL. When ``false``, views surface as tables and view resolution is delegated to the remote database. |

## Security Impact
No security impact.

This change only affects metadata handling for JDBC views and does not modify authentication, authorization, or query execution paths.

## Test Plan
- Added unit tests for JdbcMetadata#getViews with both enabled and disabled configurations
- Verified correct delegation to JdbcClient#getViews
- Verified backward compatibility with existing JDBC behavior

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add `jdbc.presto-view-analysis-enabled ` JDBC connector configuration property (default: `true`) to control whether remote connector views are analyzed by Presto. When disabled, remote views are surfaced without Presto view analysis.
```

## Summary by Sourcery

Add a configurable gate to control whether JDBC connectors expose Presto-managed views or delegate view handling entirely to the remote database.

New Features:
- Introduce the `jdbc.presto-view-analysis-enabled ` configuration property in BaseJdbcConfig to toggle Presto-managed analysis of remote JDBC views.
- Allow JdbcClient implementations to expose view definitions via a new getViews API used by JdbcMetadata when Presto view analysis is enabled.

Enhancements:
- Wire the `jdbc.presto-view-analysis-enabled ` configuration into JdbcMetadataFactory and JdbcMetadata so metadata behavior respects the connector-level setting.
- Update JDBC metadata tests to construct JdbcMetadata with the new view analysis configuration flag.