### PR TITLE
fix: Disallow rewrite_data_files in Iceberg if filter pushdown enabled

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -152,6 +152,11 @@ public class RewriteDataFilesProcedure
 
     private ConnectorDistributedProcedureHandle beginCallDistributedProcedure(ConnectorSession session, IcebergRewriteDataFilesProcedureContext procedureContext, IcebergTableLayoutHandle layoutHandle, Object[] arguments, OptionalInt sortOrderIndex)
     {
+        if (layoutHandle.isPushdownFilterEnabled()) {
+            throw new PrestoException(NOT_SUPPORTED,
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+        }
+
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
             Table icebergTable = procedureContext.getTable();
             IcebergTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -46,6 +47,7 @@ import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static java.lang.String.format;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DATA_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DELETE_FILES_PROP;
@@ -261,6 +263,47 @@ public class TestRewriteDataFilesProcedure
                             "(5, 'foo'), (6, 'bar'), " +
                             "(7, 'foo'), (8, 'bar'), " +
                             "(9, 'foo'), (10, 'bar')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesWithFilterPushdownEnabled()
+    {
+        String tableName = "example_partition_filter_pushdown_table";
+        String schemaName = getSession().getSchema().get();
+        Session sessionWithFilterPushdown = pushdownFilterEnabled();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (c1 integer, c2 varchar) with (partitioning = ARRAY['c2'])");
+
+            // create 1 files for each partition (c2 = 'foo' or 'bar')
+            assertUpdate("INSERT INTO " + tableName + " values(1, 'foo'), (2, 'foo'), (3, 'foo'), (4, 'foo'), (5, 'foo')", 5);
+            assertUpdate("INSERT INTO " + tableName + " values(1, 'bar'), (2, 'bar'), (3, 'bar'), (4, 'bar'), (5, 'bar')", 5);
+
+            // Does not support rewriting files when native-only filter push down is enabled
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+
+            // select 1 files to rewrite
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''', options => map(array['rewrite-all'], array['true']))", tableName, schemaName), 5);
+
+            Table table = loadTable(tableName);
+            //The number of data files is 2，and the number of delete files is 0
+            assertHasDataFiles(table.currentSnapshot(), 2);
+            assertHasDeleteFiles(table.currentSnapshot(), 0);
+
+            assertQuery("select * from " + tableName,
+                    "values(1, 'foo'), (1, 'bar'), " +
+                            "(2, 'foo'), (2, 'bar'), " +
+                            "(3, 'foo'), (3, 'bar'), " +
+                            "(4, 'foo'), (4, 'bar'), " +
+                            "(5, 'foo'), (5, 'bar')");
         }
         finally {
             dropTable(tableName);
@@ -1427,6 +1470,13 @@ public class TestRewriteDataFilesProcedure
         finally {
             dropTable(tableName);
         }
+    }
+
+    private Session pushdownFilterEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
     }
 
     private Table loadTable(String tableName)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestRewriteDataFilesProcedure.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.nativeworker.iceberg;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
@@ -21,6 +22,8 @@ import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
@@ -245,6 +248,47 @@ public class TestRewriteDataFilesProcedure
     }
 
     @Test
+    public void testRewriteDataFilesWithFilterPushdownEnabled()
+    {
+        String tableName = "example_partition_filter_pushdown_table";
+        String schemaName = getSession().getSchema().get();
+        Session sessionWithFilterPushdown = pushdownFilterEnabled();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (c1 integer, c2 varchar) with (partitioning = ARRAY['c2'])");
+
+            // create 1 files for each partition (c2 = 'foo' or 'bar')
+            assertUpdate("INSERT INTO " + tableName + " values(1, 'foo'), (2, 'foo'), (3, 'foo'), (4, 'foo'), (5, 'foo')", 5);
+            assertUpdate("INSERT INTO " + tableName + " values(1, 'bar'), (2, 'bar'), (3, 'bar'), (4, 'bar'), (5, 'bar')", 5);
+
+            //The number of data files is 2, and the number of delete files is 0
+            validateDataFilesAndDeleteFiles(tableName, 2L, 0L);
+
+            // Does not support rewriting files when native-only filter push down is enabled
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c1 > 3')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+            assertQueryFails(sessionWithFilterPushdown, format("call system.rewrite_data_files(table_name => '%s', schema => '%s')", tableName, schemaName),
+                    "Cannot execute rewrite_data_files when native-only filter push down is enabled.");
+
+            // select 1 files to rewrite
+            assertUpdate(format("CALL system.rewrite_data_files(table_name => '%s', schema => '%s', filter => 'c2 = ''bar''', options => map(array['rewrite-all'], array['true']))", tableName, schemaName), 5);
+            //The number of data files is 2, and the number of delete files is 0
+            validateDataFilesAndDeleteFiles(tableName, 2L, 0L);
+
+            assertQuery("select * from " + tableName,
+                    "values(1, 'foo'), (1, 'bar'), " +
+                            "(2, 'foo'), (2, 'bar'), " +
+                            "(3, 'foo'), (3, 'bar'), " +
+                            "(4, 'foo'), (4, 'bar'), " +
+                            "(5, 'foo'), (5, 'bar')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testRewriteDataFilesWithDeleteAndPartitionEvolution()
     {
         String tableName = "example_partition_evolution_table";
@@ -328,6 +372,13 @@ public class TestRewriteDataFilesProcedure
 
         //The number of data files is 5, and the number of delete files is 0
         validateDataFilesAndDeleteFiles(tableName, 5L, 0L);
+    }
+
+    private Session pushdownFilterEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
     }
 
     private void validateDataFilesAndDeleteFiles(String tableName, long dataFiles, long deleteFiles)


### PR DESCRIPTION
## Description

In Iceberg, when `pushdown_filter_enabled` is set to true for native worker, filters could be completely pushed down even when they don't align with partitioning boundaries. Since rewriting takes the entire file as the smallest unit, this may lead to data loss after rewriting. For example, executing the following SQLs on Prestissimo:

```
presto:default> create table test_table(a int, b varchar);
presto:default> insert into test_table values(1, '1001'), (2, '1002'), (3, '1003');
presto:default> set session iceberg.pushdown_filter_enabled = true;

presto:default> CALL system.rewrite_data_files(table_name => 'test_table', schema => 'default', filter => 'a > 2', options => map(array['rewrite-all'], array['true']));
CALL: 1 row

presto:default> select * from test_table;
 a |  b   
---+------
 3 | 1003 
(1 row)
```

This PR disallow executing `rewrite_data_files` when native-only filter push down is enabled. This prevents the potential data loss issue after rewriting.

## Motivation and Context

To avoid the possible issue of data loss after `rewrite_data_files` in Iceberg.

## Impact

N/A

## Test Plan

Newly added test cases to cover the scenario in PR description.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Disallow executing the Iceberg rewrite_data_files procedure when native-only filter pushdown is enabled and add coverage to ensure correct behavior under this configuration.

Bug Fixes:
- Prevent rewrite_data_files from running when Iceberg native filter pushdown is enabled to avoid potential data loss.

Enhancements:
- Introduce helper methods to create sessions with Iceberg filter pushdown enabled for reuse in tests.

Tests:
- Add connector and native worker tests verifying rewrite_data_files is rejected when filter pushdown is enabled and that data files and table contents remain correct.

## Summary by Sourcery

Disallow executing the Iceberg rewrite_data_files procedure when native-only filter pushdown is enabled to prevent potential data loss and add tests to validate this behavior.

Bug Fixes:
- Reject rewrite_data_files calls when Iceberg native filter pushdown is enabled to avoid unsafe rewrites that could lead to data loss.

Enhancements:
- Introduce a reusable session helper that enables Iceberg filter pushdown for use in tests.

Tests:
- Add connector-side tests confirming rewrite_data_files fails when filter pushdown is enabled and that table data remains intact.
- Add native worker tests verifying rewrite_data_files is rejected under filter pushdown and that file counts and table contents remain correct.