### PR TITLE
fix(native-pos): Fix MaterializedOutput correctness and crash bugs in close/finish lifecycle

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -488,8 +488,19 @@ bool MaterializedOutput::isFinished() {
   return finished_;
 }
 
+void MaterializedOutput::recordBufferStats() {
+  for (const auto& [key, value] : buffer_->stats()) {
+    addRuntimeStat(key, velox::RuntimeCounter(value));
+  }
+}
+
 void MaterializedOutput::close() {
-  finish();
+  if (!finished_) {
+    // If finish() was never called via noMoreInput(), we are on the error
+    // path. Abort the buffer instead of attempting to flush.
+    buffer_->abort();
+  }
+  recordBufferStats();
   Operator::close();
 }
 
@@ -497,35 +508,23 @@ void MaterializedOutput::finish() {
   if (finished_) {
     return;
   }
-  finished_ = true;
+
   flushBatch();
 
-  // Use Velox's allPeersFinished barrier — returns true only for the last
-  // driver to reach this point. The last driver drains and closes the writer.
-  // Wrap in try/catch because allPeersFinished throws if the task is
-  // already terminating (e.g., due to an error on another pipeline).
-  // In that case, the buffer's destructor will handle cleanup via abort().
-  try {
-    std::vector<velox::ContinuePromise> promises;
-    std::vector<std::shared_ptr<velox::exec::Driver>> peers;
-    velox::ContinueFuture peerFuture;
-    auto* driverCtx = operatorCtx()->driverCtx();
-    bool isLast = driverCtx->task->allPeersFinished(
-        planNodeId(), driverCtx->driver, &peerFuture, promises, peers);
+  std::vector<velox::ContinuePromise> peerPromises;
+  std::vector<std::shared_ptr<velox::exec::Driver>> peers;
+  velox::ContinueFuture peerFuture;
+  auto* driverCtx = operatorCtx()->driverCtx();
+  auto isLast = driverCtx->task->allPeersFinished(
+      planNodeId(), driverCtx->driver, &peerFuture, peerPromises, peers);
 
-    if (isLast) {
-      buffer_->noMoreData();
-      for (const auto& [key, value] : buffer_->stats()) {
-        addRuntimeStat(key, velox::RuntimeCounter(value));
-      }
-      for (auto& promise : promises) {
-        promise.setValue();
-      }
+  if (isLast) {
+    buffer_->noMoreData();
+    for (auto& promise : peerPromises) {
+      promise.setValue();
     }
-  } catch (const velox::VeloxRuntimeError&) {
-    // Task is terminating — abort the buffer if not already closed.
-    buffer_->abort();
   }
+
   finished_ = true;
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -125,9 +125,11 @@ class MaterializedOutput : public velox::exec::Operator {
   // Project input columns and lazy-load all children.
   void initializeInput(velox::RowVectorPtr input);
 
-  // Flush remaining data and coordinate with peer drivers. Called from
-  // noMoreInput() and close(). Idempotent via finished_ guard.
+  // Flush remaining data and coordinate with peer drivers.
   void finish();
+
+  // Publish buffer stats as operator runtime stats.
+  void recordBufferStats();
 
   // Partition input, serialize into flat buffer, and flush if threshold
   // reached.

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -105,6 +105,33 @@ std::string localShuffleReadInfo(
       .serialize();
 }
 
+// ShuffleWriter that delegates all operations to a real writer but throws
+// from noMoreData(success=true) to simulate a writer close failure.
+class FailingCloseShuffleWriter : public ShuffleWriter {
+ public:
+  explicit FailingCloseShuffleWriter(std::shared_ptr<ShuffleWriter> delegate)
+      : delegate_(std::move(delegate)) {}
+
+  void collect(int32_t partition, std::string_view key, std::string_view data)
+      override {
+    delegate_->collect(partition, key, data);
+  }
+
+  void noMoreData(bool success) override {
+    if (success) {
+      VELOX_FAIL("Simulated writer close failure");
+    }
+    delegate_->noMoreData(success);
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return delegate_->stats();
+  }
+
+ private:
+  std::shared_ptr<ShuffleWriter> delegate_;
+};
+
 } // namespace
 
 class MaterializedExchangeTest : public exec::test::OperatorTestBase {
@@ -514,6 +541,72 @@ TEST_F(MaterializedExchangeTest, replicateNullsAndAnyDisabled) {
         << "Row '" << v
         << "' should not be replicated when replicateNullsAndAny=false";
   }
+
+  cleanupDirectory(tempDir_->getPath());
+}
+
+// Verifies that exceptions from buffer_->noMoreData() (e.g., writer close
+// failure) propagate to the task instead of being silently swallowed.
+// Previously a broad try/catch in finish() caught these exceptions, causing the
+// operator to report success despite the buffer being aborted — silent data
+// loss.
+TEST_F(MaterializedExchangeTest, assertBufferCloseExceptionsArePropagated) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+      makeFlatVector<std::string>({"a", "bb", "ccc", "dddd", "eeeee", "f"}),
+  });
+
+  const int numPartitions = 4;
+  const int numDrivers = 1;
+  auto dataType = asRowType(data->type());
+
+  auto writeInfoStr = localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
+  auto writeInfo = LocalShuffleWriteInfo::deserialize(writeInfoStr);
+
+  constexpr uint64_t kMaxBytesPerPartition = 1 << 20;
+  auto realWriter = std::make_shared<LocalShuffleWriter>(
+      writeInfo.rootPath,
+      writeInfo.queryId,
+      writeInfo.shuffleId,
+      writeInfo.numPartitions,
+      kMaxBytesPerPartition,
+      writeInfo.sortedShuffle,
+      pool());
+
+  auto failingWriter =
+      std::make_shared<FailingCloseShuffleWriter>(std::move(realWriter));
+
+  auto writerPool = rootPool_->addLeafChild("writerPool");
+
+  constexpr size_t kMaxBufferedBytes = 1 << 20;
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions, failingWriter, writerPool, kMaxBufferedBytes);
+
+  std::vector<core::TypedExprPtr> keys{
+      std::make_shared<core::FieldAccessTypedExpr>(
+          dataType->childAt(0), dataType->nameOf(0))};
+
+  auto partitionFunctionSpec =
+      std::make_shared<exec::HashPartitionFunctionSpec>(
+          dataType, std::vector<column_index_t>{0});
+
+  auto valuesNode = exec::test::PlanBuilder().values({data}, true).planNode();
+  auto exchangeWriteNode = std::make_shared<MaterializedOutputNode>(
+      "exchangeWrite",
+      keys,
+      numPartitions,
+      dataType,
+      partitionFunctionSpec,
+      false,
+      valuesNode,
+      buffer);
+
+  auto taskId = makeTaskId("write", 0);
+  auto task = makeTask(taskId, exchangeWriteNode, 0);
+  task->start(numDrivers);
+
+  EXPECT_TRUE(exec::test::waitForTaskFailure(task.get(), 10'000'000))
+      << "Task should fail when buffer noMoreData() throws, not succeed silently";
 
   cleanupDirectory(tempDir_->getPath());
 }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -39,6 +39,7 @@
 #include "presto_cpp/main/operators/ShuffleWrite.h"
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/main/types/TypeParser.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/TraceUtil.h"
 // RPC plan nodes for single-operator async RPC execution
 #include <folly/json.h>
@@ -2650,8 +2651,11 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     auto shuffleWriterPool = useSystemMemory
         ? velox::memory::memoryManager()->addLeafPool(
               fmt::format("_sys.exchange_writer.{}", taskId))
+        // Add noop memory reclaimer to participate in arbitration protocol.
         : queryCtx_->pool()->addLeafChild(
-              fmt::format("exchange_writer.{}", taskId));
+              fmt::format("exchange_writer.{}", taskId),
+              true,
+              velox::exec::MemoryReclaimer::create());
     auto shuffleWriter = shuffleFactory->createWriter(
         *serializedShuffleWriteInfo_, shuffleWriterPool.get());
 


### PR DESCRIPTION
Summary:
Three fixes for the MaterializedOutput operator lifecycle:

**Fix 1 — Silent data loss (correctness):** `finish()` wrapped both `allPeersFinished()` and `buffer_->noMoreData()` in a single try/catch. If `noMoreData()` threw (e.g. writer close failure, allocation error in `coalesceRowGroups()`), the exception was silently caught, the buffer aborted, and `finished_` set to true — making the task appear successful despite dropped data. Fix: narrowed the try/catch to only `allPeersFinished()` (which legitimately throws when the task is already terminating). `noMoreData()` exceptions now propagate for proper error reporting. Also moved `finished_` assignment to after all work completes so it is a reliable success/failure indicator, and extracted `recordBufferStats()` to capture buffer stats in both success and error paths.

**Fix 2 — Velox operator contract violation causing process crash (T271770195):** `close()` called `finish()` which called `flushBatch()` — allocating memory during teardown. When `addInput()` already threw OOM, `Driver::runInternal()` catches it and calls `task->setError()`. During stack unwinding, `CancelGuard::~CancelGuard()` (implicitly noexcept) calls `close()` → `finish()` → `flushBatch()` → second OOM → `std::terminate` → SIGABRT. The Velox operator contract expects `close()` to only release resources, not do work that can throw. `PartitionedOutput::close()` follows this — it just clears vectors. Fix: `close()` no longer calls `finish()`. If `finish()` was not called via `noMoreInput()` (i.e. we are on the error path), `close()` calls `buffer_->abort()` to release resources without allocating.

**Fix 3 — Missing MemoryReclaimer (T271770232):** The `MaterializedOutputBuffer` memory pool was created in `PrestoToVeloxQueryPlan.cpp` without a `MemoryReclaimer`. When this pool triggers memory arbitration, `enterArbitration()` is a no-op — the driver stays in "running" state and the `memoryArbitrationStateCheck` callback fires `VELOX_FAIL`. Fix: pass `velox::exec::MemoryReclaimer::create()` when creating the buffer pool under the query memory path.

Differential Revision: D105587555


