### PR TITLE
fix(optimizer): Handle RPC functions inside TRY expressions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -24,8 +24,11 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.RPCNode;
@@ -33,6 +36,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 
@@ -232,6 +236,15 @@ public class RpcFunctionOptimizer
                         RpcExtractionContext context,
                         RowExpressionTreeRewriter<RpcExtractionContext> treeRewriter)
                 {
+                    if (node.getDisplayName().equals("$internal$try")
+                            && node.getArguments().size() == 1
+                            && isLambdaOrBindWithLambda(node.getArguments().get(0))) {
+                        RowExpression result = rewriteTryWithRpcFunction(node, context);
+                        if (result != null) {
+                            return result;
+                        }
+                    }
+
                     if (!rpcFunctionNames.contains(
                             node.getDisplayName().toLowerCase(Locale.ENGLISH))) {
                         return null;
@@ -258,10 +271,176 @@ public class RpcFunctionOptimizer
                         RowExpressionTreeRewriter<RpcExtractionContext> treeRewriter)
                 {
                     // Do not traverse into lambda bodies — RPC calls inside lambdas
-                    // have per-element semantics incompatible with RPCNode batching
+                    // have per-element semantics incompatible with RPCNode batching.
+                    // TRY lambdas are handled specially in rewriteCall above.
                     return node;
                 }
             };
+        }
+
+        private static boolean isLambdaOrBindWithLambda(RowExpression expression)
+        {
+            if (expression instanceof LambdaDefinitionExpression) {
+                return true;
+            }
+            if (expression instanceof SpecialFormExpression
+                    && ((SpecialFormExpression) expression).getForm() == SpecialFormExpression.Form.BIND) {
+                List<RowExpression> bindArgs = ((SpecialFormExpression) expression).getArguments();
+                return bindArgs.get(bindArgs.size() - 1) instanceof LambdaDefinitionExpression;
+            }
+            return false;
+        }
+
+        private RowExpression rewriteTryWithRpcFunction(
+                CallExpression tryCall,
+                RpcExtractionContext context)
+        {
+            RowExpression tryArgument = tryCall.getArguments().get(0);
+            LambdaDefinitionExpression lambda;
+            List<RowExpression> bindVariables;
+
+            if (tryArgument instanceof LambdaDefinitionExpression) {
+                lambda = (LambdaDefinitionExpression) tryArgument;
+                bindVariables = ImmutableList.of();
+            }
+            else {
+                SpecialFormExpression bind = (SpecialFormExpression) tryArgument;
+                List<RowExpression> bindArgs = bind.getArguments();
+                lambda = (LambdaDefinitionExpression) bindArgs.get(bindArgs.size() - 1);
+                bindVariables = bindArgs.subList(0, bindArgs.size() - 1);
+            }
+
+            RowExpression body = lambda.getBody();
+            if (!bindVariables.isEmpty()) {
+                List<String> lambdaParams = lambda.getArguments();
+                ImmutableMap.Builder<String, RowExpression> substitutions = ImmutableMap.builder();
+                for (int i = 0; i < lambdaParams.size(); i++) {
+                    substitutions.put(lambdaParams.get(i), bindVariables.get(i));
+                }
+                body = VariableSubstitutor.substitute(body, substitutions.build());
+            }
+
+            if (!containsRpcFunction(body)) {
+                return null;
+            }
+
+            RowExpression rewrittenBody = RowExpressionTreeRewriter.rewriteWith(
+                    createRpcRewriter(), body, context);
+
+            LambdaDefinitionExpression newLambda = new LambdaDefinitionExpression(
+                    lambda.getSourceLocation(),
+                    ImmutableList.of(),
+                    ImmutableList.of(),
+                    rewrittenBody);
+
+            return new CallExpression(
+                    tryCall.getSourceLocation(),
+                    tryCall.getDisplayName(),
+                    tryCall.getFunctionHandle(),
+                    tryCall.getType(),
+                    ImmutableList.of(newLambda));
+        }
+
+        private boolean containsRpcFunction(RowExpression expression)
+        {
+            if (expression instanceof CallExpression) {
+                CallExpression call = (CallExpression) expression;
+                if (rpcFunctionNames.contains(call.getDisplayName().toLowerCase(Locale.ENGLISH))) {
+                    return true;
+                }
+                return call.getArguments().stream().anyMatch(this::containsRpcFunction);
+            }
+            if (expression instanceof SpecialFormExpression) {
+                return ((SpecialFormExpression) expression).getArguments().stream()
+                        .anyMatch(this::containsRpcFunction);
+            }
+            return false;
+        }
+
+        private static class VariableSubstitutor
+                implements RowExpressionVisitor<RowExpression, Void>
+        {
+            private final Map<String, RowExpression> substitutions;
+
+            VariableSubstitutor(Map<String, RowExpression> substitutions)
+            {
+                this.substitutions = substitutions;
+            }
+
+            static RowExpression substitute(RowExpression expression, Map<String, RowExpression> substitutions)
+            {
+                return expression.accept(new VariableSubstitutor(substitutions), null);
+            }
+
+            @Override
+            public RowExpression visitCall(CallExpression call, Void context)
+            {
+                ImmutableList.Builder<RowExpression> newArgs = ImmutableList.builder();
+                boolean changed = false;
+                for (RowExpression arg : call.getArguments()) {
+                    RowExpression newArg = arg.accept(this, null);
+                    newArgs.add(newArg);
+                    changed |= newArg != arg;
+                }
+                return changed
+                        ? new CallExpression(call.getSourceLocation(), call.getDisplayName(), call.getFunctionHandle(), call.getType(), newArgs.build())
+                        : call;
+            }
+
+            @Override
+            public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+            {
+                return reference;
+            }
+
+            @Override
+            public RowExpression visitConstant(ConstantExpression literal, Void context)
+            {
+                return literal;
+            }
+
+            @Override
+            public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+            {
+                // Filter out substitutions that are shadowed by lambda parameters
+                Map<String, RowExpression> filtered = substitutions.entrySet().stream()
+                        .filter(e -> !lambda.getArguments().contains(e.getKey()))
+                        .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                if (filtered.isEmpty()) {
+                    return lambda;
+                }
+                RowExpression newBody = lambda.getBody().accept(new VariableSubstitutor(filtered), null);
+                if (newBody.equals(lambda.getBody())) {
+                    return lambda;
+                }
+                return new LambdaDefinitionExpression(
+                        lambda.getSourceLocation(),
+                        lambda.getArgumentTypes(),
+                        lambda.getArguments(),
+                        newBody);
+            }
+
+            @Override
+            public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+            {
+                RowExpression replacement = substitutions.get(reference.getName());
+                return replacement != null ? replacement : reference;
+            }
+
+            @Override
+            public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+            {
+                ImmutableList.Builder<RowExpression> newArgs = ImmutableList.builder();
+                boolean changed = false;
+                for (RowExpression arg : specialForm.getArguments()) {
+                    RowExpression newArg = arg.accept(this, null);
+                    newArgs.add(newArg);
+                    changed |= newArg != arg;
+                }
+                return changed
+                        ? new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), newArgs.build())
+                        : specialForm;
+            }
         }
 
         private static class RpcExtractionContext

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -14,15 +14,26 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
@@ -33,6 +44,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestRpcFunctionOptimizer
@@ -262,5 +275,319 @@ public class TestRpcFunctionOptimizer
         CallExpression rpcCall = createRpcCall(
                 varchar("{\"api_key\":\"test-key\"}"));
         assertEquals(invokeParseDispatchBatchSize(rpcCall), 128);
+    }
+
+    @Test
+    public void testTryWithRpcFunctionProducesRpcNode()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        // Build: $internal$try(BIND(input_col, (p) -> test_rpc_function(p, "model", "system", "{}")))
+        CallExpression rpcInsideLambda = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(
+                        new VariableReferenceExpression(Optional.empty(), "p", VARCHAR),
+                        varchar("model"),
+                        varchar("system"),
+                        varchar("{}")));
+
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(VARCHAR),
+                ImmutableList.of("p"),
+                rpcInsideLambda);
+
+        SpecialFormExpression bind = new SpecialFormExpression(
+                SpecialFormExpression.Form.BIND,
+                VARCHAR,
+                ImmutableList.of(inputVar, lambda));
+
+        CallExpression tryCall = new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                VARCHAR,
+                ImmutableList.of(bind));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, tryCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode,
+                session,
+                TypeProvider.empty(),
+                variableAllocator,
+                idAllocator,
+                WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized when TRY wraps an RPC function");
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
+                "Optimized plan should contain an RPCNode");
+    }
+
+    @Test
+    public void testTryWithoutRpcFunctionIsUnchanged()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        // Build: $internal$try(BIND(input_col, (p) -> concat(p, "suffix")))
+        CallExpression concatInsideLambda = createConcat(
+                new VariableReferenceExpression(Optional.empty(), "p", VARCHAR),
+                varchar("suffix"));
+
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(VARCHAR),
+                ImmutableList.of("p"),
+                concatInsideLambda);
+
+        SpecialFormExpression bind = new SpecialFormExpression(
+                SpecialFormExpression.Form.BIND,
+                VARCHAR,
+                ImmutableList.of(inputVar, lambda));
+
+        CallExpression tryCall = new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                VARCHAR,
+                ImmutableList.of(bind));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, tryCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode,
+                session,
+                TypeProvider.empty(),
+                variableAllocator,
+                idAllocator,
+                WarningCollector.NOOP);
+
+        assertFalse(result.isOptimizerTriggered(), "Plan should not be optimized when TRY does not wrap an RPC function");
+        assertFalse(containsPlanNode(result.getPlanNode(), RPCNode.class),
+                "Plan should not contain an RPCNode");
+    }
+
+    @Test
+    public void testDirectRpcFunctionStillWorks()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        // Build: test_rpc_function(input_col, "model", "system", "{}")  (no TRY wrapper)
+        CallExpression rpcCall = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(inputVar, varchar("model"), varchar("system"), varchar("{}")));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, rpcCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode,
+                session,
+                TypeProvider.empty(),
+                variableAllocator,
+                idAllocator,
+                WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for direct RPC function calls");
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
+                "Optimized plan should contain an RPCNode");
+    }
+
+    @Test
+    public void testTryWithDirectLambdaRpcFunction()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        // Build: $internal$try(() -> test_rpc_function(input_col, "model", "system", "{}"))
+        // Direct lambda argument without BIND
+        CallExpression rpcInsideLambda = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(inputVar, varchar("model"), varchar("system"), varchar("{}")));
+
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                rpcInsideLambda);
+
+        CallExpression tryCall = new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                VARCHAR,
+                ImmutableList.of(lambda));
+
+        PlanOptimizerResult result = optimizeWithTryCall(idAllocator, variableAllocator, inputVar, outputVar, tryCall);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for TRY with direct lambda");
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
+                "Optimized plan should contain an RPCNode");
+    }
+
+    @Test
+    public void testTryWithMultipleBoundVariables()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar1 = variableAllocator.newVariable("input_col1", VARCHAR);
+        VariableReferenceExpression inputVar2 = variableAllocator.newVariable("input_col2", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        // Build: $internal$try(BIND(input_col1, input_col2, (a, b) -> test_rpc_function(a, b, "system", "{}")))
+        CallExpression rpcInsideLambda = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(
+                        new VariableReferenceExpression(Optional.empty(), "a", VARCHAR),
+                        new VariableReferenceExpression(Optional.empty(), "b", VARCHAR),
+                        varchar("system"),
+                        varchar("{}")));
+
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(VARCHAR, VARCHAR),
+                ImmutableList.of("a", "b"),
+                rpcInsideLambda);
+
+        SpecialFormExpression bind = new SpecialFormExpression(
+                SpecialFormExpression.Form.BIND,
+                VARCHAR,
+                ImmutableList.of(inputVar1, inputVar2, lambda));
+
+        CallExpression tryCall = new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                VARCHAR,
+                ImmutableList.of(bind));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar1, inputVar2),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, tryCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for multi-param TRY");
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
+                "Optimized plan should contain an RPCNode");
+    }
+
+    private PlanOptimizerResult optimizeWithTryCall(
+            PlanNodeIdAllocator idAllocator,
+            VariableAllocator variableAllocator,
+            VariableReferenceExpression inputVar,
+            VariableReferenceExpression outputVar,
+            CallExpression tryCall)
+    {
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, tryCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        return optimizer.optimize(
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+    }
+
+    private static boolean containsPlanNode(PlanNode node, Class<? extends PlanNode> targetClass)
+    {
+        if (targetClass.isInstance(node)) {
+            return true;
+        }
+        return node.getSources().stream().anyMatch(source -> containsPlanNode(source, targetClass));
     }
 }


### PR DESCRIPTION
## Description

`TRY(rpc_func(...))` in SQL is lowered to `$internal$try(BIND(vars, lambda))`,
wrapping the RPC function inside a lambda. The `RpcFunctionOptimizer` skips
lambda bodies to avoid breaking per-element semantics in `transform()`/`filter()`
lambdas, so RPC functions inside TRY were never rewritten to use `RPCNode`.
This caused a `VeloxRuntimeError` at runtime because the stub function was
called directly instead of being dispatched through the RPC batching layer.

This change adds special handling for the `$internal$try(BIND(..., lambda))`
pattern in the optimizer:
1. Detects the `$internal$try` pattern in `rewriteCall`
2. Unwraps the BIND+lambda structure
3. Substitutes lambda parameters with the bound variables so the body uses
   plan-level variables
4. Rewrites the substituted body to extract RPC functions into `RPCNode`

Follows the same pattern as `PlanRemoteProjections.processInternalTry` which
solves the identical problem for remote function planning.

## Motivation and Context

When users write `TRY(rpc_function(...))` to gracefully handle RPC failures,
the query fails with a `VeloxRuntimeError` because the RPC function is never
extracted into an `RPCNode`. The optimizer's lambda-skipping logic, which is
correct for `transform()`/`filter()` lambdas, inadvertently blocks rewriting
of TRY-wrapped RPC calls.

## Impact

Queries using `TRY(rpc_function(...))` that previously failed at runtime will
now execute correctly. No public API changes. No performance impact on queries
that don't use TRY with RPC functions.

## Test Plan

Added unit tests in `TestRpcFunctionOptimizer`:
- `testTryWithRpcFunctionProducesRpcNode` — TRY(BIND(var, lambda)) with RPC function produces RPCNode
- `testTryWithoutRpcFunctionIsUnchanged` — TRY with non-RPC function is not modified
- `testDirectRpcFunctionStillWorks` — regression test for direct RPC calls (no TRY)
- `testTryWithDirectLambdaRpcFunction` — TRY with direct lambda (no BIND)
- `testTryWithMultipleBoundVariables` — TRY with multiple BIND variables

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```