### PR TITLE
fix: Use Principal getName instead of toString in session representation

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -573,7 +573,7 @@ public final class Session
                 transactionId,
                 clientTransactionSupport,
                 identity.getUser(),
-                identity.getPrincipal().map(Principal::toString),
+                identity.getPrincipal().map(Principal::getName),
                 source,
                 catalog,
                 schema,


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Currently, when mapping `Session` to `SessionRepresentation`, `principal.toString()` is passed as the value for the principal argument. But, inside `SessionRepresentation`, a new `BasicPrincipal` is reconstructed from that string: https://github.com/prestodb/presto/blob/81ea0f14c068d961a12a7114f8291e4178868746/presto-main-base/src/main/java/com/facebook/presto/SessionRepresentation.java#L334

Since `BasicPrincipal` expects the principal name in its constructor, we should use `getName()` instead of `toString()` when creating the `SessionRepresentation` object. This is also consistent with the rest of the Presto codebase, where `getName()` is used whenever a string representation of a `Principal` is required.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Using `toString()` may cause issues for custom access control plugins that return an overloaded implementation of `BasicPrincipal` with different implementations of `getName()` and `toString()`.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No impact.

## Test Plan
<!---Please fill in how you tested your change-->
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Ensure SessionRepresentation is built with Principal.getName() to avoid issues with custom Principal implementations relying on distinct getName() and toString() behaviors.