### PR TITLE
refactor: Add missing getter methods and fix ordering in MetadataManagerStats

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
@@ -432,6 +432,510 @@ public class MetadataManagerStats
     }
 
     @Managed
+    public long getGetCatalogNamesWithConnectorContextCalls()
+    {
+        return getCatalogNamesWithConnectorContextCalls.get();
+    }
+
+    @Managed
+    public long getIsPushdownSupportedForFilterCalls()
+    {
+        return isPushdownSupportedForFilterCalls.get();
+    }
+
+    @Managed
+    public long getCreateTableCalls()
+    {
+        return createTableCalls.get();
+    }
+
+    @Managed
+    public long getCreateTemporaryTableCalls()
+    {
+        return createTemporaryTableCalls.get();
+    }
+
+    @Managed
+    public long getDropTableCalls()
+    {
+        return dropTableCalls.get();
+    }
+
+    @Managed
+    public long getTruncateTableCalls()
+    {
+        return truncateTableCalls.get();
+    }
+
+    @Managed
+    public long getGetNewTableLayoutCalls()
+    {
+        return getNewTableLayoutCalls.get();
+    }
+
+    @Managed
+    public long getBeginCreateTableCalls()
+    {
+        return beginCreateTableCalls.get();
+    }
+
+    @Managed
+    public long getFinishCreateTableCalls()
+    {
+        return finishCreateTableCalls.get();
+    }
+
+    @Managed
+    public long getBeginCreateVectorIndexCalls()
+    {
+        return beginCreateVectorIndexCalls.get();
+    }
+
+    @Managed
+    public long getFinishCreateVectorIndexCalls()
+    {
+        return finishCreateVectorIndexCalls.get();
+    }
+
+    @Managed
+    public long getGetInsertLayoutCalls()
+    {
+        return getInsertLayoutCalls.get();
+    }
+
+    @Managed
+    public long getGetStatisticsCollectionMetadataForWriteCalls()
+    {
+        return getStatisticsCollectionMetadataForWriteCalls.get();
+    }
+
+    @Managed
+    public long getGetStatisticsCollectionMetadataCalls()
+    {
+        return getStatisticsCollectionMetadataCalls.get();
+    }
+
+    @Managed
+    public long getBeginStatisticsCollectionCalls()
+    {
+        return beginStatisticsCollectionCalls.get();
+    }
+
+    @Managed
+    public long getFinishStatisticsCollectionCalls()
+    {
+        return finishStatisticsCollectionCalls.get();
+    }
+
+    @Managed
+    public long getBeginQueryCalls()
+    {
+        return beginQueryCalls.get();
+    }
+
+    @Managed
+    public long getCleanupQueryCalls()
+    {
+        return cleanupQueryCalls.get();
+    }
+
+    @Managed
+    public long getBeginInsertCalls()
+    {
+        return beginInsertCalls.get();
+    }
+
+    @Managed
+    public long getFinishInsertCalls()
+    {
+        return finishInsertCalls.get();
+    }
+
+    @Managed
+    public long getGetDeleteRowIdColumnCalls()
+    {
+        return getDeleteRowIdColumnCalls.get();
+    }
+
+    @Managed
+    public long getGetUpdateRowIdColumnCalls()
+    {
+        return getUpdateRowIdColumnCalls.get();
+    }
+
+    @Managed
+    public long getSupportsMetadataDeleteCalls()
+    {
+        return supportsMetadataDeleteCalls.get();
+    }
+
+    @Managed
+    public long getMetadataDeleteCalls()
+    {
+        return metadataDeleteCalls.get();
+    }
+
+    @Managed
+    public long getBeginDeleteCalls()
+    {
+        return beginDeleteCalls.get();
+    }
+
+    @Managed
+    public long getFinishDeleteWithOutputCalls()
+    {
+        return finishDeleteWithOutputCalls.get();
+    }
+
+    @Managed
+    public long getBeginCallDistributedProcedureCalls()
+    {
+        return beginCallDistributedProcedureCalls.get();
+    }
+
+    @Managed
+    public long getFinishCallDistributedProcedureCalls()
+    {
+        return finishCallDistributedProcedureCalls.get();
+    }
+
+    @Managed
+    public long getBeginUpdateCalls()
+    {
+        return beginUpdateCalls.get();
+    }
+
+    @Managed
+    public long getFinishUpdateCalls()
+    {
+        return finishUpdateCalls.get();
+    }
+
+    @Managed
+    public long getGetRowChangeParadigmCalls()
+    {
+        return getRowChangeParadigmCalls.get();
+    }
+
+    @Managed
+    public long getGetMergeTargetTableRowIdColumnHandleCalls()
+    {
+        return getMergeTargetTableRowIdColumnHandleCalls.get();
+    }
+
+    @Managed
+    public long getBeginMergeCalls()
+    {
+        return beginMergeCalls.get();
+    }
+
+    @Managed
+    public long getFinishMergeCalls()
+    {
+        return finishMergeCalls.get();
+    }
+
+    @Managed
+    public long getGetCatalogHandleCalls()
+    {
+        return getCatalogHandleCalls.get();
+    }
+
+    @Managed
+    public long getGetCatalogNamesCalls()
+    {
+        return getCatalogNamesCalls.get();
+    }
+
+    @Managed
+    public long getListViewsCalls()
+    {
+        return listViewsCalls.get();
+    }
+
+    @Managed
+    public long getGetViewsCalls()
+    {
+        return getViewsCalls.get();
+    }
+
+    @Managed
+    public long getCreateViewCalls()
+    {
+        return createViewCalls.get();
+    }
+
+    @Managed
+    public long getRenameViewCalls()
+    {
+        return renameViewCalls.get();
+    }
+
+    @Managed
+    public long getDropViewCalls()
+    {
+        return dropViewCalls.get();
+    }
+
+    @Managed
+    public long getCreateMaterializedViewCalls()
+    {
+        return createMaterializedViewCalls.get();
+    }
+
+    @Managed
+    public long getDropMaterializedViewCalls()
+    {
+        return dropMaterializedViewCalls.get();
+    }
+
+    @Managed
+    public long getListMaterializedViewsCalls()
+    {
+        return listMaterializedViewsCalls.get();
+    }
+
+    @Managed
+    public long getGetMaterializedViewsCalls()
+    {
+        return getMaterializedViewsCalls.get();
+    }
+
+    @Managed
+    public long getBeginRefreshMaterializedViewCalls()
+    {
+        return beginRefreshMaterializedViewCalls.get();
+    }
+
+    @Managed
+    public long getFinishRefreshMaterializedViewCalls()
+    {
+        return finishRefreshMaterializedViewCalls.get();
+    }
+
+    @Managed
+    public long getGetReferencedMaterializedViewsCalls()
+    {
+        return getReferencedMaterializedViewsCalls.get();
+    }
+
+    @Managed
+    public long getGetMaterializedViewStatusCalls()
+    {
+        return getMaterializedViewStatusCalls.get();
+    }
+
+    @Managed
+    public long getResolveIndexCalls()
+    {
+        return resolveIndexCalls.get();
+    }
+
+    @Managed
+    public long getCreateRoleCalls()
+    {
+        return createRoleCalls.get();
+    }
+
+    @Managed
+    public long getDropRoleCalls()
+    {
+        return dropRoleCalls.get();
+    }
+
+    @Managed
+    public long getListRolesCalls()
+    {
+        return listRolesCalls.get();
+    }
+
+    @Managed
+    public long getListRoleGrantsCalls()
+    {
+        return listRoleGrantsCalls.get();
+    }
+
+    @Managed
+    public long getGrantRolesCalls()
+    {
+        return grantRolesCalls.get();
+    }
+
+    @Managed
+    public long getRevokeRolesCalls()
+    {
+        return revokeRolesCalls.get();
+    }
+
+    @Managed
+    public long getListApplicableRolesCalls()
+    {
+        return listApplicableRolesCalls.get();
+    }
+
+    @Managed
+    public long getListEnabledRolesCalls()
+    {
+        return listEnabledRolesCalls.get();
+    }
+
+    @Managed
+    public long getGrantTablePrivilegesCalls()
+    {
+        return grantTablePrivilegesCalls.get();
+    }
+
+    @Managed
+    public long getRevokeTablePrivilegesCalls()
+    {
+        return revokeTablePrivilegesCalls.get();
+    }
+
+    @Managed
+    public long getListTablePrivilegesCalls()
+    {
+        return listTablePrivilegesCalls.get();
+    }
+
+    @Managed
+    public long getCommitPageSinkAsyncCalls()
+    {
+        return commitPageSinkAsyncCalls.get();
+    }
+
+    @Managed
+    public long getGetFunctionAndTypeManagerCalls()
+    {
+        return getFunctionAndTypeManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetProcedureRegistryCalls()
+    {
+        return getProcedureRegistryCalls.get();
+    }
+
+    @Managed
+    public long getGetBlockEncodingSerdeCalls()
+    {
+        return getBlockEncodingSerdeCalls.get();
+    }
+
+    @Managed
+    public long getGetSessionPropertyManagerCalls()
+    {
+        return getSessionPropertyManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetSchemaPropertyManagerCalls()
+    {
+        return getSchemaPropertyManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetTablePropertyManagerCalls()
+    {
+        return getTablePropertyManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetColumnPropertyManagerCalls()
+    {
+        return getColumnPropertyManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetAnalyzePropertyManagerCalls()
+    {
+        return getAnalyzePropertyManagerCalls.get();
+    }
+
+    @Managed
+    public long getGetMetadataResolverCalls()
+    {
+        return getMetadataResolverCalls.get();
+    }
+
+    @Managed
+    public long getGetConnectorCapabilitiesCalls()
+    {
+        return getConnectorCapabilitiesCalls.get();
+    }
+
+    @Managed
+    public long getDropBranchCalls()
+    {
+        return dropBranchCalls.get();
+    }
+
+    @Managed
+    public long getCreateBranchCalls()
+    {
+        return createBranchCalls.get();
+    }
+
+    @Managed
+    public long getCreateTagCalls()
+    {
+        return createTagCalls.get();
+    }
+
+    @Managed
+    public long getDropTagCalls()
+    {
+        return dropTagCalls.get();
+    }
+
+    @Managed
+    public long getDropConstraintCalls()
+    {
+        return dropConstraintCalls.get();
+    }
+
+    @Managed
+    public long getAddConstraintCalls()
+    {
+        return addConstraintCalls.get();
+    }
+
+    @Managed
+    public long getSetColumnTypeCalls()
+    {
+        return setColumnTypeCalls.get();
+    }
+
+    @Managed
+    public long getRenameTableCalls()
+    {
+        return renameTableCalls.get();
+    }
+
+    @Managed
+    public long getSetTablePropertiesCalls()
+    {
+        return setTablePropertiesCalls.get();
+    }
+
+    @Managed
+    public long getAddColumnCalls()
+    {
+        return addColumnCalls.get();
+    }
+
+    @Managed
+    public long getDropColumnCalls()
+    {
+        return dropColumnCalls.get();
+    }
+
+    @Managed
+    public long getRenameColumnCalls()
+    {
+        return renameColumnCalls.get();
+    }
+
+    @Managed
     @Nested
     public TimeStat getApplyTableFunctionTime()
     {
@@ -1112,6 +1616,20 @@ public class MetadataManagerStats
 
     @Managed
     @Nested
+    public TimeStat getCreateBranchTime()
+    {
+        return createBranchTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateTagTime()
+    {
+        return createTagTime;
+    }
+
+    @Managed
+    @Nested
     public TimeStat getDropTagTime()
     {
         return dropTagTime;
@@ -1154,6 +1672,13 @@ public class MetadataManagerStats
 
     @Managed
     @Nested
+    public TimeStat getSetColumnTypeTime()
+    {
+        return setColumnTypeTime;
+    }
+
+    @Managed
+    @Nested
     public TimeStat getDropColumnTime()
     {
         return dropColumnTime;
@@ -1192,6 +1717,20 @@ public class MetadataManagerStats
     public TimeStat getGetTableStatisticsTime()
     {
         return getTableStatisticsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetCatalogNamesWithConnectorContextTime()
+    {
+        return getCatalogNamesWithConnectorContextTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getIsPushdownSupportedForFilterTime()
+    {
+        return isPushdownSupportedForFilterTime;
     }
 
     public void recordApplyTableFunctionCall(long duration)
@@ -1866,36 +2405,10 @@ public class MetadataManagerStats
         getTableStatisticsTime.add(duration, TimeUnit.NANOSECONDS);
     }
 
-    @Managed
-    public long getGetCatalogNamesWithConnectorContextCalls()
-    {
-        return getCatalogNamesWithConnectorContextCalls.get();
-    }
-
-    @Managed
-    @Nested
-    public TimeStat getGetCatalogNamesWithConnectorContextTime()
-    {
-        return getCatalogNamesWithConnectorContextTime;
-    }
-
     public void recordGetCatalogNamesWithConnectorContextCall(long duration)
     {
         getCatalogNamesWithConnectorContextCalls.incrementAndGet();
         getCatalogNamesWithConnectorContextTime.add(duration, TimeUnit.NANOSECONDS);
-    }
-
-    @Managed
-    public long getIsPushdownSupportedForFilterCalls()
-    {
-        return isPushdownSupportedForFilterCalls.get();
-    }
-
-    @Managed
-    @Nested
-    public TimeStat getIsPushdownSupportedForFilterTime()
-    {
-        return isPushdownSupportedForFilterTime;
     }
 
     public void recordIsPushdownSupportedForFilterCall(long duration)


### PR DESCRIPTION
## Description

Add missing getter methods and fix ordering in MetadataManagerStats to ensure all are exposed via JMX monitoring

## Motivation and Context

Completeness

## Impact

Metrics exposed in JMX

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Expose additional metadata operation metrics via JMX in MetadataManagerStats and align their ordering with existing statistics.

Enhancements:
- Add missing @Managed getters for numerous metadata operation counters so their values are available through JMX monitoring.
- Expose timing metrics for create branch/tag, set column type, and catalog name lookup and filter pushdown checks via @Managed @Nested accessors.
- Reorder existing JMX-exposed metrics in MetadataManagerStats to maintain a consistent, logical grouping of related statistics.