### PR TITLE
feat(optimizer): Replace timeout with scan limiting for predictable prefilter performance

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -82,10 +82,12 @@ import static java.lang.Boolean.TRUE;
  * Rewritten:
  * <p>
  * SELECT SUM(x) , userid FROM Table
- * CROSS JOIN (SELECT MAP_AGG(hash(userid)) m FROM (SELECT DISTINCT userid FROM Table LIMIT 1000)))
+ * CROSS JOIN (SELECT MAP_AGG(hash(userid)) m FROM (SELECT DISTINCT userid FROM (SELECT * FROM Table LIMIT 1000000) LIMIT 1000))
  * WHERE IF(CARDINALITY(m)=1000, m[hash(userid)], TRUE)
  * <p>
- * In addition we also add a timeout to the distinctlimit we add so that we don't get stuck trying to find the keys
+ * To avoid scanning excessive data when the distinct keys are sparse, we first limit the scan to
+ * 1000 * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000), then apply DISTINCT LIMIT on that subset.
+ * This provides predictable performance without timeout complexity.
  */
 
 public class PrefilterForLimitingAggregation
@@ -243,23 +245,35 @@ public class PrefilterForLimitingAggregation
 
             PlanNode originalSource = aggregationNode.getSource();
             PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, distinctKeys, new HashMap<>());
-            // TODO(kaikalur): See if timetout can be done in a cleaner way in the middle tier
-            DistinctLimitNode timedDistinctLimitNode = new DistinctLimitNode(
+
+            // Limit the scan to avoid excessive data when distinct keys are sparse.
+            // We scan at most 1000 * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000),
+            // then apply DISTINCT LIMIT on that subset. This provides predictable
+            // performance without timeout complexity.
+            long scanLimit = 1000 * count;
+            PlanNode limitedKeySource = new LimitNode(
                     Optional.empty(),
                     idAllocator.getNextId(),
                     keySource,
+                    scanLimit,
+                    LimitNode.Step.PARTIAL);
+
+            DistinctLimitNode distinctLimitNode = new DistinctLimitNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    limitedKeySource,
                     count,
                     false,
                     distinctKeys,
                     Optional.empty(),
-                    SystemSessionProperties.getPrefilterForGroupbyLimitTimeoutMS(session));
+                    0);
 
             FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
             RowExpression leftHashExpression = getVariableHash(distinctKeys, functionAndTypeManager);
-            RowExpression rightHashExpression = getVariableHash(timedDistinctLimitNode.getOutputVariables(), functionAndTypeManager);
+            RowExpression rightHashExpression = getVariableHash(distinctLimitNode.getOutputVariables(), functionAndTypeManager);
 
             Type mapType = createMapType(functionAndTypeManager, BIGINT, BOOLEAN);
-            PlanNode rightProjectNode = projectExpressions(timedDistinctLimitNode, idAllocator, variableAllocator, ImmutableList.of(rightHashExpression, constant(TRUE, BOOLEAN)), ImmutableList.of());
+            PlanNode rightProjectNode = projectExpressions(distinctLimitNode, idAllocator, variableAllocator, ImmutableList.of(rightHashExpression, constant(TRUE, BOOLEAN)), ImmutableList.of());
 
             VariableReferenceExpression mapAggVariable = variableAllocator.newVariable("expr", mapType);
             PlanNode crossJoinRhs = addAggregation(rightProjectNode, functionAndTypeManager, idAllocator, variableAllocator, "MAP_AGG", mapType, ImmutableList.of(), mapAggVariable, rightProjectNode.getOutputVariables().get(0), rightProjectNode.getOutputVariables().get(1));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -255,15 +255,8 @@ public class PrefilterForLimitingAggregation
             // We scan at most SCAN_LIMIT_MULTIPLIER * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000),
             // then apply DISTINCT LIMIT on that subset. This provides predictable
             // performance without timeout complexity.
-            // Use Math.multiplyExact to guard against overflow for extremely large LIMIT values.
-            long scanLimit;
-            try {
-                scanLimit = Math.multiplyExact(SCAN_LIMIT_MULTIPLIER, count);
-            }
-            catch (ArithmeticException e) {
-                // Overflow occurred, use a reasonable upper bound
-                scanLimit = Long.MAX_VALUE;
-            }
+            // Note: count is already validated to be <= 1000, so overflow is not possible.
+            long scanLimit = SCAN_LIMIT_MULTIPLIER * count;
             PlanNode limitedKeySource = new LimitNode(
                     Optional.empty(),
                     idAllocator.getNextId(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -93,6 +93,11 @@ import static java.lang.Boolean.TRUE;
 public class PrefilterForLimitingAggregation
         implements PlanOptimizer
 {
+    // Multiplier for scan limit: we scan at most SCAN_LIMIT_MULTIPLIER * LIMIT rows
+    // to find distinct keys. This provides predictable performance while ensuring
+    // we scan enough data to likely find the required distinct values.
+    private static final long SCAN_LIMIT_MULTIPLIER = 1000L;
+
     private final Metadata metadata;
     private final StatsCalculator statsCalculator;
     private boolean isEnabledForTesting;
@@ -247,10 +252,18 @@ public class PrefilterForLimitingAggregation
             PlanNode keySource = clonePlanNode(originalSource, session, metadata, idAllocator, distinctKeys, new HashMap<>());
 
             // Limit the scan to avoid excessive data when distinct keys are sparse.
-            // We scan at most 1000 * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000),
+            // We scan at most SCAN_LIMIT_MULTIPLIER * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000),
             // then apply DISTINCT LIMIT on that subset. This provides predictable
             // performance without timeout complexity.
-            long scanLimit = 1000 * count;
+            // Use Math.multiplyExact to guard against overflow for extremely large LIMIT values.
+            long scanLimit;
+            try {
+                scanLimit = Math.multiplyExact(SCAN_LIMIT_MULTIPLIER, count);
+            }
+            catch (ArithmeticException e) {
+                // Overflow occurred, use a reasonable upper bound
+                scanLimit = Long.MAX_VALUE;
+            }
             PlanNode limitedKeySource = new LimitNode(
                     Optional.empty(),
                     idAllocator.getNextId(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -256,6 +256,13 @@ public class PrefilterForLimitingAggregation
             // then apply DISTINCT LIMIT on that subset. This provides predictable
             // performance without timeout complexity.
             // Note: count is already validated to be <= 1000, so overflow is not possible.
+            //
+            // Correctness consideration: If the limited scan does not contain enough distinct
+            // keys to satisfy the LIMIT, the optimization gracefully degrades. The filter
+            // condition checks if we found all required entries (CARDINALITY(map) == count);
+            // if not, the filter becomes a no-op (TRUE), allowing all data to pass through.
+            // This ensures correct results even when distinct keys are very sparse, at the
+            // cost of reduced optimization benefit.
             long scanLimit = SCAN_LIMIT_MULTIPLIER * count;
             PlanNode limitedKeySource = new LimitNode(
                     Optional.empty(),


### PR DESCRIPTION
## Summary
Replaces the timeout-based DistinctLimitNode in PrefilterForLimitingAggregation with a scan-limiting approach for more predictable performance.

## Problem
The current implementation uses a timeout on DistinctLimitNode to prevent indefinite blocking when distinct keys are sparse. This approach has several drawbacks:
- Unpredictable performance (depends on timeout configuration)
- Risk of indefinite blocking if timeout is misconfigured
- Complex timeout handling in execution layer
- Difficult to tune timeout value for different workloads

## Solution
Instead of using timeouts, we now:
1. **Limit the source scan** to 1000 * LIMIT rows (e.g., 1,000,000 rows for LIMIT 1000)
2. **Apply DISTINCT LIMIT** on that bounded subset

This provides predictable performance without timeout complexity.

```
== RELEASE NOTES ==
General Changes
* Improve PrefilterForLimitingAggregation to use scan limiting instead of timeouts for more predictable performance. The optimization now limits the source scan to 1000 * LIMIT rows before applying DISTINCT LIMIT.
```
