### PR TITLE
refactor: Remove duplicate check of iceberg v3 validation

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -124,13 +123,6 @@ public class AddColumnTask
 
         // Handle default expression if present
         if (element.getDefaultExpression().isPresent()) {
-            if (!isIcebergTable(metadata, session, tableName)) {
-                String catalogName = tableName.getCatalogName();
-                String connectorName = getConnectorName(metadata, session, tableName);
-                throw new SemanticException(NOT_SUPPORTED, element,
-                        "Catalog '%s' (connector: %s) does not support ADD COLUMN with DEFAULT values. This feature is currently only supported for Iceberg v3 tables.", catalogName, connectorName);
-            }
-
             Expression defaultExpr = element.getDefaultExpression().get();
             Object defaultValue = ExpressionInterpreter.evaluateConstantExpression(defaultExpr, type, metadata, session, ImmutableMap.of());
             Map<String, Object> updatedProperties = new java.util.HashMap<>(columnProperties);
@@ -149,17 +141,5 @@ public class AddColumnTask
         metadata.addColumn(session, tableHandle.get(), column);
 
         return immediateFuture(null);
-    }
-
-    private static String getConnectorName(Metadata metadata, Session session, QualifiedObjectName tableName)
-    {
-        String catalogName = tableName.getCatalogName();
-        CatalogContext catalogContext = metadata.getCatalogNamesWithConnectorContext(session).get(catalogName);
-        return catalogContext != null ? catalogContext.getConnectorName() : "unknown";
-    }
-
-    private static boolean isIcebergTable(Metadata metadata, Session session, QualifiedObjectName tableName)
-    {
-        return "iceberg".equalsIgnoreCase(getConnectorName(metadata, session, tableName));
     }
 }


### PR DESCRIPTION
## Description
Remove duplicate check of iceberg v3 validation. Already present in iceberg - https://github.com/prestodb/presto/blob/master/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java#L1253

## Motivation and Context
Remove duplicate check of iceberg v3 validation

## Impact
Maintainance

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Remove duplicate Iceberg connector validation logic for ADD COLUMN with DEFAULT expressions in AddColumnTask.