### PR TITLE
fix(plugin-iceberg): Add warnings for stitching and refresh fallback

### DIFF
--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -289,22 +289,6 @@ In this example:
 Multiple equivalences can be chained together. If ``A.x = B.y`` and ``B.y = C.z``, then
 ``A.x``, ``B.y``, and ``C.z`` are all equivalent for predicate propagation.
 
-Unsupported Patterns
-^^^^^^^^^^^^^^^^^^^^
-
-Predicate stitching is **not** applied in the following cases:
-
-* **No staleness predicates available**: If the connector cannot provide staleness predicates
-* **Predicate columns not preserved**: If predicate columns are transformed or not mappable to the materialized view's output
-* **Outer joins with passthrough**: LEFT, RIGHT, and FULL OUTER joins invalidate passthrough equivalences due to null handling
-* **Expression-based equivalences**: ``CAST(col1 AS DATE) = col2`` or ``col1 = col2 + 1``
-
-When predicate stitching cannot be applied, the behavior falls back to the configured consistency mode:
-
-* If ``USE_STITCHING`` is set but stitching is not possible, the query falls back to full
-  recompute (equivalent to ``USE_VIEW_QUERY``)
-* A warning may be logged indicating why stitching was not possible
-
 Performance Considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -364,14 +348,27 @@ significantly reduce refresh time and resource usage for large views.
 Not all connectors support incremental refresh. See connector-specific documentation for
 availability, configuration, and requirements.
 
-Fallback Behavior
-^^^^^^^^^^^^^^^^^
+When the view is already fully materialized, refresh is a no-op (no data is written). If
+incremental refresh cannot be applied, the engine falls back to full refresh — see
+:ref:`admin/materialized-views:Unsupported Patterns` for the conditions.
 
-Incremental refresh automatically falls back to full refresh when incremental refresh
-is not possible (for example, the view uses unsupported operators like OUTER JOIN, or the
-connector cannot determine partition-level staleness).
+Unsupported Patterns
+--------------------
 
-When the view is already fully materialized, refresh is a no-op (no data is written).
+Predicate stitching (``USE_STITCHING``) and incremental refresh fall back to a full
+recompute, with a warning identifying the reason, under any of these conditions:
+
+* **No staleness predicates available**: the connector cannot provide partition-level
+  staleness for one or more stale base tables (unpartitioned tables, untracked partitions,
+  or non-append base changes such as ``DELETE``/``UPDATE`` where the connector requires
+  append-only inputs).
+* **Predicate columns not preserved**: predicate columns are transformed or not mappable
+  to the materialized view's output.
+* **Outer joins with passthrough**: ``LEFT``, ``RIGHT``, and ``FULL OUTER`` joins
+  invalidate passthrough equivalences due to null handling.
+* **Expression-based equivalences**: ``CAST(col1 AS DATE) = col2`` or ``col1 = col2 + 1``.
+* **Unsupported plan constructs**: nondeterministic expressions such as ``random()`` or
+  ``current_timestamp``, and operators like ``TopN``.
 
 See Also
 --------

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -3063,6 +3063,13 @@ Requirements:
 * Only ``INSERT`` operations on base tables enable partition-level staleness detection;
   ``DELETE`` or ``UPDATE`` operations cause a full refresh
 
+.. note::
+    If incremental refresh cannot be applied, the engine falls back to a full refresh
+    and emits a warning. ``DELETE`` or ``UPDATE`` on a base table also forces a full
+    refresh — the Iceberg connector only tracks partition-level staleness for
+    append-only changes. See :ref:`admin/materialized-views:Unsupported Patterns` for
+    the full list of engine-level conditions.
+
 .. _iceberg-bounded-refresh:
 
 Bounded Refresh
@@ -3121,9 +3128,11 @@ rather than the entire view. See :doc:`/admin/materialized-views` for details on
 predicate stitching works.
 
 .. note::
-    Partition-level staleness detection only works for append-only changes (INSERT).
-    DELETE or UPDATE operations on base tables cause the entire view to be treated
-    as stale, requiring full recomputation.
+    If stitching cannot be applied, the engine falls back to a full recompute and emits
+    a warning. ``DELETE`` or ``UPDATE`` on a base table also forces a full recompute —
+    the Iceberg connector only tracks partition-level staleness for append-only changes.
+    See :ref:`admin/materialized-views:Unsupported Patterns` for the full list of
+    engine-level conditions.
 
 Example with staleness handling:
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -3022,9 +3022,9 @@ by using :doc:`/sql/alter-materialized-view`; properties not specified in the
 
        ``max_snapshots_per_refresh``
      - Upper bound on snapshots consumed per base table per ``REFRESH MATERIALIZED
-       VIEW``. Defaults to the ``materialized_view_default_max_snapshots_per_refresh``
-       session property. Requires Iceberg V3 row lineage; V2 tables fall back to
-       unbounded refresh.
+       VIEW``. ``0`` means unbounded. Defaults to the
+       ``materialized_view_default_max_snapshots_per_refresh`` session property.
+       Requires Iceberg V3 row lineage; V2 tables fall back to unbounded refresh.
      - Yes
 
 The storage table inherits standard Iceberg table properties for partitioning, sorting, and file format.
@@ -3043,7 +3043,7 @@ See :doc:`/admin/materialized-views` for general information on refresh behavior
 .. _iceberg-incremental-refresh:
 
 Incremental Refresh
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 The Iceberg connector supports incremental refresh, which atomically replaces only stale
 partitions rather than recomputing the entire result set. See :ref:`admin/materialized-views:Incremental Refresh`
@@ -3066,7 +3066,7 @@ Requirements:
 .. _iceberg-bounded-refresh:
 
 Bounded Refresh
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Bounded refresh caps how far each base table advances per ``REFRESH MATERIALIZED VIEW``,
 splitting catch-up into a series of smaller refreshes. Each refresh advances each base's

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
@@ -163,6 +163,10 @@ public class DifferentialPlanRewriter
         Map<SchemaTableName, List<TupleDomain<String>>> filteredConstraints = filterPredicatesToMappedColumns(constraints, columnEquivalences);
         // If any base table is stale yet has no mapped predicates, stitching is not possible
         if (filteredConstraints.values().stream().anyMatch(List::isEmpty)) {
+            warningCollector.add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Cannot use differential stitching for materialized view " + node.getMaterializedViewName() +
+                            ": a stale base table has no predicates mapped to data-table columns. Falling back to full recompute."));
             return Optional.empty();
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
@@ -153,6 +153,10 @@ public class IncrementalRefreshRule
         // If no partition info available (unpartitioned tables or connector doesn't track partitions),
         // fall back to full refresh since we can't determine which partitions are stale
         if (status.getPartitionsFromBaseTables().isEmpty()) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Cannot perform incremental refresh for materialized view " + qualifiedViewName +
+                            ": no partition-level staleness available (unpartitioned base, untracked partitions, or non-append base changes). Falling back to full refresh."));
             return Result.ofPlanNode(node.getSource());
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewrite.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPre
 import static com.facebook.presto.spi.StandardErrorCode.MATERIALIZED_VIEW_STALE;
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_ACCESS_CONTROL_FALLBACK;
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STALE_DATA;
+import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STITCHING_FALLBACK;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
@@ -145,6 +146,12 @@ public class MaterializedViewRewrite
                     return Result.ofPlanNode(unionPlan.get());
                 }
             }
+        }
+        else if (shouldStitch) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Cannot stitch materialized view " + node.getMaterializedViewName() +
+                            ": no partition-level predicates available for stale base tables. Falling back to full recompute."));
         }
 
         PlanNode plan;


### PR DESCRIPTION
## Description
Emits `MATERIALIZED_VIEW_STITCHING_FALLBACK` at three planner fallback points:
- `MaterializedViewRewrite`: `USE_STITCHING` configured but no partition predicates available for stale bases
- `DifferentialPlanRewriter`: stale base has no predicates mapping to data-table columns
- `IncrementalRefreshRule`: incremental refresh cannot determine partition-level staleness

## Motivation and Context
`MATERIALIZED_VIEW_STITCHING_FALLBACK` existed in StandardWarningCode but was never emitted at these fallback sites, leaving the silent full-recompute invisible to users.

## Impact
New warning MATERIALIZED_VIEW_STITCHING_FALLBACK (0x13) on stitching/refresh fallback. No behavior change.

## Test Plan
Existing test coverage

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add warning when predicate stitching or incremental refresh falls back to full recompute.
```

## Summary by Sourcery

Add user-visible warnings when materialized view stitching or incremental refresh falls back to a full recompute due to missing partition-level predicates or staleness information.

Enhancements:
- Emit warnings when materialized view stitching is skipped because no partition-level predicates are available for stale base tables.
- Emit warnings when differential stitching cannot be used because stale base tables lack predicates mapped to data-table columns.
- Emit warnings when incremental refresh cannot proceed due to missing partition-level partition or staleness information, indicating a fallback to full refresh.