### PR TITLE
feat(plugin-iceberg): Make MV stitching and incremental refresh cost-based

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -618,6 +618,30 @@ Session properties set behavior changes for queries executed within the given se
        table property. ``0`` means unbounded. Default: ``0``
      - Yes
      - Yes
+   * - .. _iceberg-sess-materialized-view-stitching-strategy:
+
+       ``materialized_view_stitching_strategy``
+     - Controls when query-time stitching applies to partially stale materialized views.
+       Only takes effect when ``materialized_view_stale_read_behavior`` is ``USE_STITCHING``.
+
+       - ``ALWAYS`` (default): stitch whenever possible.
+       - ``NEVER``: always use the full view query.
+       - ``AUTOMATIC``: the cost-based optimizer chooses between the stitched union and
+         the full view query; falls back to row-count comparison when stats are unknown.
+     - Yes
+     - Yes
+   * - .. _iceberg-sess-materialized-view-incremental-refresh-strategy:
+
+       ``materialized_view_incremental_refresh_strategy``
+     - Controls when incremental (delta) refresh applies to materialized views with
+       ``refresh_type = 'INCREMENTAL'``.
+
+       - ``ALWAYS`` (default): use delta refresh whenever it is buildable.
+       - ``NEVER``: always perform a full refresh.
+       - ``AUTOMATIC``: the cost-based optimizer chooses between delta and full refresh;
+         falls back to row-count comparison when stats are unknown.
+     - Yes
+     - Yes
    * - .. _iceberg-sess-max-partitions-per-writer:
 
        ``max_partitions_per_writer``

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STALE_DATA;
+import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STITCHING_FALLBACK;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
@@ -5091,5 +5092,139 @@ public abstract class TestIcebergMaterializedViewsBase
             assertUpdate("DROP MATERIALIZED VIEW mv_security_test");
             assertUpdate("DROP TABLE mv_security_base");
         }
+    }
+
+    @Test
+    public void testIncrementalRefreshStrategyNeverForcesFullRefresh()
+    {
+        assertUpdate("CREATE TABLE cost_gate_never_base (id BIGINT, value BIGINT, dt VARCHAR) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        assertUpdate("INSERT INTO cost_gate_never_base VALUES " +
+                "(1, 100, '2024-01-01'), (2, 200, '2024-01-02'), (3, 300, '2024-01-03')", 3);
+
+        assertUpdate("CREATE MATERIALIZED VIEW cost_gate_never_mv " +
+                "WITH (partitioning = ARRAY['dt'], refresh_type = 'INCREMENTAL') AS " +
+                "SELECT id, value, dt FROM cost_gate_never_base");
+
+        assertRefreshAndFullyMaterialized("cost_gate_never_mv", 3);
+
+        assertUpdate("INSERT INTO cost_gate_never_base VALUES (4, 400, '2024-01-04')", 1);
+
+        Session neverSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty("materialized_view_incremental_refresh_strategy", "NEVER")
+                .build();
+
+        assertUpdate(neverSession, "REFRESH MATERIALIZED VIEW cost_gate_never_mv", 4);
+        assertQuery(
+                "SELECT freshness_state FROM information_schema.materialized_views " +
+                        "WHERE table_schema = 'test_schema' AND table_name = 'cost_gate_never_mv'",
+                "SELECT 'FULLY_MATERIALIZED'");
+        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__cost_gate_never_mv\"", "SELECT 4");
+
+        assertUpdate("DROP MATERIALIZED VIEW cost_gate_never_mv");
+        assertUpdate("DROP TABLE cost_gate_never_base");
+    }
+
+    @Test
+    public void testIncrementalRefreshStrategyAutomaticProducesCorrectResults()
+    {
+        // Cost picks one of {delta, full} via SelectLowestCostMVRewrite; either way the MV must end up correct.
+        assertUpdate("CREATE TABLE cost_gate_auto_base (id BIGINT, value BIGINT, dt VARCHAR) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        assertUpdate("INSERT INTO cost_gate_auto_base VALUES " +
+                "(1, 100, '2024-01-01'), (2, 200, '2024-01-02'), (3, 300, '2024-01-03')", 3);
+
+        assertUpdate("CREATE MATERIALIZED VIEW cost_gate_auto_mv " +
+                "WITH (partitioning = ARRAY['dt'], refresh_type = 'INCREMENTAL') AS " +
+                "SELECT id, value, dt FROM cost_gate_auto_base");
+
+        assertRefreshAndFullyMaterialized("cost_gate_auto_mv", 3);
+
+        assertUpdate("INSERT INTO cost_gate_auto_base VALUES (4, 400, '2024-01-04')", 1);
+
+        Session autoSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty("materialized_view_incremental_refresh_strategy", "AUTOMATIC")
+                .build();
+
+        MaterializedResult refreshResult = getQueryRunner().execute(autoSession, "REFRESH MATERIALIZED VIEW cost_gate_auto_mv");
+
+        assertTrue(
+                refreshResult.getWarnings().stream()
+                        .noneMatch(warning -> warning.getWarningCode().equals(MATERIALIZED_VIEW_STITCHING_FALLBACK.toWarningCode())),
+                "Expected no MATERIALIZED_VIEW_STITCHING_FALLBACK warning under AUTOMATIC; got: " + refreshResult.getWarnings());
+        assertQuery(
+                "SELECT freshness_state FROM information_schema.materialized_views " +
+                        "WHERE table_schema = 'test_schema' AND table_name = 'cost_gate_auto_mv'",
+                "SELECT 'FULLY_MATERIALIZED'");
+        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__cost_gate_auto_mv\"", "SELECT 4");
+        assertQuery("SELECT * FROM cost_gate_auto_mv ORDER BY id",
+                "VALUES (1, 100, '2024-01-01'), (2, 200, '2024-01-02'), (3, 300, '2024-01-03'), (4, 400, '2024-01-04')");
+
+        assertUpdate("DROP MATERIALIZED VIEW cost_gate_auto_mv");
+        assertUpdate("DROP TABLE cost_gate_auto_base");
+    }
+
+    @Test
+    public void testStitchingStrategyNeverProducesCorrectResults()
+    {
+        assertUpdate("CREATE TABLE cost_gate_stitch_never_base (id BIGINT, value BIGINT, dt VARCHAR) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        assertUpdate("INSERT INTO cost_gate_stitch_never_base VALUES " +
+                "(1, 100, '2024-01-01'), (2, 200, '2024-01-02')", 2);
+
+        assertUpdate("CREATE MATERIALIZED VIEW cost_gate_stitch_never_mv " +
+                "WITH (partitioning = ARRAY['dt']) AS " +
+                "SELECT id, value, dt FROM cost_gate_stitch_never_base");
+
+        assertRefreshAndFullyMaterialized("cost_gate_stitch_never_mv", 2);
+
+        assertUpdate("INSERT INTO cost_gate_stitch_never_base VALUES (3, 300, '2024-01-03')", 1);
+
+        Session stitchNeverSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty("materialized_view_stitching_strategy", "NEVER")
+                .setSystemProperty("materialized_view_stale_read_behavior", "USE_STITCHING")
+                .build();
+
+        assertQuery(
+                stitchNeverSession,
+                "SELECT id, value, dt FROM cost_gate_stitch_never_mv ORDER BY id",
+                "VALUES (1, 100, '2024-01-01'), (2, 200, '2024-01-02'), (3, 300, '2024-01-03')");
+
+        assertUpdate("DROP MATERIALIZED VIEW cost_gate_stitch_never_mv");
+        assertUpdate("DROP TABLE cost_gate_stitch_never_base");
+    }
+
+    @Test
+    public void testStitchingStrategyAutomaticProducesCorrectResults()
+    {
+        assertUpdate("CREATE TABLE cost_gate_stitch_auto_base (id BIGINT, value BIGINT, dt VARCHAR) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        assertUpdate("INSERT INTO cost_gate_stitch_auto_base VALUES " +
+                "(1, 100, '2024-01-01'), (2, 200, '2024-01-02')", 2);
+
+        assertUpdate("CREATE MATERIALIZED VIEW cost_gate_stitch_auto_mv " +
+                "WITH (partitioning = ARRAY['dt']) AS " +
+                "SELECT id, value, dt FROM cost_gate_stitch_auto_base");
+
+        assertRefreshAndFullyMaterialized("cost_gate_stitch_auto_mv", 2);
+
+        assertUpdate("INSERT INTO cost_gate_stitch_auto_base VALUES (3, 300, '2024-01-03')", 1);
+
+        Session stitchAutoSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty("materialized_view_stitching_strategy", "AUTOMATIC")
+                .setSystemProperty("materialized_view_stale_read_behavior", "USE_STITCHING")
+                .build();
+
+        MaterializedResult result = getQueryRunner().execute(
+                stitchAutoSession,
+                "SELECT id, value, dt FROM cost_gate_stitch_auto_mv ORDER BY id");
+        assertTrue(
+                result.getWarnings().stream()
+                        .noneMatch(warning -> warning.getWarningCode().equals(MATERIALIZED_VIEW_STITCHING_FALLBACK.toWarningCode())),
+                "Expected no MATERIALIZED_VIEW_STITCHING_FALLBACK warning under AUTOMATIC; got: " + result.getWarnings());
+        assertEquals(result.getMaterializedRows().size(), 3);
+
+        assertUpdate("DROP MATERIALIZED VIEW cost_gate_stitch_auto_mv");
+        assertUpdate("DROP TABLE cost_gate_stitch_auto_base");
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -54,6 +54,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.ShuffleForTableScanStrate
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
 import com.facebook.presto.sql.analyzer.FunctionsConfig;
 import com.facebook.presto.sql.planner.CompilerConfig;
+import com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewriteStrategy;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 import com.facebook.presto.tracing.TracingConfig;
 import com.google.common.base.Splitter;
@@ -272,6 +273,8 @@ public final class SystemSessionProperties
     public static final String MATERIALIZED_VIEW_STALENESS_WINDOW = "materialized_view_staleness_window";
     public static final String MATERIALIZED_VIEW_FORCE_STALE = "materialized_view_force_stale";
     public static final String MATERIALIZED_VIEW_DEFAULT_REFRESH_TYPE = "materialized_view_default_refresh_type";
+    public static final String MATERIALIZED_VIEW_STITCHING_STRATEGY = "materialized_view_stitching_strategy";
+    public static final String MATERIALIZED_VIEW_INCREMENTAL_REFRESH_STRATEGY = "materialized_view_incremental_refresh_strategy";
     public static final String AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY = "aggregation_if_to_filter_rewrite_strategy";
     public static final String JOINS_NOT_NULL_INFERENCE_STRATEGY = "joins_not_null_inference_strategy";
     public static final String RESOURCE_AWARE_SCHEDULING_STRATEGY = "resource_aware_scheduling_strategy";
@@ -1558,6 +1561,30 @@ public final class SystemSessionProperties
                         false,
                         value -> MaterializedViewRefreshType.valueOf(((String) value).toUpperCase()),
                         MaterializedViewRefreshType::name),
+                new PropertyMetadata<>(
+                        MATERIALIZED_VIEW_STITCHING_STRATEGY,
+                        format("Strategy controlling when query-time stitching of partially stale materialized views fires. Valid values: %s",
+                                Stream.of(MaterializedViewRewriteStrategy.values())
+                                        .map(MaterializedViewRewriteStrategy::name)
+                                        .collect(joining(", "))),
+                        VARCHAR,
+                        MaterializedViewRewriteStrategy.class,
+                        featuresConfig.getMaterializedViewStitchingStrategy(),
+                        false,
+                        value -> MaterializedViewRewriteStrategy.valueOf(((String) value).toUpperCase()),
+                        MaterializedViewRewriteStrategy::name),
+                new PropertyMetadata<>(
+                        MATERIALIZED_VIEW_INCREMENTAL_REFRESH_STRATEGY,
+                        format("Strategy controlling when incremental refresh of materialized views fires. Valid values: %s",
+                                Stream.of(MaterializedViewRewriteStrategy.values())
+                                        .map(MaterializedViewRewriteStrategy::name)
+                                        .collect(joining(", "))),
+                        VARCHAR,
+                        MaterializedViewRewriteStrategy.class,
+                        featuresConfig.getMaterializedViewIncrementalRefreshStrategy(),
+                        false,
+                        value -> MaterializedViewRewriteStrategy.valueOf(((String) value).toUpperCase()),
+                        MaterializedViewRewriteStrategy::name),
                 stringProperty(
                         DISTRIBUTED_TRACING_MODE,
                         "Mode for distributed tracing. NO_TRACE, ALWAYS_TRACE, or SAMPLE_BASED",
@@ -3311,6 +3338,16 @@ public final class SystemSessionProperties
     public static MaterializedViewRefreshType getMaterializedViewDefaultRefreshType(Session session)
     {
         return session.getSystemProperty(MATERIALIZED_VIEW_DEFAULT_REFRESH_TYPE, MaterializedViewRefreshType.class);
+    }
+
+    public static MaterializedViewRewriteStrategy getMaterializedViewStitchingStrategy(Session session)
+    {
+        return session.getSystemProperty(MATERIALIZED_VIEW_STITCHING_STRATEGY, MaterializedViewRewriteStrategy.class);
+    }
+
+    public static MaterializedViewRewriteStrategy getMaterializedViewIncrementalRefreshStrategy(Session session)
+    {
+        return session.getSystemProperty(MATERIALIZED_VIEW_INCREMENTAL_REFRESH_STRATEGY, MaterializedViewRewriteStrategy.class);
     }
 
     public static boolean isVerboseRuntimeStatsEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.security.ViewSecurity;
+import com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewriteStrategy;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -248,6 +249,8 @@ public class FeaturesConfig
     private boolean materializedViewAllowFullRefreshEnabled;
     private MaterializedViewRefreshType materializedViewDefaultRefreshType = MaterializedViewRefreshType.FULL;
     private MaterializedViewStaleReadBehavior materializedViewStaleReadBehavior = MaterializedViewStaleReadBehavior.USE_VIEW_QUERY;
+    private MaterializedViewRewriteStrategy materializedViewStitchingStrategy = MaterializedViewRewriteStrategy.ALWAYS;
+    private MaterializedViewRewriteStrategy materializedViewIncrementalRefreshStrategy = MaterializedViewRewriteStrategy.ALWAYS;
 
     private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
     private String analyzerType = "BUILTIN";
@@ -2456,6 +2459,32 @@ public class FeaturesConfig
     public FeaturesConfig setMaterializedViewStaleReadBehavior(MaterializedViewStaleReadBehavior value)
     {
         this.materializedViewStaleReadBehavior = value;
+        return this;
+    }
+
+    public MaterializedViewRewriteStrategy getMaterializedViewStitchingStrategy()
+    {
+        return materializedViewStitchingStrategy;
+    }
+
+    @Config("materialized-view-stitching-strategy")
+    @ConfigDescription("Controls when query-time stitching of partially stale materialized views fires (ALWAYS, NEVER, or AUTOMATIC for cost-based)")
+    public FeaturesConfig setMaterializedViewStitchingStrategy(MaterializedViewRewriteStrategy value)
+    {
+        this.materializedViewStitchingStrategy = value;
+        return this;
+    }
+
+    public MaterializedViewRewriteStrategy getMaterializedViewIncrementalRefreshStrategy()
+    {
+        return materializedViewIncrementalRefreshStrategy;
+    }
+
+    @Config("materialized-view-incremental-refresh-strategy")
+    @ConfigDescription("Controls when incremental refresh of materialized views fires (ALWAYS, NEVER, or AUTOMATIC for cost-based)")
+    public FeaturesConfig setMaterializedViewIncrementalRefreshStrategy(MaterializedViewRewriteStrategy value)
+    {
+        this.materializedViewIncrementalRefreshStrategy = value;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SelectLowestCostMVRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SelectLowestCostMVRewrite.java
@@ -32,7 +32,10 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 
 import java.util.List;
 
+import static com.facebook.presto.SystemSessionProperties.getMaterializedViewIncrementalRefreshStrategy;
+import static com.facebook.presto.SystemSessionProperties.getMaterializedViewStitchingStrategy;
 import static com.facebook.presto.SystemSessionProperties.isMaterializedViewQueryRewriteCostBasedSelectionEnabled;
+import static com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewriteStrategy.AUTOMATIC;
 import static com.facebook.presto.sql.planner.plan.Patterns.mvRewriteCandidates;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -63,7 +66,9 @@ public class SelectLowestCostMVRewrite
     @Override
     public boolean isEnabled(Session session)
     {
-        return isMaterializedViewQueryRewriteCostBasedSelectionEnabled(session);
+        return isMaterializedViewQueryRewriteCostBasedSelectionEnabled(session)
+                || getMaterializedViewStitchingStrategy(session) == AUTOMATIC
+                || getMaterializedViewIncrementalRefreshStrategy(session) == AUTOMATIC;
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
@@ -32,6 +32,8 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.MVRewriteCandidatesNode;
+import com.facebook.presto.spi.plan.MVRewriteCandidatesNode.MVRewriteCandidate;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
@@ -57,6 +59,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getMaterializedViewDefaultRefreshType;
+import static com.facebook.presto.SystemSessionProperties.getMaterializedViewIncrementalRefreshStrategy;
 import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
@@ -150,6 +153,15 @@ public class IncrementalRefreshRule
                     Optional.empty()));
         }
 
+        MaterializedViewRewriteStrategy strategy = getMaterializedViewIncrementalRefreshStrategy(session);
+        if (strategy == MaterializedViewRewriteStrategy.NEVER) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Incremental refresh disabled for materialized view " + qualifiedViewName +
+                            " (materialized_view_incremental_refresh_strategy=NEVER); falling back to full refresh."));
+            return Result.ofPlanNode(node.getSource());
+        }
+
         // If no partition info available (unpartitioned tables or connector doesn't track partitions),
         // fall back to full refresh since we can't determine which partitions are stale
         if (status.getPartitionsFromBaseTables().isEmpty()) {
@@ -197,8 +209,25 @@ public class IncrementalRefreshRule
                     node.getSource(), incrementalRefreshPredicates, session, idAllocator, variableAllocator, metadata, context.getLookup()));
         }
 
-        return Result.ofPlanNode(applyIncrementalRefreshPredicates(
-                deltaPlan.get(), incrementalRefreshPredicates, session, idAllocator, variableAllocator, metadata, context.getLookup()));
+        PlanNode deltaWithPredicates = applyIncrementalRefreshPredicates(
+                deltaPlan.get(), incrementalRefreshPredicates, session, idAllocator, variableAllocator, metadata, context.getLookup());
+
+        if (strategy == MaterializedViewRewriteStrategy.AUTOMATIC) {
+            PlanNode fullWithPredicates = applyIncrementalRefreshPredicates(
+                    node.getSource(), incrementalRefreshPredicates, session, idAllocator, variableAllocator, metadata, context.getLookup());
+            return Result.ofPlanNode(new MVRewriteCandidatesNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    fullWithPredicates,
+                    ImmutableList.of(new MVRewriteCandidate(
+                            deltaWithPredicates,
+                            catalogName,
+                            materializedViewName.getSchemaName(),
+                            materializedViewName.getTableName())),
+                    node.getOutputVariables()));
+        }
+
+        return Result.ofPlanNode(deltaWithPredicates);
     }
 
     /**

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewrite.java
@@ -33,6 +33,8 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.MVRewriteCandidatesNode;
+import com.facebook.presto.spi.plan.MVRewriteCandidatesNode.MVRewriteCandidate;
 import com.facebook.presto.spi.plan.MaterializedViewScanNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -42,6 +44,7 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.ViewExpression;
 import com.facebook.presto.spi.security.ViewSecurity;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Map;
@@ -49,12 +52,14 @@ import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getMaterializedViewStaleReadBehavior;
 import static com.facebook.presto.SystemSessionProperties.getMaterializedViewStalenessWindow;
+import static com.facebook.presto.SystemSessionProperties.getMaterializedViewStitchingStrategy;
 import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
 import static com.facebook.presto.SystemSessionProperties.isMaterializedViewForceStale;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
 import static com.facebook.presto.spi.StandardErrorCode.MATERIALIZED_VIEW_STALE;
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_ACCESS_CONTROL_FALLBACK;
 import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STALE_DATA;
+import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STITCHING_FALLBACK;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
@@ -126,10 +131,18 @@ public class MaterializedViewRewrite
 
         boolean canUseDataTable = canUseDataTable(session, context, node, metadataResolver, definition, status, staleReadBehavior, stalenessWindow);
         boolean shouldStitch = shouldPerformStitching(status, staleReadBehavior, stalenessWindow);
+        MaterializedViewRewriteStrategy stitchingStrategy = getMaterializedViewStitchingStrategy(session);
+        boolean stitchingDisabledByStrategy = shouldStitch && stitchingStrategy == MaterializedViewRewriteStrategy.NEVER;
+        if (stitchingDisabledByStrategy) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Stitching disabled for materialized view " + node.getMaterializedViewName() +
+                            " (materialized_view_stitching_strategy=NEVER); falling back to full view query."));
+        }
         if (!status.isFullyMaterialized() && !status.getPartitionsFromBaseTables().isEmpty()) {
             Map<SchemaTableName, MaterializedDataPredicates> constraints = status.getPartitionsFromBaseTables();
 
-            if (shouldStitch && canUseDataTableWithSecurityChecks(node, metadataResolver, session, definition, context)) {
+            if (shouldStitch && !stitchingDisabledByStrategy && canUseDataTableWithSecurityChecks(node, metadataResolver, session, definition, context)) {
                 Optional<PlanNode> unionPlan = buildStitchedPlan(
                         metadata,
                         session,
@@ -142,6 +155,9 @@ public class MaterializedViewRewrite
                         context.getWarningCollector());
 
                 if (unionPlan.isPresent()) {
+                    if (stitchingStrategy == MaterializedViewRewriteStrategy.AUTOMATIC) {
+                        return Result.ofPlanNode(buildAutomaticCandidates(node, unionPlan.get(), idAllocator));
+                    }
                     return Result.ofPlanNode(unionPlan.get());
                 }
             }
@@ -158,19 +174,43 @@ public class MaterializedViewRewrite
             mappings = node.getViewQueryMappings();
         }
 
+        return Result.ofPlanNode(projectToOutputs(node, plan, mappings, idAllocator));
+    }
+
+    private PlanNode buildAutomaticCandidates(MaterializedViewScanNode node, PlanNode stitchedPlan, PlanNodeIdAllocator idAllocator)
+    {
+        PlanNode projectedViewQuery = projectToOutputs(node, node.getViewQueryPlan(), node.getViewQueryMappings(), idAllocator);
+        QualifiedObjectName mvName = node.getMaterializedViewName();
+        return new MVRewriteCandidatesNode(
+                node.getSourceLocation(),
+                idAllocator.getNextId(),
+                projectedViewQuery,
+                ImmutableList.of(new MVRewriteCandidate(
+                        stitchedPlan,
+                        mvName.getCatalogName(),
+                        mvName.getSchemaName(),
+                        mvName.getObjectName())),
+                node.getOutputVariables());
+    }
+
+    private static ProjectNode projectToOutputs(
+            MaterializedViewScanNode node,
+            PlanNode plan,
+            Map<VariableReferenceExpression, VariableReferenceExpression> mappings,
+            PlanNodeIdAllocator idAllocator)
+    {
         Assignments.Builder assignments = Assignments.builder();
         for (VariableReferenceExpression outputVariable : node.getOutputVariables()) {
             VariableReferenceExpression sourceVariable = mappings.get(outputVariable);
             requireNonNull(sourceVariable, "No mapping found for output variable: " + outputVariable);
             assignments.put(outputVariable, sourceVariable);
         }
-
-        return Result.ofPlanNode(new ProjectNode(
+        return new ProjectNode(
                 node.getSourceLocation(),
                 idAllocator.getNextId(),
                 plan,
                 assignments.build(),
-                LOCAL));
+                LOCAL);
     }
 
     private boolean canUseDataTable(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewriteStrategy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/MaterializedViewRewriteStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.materializedview;
+
+public enum MaterializedViewRewriteStrategy
+{
+    ALWAYS,
+    NEVER,
+    AUTOMATIC
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStra
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PushDownFilterThroughCrossJoinStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
+import com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewriteStrategy;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -209,6 +210,8 @@ public class TestFeaturesConfig
                 .setMaterializedViewAllowFullRefreshEnabled(false)
                 .setMaterializedViewDefaultRefreshType(MaterializedViewRefreshType.FULL)
                 .setMaterializedViewStaleReadBehavior(MaterializedViewStaleReadBehavior.USE_VIEW_QUERY)
+                .setMaterializedViewStitchingStrategy(MaterializedViewRewriteStrategy.ALWAYS)
+                .setMaterializedViewIncrementalRefreshStrategy(MaterializedViewRewriteStrategy.ALWAYS)
                 .setVerboseRuntimeStatsEnabled(false)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED)
                 .setAnalyzerType("BUILTIN")
@@ -461,6 +464,8 @@ public class TestFeaturesConfig
                 .put("materialized-view-allow-full-refresh-enabled", "true")
                 .put("materialized-view-default-refresh-type", "INCREMENTAL")
                 .put("materialized-view-stale-read-behavior", "FAIL")
+                .put("materialized-view-stitching-strategy", "AUTOMATIC")
+                .put("materialized-view-incremental-refresh-strategy", "NEVER")
                 .put("analyzer-type", "CRUX")
                 .put("pre-process-metadata-calls", "true")
                 .put("verbose-runtime-stats-enabled", "true")
@@ -709,6 +714,8 @@ public class TestFeaturesConfig
                 .setMaterializedViewAllowFullRefreshEnabled(true)
                 .setMaterializedViewDefaultRefreshType(MaterializedViewRefreshType.INCREMENTAL)
                 .setMaterializedViewStaleReadBehavior(MaterializedViewStaleReadBehavior.FAIL)
+                .setMaterializedViewStitchingStrategy(MaterializedViewRewriteStrategy.AUTOMATIC)
+                .setMaterializedViewIncrementalRefreshStrategy(MaterializedViewRewriteStrategy.NEVER)
                 .setVerboseRuntimeStatsEnabled(true)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF)
                 .setAnalyzerType("CRUX")

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSelectLowestCostMVRewrite.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSelectLowestCostMVRewrite.java
@@ -338,6 +338,135 @@ public class TestSelectLowestCostMVRewrite
         }
     }
 
+    @Test
+    public void testRuleEnabledByStitchingStrategyAutomatic()
+    {
+        try (RuleTester strategyTester = new RuleTester(ImmutableList.of(), ImmutableMap.of(
+                "materialized_view_query_rewrite_cost_based_selection_enabled", "false",
+                "materialized_view_stitching_strategy", "AUTOMATIC"), Optional.of(NODES_COUNT))) {
+            PlanNode result = strategyTester.assertThat(new SelectLowestCostMVRewrite(COST_COMPARATOR))
+                    .overrideStats("origSrc", statsEstimate(10000, 80000))
+                    .overrideStats("mv1Src", statsEstimate(100, 800))
+                    .on(p -> {
+                        VariableReferenceExpression col = p.variable("col", BIGINT);
+                        return new MVRewriteCandidatesNode(
+                                Optional.empty(),
+                                new PlanNodeId("mvnode"),
+                                p.filter(new PlanNodeId("origFilter"), TRUE_CONSTANT, p.values(new PlanNodeId("origSrc"), 1, col)),
+                                ImmutableList.of(new MVRewriteCandidate(
+                                        p.filter(new PlanNodeId("mv1Filter"), TRUE_CONSTANT, p.values(new PlanNodeId("mv1Src"), 1, col)),
+                                        "catalog", "schema", "mv1")),
+                                ImmutableList.of(col));
+                    })
+                    .get();
+            assertTrue(result instanceof FilterNode);
+            assertEquals(result.getId(), new PlanNodeId("mv1Filter"));
+        }
+    }
+
+    @Test
+    public void testRuleEnabledByIncrementalRefreshStrategyAutomatic()
+    {
+        try (RuleTester strategyTester = new RuleTester(ImmutableList.of(), ImmutableMap.of(
+                "materialized_view_query_rewrite_cost_based_selection_enabled", "false",
+                "materialized_view_incremental_refresh_strategy", "AUTOMATIC"), Optional.of(NODES_COUNT))) {
+            PlanNode result = strategyTester.assertThat(new SelectLowestCostMVRewrite(COST_COMPARATOR))
+                    .overrideStats("origSrc", statsEstimate(10000, 80000))
+                    .overrideStats("mv1Src", statsEstimate(100, 800))
+                    .on(p -> {
+                        VariableReferenceExpression col = p.variable("col", BIGINT);
+                        return new MVRewriteCandidatesNode(
+                                Optional.empty(),
+                                new PlanNodeId("mvnode"),
+                                p.filter(new PlanNodeId("origFilter"), TRUE_CONSTANT, p.values(new PlanNodeId("origSrc"), 1, col)),
+                                ImmutableList.of(new MVRewriteCandidate(
+                                        p.filter(new PlanNodeId("mv1Filter"), TRUE_CONSTANT, p.values(new PlanNodeId("mv1Src"), 1, col)),
+                                        "catalog", "schema", "mv1")),
+                                ImmutableList.of(col));
+                    })
+                    .get();
+            assertTrue(result instanceof FilterNode);
+            assertEquals(result.getId(), new PlanNodeId("mv1Filter"));
+        }
+    }
+
+    @Test
+    public void testStitchingStrategyAutomaticKeepsOriginalWhenCheaper()
+    {
+        try (RuleTester strategyTester = new RuleTester(ImmutableList.of(), ImmutableMap.of(
+                "materialized_view_query_rewrite_cost_based_selection_enabled", "false",
+                "materialized_view_stitching_strategy", "AUTOMATIC"), Optional.of(NODES_COUNT))) {
+            PlanNode result = strategyTester.assertThat(new SelectLowestCostMVRewrite(COST_COMPARATOR))
+                    .overrideStats("origSrc", statsEstimate(100, 800))
+                    .overrideStats("mv1Src", statsEstimate(10000, 80000))
+                    .on(p -> {
+                        VariableReferenceExpression col = p.variable("col", BIGINT);
+                        return new MVRewriteCandidatesNode(
+                                Optional.empty(),
+                                new PlanNodeId("mvnode"),
+                                p.filter(new PlanNodeId("origFilter"), TRUE_CONSTANT, p.values(new PlanNodeId("origSrc"), 1, col)),
+                                ImmutableList.of(new MVRewriteCandidate(
+                                        p.filter(new PlanNodeId("mv1Filter"), TRUE_CONSTANT, p.values(new PlanNodeId("mv1Src"), 1, col)),
+                                        "catalog", "schema", "mv1")),
+                                ImmutableList.of(col));
+                    })
+                    .get();
+            assertTrue(result instanceof FilterNode);
+            assertEquals(result.getId(), new PlanNodeId("origFilter"));
+        }
+    }
+
+    @Test
+    public void testIncrementalRefreshStrategyAutomaticKeepsOriginalWhenCheaper()
+    {
+        try (RuleTester strategyTester = new RuleTester(ImmutableList.of(), ImmutableMap.of(
+                "materialized_view_query_rewrite_cost_based_selection_enabled", "false",
+                "materialized_view_incremental_refresh_strategy", "AUTOMATIC"), Optional.of(NODES_COUNT))) {
+            PlanNode result = strategyTester.assertThat(new SelectLowestCostMVRewrite(COST_COMPARATOR))
+                    .overrideStats("origSrc", statsEstimate(100, 800))
+                    .overrideStats("mv1Src", statsEstimate(10000, 80000))
+                    .on(p -> {
+                        VariableReferenceExpression col = p.variable("col", BIGINT);
+                        return new MVRewriteCandidatesNode(
+                                Optional.empty(),
+                                new PlanNodeId("mvnode"),
+                                p.filter(new PlanNodeId("origFilter"), TRUE_CONSTANT, p.values(new PlanNodeId("origSrc"), 1, col)),
+                                ImmutableList.of(new MVRewriteCandidate(
+                                        p.filter(new PlanNodeId("mv1Filter"), TRUE_CONSTANT, p.values(new PlanNodeId("mv1Src"), 1, col)),
+                                        "catalog", "schema", "mv1")),
+                                ImmutableList.of(col));
+                    })
+                    .get();
+            assertTrue(result instanceof FilterNode);
+            assertEquals(result.getId(), new PlanNodeId("origFilter"));
+        }
+    }
+
+    @Test
+    public void testRuleDisabledWhenAllRelevantPropertiesOff()
+    {
+        try (RuleTester offTester = new RuleTester(ImmutableList.of(), ImmutableMap.of(
+                "materialized_view_query_rewrite_cost_based_selection_enabled", "false",
+                "materialized_view_stitching_strategy", "ALWAYS",
+                "materialized_view_incremental_refresh_strategy", "NEVER"), Optional.of(NODES_COUNT))) {
+            offTester.assertThat(new SelectLowestCostMVRewrite(COST_COMPARATOR))
+                    .overrideStats("origSrc", statsEstimate(10000, 80000))
+                    .overrideStats("mv1Src", statsEstimate(100, 800))
+                    .on(p -> {
+                        VariableReferenceExpression col = p.variable("col", BIGINT);
+                        return new MVRewriteCandidatesNode(
+                                Optional.empty(),
+                                new PlanNodeId("mvnode"),
+                                p.filter(new PlanNodeId("origFilter"), TRUE_CONSTANT, p.values(new PlanNodeId("origSrc"), 1, col)),
+                                ImmutableList.of(new MVRewriteCandidate(
+                                        p.filter(new PlanNodeId("mv1Filter"), TRUE_CONSTANT, p.values(new PlanNodeId("mv1Src"), 1, col)),
+                                        "catalog", "schema", "mv1")),
+                                ImmutableList.of(col));
+                    })
+                    .doesNotFire();
+        }
+    }
+
     private static PlanNodeStatsEstimate statsEstimate(double rowCount, double totalSize)
     {
         return PlanNodeStatsEstimate.builder()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestIncrementalRefreshRule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestIncrementalRefreshRule.java
@@ -196,6 +196,36 @@ public class TestIncrementalRefreshRule
                 .doesNotFire();
     }
 
+    @Test
+    public void testNeverStrategyFallsBackToFullRefresh()
+    {
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                tester().getMetadata(),
+                createMvDefinitionWithMappings(),
+                createStaleStatus());
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .setSystemProperty("materialized_view_incremental_refresh_strategy", "NEVER")
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
+    @Test
+    public void testAutomaticStrategyFallsBackWhenDeltaPlanCannotBeBuilt()
+    {
+        // Values-only source: buildDeltaPlanForRefresh returns empty, the rule emits the fallback warning and
+        // returns the (no-op) narrowed source. No MVRewriteCandidatesNode is emitted on this path.
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                tester().getMetadata(),
+                createMvDefinitionWithMappings(),
+                createStaleStatus());
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .setSystemProperty("materialized_view_incremental_refresh_strategy", "AUTOMATIC")
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
     private PlanNode buildRefreshPlan(PlanBuilder planBuilder)
     {
         VariableReferenceExpression idVar = planBuilder.variable("id", BIGINT);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestMaterializedViewRewrite.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestMaterializedViewRewrite.java
@@ -388,6 +388,48 @@ public class TestMaterializedViewRewrite
     }
 
     @Test
+    public void testNeverStitchingStrategyUsesViewQuery()
+    {
+        QualifiedObjectName materializedViewName = QualifiedObjectName.valueOf("catalog.schema.mv");
+
+        // Stale MV with USE_STITCHING behavior - would normally stitch
+        MaterializedViewStalenessConfig stalenessConfig = new MaterializedViewStalenessConfig(
+                MaterializedViewStaleReadBehavior.USE_STITCHING,
+                new Duration(0, TimeUnit.SECONDS));
+
+        Metadata metadata = new TestingMetadataWithStalenessConfig(
+                false,
+                stalenessConfig,
+                Optional.empty(),
+                DEFINER,
+                ImmutableMap.of(
+                        new SchemaTableName("schema", "base_table"),
+                        new MaterializedViewStatus.MaterializedDataPredicates(
+                                ImmutableList.of(TupleDomain.all()),
+                                ImmutableList.of("ds"))));
+
+        tester().assertThat(new MaterializedViewRewrite(metadata, new AllowAllAccessControl()))
+                .setSystemProperty("materialized_view_stitching_strategy", "NEVER")
+                .on(planBuilder -> {
+                    VariableReferenceExpression outputA = planBuilder.variable("a", BIGINT);
+                    VariableReferenceExpression dataTableA = planBuilder.variable("data_table_a", BIGINT);
+                    VariableReferenceExpression viewQueryA = planBuilder.variable("view_query_a", BIGINT);
+
+                    return planBuilder.materializedViewScan(
+                            materializedViewName,
+                            planBuilder.values(dataTableA),
+                            planBuilder.values(viewQueryA),
+                            ImmutableMap.of(outputA, dataTableA),
+                            ImmutableMap.of(outputA, viewQueryA),
+                            outputA);
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("view_query_a")),
+                                values("view_query_a")));
+    }
+
+    @Test
     public void testStitchingBlockedByRowFilterUsesViewQuery()
     {
         QualifiedObjectName materializedViewName = QualifiedObjectName.valueOf("catalog.schema.mv");


### PR DESCRIPTION
## Description
Replace the on/off stitching flag with a three-way strategy (`ALWAYS` / `NEVER` / `AUTOMATIC`) for both query-time MV stitching and refresh-time incremental refresh. Under `AUTOMATIC`, the rule emits an `MVRewriteCandidatesNode` holding both alternatives (stitch vs. full view query; delta vs. full refresh) and the existing `SelectLowestCostMVRewrite` pass picks the cheaper via `CostProvider`. Falls back to row-count comparison when stats are unknown.

## Motivation and Context
MV stitching and incremental refresh fired unconditionally when enabled. Stitching is the wrong choice when almost all partitions are stale or the base scan is cheap — the optimizer should decide, not a static flag.

## Impact
Two new session properties (both default `ALWAYS`, preserving existing behavior):
- `materialized_view_stitching_strategy` — controls `MaterializedViewRewrite`
- `materialized_view_incremental_refresh_strategy` — controls `IncrementalRefreshRule`

Two new config properties: `materialized-view-stitching-strategy`, `materialized-view-incremental-refresh-strategy`. Documented in the Iceberg connector session properties table.

## Test Plan
- `TestIncrementalRefreshRule`: `NEVER` fallback and `AUTOMATIC` fallback (delta plan unbuildable)
- `TestMaterializedViewRewrite`: `NEVER` strategy routes to view query instead of stale data table
- `TestSelectLowestCostMVRewrite`: rule enabled by each `AUTOMATIC` strategy; stats-seeded tests confirming both CBO directions (candidate wins / original wins) for each strategy
- `TestIcebergMaterializedViewsBase`: correctness tests for `NEVER` and `AUTOMATIC` on both stitching and incremental refresh paths

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add `materialized_view_stitching_strategy` and `materialized_view_incremental_refresh_strategy` session properties (values: `ALWAYS`, `NEVER`, `AUTOMATIC`; default: `ALWAYS`). Under `AUTOMATIC`, the optimizer selects between the rewrite and the full alternative based on cost; when stats are unavailable it falls back to row-count comparison.
```

## Summary by Sourcery

Introduce configurable, cost-based strategies for Iceberg materialized view stitching and incremental refresh, and integrate them with MV rewrite planning.

New Features:
- Add session and config properties to control materialized view stitching and incremental refresh strategies (ALWAYS, NEVER, AUTOMATIC).

Enhancements:
- Route query-time stitching and incremental refresh planning through a cost-based MV rewrite selector when strategies are set to AUTOMATIC.
- Fall back to full view queries or full refresh with warnings when stitching or incremental refresh are disabled by strategy.
- Extend SelectLowestCostMVRewrite enablement logic to trigger based on stitching and incremental refresh strategies, not just a dedicated cost-based flag.

Tests:
- Add planner and Iceberg connector tests to verify behavior of NEVER and AUTOMATIC strategies for stitching and incremental refresh, including correctness, warnings, and fallback behavior.
- Update FeaturesConfig tests to cover defaults and explicit mappings for the new strategy properties.