### PR TITLE
fix(security): Upgrade redshift-jdbc42 to 2.2.7 to address CVE-2026-8178

### DIFF
--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.1.0.32</version>
+            <version>2.2.7</version>
         </dependency>
 
         <!-- Presto SPI -->


### PR DESCRIPTION
## Description
Upgrade redshift-jdbc42 to 2.2.7 to address CVE-2026-8178

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Regression test suite report

<img width="1728" height="743" alt="Screenshot 2026-05-27 at 11 16 47 AM" src="https://github.com/user-attachments/assets/2217d14a-83e4-466b-8be9-f1f3fd5cdaaf" />

<img width="638" height="254" alt="Screenshot 2026-05-21 at 1 08 17 PM" src="https://github.com/user-attachments/assets/f209e015-7583-47a9-ba84-2de9a1cf9d24" />
<img width="1725" height="792" alt="Screenshot 2026-05-21 at 1 07 01 PM" src="https://github.com/user-attachments/assets/37d4c0b9-2ade-43d3-b01c-48164b64b3c3" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

`== RELEASE NOTES ==`

```
Security Changes
* Upgrade redshift-jdbc42 to 2.2.7 in response to `CVE-2026-8178  <https://github.com/advisories/GHSA-wmmv-vvg5-993q>`_.

```
