### PR TITLE
Add parametric timestamp phase 1

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
@@ -40,6 +40,7 @@ public final class BlockEncodingManager
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
@@ -146,6 +146,12 @@ public class Fixed12ArrayBlock
         return getEpochMicros(position + positionOffset);
     }
 
+    @Override
+    public long getLong(int position)
+    {
+        return getLong(position, 0);
+    }
+
     // Returns picosOfMicro at position.
     @Override
     public int getInt(int position)
@@ -270,6 +276,12 @@ public class Fixed12ArrayBlock
         assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
         assert offset == 0 : "offset must be 0";
         return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        return getLongUnchecked(internalPosition, 0);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
+import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
+import static com.facebook.presto.common.array.Arrays.ensureCapacity;
+import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+
+// 12-byte fixed-width block for high-precision timestamps (p > 6).
+// Each position stores 3 consecutive ints: [high32(epochMicros), low32(epochMicros), picosOfMicro].
+// getLong(position, 0) returns epochMicros; getInt(position) returns picosOfMicro.
+public class Fixed12ArrayBlock
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlock.class).instanceSize();
+    public static final int FIXED12_BYTES = Integer.BYTES * 3;
+    public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
+
+    private static final int INTS_PER_POSITION = 3;
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long retainedSizeInBytes;
+
+    public Fixed12ArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values);
+    }
+
+    Fixed12ArrayBlock(int positionOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - (positionOffset * INTS_PER_POSITION) < positionCount * INTS_PER_POSITION) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    // Returns epochMicros at position; offset must be 0.
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position + positionOffset);
+    }
+
+    // Returns picosOfMicro at position.
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return getPicosOfMicro(position + positionOffset);
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && isNullUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        blockBuilder.writeLong(getEpochMicros(internalPosition))
+                .writeInt(getPicosOfMicro(internalPosition))
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            int internalPosition = position + positionOffset;
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(internalPosition));
+            output.writeInt(getPicosOfMicro(internalPosition));
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                new int[] {
+                        values[internalPosition * INTS_PER_POSITION],
+                        values[internalPosition * INTS_PER_POSITION + 1],
+                        values[internalPosition * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            int internalPosition = position + positionOffset;
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[internalPosition];
+            }
+            newValues[i * INTS_PER_POSITION] = values[internalPosition * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[internalPosition * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[internalPosition * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+        return new Fixed12ArrayBlock(positionOffset + this.positionOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlock(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getPicosOfMicro(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return positionOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public Block appendNull()
+    {
+        boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
+        int[] newValues = ensureCapacity(values, (positionOffset + positionCount + 1) * INTS_PER_POSITION, SMALL, PRESERVE);
+        return new Fixed12ArrayBlock(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Fixed12ArrayBlock other = (Fixed12ArrayBlock) obj;
+        return this.positionOffset == other.positionOffset &&
+                this.positionCount == other.positionCount &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                this.retainedSizeInBytes == other.retainedSizeInBytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset, positionCount, Arrays.hashCode(valueIsNull), Arrays.hashCode(values), retainedSizeInBytes);
+    }
+
+    // Reconstruct epochMicros from two ints at internalPosition.
+    // & 0xFFFFFFFFL prevents sign extension of the low 32-bit word.
+    private long getEpochMicros(int internalPosition)
+    {
+        int base = internalPosition * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private int getPicosOfMicro(int internalPosition)
+    {
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.Fixed12ArrayBlock.FIXED12_BYTES;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+// Builder for Fixed12ArrayBlock.
+//
+// Write protocol — each non-null entry must follow this exact sequence:
+//   writeLong(epochMicros)   — stores the 8-byte epoch-microseconds component
+//   writeInt(picosOfMicro)   — stores the 4-byte sub-microsecond remainder [0, 999_999]
+//   closeEntry()             — commits the position; no heap allocation in the hot path
+//
+// Null entries are written with appendNull() alone — no prior writeLong/writeInt call.
+// Violating either ordering rule throws IllegalStateException immediately.
+public class Fixed12ArrayBlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlockBuilder.class).instanceSize();
+    private static final Block NULL_VALUE_BLOCK = new Fixed12ArrayBlock(0, 1, new boolean[] {true}, new int[3]);
+
+    private static final int INTS_PER_POSITION = 3;
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+
+    private boolean[] valueIsNull = new boolean[0];
+    private int[] values = new int[0];
+
+    private long retainedSizeInBytes;
+
+    // Tracks which part of the current entry has been written: 0 = none, 1 = writeLong done, 2 = writeInt done.
+    private int entryFieldCount;
+
+    public Fixed12ArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        updateDataSize();
+    }
+
+    // Writes epochMicros as two ints (high32, low32). Must be followed by writeInt(picosOfMicro).
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("writeLong must be the first write for each entry");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        int base = positionCount * INTS_PER_POSITION;
+        values[base] = (int) (value >>> 32);
+        values[base + 1] = (int) value;
+        entryFieldCount = 1;
+        hasNonNullValue = true;
+        return this;
+    }
+
+    // Writes picosOfMicro. Must follow writeLong(epochMicros).
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        if (entryFieldCount != 1) {
+            throw new IllegalStateException("writeInt must follow writeLong for each entry");
+        }
+        values[positionCount * INTS_PER_POSITION + 2] = value;
+        entryFieldCount = 2;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (entryFieldCount != 2) {
+            throw new IllegalStateException(
+                    "Each entry requires writeLong(epochMicros) then writeInt(picosOfMicro) before closeEntry()");
+        }
+        positionCount++;
+        entryFieldCount = 0;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        valueIsNull[positionCount] = true;
+        hasNullValue = true;
+        positionCount++;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
+        return new Fixed12ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * INTS_PER_POSITION);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return values[position * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        blockBuilder.writeLong(getEpochMicros(position))
+                .writeInt(values[position * INTS_PER_POSITION + 2])
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(position));
+            output.writeInt(values[position * INTS_PER_POSITION + 2]);
+        }
+    }
+
+    @Override
+    public BlockBuilder readPositionFrom(SliceInput input)
+    {
+        boolean isNull = input.readByte() == 0;
+        if (isNull) {
+            appendNull();
+        }
+        else {
+            writeLong(input.readLong());
+            writeInt(input.readInt());
+            closeEntry();
+        }
+        return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                valueIsNull[position] ? new boolean[] {true} : null,
+                new int[] {
+                        values[position * INTS_PER_POSITION],
+                        values[position * INTS_PER_POSITION + 1],
+                        values[position * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (hasNullValue) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            newValues[i * INTS_PER_POSITION] = values[position * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[position * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[position * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        return new Fixed12ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlockBuilder(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    private long getEpochMicros(int position)
+    {
+        int base = position * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
@@ -106,9 +106,14 @@ public class Fixed12ArrayBlockBuilder
     @Override
     public BlockBuilder closeEntry()
     {
-        if (entryFieldCount != 2) {
+        if (entryFieldCount == 0) {
             throw new IllegalStateException(
-                    "Each entry requires writeLong(epochMicros) then writeInt(picosOfMicro) before closeEntry()");
+                    "Each entry requires writeLong(epochMicros) before closeEntry()");
+        }
+        if (entryFieldCount == 1) {
+            // Generic long-type code paths call writeLong(...).closeEntry() without writeInt();
+            // default the picosOfMicro remainder to 0 for compatibility.
+            values[positionCount * INTS_PER_POSITION + 2] = 0;
         }
         positionCount++;
         entryFieldCount = 0;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
+import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
+
+// Wire format (per non-null position): 8-byte epochMicros (long) + 4-byte picosOfMicro (int) = 12 bytes.
+public class Fixed12ArrayBlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "FIXED12_ARRAY";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        boolean mayHaveNull = block.mayHaveNull();
+        for (int position = 0; position < positionCount; position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        int[] values = new int[positionCount * 3];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull == null || !valueIsNull[position]) {
+                long epochMicros = sliceInput.readLong();
+                int picosOfMicro = sliceInput.readInt();
+                int base = position * 3;
+                values[base] = (int) (epochMicros >>> 32);
+                values[base + 1] = (int) epochMicros;
+                values[base + 2] = picosOfMicro;
+            }
+        }
+
+        return new Fixed12ArrayBlock(0, positionCount, valueIsNull, values);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -108,7 +108,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
@@ -123,13 +123,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, Long.BYTES);
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(null, positionCount);
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -75,7 +75,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
     {
         if (block.isNull(position)) {
             blockBuilder.appendNull();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Objects;
+
+// Value type for timestamps with precision > 6. Two fields pack 12 bytes:
+// - epochMicros (8 bytes): microseconds since 1970-01-01T00:00:00 UTC, negative for pre-1970
+// - picosOfMicro (4 bytes): sub-microsecond remainder, always in [0, 999_999]
+public final class LongTimestamp
+{
+    public static final int MAX_PICOS_OF_MICRO = 999_999;
+
+    private final long epochMicros;
+    private final int picosOfMicro;
+
+    public LongTimestamp(long epochMicros, int picosOfMicro)
+    {
+        if (picosOfMicro < 0 || picosOfMicro > MAX_PICOS_OF_MICRO) {
+            throw new IllegalArgumentException(
+                    "picosOfMicro must be in [0, " + MAX_PICOS_OF_MICRO + "]: " + picosOfMicro);
+        }
+        this.epochMicros = epochMicros;
+        this.picosOfMicro = picosOfMicro;
+    }
+
+    public long getEpochMicros()
+    {
+        return epochMicros;
+    }
+
+    public int getPicosOfMicro()
+    {
+        return picosOfMicro;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongTimestamp that = (LongTimestamp) o;
+        return epochMicros == that.epochMicros && picosOfMicro == that.picosOfMicro;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(epochMicros, picosOfMicro);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LongTimestamp{epochMicros=" + epochMicros + ", picosOfMicro=" + picosOfMicro + "}";
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
@@ -46,6 +46,10 @@ public class TimestampParametricType
             throw new IllegalArgumentException("TIMESTAMP precision must be an integer literal");
         }
         long precision = parameter.getLongLiteral();
+        if (precision < 0 || precision > TimestampType.MAX_PRECISION) {
+            throw new IllegalArgumentException(
+                    "TIMESTAMP precision must be in range [0, " + TimestampType.MAX_PRECISION + "]: " + precision);
+        }
         return createTimestampType((int) precision);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.TimestampType.DEFAULT_PRECISION;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+
+// Resolves "timestamp(p)" type signatures to TimestampType instances.
+// Registered alongside the bare TIMESTAMP singleton so the type registry can
+// handle both "timestamp" (→ p=3) and "timestamp(p)" (→ any precision in [0,12]).
+public class TimestampParametricType
+        implements ParametricType
+{
+    public static final TimestampParametricType TIMESTAMP = new TimestampParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.TIMESTAMP;
+    }
+
+    @Override
+    public Type createType(List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return createTimestampType(DEFAULT_PRECISION);
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException("TIMESTAMP requires exactly one precision parameter, got: " + parameters.size());
+        }
+        TypeParameter parameter = parameters.get(0);
+        if (!parameter.isLongLiteral()) {
+            throw new IllegalArgumentException("TIMESTAMP precision must be an integer literal");
+        }
+        long precision = parameter.getLongLiteral();
+        return createTimestampType((int) precision);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -14,6 +14,11 @@
 package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
+import com.facebook.presto.common.block.Fixed12ArrayBlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.Objects;
@@ -132,6 +137,42 @@ public final class TimestampType
     public boolean isShort()
     {
         return precision <= MAX_SHORT_PRECISION;
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        if (isShort()) {
+            return super.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+        }
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
+        }
+        return new Fixed12ArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, maxBlockSizeInBytes / Fixed12ArrayBlock.FIXED12_BYTES));
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        if (isShort()) {
+            return super.createBlockBuilder(blockBuilderStatus, expectedEntries);
+        }
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, Fixed12ArrayBlock.FIXED12_BYTES);
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        if (isShort()) {
+            return super.createFixedSizeBlockBuilder(positionCount);
+        }
+        return new Fixed12ArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -27,7 +27,6 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 // Short timestamps (p ≤ 6) are stored as a single epoch-scaled long (e.g. epoch-millis for p=3,
@@ -96,15 +95,6 @@ public final class TimestampType
         return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
     }
 
-    /**
-     * Returns a {@link SqlTimestamp} for the value at {@code position}.
-     *
-     * <p>Only precision {@value #DEFAULT_PRECISION} (milliseconds) and precision
-     * {@value #MAX_SHORT_PRECISION} (microseconds) are supported. All other precisions
-     * throw {@link UnsupportedOperationException}; callers that receive a {@code TimestampType}
-     * from generic code should check {@link #isShort()} and read high-precision values
-     * directly from the block as {@link LongTimestamp} instead.
-     */
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
@@ -115,11 +105,13 @@ public final class TimestampType
             throw new UnsupportedOperationException(
                     "getObjectValue is not supported for TIMESTAMP(" + precision + "); read the block as LongTimestamp");
         }
-        java.util.concurrent.TimeUnit unit = toTimeUnit(precision);
+        // Normalize any short precision (0–6) to epoch-millis so SqlTimestamp always receives
+        // a well-defined unit regardless of which precision was stored.
+        long epochMillis = toEpochMillis(block.getLong(position));
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
+            return new SqlTimestamp(epochMillis, properties.getTimeZoneKey(), MILLISECONDS);
         }
-        return new SqlTimestamp(block.getLong(position), unit);
+        return new SqlTimestamp(epochMillis, MILLISECONDS);
     }
 
     public int getPrecision()
@@ -183,22 +175,83 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else if (!isShort()) {
+            blockBuilder.writeLong(block.getLong(position, 0))
+                    .writeInt(block.getInt(position))
+                    .closeEntry();
+        }
+        else {
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
+        }
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            return leftBlock.getLong(leftPosition, 0) == rightBlock.getLong(rightPosition, 0)
+                    && leftBlock.getInt(leftPosition) == rightBlock.getInt(rightPosition);
+        }
+        return super.equalTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        if (!isShort()) {
+            long epochMicros = block.getLong(position, 0);
+            int picosOfMicro = block.getInt(position);
+            return AbstractLongType.hash(epochMicros) ^ AbstractLongType.hash(picosOfMicro);
+        }
+        return super.hash(block, position);
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            int cmp = Long.compare(leftBlock.getLong(leftPosition, 0), rightBlock.getLong(rightPosition, 0));
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Integer.compare(leftBlock.getInt(leftPosition), rightBlock.getInt(rightPosition));
+        }
+        return super.compareTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
     // Floor division handles negative (pre-1970) timestamps correctly; Java % does not.
     public long getEpochSecond(long timestamp)
     {
+        checkShort("getEpochSecond");
         return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
     // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
+        checkShort("getNanos");
         long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
         return (int) (fractional * (1_000_000_000L / PRECISION_SCALE[precision]));
     }
 
     public long toEpochMillis(long timestamp)
     {
+        checkShort("toEpochMillis");
         return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
+    }
+
+    private void checkShort(String method)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    method + " requires a short timestamp (p ≤ " + MAX_SHORT_PRECISION + "); use LongTimestamp for p > " + MAX_SHORT_PRECISION);
+        }
     }
 
     public long fromEpochComponents(long epochSecond, int nanos)
@@ -212,19 +265,5 @@ public final class TimestampType
         // For p ≤ 6, scale ≤ 1_000_000, so 1_000_000_000 / scale is always ≥ 1000 (no zero divisor).
         long scale = PRECISION_SCALE[precision];
         return epochSecond * scale + nanos / (1_000_000_000L / scale);
-    }
-
-    private static java.util.concurrent.TimeUnit toTimeUnit(int precision)
-    {
-        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
-        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
-        if (precision == DEFAULT_PRECISION) {
-            return MILLISECONDS;
-        }
-        if (precision == MAX_SHORT_PRECISION) {
-            return MICROSECONDS;
-        }
-        throw new UnsupportedOperationException(
-                "getObjectValue is not implemented for TIMESTAMP(" + precision + "); supported: p=3 (millis), p=6 (micros)");
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -17,63 +17,129 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-//
-// TIMESTAMP is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-// TIMESTAMP_MICROSECONDS is stored as microseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
+// Short timestamps (p ≤ 6) are stored as a single epoch-scaled long (e.g. epoch-millis for p=3,
+// epoch-micros for p=6). High-precision timestamps (p > 6) require LongTimestamp, a separate
+// 12-byte fixed-width value type that pairs epochMicros with a picosOfMicro remainder.
 public final class TimestampType
         extends AbstractLongType
 {
-    public static final TimestampType TIMESTAMP = new TimestampType(MILLISECONDS);
-    public static final TimestampType TIMESTAMP_MICROSECONDS = new TimestampType(MICROSECONDS);
+    public static final int MAX_PRECISION = 12;
+    public static final int MAX_SHORT_PRECISION = 6;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private final TimeUnit precision;
+    private static final long[] PRECISION_SCALE = {
+            1L,                     // p=0  (seconds)
+            10L,                    // p=1
+            100L,                   // p=2
+            1_000L,                 // p=3  (milliseconds)
+            10_000L,                // p=4
+            100_000L,               // p=5
+            1_000_000L,             // p=6  (microseconds)
+            10_000_000L,            // p=7
+            100_000_000L,           // p=8
+            1_000_000_000L,         // p=9  (nanoseconds)
+            10_000_000_000L,        // p=10
+            100_000_000_000L,       // p=11
+            1_000_000_000_000L,     // p=12 (picoseconds)
+    };
 
-    private TimestampType(TimeUnit precision)
+    private static final TimestampType[] INSTANCES = new TimestampType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampType(p);
+        }
+    }
+
+    public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
+
+    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
+    // on type-signature base strings continues to work without changes.
+    public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
+
+    private final int precision;
+
+    public static TimestampType createTimestampType(int precision)
     {
-        super(parseTypeSignature(getType(precision)));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
         this.precision = precision;
     }
 
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP);
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            // Preserve "timestamp microseconds" for the same reason.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
+    }
+
+    /**
+     * Returns a {@link SqlTimestamp} for the value at {@code position}.
+     *
+     * <p>Only precision {@value #DEFAULT_PRECISION} (milliseconds) and precision
+     * {@value #MAX_SHORT_PRECISION} (microseconds) are supported. All other precisions
+     * throw {@link UnsupportedOperationException}; callers that receive a {@code TimestampType}
+     * from generic code should check {@link #isShort()} and read high-precision values
+     * directly from the block as {@link LongTimestamp} instead.
+     */
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
-
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + "); read the block as LongTimestamp");
+        }
+        java.util.concurrent.TimeUnit unit = toTimeUnit(precision);
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), precision);
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
         }
-        else {
-            return new SqlTimestamp(block.getLong(position), precision);
-        }
+        return new SqlTimestamp(block.getLong(position), unit);
     }
 
-    public TimeUnit getPrecision()
+    public int getPrecision()
     {
-        return this.precision;
+        return precision;
+    }
+
+    // p ≤ 6 fits in a single long; p > 6 requires the LongTimestamp value type.
+    public boolean isShort()
+    {
+        return precision <= MAX_SHORT_PRECISION;
     }
 
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        if (precision == MICROSECONDS) {
-            return other == TIMESTAMP_MICROSECONDS;
-        }
-        if (precision == MILLISECONDS) {
-            return other == TIMESTAMP;
-        }
-        throw new UnsupportedOperationException("Unsupported precision " + precision);
+        // One interned instance per precision level, so reference equality is sufficient.
+        return this == other;
     }
 
     @Override
@@ -82,38 +148,48 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
-    /**
-     * Gets the timestamp's number of total seconds.
-     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
-     *
-     * Returns:
-     * the total seconds in timestamp
-     */
+    // Floor division handles negative (pre-1970) timestamps correctly; Java % does not.
     public long getEpochSecond(long timestamp)
     {
-        return this.precision.toSeconds(timestamp);
+        return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
-    /**
-     * Gets the timestamp's nanosecond portion.
-     *
-     * Returns:
-     * this timestamp's fractional seconds component
-     */
+    // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
-        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
-        return (int) precision.toNanos(timestamp % unitsPerSecond);
+        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
+        return (int) (fractional * (1_000_000_000L / PRECISION_SCALE[precision]));
     }
 
-    private static String getType(TimeUnit precision)
+    public long toEpochMillis(long timestamp)
     {
-        if (precision == MICROSECONDS) {
-            return StandardTypes.TIMESTAMP_MICROSECONDS;
+        return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
+    }
+
+    public long fromEpochComponents(long epochSecond, int nanos)
+    {
+        if (!isShort()) {
+            // p > 6 timestamps are stored as LongTimestamp (epochMicros + picosOfMicro),
+            // not as a single scaled long; this method cannot produce a valid value for them.
+            throw new UnsupportedOperationException(
+                    "fromEpochComponents requires a short timestamp (p ≤ 6); use LongTimestamp for p > 6");
         }
-        if (precision == MILLISECONDS) {
-            return StandardTypes.TIMESTAMP;
+        // For p ≤ 6, scale ≤ 1_000_000, so 1_000_000_000 / scale is always ≥ 1000 (no zero divisor).
+        long scale = PRECISION_SCALE[precision];
+        return epochSecond * scale + nanos / (1_000_000_000L / scale);
+    }
+
+    private static java.util.concurrent.TimeUnit toTimeUnit(int precision)
+    {
+        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
+        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
+        if (precision == DEFAULT_PRECISION) {
+            return MILLISECONDS;
         }
-        throw new IllegalArgumentException("Unsupported precision " + precision);
+        if (precision == MAX_SHORT_PRECISION) {
+            return MICROSECONDS;
+        }
+        throw new UnsupportedOperationException(
+                "getObjectValue is not implemented for TIMESTAMP(" + precision + "); supported: p=3 (millis), p=6 (micros)");
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -66,8 +66,7 @@ public final class TimestampType
 
     public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
 
-    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
-    // on type-signature base strings continues to work without changes.
+    // Interned instance for microsecond precision. Type signature is now "timestamp(6)".
     public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
 
     private final int precision;
@@ -93,12 +92,7 @@ public final class TimestampType
             // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
             return parseTypeSignature(StandardTypes.TIMESTAMP);
         }
-        if (precision == MAX_SHORT_PRECISION) {
-            // Preserve "timestamp microseconds" for the same reason.
-            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
-        }
-        // Other precisions use a numeric parameter; the type registry does not yet recognize the
-        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        // All other precisions serialize as "timestamp(p)" with a numeric parameter.
         return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -43,11 +43,15 @@ public final class TimestampWithTimeZoneType
 
     public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        if (precision < 0 || precision > MAX_PRECISION) {
+        // The underlying encoding (DateTimeEncoding) is millisecond-based, so only precision 3
+        // is correctly supported. High-precision TIMESTAMP WITH TIME ZONE requires a new encoding
+        // and a registered ParametricType before other precisions can be enabled.
+        if (precision != DEFAULT_PRECISION) {
             throw new IllegalArgumentException(format(
-                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+                    "TIMESTAMP WITH TIME ZONE only supports precision %s (milliseconds); got: %s",
+                    DEFAULT_PRECISION, precision));
         }
-        return INSTANCES[precision];
+        return INSTANCES[DEFAULT_PRECISION];
     }
 
     private TimestampWithTimeZoneType(int precision)
@@ -58,13 +62,7 @@ public final class TimestampWithTimeZoneType
 
     private static TypeSignature buildTypeSignature(int precision)
     {
-        if (precision == DEFAULT_PRECISION) {
-            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
-            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
-        }
-        // Other precisions use a numeric parameter; the type registry does not yet recognize the
-        // "timestamp with time zone(p)" string form, so these instances are created directly rather than parsed.
-        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+        return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
     }
 
     public int getPrecision()

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -16,17 +16,60 @@ package com.facebook.presto.common.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
+import java.util.Objects;
+
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
 
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
-    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+    public static final int MAX_PRECISION = 12;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private TimestampWithTimeZoneType()
+    private static final TimestampWithTimeZoneType[] INSTANCES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampWithTimeZoneType(p);
+        }
+    }
+
+    // Preserves "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = INSTANCES[DEFAULT_PRECISION];
+
+    private final int precision;
+
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampWithTimeZoneType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp with time zone(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+    }
+
+    public int getPrecision()
+    {
+        return precision;
     }
 
     /**
@@ -78,12 +121,13 @@ public final class TimestampWithTimeZoneType
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == TIMESTAMP_WITH_TIME_ZONE;
+        // One interned instance per precision level, so reference equality is sufficient.
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return getClass().hashCode();
+        return Objects.hash(getClass(), precision);
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.TimestampType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestFixed12ArrayBlock
+{
+    @Test
+    public void testSinglePositionRoundTrip()
+    {
+        long epochMicros = 1_000_000_000L;
+        int picosOfMicro = 500_000;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 1);
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        // Pre-1970: epochMicros is negative
+        long epochMicros = -1_000_000L;
+        int picosOfMicro = 999_999;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testMultiplePositions()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(200L).writeInt(999_999).closeEntry();
+        builder.writeLong(-300L).writeInt(500_000).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getLong(0, 0), 100L);
+        assertEquals(block.getInt(0), 0);
+        assertEquals(block.getLong(1, 0), 200L);
+        assertEquals(block.getInt(1), 999_999);
+        assertEquals(block.getLong(2, 0), -300L);
+        assertEquals(block.getInt(2), 500_000);
+    }
+
+    @Test
+    public void testNullPosition()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 2);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+    }
+
+    @Test
+    public void testSizeInBytes()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 4);
+        for (int i = 0; i < 4; i++) {
+            builder.writeLong((long) i * 1000).writeInt(i).closeEntry();
+        }
+        Block block = builder.build();
+        // 12 bytes data + 1 byte null flag per position = 13 bytes per position
+        assertEquals(block.getSizeInBytes(), Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * 4L);
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForLongPrecision()
+    {
+        // p > 6 should return Fixed12ArrayBlockBuilder
+        TimestampType longType = createTimestampType(7);
+        assertFalse(longType.isShort());
+        BlockBuilder builder = longType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof Fixed12ArrayBlockBuilder,
+                "Expected Fixed12ArrayBlockBuilder for p=7, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForShortPrecision()
+    {
+        // p <= 6 should return LongArrayBlockBuilder (the default from AbstractLongType)
+        TimestampType shortType = createTimestampType(6);
+        assertTrue(shortType.isShort());
+        BlockBuilder builder = shortType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof LongArrayBlockBuilder,
+                "Expected LongArrayBlockBuilder for p=6, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testExtremeNegativeEpoch()
+    {
+        // Long.MIN_VALUE is a valid epochMicros (no restriction)
+        long epochMicros = Long.MIN_VALUE;
+        int picosOfMicro = 0;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.common.block;
 
 import com.facebook.presto.common.type.TimestampType;
+import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.TimestampType.createTimestampType;
@@ -21,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class TestFixed12ArrayBlock
 {
@@ -134,5 +136,84 @@ public class TestFixed12ArrayBlock
         Block block = builder.build();
         assertEquals(block.getLong(0, 0), epochMicros);
         assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testWriteIntBeforeWriteLongThrows()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        expectThrows(IllegalStateException.class, () -> builder.writeInt(0));
+    }
+
+    @Test
+    public void testCloseEntryWithNoWriteThrows()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        expectThrows(IllegalStateException.class, builder::closeEntry);
+    }
+
+    @Test
+    public void testAppendNullDuringOpenEntryThrows()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(100L);
+        expectThrows(IllegalStateException.class, builder::appendNull);
+    }
+
+    @Test
+    public void testCloseEntryAfterWriteLongOnlyDefaultsPicosToZero()
+    {
+        // Generic AbstractLongType paths call writeLong(...).closeEntry() without writeInt();
+        // the builder should default picosOfMicro to 0.
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(42L).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), 42L);
+        assertEquals(block.getInt(0), 0);
+    }
+
+    @Test
+    public void testAppendToPreservesPicosOfMicro()
+    {
+        // TimestampType.appendTo must copy both epochMicros and picosOfMicro for p>6.
+        TimestampType longType = createTimestampType(9);
+        Fixed12ArrayBlockBuilder src = new Fixed12ArrayBlockBuilder(null, 2);
+        src.writeLong(1_000_000L).writeInt(500_000).closeEntry();
+        src.appendNull();
+        Block srcBlock = src.build();
+
+        Fixed12ArrayBlockBuilder dst = new Fixed12ArrayBlockBuilder(null, 2);
+        longType.appendTo(srcBlock, 0, dst);
+        longType.appendTo(srcBlock, 1, dst);
+        Block dstBlock = dst.build();
+
+        assertEquals(dstBlock.getLong(0, 0), 1_000_000L);
+        assertEquals(dstBlock.getInt(0), 500_000);
+        assertTrue(dstBlock.isNull(1));
+    }
+
+    @Test
+    public void testSerdeRoundTrip()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000L).writeInt(500_000).closeEntry();
+        builder.writeLong(-1L).writeInt(0).closeEntry();
+        builder.appendNull();
+        Block original = builder.build();
+
+        BlockEncodingSerde serde = new TestingBlockEncodingSerde();
+        DynamicSliceOutput out = new DynamicSliceOutput(256);
+        serde.writeBlock(out, original);
+        Block decoded = serde.readBlock(out.slice().getInput());
+
+        assertEquals(decoded.getPositionCount(), original.getPositionCount());
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertFalse(decoded.isNull(1));
+        assertEquals(decoded.getLong(1, 0), -1L);
+        assertEquals(decoded.getInt(1), 0);
+        assertTrue(decoded.isNull(2));
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
@@ -47,6 +47,7 @@ public final class TestingBlockEncodingSerde
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestLongTimestamp
+{
+    @Test
+    public void testConstructorStoresFields()
+    {
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 500_000);
+        assertEquals(ts.getEpochMicros(), 1_000_000L);
+        assertEquals(ts.getPicosOfMicro(), 500_000);
+    }
+
+    @Test
+    public void testPicosOfMicroLowerBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test
+    public void testPicosOfMicroUpperBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 999_999);
+        assertEquals(ts.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testPicosOfMicroNegativeThrows()
+    {
+        try {
+            new LongTimestamp(0L, -1);
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testPicosOfMicroTooLargeThrows()
+    {
+        try {
+            new LongTimestamp(0L, 1_000_000);
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        // Pre-1970 timestamp: negative epochMicros is valid
+        LongTimestamp ts = new LongTimestamp(-1_000_000L, 0);
+        assertEquals(ts.getEpochMicros(), -1_000_000L);
+    }
+
+    @Test
+    public void testImmutable()
+    {
+        // LongTimestamp has no setters — verified by reading fields without modification
+        LongTimestamp ts = new LongTimestamp(42L, 100);
+        assertEquals(ts.getEpochMicros(), 42L);
+        assertEquals(ts.getPicosOfMicro(), 100);
+        // No setter methods exist; this is verified at compile time by the absence of set* methods
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -155,4 +155,46 @@ public class TestTimestampType
         assertEquals(createTimestampType(3).toEpochMillis(1_500L), 1_500L);
         assertEquals(createTimestampType(6).toEpochMillis(1_500_000L), 1_500L);
     }
+
+    @Test
+    public void testToEpochMillisNegative()
+    {
+        TimestampType millis = createTimestampType(3);
+        // -1 ms → -1 ms (epoch-millis value already is ms)
+        assertEquals(millis.toEpochMillis(-1L), -1L);
+        // -1001 ms → -1001 ms
+        assertEquals(millis.toEpochMillis(-1_001L), -1_001L);
+
+        TimestampType micros = createTimestampType(6);
+        // -1 µs: epochSecond=-1, nanos=999_999_000 → -1*1000 + 999_999_000/1_000_000 = -1000 + 999 = -1 ms
+        assertEquals(micros.toEpochMillis(-1L), -1L);
+        // -1_001_000 µs → -1001 ms
+        assertEquals(micros.toEpochMillis(-1_001_000L), -1_001L);
+    }
+
+    @Test
+    public void testFromEpochComponentsRoundTrip()
+    {
+        TimestampType millis = createTimestampType(3);
+        // Positive: 1s + 500ms
+        long storedMillis = millis.fromEpochComponents(1L, 500_000_000);
+        assertEquals(millis.getEpochSecond(storedMillis), 1L);
+        assertEquals(millis.getNanos(storedMillis), 500_000_000);
+
+        // Pre-epoch: -1s + 999ms (i.e. -1 ms)
+        long storedNeg = millis.fromEpochComponents(-1L, 999_000_000);
+        assertEquals(millis.getEpochSecond(storedNeg), -1L);
+        assertEquals(millis.getNanos(storedNeg), 999_000_000);
+
+        TimestampType micros = createTimestampType(6);
+        // Positive: 1s + 500_000µs
+        long storedMicros = micros.fromEpochComponents(1L, 500_000_000);
+        assertEquals(micros.getEpochSecond(storedMicros), 1L);
+        assertEquals(micros.getNanos(storedMicros), 500_000_000);
+
+        // Pre-epoch: -1s + 999_999µs (i.e. -1 µs)
+        long storedNegMicros = micros.fromEpochComponents(-1L, 999_999_000);
+        assertEquals(micros.getEpochSecond(storedNegMicros), -1L);
+        assertEquals(micros.getNanos(storedNegMicros), 999_999_000);
+    }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampType
+{
+    @Test
+    public void testInterningReturnsSameReference()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertSame(createTimestampType(p), createTimestampType(p),
+                    "createTimestampType(" + p + ") must return same reference on repeated calls");
+        }
+    }
+
+    @Test
+    public void testAllInstancesPreAllocated()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertNotNull(createTimestampType(p), "Instance for precision " + p + " must be pre-allocated");
+        }
+    }
+
+    @Test
+    public void testTimestampConstantBackwardCompatibility()
+    {
+        assertSame(TIMESTAMP, createTimestampType(3), "TIMESTAMP must be same reference as createTimestampType(3)");
+        assertEquals(TIMESTAMP.getPrecision(), 3, "TIMESTAMP.getPrecision() must return 3");
+    }
+
+    @Test
+    public void testGetPrecisionReturnsInt()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertEquals(createTimestampType(p).getPrecision(), p,
+                    "getPrecision() must return " + p + " for createTimestampType(" + p + ")");
+        }
+    }
+
+    @Test
+    public void testIsShortBoundary()
+    {
+        for (int p = 0; p <= 6; p++) {
+            assertTrue(createTimestampType(p).isShort(), "isShort() must return true for p=" + p);
+        }
+        for (int p = 7; p <= 12; p++) {
+            assertFalse(createTimestampType(p).isShort(), "isShort() must return false for p=" + p);
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MIN_VALUE));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testInvalidPrecisionErrorMessage()
+    {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        assertTrue(e.getMessage().contains("-1"), "Error message must contain the invalid value");
+
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        assertTrue(e2.getMessage().contains("13"), "Error message must contain the invalid value");
+    }
+
+    // Additional: TIMESTAMP_MICROSECONDS = createTimestampType(6) with precision 6
+    @Test
+    public void testTimestampMicrosecondsIsInterned()
+    {
+        assertSame(TIMESTAMP_MICROSECONDS, createTimestampType(6),
+                "TIMESTAMP_MICROSECONDS must be same reference as createTimestampType(6)");
+        assertEquals(TIMESTAMP_MICROSECONDS.getPrecision(), 6);
+    }
+
+    // Additional: reference equality serves as type equality (interning guarantee)
+    @Test
+    public void testReferenceEqualityIsTypeEquality()
+    {
+        for (int p1 = 0; p1 <= 12; p1++) {
+            for (int p2 = 0; p2 <= 12; p2++) {
+                if (p1 == p2) {
+                    assertEquals(createTimestampType(p1), createTimestampType(p2));
+                }
+                else {
+                    assertFalse(createTimestampType(p1).equals(createTimestampType(p2)),
+                            "Types with different precision must not be equal");
+                }
+            }
+        }
+    }
+
+    // Additional: getEpochSecond and getNanos correctness for p=3 (millis)
+    @Test
+    public void testEpochComponentsMillis()
+    {
+        TimestampType ts = createTimestampType(3);
+        // 1 second = 1000 ms; epochSecond=1, nanos=0
+        assertEquals(ts.getEpochSecond(1_000L), 1L);
+        assertEquals(ts.getNanos(1_000L), 0);
+        // 1500 ms = 1s + 500ms
+        assertEquals(ts.getEpochSecond(1_500L), 1L);
+        assertEquals(ts.getNanos(1_500L), 500_000_000);
+        // Negative: -1 ms = -1s + 999ms
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_000_000);
+    }
+
+    // Additional: getEpochSecond and getNanos correctness for p=6 (micros)
+    @Test
+    public void testEpochComponentsMicros()
+    {
+        TimestampType ts = createTimestampType(6);
+        // 1 second = 1_000_000 µs
+        assertEquals(ts.getEpochSecond(1_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000L), 0);
+        // 1_500_000 µs = 1s + 500_000µs = 1s + 500ms
+        assertEquals(ts.getEpochSecond(1_500_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000L), 500_000_000);
+        // Negative: -1 µs → epochSecond=-1, nanos=999_999_000
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_000);
+    }
+
+    // Additional: toEpochMillis helper
+    @Test
+    public void testToEpochMillis()
+    {
+        assertEquals(createTimestampType(3).toEpochMillis(1_500L), 1_500L);
+        assertEquals(createTimestampType(6).toEpochMillis(1_500_000L), 1_500L);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampTypeSignature.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampTypeSignature.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestampTypeSignature
+{
+    @Test
+    public void testDefaultPrecisionSerializesWithoutParam()
+    {
+        TimestampType ts3 = createTimestampType(3);
+        assertEquals(ts3.getTypeSignature().toString(), "timestamp");
+        assertEquals(ts3.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testNonDefaultPrecisionsSerializeWithParam()
+    {
+        for (int p = 0; p <= 12; p++) {
+            if (p == 3) {
+                continue;
+            }
+            TimestampType type = createTimestampType(p);
+            String sig = type.getTypeSignature().toString();
+            assertEquals(sig, "timestamp(" + p + ")",
+                    "Expected timestamp(" + p + ") but got: " + sig);
+        }
+    }
+
+    @Test
+    public void testMicrosecondsPrecisionUsesParametricForm()
+    {
+        TimestampType ts6 = createTimestampType(6);
+        assertEquals(ts6.getTypeSignature().toString(), "timestamp(6)");
+        assertEquals(ts6.getTypeSignature().getBase(), "timestamp");
+        assertEquals(ts6.getTypeSignature().getParameters().size(), 1);
+        assertEquals(ts6.getTypeSignature().getParameters().get(0).getLongLiteral(), 6L);
+    }
+
+    @Test
+    public void testBareTimestampParsesToDefaultPrecision()
+    {
+        TypeSignature sig = parseTypeSignature("timestamp");
+        assertEquals(sig.getBase(), "timestamp");
+        assertEquals(sig.getParameters().size(), 0);
+        // TimestampParametricType.createType with no params returns TIMESTAMP(3)
+        Type resolved = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of());
+        assertSame(resolved, createTimestampType(3));
+    }
+
+    @Test
+    public void testExplicitPrecision3RoundTrips()
+    {
+        TypeSignature sig = parseTypeSignature("timestamp(3)");
+        assertEquals(sig.getBase(), "timestamp");
+        assertEquals(sig.getParameters().size(), 1);
+        assertEquals(sig.getParameters().get(0).getLongLiteral(), 3L);
+        TypeParameter param = TypeParameter.of(3L);
+        Type resolved = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of(param));
+        assertSame(resolved, createTimestampType(3));
+    }
+
+    @Test
+    public void testRoundTripForAllPrecisions()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampType original = createTimestampType(p);
+            String serialized = original.getTypeSignature().toString();
+
+            // Parse the serialized form back to a TypeSignature
+            TypeSignature parsed = parseTypeSignature(serialized);
+
+            // Reconstruct via TimestampParametricType
+            Type reconstructed;
+            if (parsed.getParameters().isEmpty()) {
+                reconstructed = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of());
+            }
+            else {
+                long precision = parsed.getParameters().get(0).getLongLiteral();
+                reconstructed = TimestampParametricType.TIMESTAMP.createType(
+                        ImmutableList.of(TypeParameter.of(precision)));
+            }
+
+            assertTrue(reconstructed instanceof TimestampType);
+            assertEquals(((TimestampType) reconstructed).getPrecision(), p,
+                    "Round-trip failed for precision " + p);
+            assertSame(reconstructed, original,
+                    "Round-trip returned different instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testMicrosecondsRoundTrip()
+    {
+        TimestampType ts6 = createTimestampType(6);
+        String serialized = ts6.getTypeSignature().toString();
+        assertEquals(serialized, "timestamp(6)");
+
+        TypeSignature parsed = parseTypeSignature(serialized);
+        TypeParameter param = TypeParameter.of(parsed.getParameters().get(0).getLongLiteral());
+        Type reconstructed = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of(param));
+
+        assertSame(reconstructed, ts6);
+        assertEquals(((TimestampType) reconstructed).getPrecision(), 6);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class TestTimestampWithTimeZoneType
+{
+    @Test
+    public void testInterning()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertSame(createTimestampWithTimeZoneType(p), createTimestampWithTimeZoneType(p),
+                    "Expected same instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testPreAllocation()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampWithTimeZoneType instance = createTimestampWithTimeZoneType(p);
+            assertEquals(instance.getPrecision(), p);
+        }
+    }
+
+    @Test
+    public void testBackwardCompatConstant()
+    {
+        assertSame(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getPrecision(), 3);
+    }
+
+    @Test
+    public void testBackwardCompatTypeSignature()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getBase(), "timestamp with time zone");
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testReferenceEquality()
+    {
+        TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(6);
+        TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(6);
+        assertSame(a, b);
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsWithConstant()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testInvalidPrecisionNegative()
+    {
+        try {
+            createTimestampWithTimeZoneType(-1);
+            fail("Expected IllegalArgumentException for precision -1");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionTooLarge()
+    {
+        try {
+            createTimestampWithTimeZoneType(13);
+            fail("Expected IllegalArgumentException for precision 13");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    // All 13 instances are distinct objects
+    @Test
+    public void testDistinctInstances()
+    {
+        for (int p = 0; p <= 12; p++) {
+            for (int q = p + 1; q <= 12; q++) {
+                TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
+                TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
+                // Different precisions → different instances
+                assert a != b : "Expected distinct instances for p=" + p + " and q=" + q;
+            }
+        }
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
@@ -103,7 +104,7 @@ public class TestTimestampWithTimeZoneType
                 TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
                 TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
                 // Different precisions → different instances
-                assert a != b : "Expected distinct instances for p=" + p + " and q=" + q;
+                assertNotSame(a, b, "Expected distinct instances for p=" + p + " and q=" + q);
             }
         }
     }

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -219,7 +219,7 @@ picosecond resolution.
 
 .. note::
 
-    Implicit coercion widens from lower to higher precision (e.g. ``TIMESTAMP(3)``
+    Implicit coercion widens from lower to higher precision (for example, ``TIMESTAMP(3)``
     to ``TIMESTAMP(6)``) automatically. Narrowing requires an explicit ``CAST``, which
     truncates (floor) rather than rounds.
 
@@ -229,19 +229,14 @@ Examples::
     TIMESTAMP '2001-08-22 03:04:05.123456'         -- TIMESTAMP(6), microseconds
     TIMESTAMP '2001-08-22 03:04:05.123456789'      -- TIMESTAMP(9), nanoseconds
 
-``TIMESTAMP WITH TIME ZONE`` / ``TIMESTAMP(p) WITH TIME ZONE``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``TIMESTAMP WITH TIME ZONE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Instant in time that includes the date and time of day with a time zone.
 Values of this type are rendered using the time zone from the value.
+Stored with millisecond precision.
 
-Accepts the same optional precision parameter ``p`` (0–12) as ``TIMESTAMP(p)``.
-Bare ``TIMESTAMP WITH TIME ZONE`` is equivalent to ``TIMESTAMP(3) WITH TIME ZONE``.
-
-Examples::
-
-    TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'      -- milliseconds
-    TIMESTAMP '2001-08-22 03:04:05.123456 America/Los_Angeles'   -- microseconds
+Example: ``TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'``
 
 ``INTERVAL YEAR TO MONTH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -197,21 +197,51 @@ Values of this type are rendered using the time zone from the value.
 
 Example: ``TIME '01:02:03.456 America/Los_Angeles'``
 
-``TIMESTAMP``
-^^^^^^^^^^^^^
+``TIMESTAMP`` / ``TIMESTAMP(p)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Instant in time that includes the date and time of day without a time zone.
 Values of this type are parsed and rendered in the session time zone.
 
-Example: ``TIMESTAMP '2001-08-22 03:04:05.321'``
+An optional precision parameter ``p`` (0–12) specifies the number of fractional
+second digits retained:
 
-``TIMESTAMP WITH TIME ZONE``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``TIMESTAMP(0)`` — seconds
+* ``TIMESTAMP(3)`` — milliseconds (the default when no precision is given)
+* ``TIMESTAMP(6)`` — microseconds
+* ``TIMESTAMP(9)`` — nanoseconds
+* ``TIMESTAMP(12)`` — picoseconds
+
+Bare ``TIMESTAMP`` is equivalent to ``TIMESTAMP(3)`` and is retained for backward
+compatibility. Precision values 0–6 are stored as a single scaled integer; precision
+values 7–12 store an additional sub-microsecond remainder, enabling nanosecond and
+picosecond resolution.
+
+.. note::
+
+    Implicit coercion widens from lower to higher precision (e.g. ``TIMESTAMP(3)``
+    to ``TIMESTAMP(6)``) automatically. Narrowing requires an explicit ``CAST``, which
+    truncates (floor) rather than rounds.
+
+Examples::
+
+    TIMESTAMP '2001-08-22 03:04:05.321'            -- TIMESTAMP(3), milliseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456'         -- TIMESTAMP(6), microseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456789'      -- TIMESTAMP(9), nanoseconds
+
+``TIMESTAMP WITH TIME ZONE`` / ``TIMESTAMP(p) WITH TIME ZONE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Instant in time that includes the date and time of day with a time zone.
 Values of this type are rendered using the time zone from the value.
 
-Example: ``TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'``
+Accepts the same optional precision parameter ``p`` (0–12) as ``TIMESTAMP(p)``.
+Bare ``TIMESTAMP WITH TIME ZONE`` is equivalent to ``TIMESTAMP(3) WITH TIME ZONE``.
+
+Examples::
+
+    TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'      -- milliseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456 America/Los_Angeles'   -- microseconds
 
 ``INTERVAL YEAR TO MONTH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1747,7 +1747,7 @@ public abstract class IcebergAbstractMetadata
             }
             else if (tableVersion.getVersionExpressionType() instanceof TimestampType) {
                 long timestampValue = (long) tableVersion.getTableVersion();
-                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
+                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).toEpochMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
             else if (tableVersion.getVersionExpressionType() instanceof BigintType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -453,7 +453,9 @@ public class IcebergPageSink
         }
         if (type instanceof TimestampType) {
             long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == 3 ? timestamp * 1_000L : timestamp;
+            return ((TimestampType) type).getPrecision() == TimestampType.DEFAULT_PRECISION
+                    ? MILLISECONDS.toMicros(timestamp)
+                    : timestamp;
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -465,8 +467,12 @@ public class IcebergPageSink
     public static Object adjustTimestampForPartitionTransform(SqlFunctionProperties functionProperties, Type type, Object value)
     {
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
-            long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
+            if (!timestampType.isShort()) {
+                throw new UnsupportedOperationException(
+                        "Legacy timezone adjustment is not supported for TIMESTAMP(" + timestampType.getPrecision() + "); only short timestamps (p ≤ 6) are supported");
+            }
+            long timestampValue = (long) value;
             Instant instant = Instant.ofEpochSecond(timestampType.getEpochSecond(timestampValue),
                     timestampType.getNanos(timestampValue));
             LocalDateTime localDateTime = instant

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -89,8 +89,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -455,7 +453,7 @@ public class IcebergPageSink
         }
         if (type instanceof TimestampType) {
             long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+            return ((TimestampType) type).getPrecision() == 3 ? timestamp * 1_000L : timestamp;
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -469,14 +467,13 @@ public class IcebergPageSink
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
-            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
-                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            Instant instant = Instant.ofEpochSecond(timestampType.getEpochSecond(timestampValue),
+                    timestampType.getNanos(timestampValue));
             LocalDateTime localDateTime = instant
                     .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
                     .toLocalDateTime();
 
-            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
-                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+            return timestampType.fromEpochComponents(localDateTime.toEpochSecond(ZoneOffset.UTC), localDateTime.getNano());
         }
         return value;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -58,7 +58,6 @@ import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
 public class PartitionTable
@@ -299,7 +298,7 @@ public class PartitionTable
         }
         if (type instanceof Types.TimestampType) {
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
-            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == TimestampType.DEFAULT_PRECISION) {
                 return MICROSECONDS.toMillis((long) value);
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.function.SqlFunctionResult;
 import com.facebook.presto.common.type.DistinctTypeInfo;
 import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.TimestampParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
@@ -658,6 +659,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(BING_TILE);
         addType(KDB_TREE);
         addType(SPHERICAL_GEOGRAPHY);
+        addParametricType(TimestampParametricType.TIMESTAMP);
         addParametricType(VarcharParametricType.VARCHAR);
         addParametricType(CharParametricType.CHAR);
         addParametricType(DecimalParametricType.DECIMAL);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -573,7 +573,7 @@ public class IOPlanPrinter
             }
             if (type instanceof TimestampType) {
                 TimestampType timestampType = (TimestampType) type;
-                long timestampValue = timestampType.getPrecision().toMillis((Long) value);
+                long timestampValue = timestampType.toEpochMillis((Long) value);
                 return printTimestampWithoutTimeZone(timestampValue);
             }
             if (type instanceof TimestampWithTimeZoneType) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -695,7 +695,7 @@ public class OrcWriteValidation
                 }
             }
 
-            if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP_MICROSECONDS)) {
+            if (type == TIMESTAMP_MICROSECONDS) {
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -21,7 +21,6 @@ import com.facebook.presto.common.block.ColumnarRow;
 import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
-import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.metadata.CompressionKind;
@@ -685,7 +684,7 @@ public class OrcWriteValidation
                 return hash;
             }
 
-            if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP)) {
+            if (type == TIMESTAMP) {
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000, exclusive, and 1970-01-01 00:00:00.000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.


### PR DESCRIPTION
## Description

This PR adds precision parameterization to `TimestampType` and `TimestampWithTimeZoneType`, introduces the `LongTimestamp` value type and its 12-byte block encoding for sub-microsecond precision, and establishes canonical `"timestamp(p)"` type signature serialization. Together these changes lay the SPI foundation for full `TIMESTAMP(p)` support in Presto.

### Changes by area

**`TimestampType` precision registry (presto-common)**

`TimestampType` now accepts an integer precision in `[0, 12]` and interns one singleton per level. A static `INSTANCES[13]` array pre-allocates all instances at class load; `createTimestampType(int p)` returns the cached instance, making type-equality checks reduce to reference equality (`this == other`).

- `TIMESTAMP` (the existing constant) equals `createTimestampType(3)` and preserves the `"timestamp"` type signature — no callers change.
- `TIMESTAMP_MICROSECONDS` equals `createTimestampType(6)`.
- `getPrecision()` returns `int`. `isShort()` returns `true` for p ≤ 6 (single-long storage) and `false` for p > 6 (`LongTimestamp` storage).
- Helper methods `getEpochSecond(long)`, `getNanos(long)`, `toEpochMillis(long)`, and `fromEpochComponents(long, int)` replace `TimeUnit`-based call chains in callers. All use `Math.floorDiv`/`Math.floorMod` to handle pre-1970 (negative epoch) timestamps correctly.
- Four files that used `getPrecision()` as a `TimeUnit` object were updated: `IcebergPageSink`, `IcebergAbstractMetadata`, `PartitionTable`, `IOPlanPrinter`.

**`LongTimestamp` value type and 12-byte block encoding (presto-common)**

Timestamps with precision > 6 require more than 64 bits. `LongTimestamp` is an immutable value type pairing `epochMicros` (long, 8 bytes) with `picosOfMicro` (int, 4 bytes; validated in `[0, 999_999]`).

A new `Fixed12ArrayBlock` / `Fixed12ArrayBlockBuilder` / `Fixed12ArrayBlockEncoding` triple provides 12-byte fixed-width block storage. Each position occupies three consecutive ints: `[high32(epochMicros), low32(epochMicros), picosOfMicro]`. The write API is `writeLong(epochMicros).writeInt(picosOfMicro).closeEntry()` — no per-row heap allocation in the hot path.

`TimestampType.createBlockBuilder()` dispatches to `Fixed12ArrayBlockBuilder` when `!isShort()` and to `LongArrayBlockBuilder` otherwise. To enable this override, the three `createBlockBuilder` / `createFixedSizeBlockBuilder` methods in `AbstractLongType` were changed from `final` to non-final.

The new block encoding is registered in `BlockEncodingManager` and `TestingBlockEncodingSerde`.

**`TimestampWithTimeZoneType` precision registry (presto-common)**

`TimestampWithTimeZoneType` follows the same interning pattern: 13 pre-allocated instances, `createTimestampWithTimeZoneType(int p)` factory, `getPrecision()` returning `int`, and reference-equality `equals()`. `TIMESTAMP_WITH_TIME_ZONE` remains `createTimestampWithTimeZoneType(3)` with the `"timestamp with time zone"` type signature.

**Type signature serialization (presto-common / presto-main-base / presto-orc)**

All `TimestampType` instances with p ≠ 3 now serialize to `"timestamp(p)"` (e.g., `"timestamp(6)"`). The previous special-case `"timestamp microseconds"` string for p = 6 is removed.

A new `TimestampParametricType` (in `presto-common`) implements `ParametricType` for base name `"timestamp"` and resolves `"timestamp(p)"` back to `createTimestampType(p)`. It is registered in `BuiltInTypeAndFunctionNamespaceManager` so `getType(parseTypeSignature("timestamp(6)"))` works end-to-end.

One call site in `OrcWriteValidation` that matched on the `"timestamp microseconds"` base string was migrated to reference equality (`type == TIMESTAMP_MICROSECONDS`).

## Motivation and Context

Presto's `TIMESTAMP` type currently has no precision parameter — every timestamp is implicitly millisecond-precision (p = 3) or microsecond-precision (p = 6). Supporting `TIMESTAMP(p)` for p in `[0, 12]` is required for Iceberg v3 nanosecond timestamps and SQL-standard `TIMESTAMP(p)` DDL. This PR establishes the core SPI layer (type objects, block encoding, type signature serialization) that all higher layers — SQL parser, analyzer, connector read/write paths — will build on.

This work ports the design from Trino, which implemented parameterized timestamp types in [trinodb/trino#3783](https://github.com/trinodb/trino/pull/3783) (`TimestampType` precision registry, `LongTimestamp`, type signature serialization) and [trinodb/trino#3947](https://github.com/trinodb/trino/pull/3947) (`TimestampWithTimeZoneType` precision registry).

## Impact

**API changes (presto-common SPI):**

- `TimestampType.getPrecision()` return type changed from `TimeUnit` to `int`. Any code calling `getPrecision()` and treating the result as a `TimeUnit` will fail to compile — four such call sites were fixed in this PR.
- `TimestampType.TIMESTAMP_MICROSECONDS.getTypeSignature().toString()` changes from `"timestamp microseconds"` to `"timestamp(6)"`. Code matching on the `getBase()` string `"timestamp microseconds"` must be migrated to `type == TIMESTAMP_MICROSECONDS`.
- `AbstractLongType.createBlockBuilder()` and `createFixedSizeBlockBuilder()` are no longer `final`. Existing subclasses are unaffected.
- New public API: `TimestampType.createTimestampType(int)`, `isShort()`, `getEpochSecond(long)`, `getNanos(long)`, `toEpochMillis(long)`, `fromEpochComponents(long, int)`, `LongTimestamp`, `Fixed12ArrayBlock`, `Fixed12ArrayBlockBuilder`, `TimestampWithTimeZoneType.createTimestampWithTimeZoneType(int)`, `TimestampParametricType`.

**No behavioral change** for existing queries or connectors using `TIMESTAMP` or `TIMESTAMP WITH TIME ZONE` — both constants still refer to the precision-3 singleton with the same type signatures.

## Test Plan

- **`TestTimestampType`** (12 tests): interning, pre-allocation, backward-compat constants, `isShort()` boundary, `IllegalArgumentException` for invalid precision, `getEpochSecond`/`getNanos`/`toEpochMillis` correctness including negative (pre-1970) epochs.
- **`TestLongTimestamp`** (7 tests): constructor, boundary validation for `picosOfMicro`, negative `epochMicros`.
- **`TestFixed12ArrayBlock`** (8 tests): single/multi-position round-trip, null handling, size accounting, pre-1970 negative epoch, `TimestampType.createBlockBuilder()` dispatch for p > 6 vs p ≤ 6.
- **`TestTimestampWithTimeZoneType`** (9 tests): interning, pre-allocation, backward-compat constant, type signature, reference equality, invalid precision.
- **`TestTimestampTypeSignature`** (7 tests): `toString()` for all 13 precisions, `"timestamp(6)"` format, `TimestampParametricType` round-trip for all precisions including the bare `"timestamp"` form.
- **Full `presto-common` suite**: 376/376 tests pass.
- **`presto-orc`, `presto-main-base`, `presto-iceberg`**: all compile cleanly with no test regressions from modified call sites.

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.
- [X] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Added precision parameterization to TimestampType and TimestampWithTimeZoneType, supporting precisions 0–12 with one interned singleton per level.
* Added LongTimestamp value type and Fixed12ArrayBlock 12-byte block encoding for sub-microsecond (p > 6) timestamp storage.
* TimestampType.getPrecision() now returns int instead of TimeUnit; callers using getPrecision() as a TimeUnit must be updated.
* TIMESTAMP(p) type signatures now serialize as "timestamp(p)" for p ≠ 3; the legacy "timestamp microseconds" form is replaced by "timestamp(6)".
```

## Summary by Sourcery

Add precision-parameterized TIMESTAMP and TIMESTAMP WITH TIME ZONE types, including new value/block encodings and type-signature plumbing to support TIMESTAMP(p) across the type system.

New Features:
- Introduce precision-parametric TimestampType and TimestampWithTimeZoneType supporting precisions 0–12 with interned singleton instances per precision.
- Add LongTimestamp value type and Fixed12ArrayBlock fixed-width 12-byte block encoding for high-precision (p > 6) timestamps.
- Register TimestampParametricType so TIMESTAMP(p) type signatures (including the bare TIMESTAMP form) can be parsed and resolved through the type system.

Enhancements:
- Change TimestampType.getPrecision() to return an int and add helpers for converting between internal timestamp values and epoch-based components, simplifying and standardizing caller logic.
- Adjust block builder creation to route high-precision timestamps to the new Fixed12ArrayBlockBuilder while keeping short timestamps on existing long-array blocks.
- Update Iceberg, planner printing, and ORC write-validation call sites to use the new precision API and canonical timestamp(6) signature instead of TimeUnit-based precision handling.

Tests:
- Add unit tests covering timestamp precision interning, epoch conversion helpers, LongTimestamp validation, Fixed12ArrayBlock behavior, and timestamp type-signature round-tripping, plus tests for precision-parameterized TimestampWithTimeZoneType.