### PR TITLE
chore(deps): Upgrade datasketches-java to version 6.2.0

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -273,7 +273,7 @@
         <dependency>
             <groupId>org.apache.datasketches</groupId>
             <artifactId>datasketches-java</artifactId>
-            <version>6.1.1</version>
+            <version>6.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Description
Upgrade datasketches-java to version 6.2.0

## Motivation and Context
- Bumps the dependency to the latest available version.
- Includes upstream bug fixes and improvements.
- No functional code changes.

## Impact
This is a dependency bump with no functional code changes. Version 6.2.0 includes upstream bug fixes and performance improvements while maintaining backward compatibility. Versions 7.0.0 and above introduced breaking API changes (package restructuring, method signature changes) that would require code modifications and could affect compatibility with Apache Pinot, so 6.2.0 was chosen as the safest upgrade path.

## Test Plan

Locally tested

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

