### PR TITLE
fix(plugin-iceberg): Fix duplicate view creation in Hive catalog

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -677,6 +677,13 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-metastore</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveMetastoreLock.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveMetastoreLock.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.Objects.requireNonNull;
+
+// JVM mutex short-circuits redundant HMS lock RPCs from the same process; HMS lock provides cross-process serialization.
+final class HiveMetastoreLock
+        implements AutoCloseable
+{
+    private static final Logger log = Logger.get(HiveMetastoreLock.class);
+    private static final long LOCK_CACHE_EVICTION_MILLIS = TimeUnit.MINUTES.toMillis(10);
+
+    private static LoadingCache<String, ReentrantLock> jvmLockCache;
+
+    private final ExtendedHiveMetastore metastore;
+    private final MetastoreContext metastoreContext;
+    private final String databaseName;
+    private final String objectName;
+    private final ReentrantLock jvmMutex;
+    private final Optional<Long> hmsLockId;
+
+    private HiveMetastoreLock(
+            ExtendedHiveMetastore metastore,
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String objectName,
+            ReentrantLock jvmMutex,
+            Optional<Long> hmsLockId)
+    {
+        this.metastore = metastore;
+        this.metastoreContext = metastoreContext;
+        this.databaseName = databaseName;
+        this.objectName = objectName;
+        this.jvmMutex = jvmMutex;
+        this.hmsLockId = hmsLockId;
+    }
+
+    static HiveMetastoreLock acquire(
+            ExtendedHiveMetastore metastore,
+            MetastoreContext metastoreContext,
+            boolean useHmsLock,
+            String databaseName,
+            String objectName)
+    {
+        requireNonNull(metastore, "metastore is null");
+        requireNonNull(metastoreContext, "metastoreContext is null");
+        requireNonNull(databaseName, "databaseName is null");
+        requireNonNull(objectName, "objectName is null");
+
+        initJvmLockCache();
+        ReentrantLock mutex = jvmLockCache.getUnchecked(databaseName + "." + objectName);
+        mutex.lock();
+        Optional<Long> lockId = Optional.empty();
+        try {
+            if (useHmsLock) {
+                lockId = metastore.lock(metastoreContext, databaseName, objectName);
+            }
+        }
+        catch (Throwable e) {
+            mutex.unlock();
+            throw e;
+        }
+        return new HiveMetastoreLock(metastore, metastoreContext, databaseName, objectName, mutex, lockId);
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            hmsLockId.ifPresent(id -> metastore.unlock(metastoreContext, id));
+        }
+        catch (Exception e) {
+            log.error(e, "Failed to unlock %s.%s (lockId=%s)", databaseName, objectName, hmsLockId.orElse(null));
+        }
+        finally {
+            jvmMutex.unlock();
+        }
+    }
+
+    // TODO: derive from config
+    private static synchronized void initJvmLockCache()
+    {
+        if (jvmLockCache == null) {
+            jvmLockCache = CacheBuilder.newBuilder()
+                    .expireAfterAccess(LOCK_CACHE_EVICTION_MILLIS, TimeUnit.MILLISECONDS)
+                    .build(new CacheLoader<String, ReentrantLock>()
+                    {
+                        @Override
+                        public ReentrantLock load(String fullName)
+                        {
+                            return new ReentrantLock();
+                        }
+                    });
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -31,9 +31,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Sets;
@@ -64,9 +61,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
@@ -135,8 +130,6 @@ public class HiveTableOperations
     private boolean shouldRefresh = true;
     private int version = -1;
 
-    private static LoadingCache<String, ReentrantLock> commitLockCache;
-
     public HiveTableOperations(
             ExtendedHiveMetastore metastore,
             MetastoreContext metastoreContext,
@@ -197,25 +190,6 @@ public class HiveTableOperations
         this.owner = requireNonNull(owner, "owner is null");
         this.location = requireNonNull(location, "location is null");
         this.config = requireNonNull(config, "config is null");
-        //TODO: duration from config
-        initTableLevelLockCache(TimeUnit.MINUTES.toMillis(10));
-    }
-
-    private static synchronized void initTableLevelLockCache(long evictionTimeout)
-    {
-        if (commitLockCache == null) {
-            commitLockCache = CacheBuilder.newBuilder()
-                    .expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS)
-                    .build(
-                            new CacheLoader<String, ReentrantLock>()
-                            {
-                                @Override
-                                public ReentrantLock load(String fullName)
-                                {
-                                    return new ReentrantLock();
-                                }
-                            });
-        }
     }
 
     @Override
@@ -273,19 +247,11 @@ public class HiveTableOperations
         String newMetadataLocation = writeNewMetadata(metadata, version + 1);
 
         Table table;
-        Optional<Long> lockId = Optional.empty();
         boolean useHMSLock = Optional.ofNullable(metadata.property(TableProperties.HIVE_LOCK_ENABLED, null))
                 .map(Boolean::parseBoolean)
                 .orElse(config.getLockingEnabled());
-        ReentrantLock tableLevelMutex = commitLockCache.getUnchecked(database + "." + tableName);
-        // getting a process-level lock per table to avoid concurrent commit attempts to the same table from the same
-        // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
-        tableLevelMutex.lock();
-        try {
+        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, metastoreContext, useHMSLock, database, tableName)) {
             try {
-                if (useHMSLock) {
-                    lockId = metastore.lock(metastoreContext, database, tableName);
-                }
                 if (base == null) {
                     String tableComment = metadata.properties().get(TABLE_COMMENT);
                     Map<String, String> parameters = new HashMap<>();
@@ -401,15 +367,6 @@ public class HiveTableOperations
         }
         finally {
             shouldRefresh = true;
-            try {
-                lockId.ifPresent(id -> metastore.unlock(metastoreContext, id));
-            }
-            catch (Exception e) {
-                log.error(e, "Failed to unlock: %s", lockId.orElse(null));
-            }
-            finally {
-                tableLevelMutex.unlock();
-            }
         }
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -827,31 +827,37 @@ public class IcebergHiveMetadata
             Map<String, String> properties)
     {
         MetastoreContext metastoreContext = getMetastoreContext(session);
-
-        Optional<Table> existingTable = getHiveTable(session, viewName);
-        if (!existingTable.isPresent() || !isIcebergMaterializedView(existingTable.get())) {
-            throw new PrestoException(NOT_FOUND, "Materialized view not found: " + viewName);
-        }
-
-        Table table = existingTable.get();
-
-        ImmutableMap.Builder<String, String> mergedProperties = ImmutableMap.builder();
-        mergedProperties.putAll(table.getParameters());
-        mergedProperties.putAll(properties);
-
-        Table updatedTable = Table.builder(table)
-                .setParameters(mergedProperties.buildKeepingLast())
-                .build();
-
-        PrincipalPrivileges privileges = buildInitialPrivilegeSet(table.getOwner());
-        metastore.replaceTable(
+        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(
+                metastore,
                 metastoreContext,
+                hiveTableOperationsConfig.getLockingEnabled(),
                 viewName.getSchemaName(),
-                viewName.getTableName(),
-                updatedTable,
-                privileges);
+                viewName.getTableName())) {
+            Optional<Table> existingTable = getHiveTable(session, viewName);
+            if (!existingTable.isPresent() || !isIcebergMaterializedView(existingTable.get())) {
+                throw new PrestoException(NOT_FOUND, "Materialized view not found: " + viewName);
+            }
 
-        tableCache.invalidate(viewName);
+            Table table = existingTable.get();
+
+            ImmutableMap.Builder<String, String> mergedProperties = ImmutableMap.builder();
+            mergedProperties.putAll(table.getParameters());
+            mergedProperties.putAll(properties);
+
+            Table updatedTable = Table.builder(table)
+                    .setParameters(mergedProperties.buildKeepingLast())
+                    .build();
+
+            PrincipalPrivileges privileges = buildInitialPrivilegeSet(table.getOwner());
+            metastore.replaceTable(
+                    metastoreContext,
+                    viewName.getSchemaName(),
+                    viewName.getTableName(),
+                    updatedTable,
+                    privileges);
+
+            tableCache.invalidate(viewName);
+        }
     }
 
     private static boolean isIcebergMaterializedView(Table table)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestHiveMetastoreLock.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestHiveMetastoreLock.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.UnimplementedHiveMetastore;
+import com.facebook.presto.spi.WarningCollector;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveMetastoreLock
+{
+    private static final MetastoreContext METASTORE_CONTEXT = new MetastoreContext(
+            "test_user",
+            "test_query",
+            Optional.empty(),
+            Collections.emptySet(),
+            Optional.empty(),
+            Optional.empty(),
+            false,
+            HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+            WarningCollector.NOOP,
+            new RuntimeStats());
+
+    @Test
+    public void testJvmMutexSerializesConcurrentSections()
+            throws Exception
+    {
+        int threadCount = 4;
+        int iterationsPerThread = 10;
+        AtomicInteger inFlight = new AtomicInteger();
+        AtomicInteger maxInFlight = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount * iterationsPerThread);
+
+        UnimplementedHiveMetastore metastore = new UnimplementedHiveMetastore();
+        try {
+            for (int i = 0; i < threadCount * iterationsPerThread; i++) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+                        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, METASTORE_CONTEXT, false, "db", "obj")) {
+                            int current = inFlight.incrementAndGet();
+                            maxInFlight.updateAndGet(previous -> Math.max(previous, current));
+                            Thread.sleep(2);
+                            inFlight.decrementAndGet();
+                        }
+                    }
+                    catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS), "sections did not complete in time");
+        }
+        finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals(maxInFlight.get(), 1, "lock failed to serialize: max concurrent in-flight = " + maxInFlight.get());
+    }
+
+    @Test
+    public void testHmsLockAcquiredAndReleasedWhenEnabled()
+    {
+        AtomicInteger lockCount = new AtomicInteger();
+        AtomicInteger unlockCount = new AtomicInteger();
+        UnimplementedHiveMetastore metastore = new UnimplementedHiveMetastore()
+        {
+            @Override
+            public Optional<Long> lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+            {
+                return Optional.of((long) lockCount.incrementAndGet());
+            }
+
+            @Override
+            public void unlock(MetastoreContext metastoreContext, long lockId)
+            {
+                unlockCount.incrementAndGet();
+            }
+        };
+
+        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, METASTORE_CONTEXT, true, "db", "obj_a")) {
+            // body intentionally empty — assertions verify lock/unlock side effects on entry/exit
+        }
+        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, METASTORE_CONTEXT, true, "db", "obj_b")) {
+            // body intentionally empty — assertions verify lock/unlock side effects on entry/exit
+        }
+
+        assertEquals(lockCount.get(), 2);
+        assertEquals(unlockCount.get(), 2);
+    }
+
+    @Test
+    public void testHmsLockNotAcquiredWhenDisabled()
+    {
+        AtomicInteger lockCount = new AtomicInteger();
+        AtomicInteger unlockCount = new AtomicInteger();
+        UnimplementedHiveMetastore metastore = new UnimplementedHiveMetastore()
+        {
+            @Override
+            public Optional<Long> lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+            {
+                lockCount.incrementAndGet();
+                return Optional.of(1L);
+            }
+
+            @Override
+            public void unlock(MetastoreContext metastoreContext, long lockId)
+            {
+                unlockCount.incrementAndGet();
+            }
+        };
+
+        try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, METASTORE_CONTEXT, false, "db", "obj")) {
+            // body intentionally empty — assertion verifies lock() is never called when the flag is off
+        }
+
+        assertEquals(lockCount.get(), 0);
+        assertEquals(unlockCount.get(), 0);
+    }
+
+    @Test
+    public void testHmsLockReleasedOnExceptionInProtectedSection()
+    {
+        AtomicInteger lockCount = new AtomicInteger();
+        AtomicInteger unlockCount = new AtomicInteger();
+        UnimplementedHiveMetastore metastore = new UnimplementedHiveMetastore()
+        {
+            @Override
+            public Optional<Long> lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+            {
+                return Optional.of((long) lockCount.incrementAndGet());
+            }
+
+            @Override
+            public void unlock(MetastoreContext metastoreContext, long lockId)
+            {
+                unlockCount.incrementAndGet();
+            }
+        };
+
+        RuntimeException expected = new RuntimeException("boom");
+        try {
+            try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(metastore, METASTORE_CONTEXT, true, "db", "obj")) {
+                throw expected;
+            }
+        }
+        catch (RuntimeException actual) {
+            assertEquals(actual, expected);
+        }
+
+        assertEquals(lockCount.get(), 1);
+        assertEquals(unlockCount.get(), 1, "unlock must run even when the protected section threw");
+    }
+
+    @Test
+    public void testJvmMutexReleasedWhenHmsLockAcquisitionFails()
+            throws Exception
+    {
+        AtomicInteger lockAttempts = new AtomicInteger();
+        UnimplementedHiveMetastore failingMetastore = new UnimplementedHiveMetastore()
+        {
+            @Override
+            public Optional<Long> lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+            {
+                lockAttempts.incrementAndGet();
+                throw new RuntimeException("hms unavailable");
+            }
+        };
+
+        try {
+            HiveMetastoreLock.acquire(failingMetastore, METASTORE_CONTEXT, true, "db", "obj_fail");
+        }
+        catch (RuntimeException ignored) {
+        }
+
+        // If the JVM mutex had leaked, the next acquire on the same key would block forever.
+        CountDownLatch acquired = new CountDownLatch(1);
+        Thread acquirer = new Thread(() -> {
+            try (HiveMetastoreLock ignored = HiveMetastoreLock.acquire(
+                    new UnimplementedHiveMetastore(), METASTORE_CONTEXT, false, "db", "obj_fail")) {
+                acquired.countDown();
+            }
+        });
+        acquirer.start();
+        assertTrue(acquired.await(5, TimeUnit.SECONDS), "JVM mutex leaked after HMS lock acquisition failure");
+        acquirer.join();
+        assertEquals(lockAttempts.get(), 1);
+    }
+}


### PR DESCRIPTION
## Description
`IcebergHiveMetadata.updateIcebergViewProperties` did read-merge-`replaceTable` with no lock held, so concurrent `REFRESH MATERIALIZED VIEW` on a Hive-backed Iceberg MV could lose a watermark update. Wrapped it in the same per-object JVM mutex + HMS lock `HiveTableOperations.commit` uses, extracted to a shared `HiveMetastoreLock`.

## Motivation and Context
Two concurrent `REFRESH MATERIALIZED VIEW` invocations on the same Hive-backed Iceberg MV can lose a watermark update — the later writer's `replaceTable` overwrites the earlier one's snapshot pointer.  This change will prevent potential corruption if two REFRESH statements are issued concurrently.

## Impact
Hive-backed deployments with `iceberg.engine.hive.lock-enabled` (default `true`) only.

## Test Plan
- New `TestHiveMetastoreLock` (5 tests)
- `TestIcebergMaterializedViews`

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==
Hive Connector Changes
* Fix race where concurrent ``REFRESH MATERIALIZED VIEW`` on the same Hive-backed Iceberg materialized view could lose a watermark update.
```

## Summary by Sourcery

Introduce a reusable metastore lock abstraction and apply it to Iceberg Hive operations to ensure serialized metadata updates without duplicate view creation.

Bug Fixes:
- Prevent duplicate or inconsistent updates when modifying Iceberg materialized view properties by guarding the operation with a metastore lock.

Enhancements:
- Refactor HiveTableOperations commit locking to use a shared HiveMetastoreLock that combines a JVM-level mutex with optional Hive Metastore locks for cross-process coordination.

Build:
- Add presto-hive-metastore test-jar as a test dependency for Iceberg module locking tests.

Tests:
- Add unit tests covering HiveMetastoreLock behavior for JVM-level serialization, optional HMS lock acquisition and release, and robustness in the face of exceptions and lock acquisition failures.