### PR TITLE
feat: Wire up IndexSource splits to Spark task sources

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTask
 import com.facebook.presto.spark.classloader_interface.SerializedTaskInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.PartitioningHandle;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -369,7 +370,7 @@ public class PrestoSparkRddFactory
     private static List<PrestoSparkSource> findTableScanNodes(PlanNode node)
     {
         return searchFrom(node)
-                .where(TableScanNode.class::isInstance)
+                .where(n -> n instanceof TableScanNode || n instanceof IndexSourceNode)
                 .findAll().stream().map(t -> new PrestoSparkSource(t.getId(), t)).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Summary:
`findTableScanNodes()` does not match `IndexSourceNode`, so index splits never reach Spark task assignments. `IndexLookupJoin` sees zero index splits and produces no matches -- inner joins return empty results, and left joins silently fill the right side with NULLs.

Fix: extend the predicate to also match `IndexSourceNode`.

## Release Notes

```
== NO RELEASE NOTE ==
```