### PR TITLE
feat(plugin-hive): Add read_files PTVF to support schema inference

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -1438,6 +1438,65 @@ Drop a schema::
 
     DROP SCHEMA hive.web
 
+Table Functions
+---------------
+
+``read_files``
+^^^^^^^^^^^^^^
+
+Polymorphic table function that scans a storage path, inferring the
+output schema from the files' footers. Supports ``PARQUET`` only.
+
+Syntax::
+
+    SELECT * FROM TABLE(
+      hive.system.read_files(
+        location => '<path>',
+        format   => 'parquet'));
+
+Arguments:
+
+``LOCATION`` (``VARCHAR``, required)
+  Storage path. Any URI reachable through the Hive catalog's
+  filesystem configuration. Listing is recursive. Hidden files
+  (``_*``, ``.*``) and zero-length files are skipped.
+
+``FORMAT`` (``VARCHAR``, required)
+  Case-insensitive. Only ``parquet`` is accepted.
+
+``MAX_FILE_COUNT`` (``INTEGER``, default ``100``)
+  Caps the number of files sampled at analyze time and scanned at
+  execution time. Listing stops once this many files have been
+  collected. Must be positive.
+
+CTAS::
+
+    CREATE TABLE my_table AS
+    SELECT * FROM TABLE(hive.system.read_files('s3://bucket/prefix/', 'parquet'));
+
+``INSERT``::
+
+    INSERT INTO my_table
+    SELECT * FROM TABLE(hive.system.read_files('s3://bucket/prefix/', 'parquet'));
+
+Schema unification across files (footers read at analyze time):
+
+* Column key by name, case-insensitive.
+* Column missing from some files: nullable in the merged schema.
+* Pairwise widening: integer chain
+  (``TINYINT`` → ``SMALLINT`` → ``INTEGER`` → ``BIGINT``); integer +
+  floating → ``DOUBLE``; ``DECIMAL(p,s)`` rescaled to fit both inputs
+  (fail if widened precision exceeds 38); ``VARCHAR(n)`` +
+  ``VARCHAR(m)`` → ``VARCHAR(max(n,m))`` (unbounded prevails);
+  ``CHAR`` analogously. ``ROW`` / ``ARRAY`` / ``MAP`` recurse
+  element-wise.
+* Type conflict fails with the column and both file paths in the
+  error. No silent ``VARCHAR`` fallback.
+
+Listing is always recursive from ``LOCATION``; subdirectory files
+are sampled at analyze time and scanned at execution time. No
+glob/pattern argument is supported.
+
 Hive Connector Limitations
 --------------------------
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveTableHandle.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveTableHandle.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.metastore.Table;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;
@@ -27,32 +29,67 @@ public class HiveTableHandle
         extends BaseHiveTableHandle
 {
     private final Optional<List<List<String>>> analyzePartitionValues;
+    // Bypasses metastore lookup in the Hive connector when present.
+    private final Optional<Table> syntheticTable;
+    // When present, bypasses directory listing at split-gen and uses this file list verbatim.
+    private final Optional<List<SyntheticHiveFileInfo>> syntheticFiles;
 
     @JsonCreator
     public HiveTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
-            @JsonProperty("analyzePartitionValues") Optional<List<List<String>>> analyzePartitionValues)
+            @JsonProperty("analyzePartitionValues") Optional<List<List<String>>> analyzePartitionValues,
+            @JsonProperty("syntheticTable") Optional<Table> syntheticTable,
+            @JsonProperty("syntheticFiles") Optional<List<SyntheticHiveFileInfo>> syntheticFiles)
     {
         super(schemaName, tableName);
 
         this.analyzePartitionValues = requireNonNull(analyzePartitionValues, "analyzePartitionValues is null");
+        this.syntheticTable = requireNonNull(syntheticTable, "syntheticTable is null");
+        this.syntheticFiles = requireNonNull(syntheticFiles, "syntheticFiles is null").map(ImmutableList::copyOf);
+    }
+
+    public HiveTableHandle(String schemaName, String tableName, Optional<List<List<String>>> analyzePartitionValues)
+    {
+        this(schemaName, tableName, analyzePartitionValues, Optional.empty(), Optional.empty());
     }
 
     public HiveTableHandle(String schemaName, String tableName)
     {
-        this(schemaName, tableName, Optional.empty());
+        this(schemaName, tableName, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public HiveTableHandle withAnalyzePartitionValues(Optional<List<List<String>>> analyzePartitionValues)
     {
-        return new HiveTableHandle(getSchemaName(), getTableName(), analyzePartitionValues);
+        return new HiveTableHandle(getSchemaName(), getTableName(), analyzePartitionValues, syntheticTable, syntheticFiles);
+    }
+
+    public HiveTableHandle withSyntheticTable(Table table)
+    {
+        return new HiveTableHandle(getSchemaName(), getTableName(), analyzePartitionValues, Optional.of(requireNonNull(table, "table is null")), syntheticFiles);
+    }
+
+    public HiveTableHandle withSyntheticFiles(List<SyntheticHiveFileInfo> files)
+    {
+        return new HiveTableHandle(getSchemaName(), getTableName(), analyzePartitionValues, syntheticTable, Optional.of(requireNonNull(files, "files is null")));
     }
 
     @JsonProperty
     public Optional<List<List<String>>> getAnalyzePartitionValues()
     {
         return analyzePartitionValues;
+    }
+
+    @JsonProperty
+    public Optional<Table> getSyntheticTable()
+    {
+        return syntheticTable;
+    }
+
+    @JsonProperty
+    public Optional<List<SyntheticHiveFileInfo>> getSyntheticFiles()
+    {
+        return syntheticFiles;
     }
 
     @Override
@@ -84,6 +121,8 @@ public class HiveTableHandle
                 .add("schemaName", getSchemaName())
                 .add("tableName", getTableName())
                 .add("analyzePartitionValues", analyzePartitionValues)
+                .add("syntheticTable", syntheticTable)
+                .add("syntheticFiles", syntheticFiles.map(List::size).map(n -> n + " files"))
                 .toString();
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/SyntheticHiveFileInfo.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/SyntheticHiveFileInfo.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class SyntheticHiveFileInfo
+{
+    private final String path;
+    private final long length;
+    private final long modificationTime;
+
+    @JsonCreator
+    public SyntheticHiveFileInfo(
+            @JsonProperty("path") String path,
+            @JsonProperty("length") long length,
+            @JsonProperty("modificationTime") long modificationTime)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.length = length;
+        this.modificationTime = modificationTime;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public long getLength()
+    {
+        return length;
+    }
+
+    @JsonProperty
+    public long getModificationTime()
+    {
+        return modificationTime;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SyntheticHiveFileInfo that = (SyntheticHiveFileInfo) o;
+        return length == that.length && modificationTime == that.modificationTime && path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(path, length, modificationTime);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata;
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
@@ -63,6 +64,7 @@ public class HiveConnector
     private final ConnectorNodePartitioningProvider nodePartitioningProvider;
     private final Set<SystemTable> systemTables;
     private final Set<Procedure> procedures;
+    private final Set<ConnectorTableFunction> tableFunctions;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
@@ -84,6 +86,7 @@ public class HiveConnector
             ConnectorNodePartitioningProvider nodePartitioningProvider,
             Set<SystemTable> systemTables,
             Set<Procedure> procedures,
+            Set<ConnectorTableFunction> tableFunctions,
             List<PropertyMetadata<?>> sessionProperties,
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
@@ -101,6 +104,7 @@ public class HiveConnector
         this.nodePartitioningProvider = requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
         this.systemTables = ImmutableSet.copyOf(requireNonNull(systemTables, "systemTables is null"));
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
+        this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
         this.sessionProperties = ImmutableList.copyOf(requireNonNull(sessionProperties, "sessionProperties is null"));
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
@@ -158,6 +162,12 @@ public class HiveConnector
     public Set<Procedure> getProcedures()
     {
         return procedures;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return tableFunctions;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.util.RebindSafeMBeanServer;
 import com.facebook.presto.hive.authentication.HiveAuthenticationModule;
 import com.facebook.presto.hive.azure.HiveAzureModule;
+import com.facebook.presto.hive.functions.HiveTableFunctionModule;
 import com.facebook.presto.hive.gcs.HiveGcsModule;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
@@ -51,6 +52,7 @@ import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSpl
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -121,6 +123,7 @@ public class HiveConnectorFactory
                     new HiveSecurityModule(),
                     new HiveAuthenticationModule(),
                     new HiveProcedureModule(),
+                    new HiveTableFunctionModule(),
                     new CachingModule(),
                     new HiveCommonModule(),
                     binder -> {
@@ -158,6 +161,7 @@ public class HiveConnectorFactory
             HiveAnalyzeProperties hiveAnalyzeProperties = injector.getInstance(HiveAnalyzeProperties.class);
             ConnectorAccessControl accessControl = new SystemTableAwareAccessControl(injector.getInstance(ConnectorAccessControl.class));
             Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
+            Set<ConnectorTableFunction> tableFunctions = injector.getInstance(Key.get(new TypeLiteral<Set<ConnectorTableFunction>>() {}));
             ConnectorPlanOptimizerProvider planOptimizerProvider = injector.getInstance(ConnectorPlanOptimizerProvider.class);
 
             List<PropertyMetadata<?>> allSessionProperties = new ArrayList<>(hiveSessionProperties.getSessionProperties());
@@ -173,6 +177,7 @@ public class HiveConnectorFactory
                     new ClassLoaderSafeNodePartitioningProvider(connectorDistributionProvider, classLoader),
                     ImmutableSet.of(),
                     procedures,
+                    tableFunctions,
                     allSessionProperties,
                     SchemaProperties.SCHEMA_PROPERTIES,
                     hiveTableProperties.getTableProperties(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -29,6 +29,8 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.LocationService.WriteInfo;
 import com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import com.facebook.presto.hive.functions.ReadFilesFunction;
+import com.facebook.presto.hive.functions.ReadFilesHandle;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
@@ -81,9 +83,11 @@ import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
 import com.facebook.presto.spi.constraints.NotNullConstraint;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -682,7 +686,8 @@ public class HiveMetadata
     {
         MetastoreContext metastoreContext = getMetastoreContext(session);
         HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
-        Optional<Table> table = metastore.getTable(metastoreContext, hiveTableHandle);
+        Optional<Table> table = hiveTableHandle.getSyntheticTable().map(Optional::of)
+                .orElseGet(() -> metastore.getTable(metastoreContext, hiveTableHandle));
         return getTableMetadata(table, hiveTableHandle.getSchemaTableName(), metastoreContext, session);
     }
 
@@ -915,6 +920,10 @@ public class HiveMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         if (!isStatisticsEnabled(session)) {
+            return TableStatistics.empty();
+        }
+
+        if (((HiveTableHandle) tableHandle).getSyntheticTable().isPresent()) {
             return TableStatistics.empty();
         }
 
@@ -2863,8 +2872,9 @@ public class HiveMetadata
         }
 
         TupleDomain<Subfield> domainPredicate = hivePartitionResult.getEffectivePredicate().transform(HiveMetadata::toSubfield);
-        Table table = metastore.getTable(getMetastoreContext(session), handle)
-                .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
+        Table table = handle.getSyntheticTable().orElseGet(() ->
+                metastore.getTable(getMetastoreContext(session), handle)
+                        .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName())));
 
         String layoutString = createTableLayoutString(session, handle.getSchemaTableName(), hivePartitionResult.getBucketHandle(), hivePartitionResult.getBucketFilter(), TRUE_CONSTANT, domainPredicate);
         Optional<Set<HiveColumnHandle>> requestedColumns = desiredColumns.map(columns -> columns.stream().map(column -> (HiveColumnHandle) column).collect(toImmutableSet()));
@@ -3954,6 +3964,69 @@ public class HiveMetadata
         MetastoreContext metastoreContext = getMetastoreContext(session);
         metastore.addConstraint(metastoreContext, hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), tableConstraint);
     }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    {
+        if (handle instanceof ReadFilesHandle) {
+            return Optional.of(buildReadFilesTableFunctionResult(session, (ReadFilesHandle) handle));
+        }
+        return Optional.empty();
+    }
+
+    private TableFunctionApplicationResult<ConnectorTableHandle> buildReadFilesTableFunctionResult(ConnectorSession session, ReadFilesHandle handle)
+    {
+        ImmutableList.Builder<Column> dataColumns = ImmutableList.builder();
+        ImmutableList.Builder<ColumnHandle> columnHandles = ImmutableList.builder();
+        List<ColumnMetadata> columns = handle.getColumns();
+        for (int ordinal = 0; ordinal < columns.size(); ordinal++) {
+            ColumnMetadata column = columns.get(ordinal);
+            HiveType hiveType = toHiveType(typeTranslator, column.getType());
+            dataColumns.add(new Column(column.getName(), hiveType, Optional.empty(), Optional.empty()));
+            columnHandles.add(new HiveColumnHandle(
+                    column.getName(),
+                    hiveType,
+                    column.getType().getTypeSignature(),
+                    ordinal,
+                    REGULAR,
+                    Optional.empty(),
+                    Optional.empty()));
+        }
+
+        Storage storage = new Storage(
+                fromHiveStorageFormat(handle.getFormat()),
+                handle.getLocation(),
+                Optional.empty(),
+                false,
+                ImmutableMap.of(),
+                ImmutableMap.of());
+
+        String syntheticTableName = ReadFilesFunction.NAME + "_" + session.getQueryId().replace('-', '_');
+        Table syntheticTable = new Table(
+                Optional.empty(),
+                ReadFilesFunction.SCHEMA_NAME,
+                syntheticTableName,
+                session.getUser(),
+                PrestoTableType.EXTERNAL_TABLE,
+                storage,
+                dataColumns.build(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                Optional.empty());
+
+        ImmutableList.Builder<SyntheticHiveFileInfo> fileInfos = ImmutableList.builder();
+        for (ReadFilesHandle.FileEntry file : handle.getFiles()) {
+            fileInfos.add(new SyntheticHiveFileInfo(file.getPath(), file.getLength(), file.getModificationTime()));
+        }
+
+        HiveTableHandle tableHandle = new HiveTableHandle(ReadFilesFunction.SCHEMA_NAME, syntheticTableName)
+                .withSyntheticTable(syntheticTable)
+                .withSyntheticFiles(fileInfos.build());
+
+        return new TableFunctionApplicationResult<>(tableHandle, columnHandles.build());
+    }
+
 
     private enum SystemTableHandler
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -476,6 +476,9 @@ public class HivePartitionManager
 
     private Table getTable(ConnectorSession session, SemiTransactionalHiveMetastore metastore, HiveTableHandle hiveTableHandle, boolean offlineDataDebugModeEnabled)
     {
+        if (hiveTableHandle.getSyntheticTable().isPresent()) {
+            return hiveTableHandle.getSyntheticTable().get();
+        }
         MetastoreContext context = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getClientTags(), session.getSource(), getMetastoreHeaders(session), isUserDefinedTypeEncodingEnabled(session), metastore.getColumnConverterProvider(), session.getWarningCollector(), session.getRuntimeStats());
         Optional<Table> target = metastore.getTable(context, hiveTableHandle);
         if (!target.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.spi.ColumnHandle;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -30,6 +31,8 @@ public class HivePartitionMetadata
     // This is a set of columns whose domain could be removed from table layout because all values in the partition will satisfy.
     private final Set<ColumnHandle> redundantColumnDomains;
     private final Optional<byte[]> rowIdPartitionComponent;
+    // When present, drives split-gen directly and bypasses the directory listing.
+    private final Optional<List<HiveFileInfo>> syntheticFiles;
 
     HivePartitionMetadata(
             HivePartition hivePartition,
@@ -39,12 +42,25 @@ public class HivePartitionMetadata
             Set<ColumnHandle> redundantColumnDomains,
             Optional<byte[]> rowIdPartitionComponent)
     {
+        this(hivePartition, partition, tableToPartitionMapping, encryptionInformation, redundantColumnDomains, rowIdPartitionComponent, Optional.empty());
+    }
+
+    HivePartitionMetadata(
+            HivePartition hivePartition,
+            Optional<Partition> partition,
+            TableToPartitionMapping tableToPartitionMapping,
+            Optional<EncryptionInformation> encryptionInformation,
+            Set<ColumnHandle> redundantColumnDomains,
+            Optional<byte[]> rowIdPartitionComponent,
+            Optional<List<HiveFileInfo>> syntheticFiles)
+    {
         this.partition = requireNonNull(partition, "partition is null");
         this.hivePartition = requireNonNull(hivePartition, "hivePartition is null");
         this.tableToPartitionMapping = requireNonNull(tableToPartitionMapping, "tableToPartitionMapping is null");
         this.encryptionInformation = requireNonNull(encryptionInformation, "encryptionInformation is null");
         this.redundantColumnDomains = requireNonNull(redundantColumnDomains, "redundantColumnDomains is null");
         this.rowIdPartitionComponent = requireNonNull(rowIdPartitionComponent, "rowIdPartitionComponent is null");
+        this.syntheticFiles = requireNonNull(syntheticFiles, "syntheticFiles is null");
     }
 
     public HivePartition getHivePartition()
@@ -78,5 +94,10 @@ public class HivePartitionMetadata
     public Optional<byte[]> getRowIdPartitionComponent()
     {
         return this.rowIdPartitionComponent;
+    }
+
+    public Optional<List<HiveFileInfo>> getSyntheticFiles()
+    {
+        return syntheticFiles;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -303,6 +303,9 @@ public class HiveSplitManager
         // sort partitions
         partitions = Ordering.natural().onResultOf(HivePartition::getPartitionId).reverse().sortedCopy(partitions);
 
+        Optional<List<HiveFileInfo>> syntheticFiles = layout.getHiveTableHandle()
+                .flatMap(HiveTableHandle::getSyntheticFiles)
+                .map(HiveSplitManager::toHiveFileInfos);
         Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(
                 metastore,
                 table,
@@ -313,7 +316,8 @@ public class HiveSplitManager
                 splitSchedulingContext.getWarningCollector(),
                 layout.getRequestedColumns(),
                 layout.getPredicateColumns(),
-                layout.getDomainPredicate().getDomains());
+                layout.getDomainPredicate().getDomains(),
+                syntheticFiles);
 
         double ratio = getSplitScanRatio(session, tableName, layout, metadata, partitions);
 
@@ -488,6 +492,23 @@ public class HiveSplitManager
         return splitSource;
     }
 
+    private static List<HiveFileInfo> toHiveFileInfos(List<SyntheticHiveFileInfo> files)
+    {
+        ImmutableList.Builder<HiveFileInfo> result = ImmutableList.builderWithExpectedSize(files.size());
+        for (SyntheticHiveFileInfo file : files) {
+            BlockLocation wholeFileBlock = new BlockLocation(ImmutableList.of(), 0L, file.getLength());
+            result.add(new HiveFileInfo(
+                    file.getPath(),
+                    false,
+                    ImmutableList.of(wholeFileBlock),
+                    file.getLength(),
+                    file.getModificationTime(),
+                    Optional.empty(),
+                    ImmutableMap.of()));
+        }
+        return result.build();
+    }
+
     private static Map<Integer, Domain> getInfoColumnConstraints(TupleDomain<Subfield> domainPredicate, Map<String, HiveColumnHandle> predicateColumns)
     {
         checkArgument(!domainPredicate.isNone(), "Unexpected domain predicate: none");
@@ -520,7 +541,8 @@ public class HiveSplitManager
             WarningCollector warningCollector,
             Optional<Set<HiveColumnHandle>> requestedColumns,
             Map<String, HiveColumnHandle> predicateColumns,
-            Optional<Map<Subfield, Domain>> domains)
+            Optional<Map<Subfield, Domain>> domains,
+            Optional<List<HiveFileInfo>> syntheticFiles)
     {
         if (hivePartitions.isEmpty()) {
             return ImmutableList.of();
@@ -537,7 +559,8 @@ public class HiveSplitManager
                         TableToPartitionMapping.empty(),
                         encryptionInformationProvider.getReadEncryptionInformation(session, table, allRequestedColumns),
                         ImmutableSet.of(),
-                        Optional.empty()));
+                        Optional.empty(),
+                        syntheticFiles));
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -332,6 +332,9 @@ public class HiveTableLayoutHandle
 
     public Table getTable(SemiTransactionalHiveMetastore metastore, MetastoreContext metastoreContext)
     {
+        if (hiveTableHandle.isPresent() && hiveTableHandle.get().getSyntheticTable().isPresent()) {
+            return hiveTableHandle.get().getSyntheticTable().get();
+        }
         Optional<Table> table;
         if (hiveTableHandle.isPresent()) {
             table = metastore.getTable(metastoreContext, hiveTableHandle.get());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -491,6 +491,16 @@ public class StoragePartitionLoader
             return hiveSplitSource.addToQueue(getBucketedSplits(path, fs, splitFactory, tableBucketInfo.get(), bucketConversion, partitionName, partition.getPartition(), splittable));
         }
 
+        if (partition.getSyntheticFiles().isPresent()) {
+            Iterator<InternalHiveSplit> syntheticSplits = partition.getSyntheticFiles().get().stream()
+                    .map(file -> splitFactory.createInternalHiveSplit(file, splittable))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .iterator();
+            fileIterators.addLast(syntheticSplits);
+            return COMPLETED_FUTURE;
+        }
+
         fileIterators.addLast(createInternalHiveSplitIterator(path, fs, splitFactory, splittable, partition.getPartition()));
         return COMPLETED_FUTURE;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/HiveTableFunctionModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/HiveTableFunctionModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+
+public class HiveTableFunctionModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        Multibinder<ConnectorTableFunction> tableFunctions = Multibinder.newSetBinder(binder, ConnectorTableFunction.class);
+        tableFunctions.addBinding().toProvider(ReadFilesFunction.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/ReadFilesFunction.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/ReadFilesFunction.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveStorageFormat;
+import com.facebook.presto.hive.functions.schema.ParquetSchemaExtractor;
+import com.facebook.presto.hive.functions.schema.SchemaMerger;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.table.AbstractConnectorTableFunction;
+import com.facebook.presto.spi.function.table.Argument;
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.facebook.presto.spi.function.table.Descriptor;
+import com.facebook.presto.spi.function.table.ScalarArgument;
+import com.facebook.presto.spi.function.table.ScalarArgumentSpecification;
+import com.facebook.presto.spi.function.table.TableFunctionAnalysis;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ReadFilesFunction
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "read_files";
+    public static final String LOCATION_ARGUMENT = "LOCATION";
+    public static final String FORMAT_ARGUMENT = "FORMAT";
+    public static final String MAX_FILE_COUNT_ARGUMENT = "MAX_FILE_COUNT";
+    public static final long DEFAULT_MAX_FILE_COUNT = 100L;
+
+    private final HdfsEnvironment hdfsEnvironment;
+    private final FileFormatDataSourceStats stats;
+    private final TypeManager typeManager;
+
+    @Inject
+    public ReadFilesFunction(HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats, TypeManager typeManager)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ReadFilesFunctionImpl();
+    }
+
+    private final class ReadFilesFunctionImpl
+            extends AbstractConnectorTableFunction
+    {
+        ReadFilesFunctionImpl()
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    ImmutableList.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name(LOCATION_ARGUMENT)
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name(FORMAT_ARGUMENT)
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name(MAX_FILE_COUNT_ARGUMENT)
+                                    .type(INTEGER)
+                                    .defaultValue(DEFAULT_MAX_FILE_COUNT)
+                                    .build()),
+                    GENERIC_TABLE);
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+        {
+            String location = requiredString(arguments, LOCATION_ARGUMENT);
+            String formatString = requiredString(arguments, FORMAT_ARGUMENT);
+            HiveStorageFormat format = parseFormat(formatString);
+            int maxFileCount = ((Number) requireNonNullValue(arguments, MAX_FILE_COUNT_ARGUMENT)).intValue();
+            if (maxFileCount <= 0) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("%s must be positive, got %d", MAX_FILE_COUNT_ARGUMENT, maxFileCount));
+            }
+
+            List<ReadFilesHandle.FileEntry> files = listFiles(session, location, maxFileCount);
+            if (files.isEmpty()) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("No files found at location: %s", location));
+            }
+
+            ParquetSchemaExtractor extractor = new ParquetSchemaExtractor(typeManager, stats);
+            List<List<ColumnMetadata>> perFileSchemas = new ArrayList<>(files.size());
+            List<String> perFilePaths = new ArrayList<>(files.size());
+            for (ReadFilesHandle.FileEntry file : files) {
+                try {
+                    perFileSchemas.add(extractor.extract(new Path(file.getPath()), hdfsEnvironment, session));
+                    perFilePaths.add(file.getPath());
+                }
+                catch (IOException e) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Failed to read Parquet footer at %s: %s", file.getPath(), e.getMessage()), e);
+                }
+            }
+
+            List<ColumnMetadata> mergedColumns = SchemaMerger.merge(perFileSchemas, perFilePaths, typeManager);
+
+            ImmutableList.Builder<Descriptor.Field> descriptorFields = ImmutableList.builder();
+            for (ColumnMetadata column : mergedColumns) {
+                descriptorFields.add(new Descriptor.Field(Optional.of(column.getName()), Optional.of(column.getType())));
+            }
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(new Descriptor(descriptorFields.build()))
+                    .handle(new ReadFilesHandle(location, format, files, mergedColumns))
+                    .build();
+        }
+    }
+
+    private List<ReadFilesHandle.FileEntry> listFiles(ConnectorSession session, String location, int maxFileCount)
+    {
+        Path basePath = new Path(location);
+        HdfsContext context = new HdfsContext(session);
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, basePath);
+            RemoteIterator<LocatedFileStatus> iterator = fileSystem.listFiles(basePath, true);
+            List<ReadFilesHandle.FileEntry> files = new ArrayList<>();
+            String basePrefix = basePath.toString();
+            while (iterator.hasNext() && files.size() < maxFileCount) {
+                LocatedFileStatus status = iterator.next();
+                if (status.isDirectory()) {
+                    continue;
+                }
+                if (status.getLen() == 0L) {
+                    continue;
+                }
+                if (hasHiddenComponent(basePrefix, status.getPath().toString())) {
+                    continue;
+                }
+                files.add(new ReadFilesHandle.FileEntry(status.getPath().toString(), status.getLen(), status.getModificationTime()));
+            }
+            return files;
+        }
+        catch (FileNotFoundException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Location does not exist: %s", location));
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Failed to list files at %s: %s", location, e.getMessage()), e);
+        }
+    }
+
+    private static boolean hasHiddenComponent(String basePrefix, String filePath)
+    {
+        if (!filePath.startsWith(basePrefix)) {
+            return false;
+        }
+        String suffix = filePath.substring(basePrefix.length());
+        for (String segment : suffix.split("/")) {
+            if (!segment.isEmpty() && (segment.startsWith("_") || segment.startsWith("."))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @VisibleForTesting
+    static HiveStorageFormat parseFormat(String formatString)
+    {
+        HiveStorageFormat parsed;
+        try {
+            parsed = HiveStorageFormat.valueOf(formatString.toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unknown format: %s. read_files Phase 1 supports only PARQUET.", formatString));
+        }
+        if (parsed != HiveStorageFormat.PARQUET) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Format %s is not supported by read_files Phase 1; only PARQUET is supported.", parsed));
+        }
+        return parsed;
+    }
+
+    private static String requiredString(Map<String, Argument> arguments, String name)
+    {
+        Object value = requireNonNullValue(arguments, name);
+        return ((Slice) value).toStringUtf8();
+    }
+
+    private static Object requireNonNullValue(Map<String, Argument> arguments, String name)
+    {
+        ScalarArgument argument = (ScalarArgument) arguments.get(name);
+        if (argument == null) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("%s argument is missing", name));
+        }
+        Object value = argument.getValue();
+        if (value == null) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("%s argument must not be null", name));
+        }
+        return value;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/ReadFilesHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/ReadFilesHandle.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.hive.HiveStorageFormat;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ReadFilesHandle
+        implements ConnectorTableFunctionHandle
+{
+    private final String location;
+    private final HiveStorageFormat format;
+    private final List<FileEntry> files;
+    private final List<ColumnMetadata> columns;
+
+    @JsonCreator
+    public ReadFilesHandle(
+            @JsonProperty("location") String location,
+            @JsonProperty("format") HiveStorageFormat format,
+            @JsonProperty("files") List<FileEntry> files,
+            @JsonProperty("columns") List<ColumnMetadata> columns)
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.format = requireNonNull(format, "format is null");
+        this.files = ImmutableList.copyOf(requireNonNull(files, "files is null"));
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+    }
+
+    @JsonProperty
+    public String getLocation()
+    {
+        return location;
+    }
+
+    @JsonProperty
+    public HiveStorageFormat getFormat()
+    {
+        return format;
+    }
+
+    @JsonProperty
+    public List<FileEntry> getFiles()
+    {
+        return files;
+    }
+
+    @JsonProperty
+    public List<ColumnMetadata> getColumns()
+    {
+        return columns;
+    }
+
+    public static class FileEntry
+    {
+        private final String path;
+        private final long length;
+        private final long modificationTime;
+
+        @JsonCreator
+        public FileEntry(
+                @JsonProperty("path") String path,
+                @JsonProperty("length") long length,
+                @JsonProperty("modificationTime") long modificationTime)
+        {
+            this.path = requireNonNull(path, "path is null");
+            this.length = length;
+            this.modificationTime = modificationTime;
+        }
+
+        @JsonProperty
+        public String getPath()
+        {
+            return path;
+        }
+
+        @JsonProperty
+        public long getLength()
+        {
+            return length;
+        }
+
+        @JsonProperty
+        public long getModificationTime()
+        {
+            return modificationTime;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FileEntry that = (FileEntry) o;
+            return length == that.length && modificationTime == that.modificationTime && path.equals(that.path);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(path, length, modificationTime);
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/FileSchemaExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/FileSchemaExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.schema;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Implementations read only the footer/tail (no data blocks). Empty but well-formed files
+ * must succeed; malformed footers must throw {@code PrestoException(HIVE_BAD_DATA)} with
+ * the file path in the message.
+ */
+public interface FileSchemaExtractor
+{
+    List<ColumnMetadata> extract(Path file, HdfsEnvironment hdfs, ConnectorSession session)
+            throws IOException;
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/ParquetSchemaExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/ParquetSchemaExtractor.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.schema;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.parquet.HdfsParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.parquet.ParquetToPrestoTypeConverter.fromParquet;
+import static com.facebook.presto.parquet.cache.MetadataReader.readFooter;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+public class ParquetSchemaExtractor
+        implements FileSchemaExtractor
+{
+    private final TypeManager typeManager;
+    private final FileFormatDataSourceStats stats;
+
+    public ParquetSchemaExtractor(TypeManager typeManager, FileFormatDataSourceStats stats)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.stats = requireNonNull(stats, "stats is null");
+    }
+
+    @Override
+    public List<ColumnMetadata> extract(Path file, HdfsEnvironment hdfs, ConnectorSession session)
+            throws IOException
+    {
+        requireNonNull(file, "file is null");
+        requireNonNull(hdfs, "hdfs is null");
+        requireNonNull(session, "session is null");
+
+        HdfsContext context = new HdfsContext(session);
+        FileSystem fileSystem = hdfs.getFileSystem(context, file);
+        long fileSize = fileSystem.getFileStatus(file).getLen();
+        try (FSDataInputStream inputStream = fileSystem.open(file);
+                ParquetDataSource dataSource = new HdfsParquetDataSource(new ParquetDataSourceId(file.toString()), inputStream, stats)) {
+            return extractFromDataSource(dataSource, file, fileSize, typeManager);
+        }
+    }
+
+    static List<ColumnMetadata> extractFromDataSource(ParquetDataSource dataSource, Path file, long fileSize, TypeManager typeManager)
+    {
+        MessageType schema;
+        try {
+            ParquetMetadata metadata = readFooter(dataSource, fileSize, Optional.empty(), false).getParquetMetadata();
+            schema = metadata.getFileMetaData().getSchema();
+        }
+        catch (IOException | RuntimeException e) {
+            throw new PrestoException(HIVE_BAD_DATA, format("Failed to read Parquet footer for %s", file), e);
+        }
+
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+        for (org.apache.parquet.schema.Type field : schema.getFields()) {
+            Type prestoType;
+            try {
+                prestoType = fromParquet(field, typeManager);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(HIVE_BAD_DATA, format("Unsupported Parquet column %s in %s: %s", field.getName(), file, e.getMessage()), e);
+            }
+            columns.add(ColumnMetadata.builder()
+                    .setName(field.getName())
+                    .setType(prestoType)
+                    .setNullable(field.getRepetition() != REQUIRED)
+                    .build());
+        }
+        return columns.build();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/SchemaMerger.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/functions/schema/SchemaMerger.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.schema;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.FixedWidthType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TypeUtils.isApproximateNumericType;
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class SchemaMerger
+{
+    private static final int DECIMAL_MAX_PRECISION = 38;
+
+    private SchemaMerger() {}
+
+    /**
+     * Column key is lowercased name; output order follows first-seen ordering.
+     * Incompatible types throw {@code INVALID_FUNCTION_ARGUMENT}; no VARCHAR fallback.
+     *
+     * @param filePaths parallel to {@code perFileSchemas}; used only in error messages.
+     */
+    public static List<ColumnMetadata> merge(List<List<ColumnMetadata>> perFileSchemas, List<String> filePaths, TypeManager typeManager)
+    {
+        requireNonNull(perFileSchemas, "perFileSchemas is null");
+        requireNonNull(filePaths, "filePaths is null");
+        requireNonNull(typeManager, "typeManager is null");
+        if (perFileSchemas.size() != filePaths.size()) {
+            throw new IllegalArgumentException(format("perFileSchemas has %d entries but filePaths has %d", perFileSchemas.size(), filePaths.size()));
+        }
+        if (perFileSchemas.isEmpty()) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Cannot merge schemas: no files");
+        }
+
+        int fileCount = perFileSchemas.size();
+        LinkedHashMap<String, MergedColumn> byKey = new LinkedHashMap<>();
+        for (int fileIndex = 0; fileIndex < fileCount; fileIndex++) {
+            String filePath = filePaths.get(fileIndex);
+            for (ColumnMetadata column : perFileSchemas.get(fileIndex)) {
+                String key = column.getName().toLowerCase(Locale.ROOT);
+                MergedColumn existing = byKey.get(key);
+                if (existing == null) {
+                    byKey.put(key, new MergedColumn(column.getName(), column.getType(), column.isNullable(), filePath));
+                }
+                else {
+                    existing.type = widen(existing.type, column.getType(), column.getName(), existing.firstSeenPath, filePath, typeManager);
+                    existing.nullable = existing.nullable || column.isNullable();
+                    existing.seenCount++;
+                }
+            }
+        }
+
+        ImmutableList.Builder<ColumnMetadata> result = ImmutableList.builder();
+        for (MergedColumn merged : byKey.values()) {
+            boolean nullable = merged.nullable || merged.seenCount < fileCount;
+            result.add(ColumnMetadata.builder()
+                    .setName(merged.name)
+                    .setType(merged.type)
+                    .setNullable(nullable)
+                    .build());
+        }
+        return result.build();
+    }
+
+    private static Type widen(Type a, Type b, String columnPath, String fileA, String fileB, TypeManager typeManager)
+    {
+        if (a.equals(b)) {
+            return a;
+        }
+        if (isExactNumericType(a) && isExactNumericType(b)) {
+            return ((FixedWidthType) a).getFixedSize() >= ((FixedWidthType) b).getFixedSize() ? a : b;
+        }
+        if ((isExactNumericType(a) || isApproximateNumericType(a)) && (isExactNumericType(b) || isApproximateNumericType(b))) {
+            return DOUBLE;
+        }
+        if (a instanceof DecimalType && b instanceof DecimalType) {
+            return widerDecimal((DecimalType) a, (DecimalType) b, columnPath, fileA, fileB);
+        }
+        if (a instanceof VarcharType && b instanceof VarcharType) {
+            VarcharType va = (VarcharType) a;
+            VarcharType vb = (VarcharType) b;
+            if (va.isUnbounded() || vb.isUnbounded()) {
+                return VarcharType.createUnboundedVarcharType();
+            }
+            return VarcharType.createVarcharType(max(va.getLengthSafe(), vb.getLengthSafe()));
+        }
+        if (a instanceof CharType && b instanceof CharType) {
+            return CharType.createCharType(max(((CharType) a).getLength(), ((CharType) b).getLength()));
+        }
+        if (a instanceof RowType && b instanceof RowType) {
+            return mergeRow((RowType) a, (RowType) b, columnPath, fileA, fileB, typeManager);
+        }
+        if (a instanceof ArrayType && b instanceof ArrayType) {
+            Type element = widen(((ArrayType) a).getElementType(), ((ArrayType) b).getElementType(), columnPath + ".element", fileA, fileB, typeManager);
+            return new ArrayType(element);
+        }
+        if (a instanceof MapType && b instanceof MapType) {
+            Type key = widen(((MapType) a).getKeyType(), ((MapType) b).getKeyType(), columnPath + ".key", fileA, fileB, typeManager);
+            Type value = widen(((MapType) a).getValueType(), ((MapType) b).getValueType(), columnPath + ".value", fileA, fileB, typeManager);
+            return typeManager.getParameterizedType(
+                    StandardTypes.MAP,
+                    ImmutableList.of(TypeSignatureParameter.of(key.getTypeSignature()), TypeSignatureParameter.of(value.getTypeSignature())));
+        }
+        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format(
+                "Incompatible types for column '%s': %s in %s vs %s in %s",
+                columnPath, a, fileA, b, fileB));
+    }
+
+    private static RowType mergeRow(RowType a, RowType b, String columnPath, String fileA, String fileB, TypeManager typeManager)
+    {
+        LinkedHashMap<String, RowType.Field> mergedFields = new LinkedHashMap<>();
+        List<RowType.Field> aFields = a.getFields();
+        for (RowType.Field field : aFields) {
+            String fieldKey = fieldKey(field);
+            mergedFields.put(fieldKey, field);
+        }
+        for (RowType.Field bField : b.getFields()) {
+            String fieldKey = fieldKey(bField);
+            RowType.Field existing = mergedFields.get(fieldKey);
+            if (existing == null) {
+                mergedFields.put(fieldKey, bField);
+            }
+            else {
+                String nestedPath = columnPath + "." + bField.getName().orElse(fieldKey);
+                Type merged = widen(existing.getType(), bField.getType(), nestedPath, fileA, fileB, typeManager);
+                mergedFields.put(fieldKey, new RowType.Field(existing.getName(), merged));
+            }
+        }
+        return RowType.from(new ArrayList<>(mergedFields.values()));
+    }
+
+    private static String fieldKey(RowType.Field field)
+    {
+        Optional<String> name = field.getName();
+        if (!name.isPresent()) {
+            return "$anonymous_" + System.identityHashCode(field);
+        }
+        return name.get().toLowerCase(Locale.ROOT);
+    }
+
+    private static DecimalType widerDecimal(DecimalType a, DecimalType b, String columnPath, String fileA, String fileB)
+    {
+        int integerDigits = max(a.getPrecision() - a.getScale(), b.getPrecision() - b.getScale());
+        int scale = max(a.getScale(), b.getScale());
+        int precision = integerDigits + scale;
+        if (precision > DECIMAL_MAX_PRECISION) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format(
+                    "Cannot merge DECIMAL types for column '%s': widened to precision %d which exceeds max %d. %s in %s vs %s in %s",
+                    columnPath, precision, DECIMAL_MAX_PRECISION, a, fileA, b, fileB));
+        }
+        return DecimalType.createDecimalType(precision, scale);
+    }
+
+    private static final class MergedColumn
+    {
+        final String name;
+        Type type;
+        boolean nullable;
+        final String firstSeenPath;
+        int seenCount = 1;
+
+        MergedColumn(String name, Type type, boolean nullable, String firstSeenPath)
+        {
+            this.name = name;
+            this.type = type;
+            this.nullable = nullable;
+            this.firstSeenPath = firstSeenPath;
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/functions/TestReadFilesFunction.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/functions/TestReadFilesFunction.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.hive.HiveStorageFormat;
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestReadFilesFunction
+{
+    @Test
+    public void testParseFormatAcceptsParquet()
+    {
+        assertEquals(ReadFilesFunction.parseFormat("PARQUET"), HiveStorageFormat.PARQUET);
+        assertEquals(ReadFilesFunction.parseFormat("parquet"), HiveStorageFormat.PARQUET);
+        assertEquals(ReadFilesFunction.parseFormat("Parquet"), HiveStorageFormat.PARQUET);
+    }
+
+    @Test
+    public void testParseFormatRejectsAvro()
+    {
+        assertRejected("avro");
+    }
+
+    @Test
+    public void testParseFormatRejectsCsv()
+    {
+        assertRejected("csv");
+    }
+
+    @Test
+    public void testParseFormatRejectsJson()
+    {
+        assertRejected("json");
+    }
+
+    @Test
+    public void testParseFormatRejectsOrc()
+    {
+        assertRejected("orc");
+    }
+
+    @Test
+    public void testParseFormatRejectsDwrf()
+    {
+        assertRejected("dwrf");
+    }
+
+    @Test
+    public void testParseFormatRejectsBogus()
+    {
+        assertRejected("foo");
+    }
+
+    private static void assertRejected(String formatString)
+    {
+        try {
+            ReadFilesFunction.parseFormat(formatString);
+            fail("Expected PrestoException for format: " + formatString);
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), INVALID_FUNCTION_ARGUMENT.toErrorCode());
+            assertTrue(e.getMessage().toUpperCase().contains("PARQUET"),
+                    "Expected error to mention PARQUET as the supported format, got: " + e.getMessage());
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/functions/TestReadFilesIntegration.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/functions/TestReadFilesIntegration.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.hive.HivePlugin;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestReadFilesIntegration
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "hive";
+    private static final String SCHEMA = "read_files_schema";
+
+    private Path tempRoot;
+    private String singleFileLocation;
+    private String multiFileMergeableLocation;
+    private String multiFileConflictLocation;
+    private String emptyLocation;
+    private String nestedDirectoryLocation;
+    private String hiddenFilesLocation;
+    private String nestedTypesLocation;
+    private String threeFileLocation;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session bootstrapSession = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(bootstrapSession)
+                .setExtraProperties(ImmutableMap.of())
+                .build();
+
+        queryRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.storage-format", "PARQUET")
+                .build();
+        queryRunner.createCatalog(CATALOG, CATALOG, properties);
+        queryRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUpFixtures()
+            throws IOException
+    {
+        tempRoot = Files.createTempDirectory("read_files_fixtures_");
+
+        Path singleFile = sourceParquetFile(
+                "single_src",
+                "CAST(id AS BIGINT) AS id, CAST(name AS VARCHAR) AS name",
+                "(1, 'a'), (2, 'b'), (3, 'c')",
+                "t(id, name)");
+        Path singleFileDir = tempRoot.resolve("single");
+        Files.createDirectories(singleFileDir);
+        Files.copy(singleFile, singleFileDir.resolve("file.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        singleFileLocation = singleFileDir.toUri().toString();
+
+        Path intFile = sourceParquetFile(
+                "merge_int_src",
+                "CAST(n AS INTEGER) AS n",
+                "(1), (2)",
+                "t(n)");
+        Path bigintFile = sourceParquetFile(
+                "merge_bigint_src",
+                "CAST(n AS BIGINT) AS n",
+                "(100000000000)",
+                "t(n)");
+        Path mergeableDir = tempRoot.resolve("mergeable");
+        Files.createDirectories(mergeableDir);
+        Files.copy(intFile, mergeableDir.resolve("int.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(bigintFile, mergeableDir.resolve("bigint.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        multiFileMergeableLocation = mergeableDir.toUri().toString();
+
+        Path conflictBigintFile = sourceParquetFile(
+                "conflict_bigint_src",
+                "CAST(x AS BIGINT) AS x",
+                "(1)",
+                "t(x)");
+        Path conflictVarcharFile = sourceParquetFile(
+                "conflict_varchar_src",
+                "CAST(x AS VARCHAR) AS x",
+                "('not_a_number')",
+                "t(x)");
+        Path conflictDir = tempRoot.resolve("conflict");
+        Files.createDirectories(conflictDir);
+        Files.copy(conflictBigintFile, conflictDir.resolve("a.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(conflictVarcharFile, conflictDir.resolve("b.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        multiFileConflictLocation = conflictDir.toUri().toString();
+
+        Path emptyDir = tempRoot.resolve("empty");
+        Files.createDirectories(emptyDir);
+        emptyLocation = emptyDir.toUri().toString();
+
+        Path nestedDir = tempRoot.resolve("nested");
+        Path subA = nestedDir.resolve("part=A");
+        Path subB = nestedDir.resolve("part=B");
+        Files.createDirectories(subA);
+        Files.createDirectories(subB);
+        Path nestedFileA = sourceParquetFile(
+                "nested_a_src",
+                "CAST(id AS BIGINT) AS id",
+                "(10), (20)",
+                "t(id)");
+        Path nestedFileB = sourceParquetFile(
+                "nested_b_src",
+                "CAST(id AS BIGINT) AS id",
+                "(30)",
+                "t(id)");
+        Files.copy(nestedFileA, subA.resolve("data.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(nestedFileB, subB.resolve("data.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        nestedDirectoryLocation = nestedDir.toUri().toString();
+
+        Path hiddenDir = tempRoot.resolve("hidden");
+        Files.createDirectories(hiddenDir);
+        Path realFile = sourceParquetFile(
+                "hidden_real_src",
+                "CAST(id AS BIGINT) AS id",
+                "(1), (2)",
+                "t(id)");
+        Files.copy(realFile, hiddenDir.resolve("real.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(realFile, hiddenDir.resolve("_meta.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(realFile, hiddenDir.resolve(".staging.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        Path hiddenSubDir = hiddenDir.resolve(".prestoPermissions");
+        Files.createDirectories(hiddenSubDir);
+        Files.copy(realFile, hiddenSubDir.resolve("user_token"), StandardCopyOption.REPLACE_EXISTING);
+        hiddenFilesLocation = hiddenDir.toUri().toString();
+
+        Path threeDir = tempRoot.resolve("three");
+        Files.createDirectories(threeDir);
+        for (int i = 0; i < 3; i++) {
+            Path source = sourceParquetFile(
+                    "three_src_" + i,
+                    "CAST(v AS BIGINT) AS v",
+                    "(" + i + ")",
+                    "t(v)");
+            Files.copy(source, threeDir.resolve("part_" + i + ".parquet"), StandardCopyOption.REPLACE_EXISTING);
+        }
+        threeFileLocation = threeDir.toUri().toString();
+
+        Path nestedTypesDir = tempRoot.resolve("nested_types");
+        Files.createDirectories(nestedTypesDir);
+        Path nestedTypesFile = sourceParquetFile(
+                "nested_types_src",
+                "CAST(ROW(1, 'a') AS ROW(x BIGINT, y VARCHAR)) AS r, " +
+                        "CAST(ARRAY[1, 2, 3] AS ARRAY(BIGINT)) AS arr, " +
+                        "CAST(MAP(ARRAY['k1'], ARRAY[100]) AS MAP(VARCHAR, BIGINT)) AS m",
+                "(1)",
+                "t(dummy)");
+        Files.copy(nestedTypesFile, nestedTypesDir.resolve("nested.parquet"), StandardCopyOption.REPLACE_EXISTING);
+        nestedTypesLocation = nestedTypesDir.toUri().toString();
+    }
+
+    private Path sourceParquetFile(String tableName, String projection, String values, String columnAlias)
+    {
+        String fqn = format("%s.%s.%s", CATALOG, SCHEMA, tableName);
+        getQueryRunner().execute(format(
+                "CREATE TABLE %s AS SELECT %s FROM (VALUES %s) %s",
+                fqn, projection, values, columnAlias));
+        String path = (String) computeActual(format("SELECT \"$path\" FROM %s LIMIT 1", fqn)).getOnlyValue();
+        return Paths.get(URI.create(path));
+    }
+
+    @Test
+    public void testSelectFromPtf()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT id, name FROM TABLE(%s.system.read_files('%s', 'parquet')) ORDER BY id",
+                CATALOG, singleFileLocation));
+
+        assertEquals(result.getRowCount(), 3);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 1L);
+        assertEquals(result.getMaterializedRows().get(0).getField(1), "a");
+        assertEquals(result.getMaterializedRows().get(2).getField(0), 3L);
+        assertEquals(result.getMaterializedRows().get(2).getField(1), "c");
+    }
+
+    @Test
+    public void testCtasFromPtf()
+    {
+        String targetTable = format("%s.%s.ctas_target", CATALOG, SCHEMA);
+        try {
+            getQueryRunner().execute(format(
+                    "CREATE TABLE %s AS SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                    targetTable, CATALOG, singleFileLocation));
+
+            MaterializedResult rows = computeActual(format("SELECT id, name FROM %s ORDER BY id", targetTable));
+            assertEquals(rows.getRowCount(), 3);
+
+            MaterializedResult schema = computeActual(format("DESCRIBE %s", targetTable));
+            assertEquals(schema.getMaterializedRows().get(0).getField(0), "id");
+            assertEquals(schema.getMaterializedRows().get(0).getField(1), "bigint");
+            assertEquals(schema.getMaterializedRows().get(1).getField(0), "name");
+            assertEquals(schema.getMaterializedRows().get(1).getField(1), "varchar");
+        }
+        finally {
+            getQueryRunner().execute(format("DROP TABLE IF EXISTS %s", targetTable));
+        }
+    }
+
+    @Test
+    public void testInsertIntoFromPtf()
+    {
+        String targetTable = format("%s.%s.insert_target", CATALOG, SCHEMA);
+        try {
+            getQueryRunner().execute(format(
+                    "CREATE TABLE %s (id BIGINT, name VARCHAR)", targetTable));
+            getQueryRunner().execute(format(
+                    "INSERT INTO %s SELECT id, name FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                    targetTable, CATALOG, singleFileLocation));
+            MaterializedResult rows = computeActual(format("SELECT count(*) FROM %s", targetTable));
+            assertEquals(rows.getOnlyValue(), 3L);
+        }
+        finally {
+            getQueryRunner().execute(format("DROP TABLE IF EXISTS %s", targetTable));
+        }
+    }
+
+    @Test
+    public void testExplainShowsTableScan()
+    {
+        String plan = (String) computeActual(format(
+                "EXPLAIN SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                CATALOG, singleFileLocation)).getOnlyValue();
+
+        assertTrue(plan.contains("TableScan"), "Expected TableScan in plan, got:\n" + plan);
+        assertFalse(plan.contains("TableFunctionProcessor"), "Expected no TableFunctionProcessor in plan, got:\n" + plan);
+    }
+
+    @Test
+    public void testRejectsAvro()
+    {
+        assertFormatRejected("avro");
+    }
+
+    @Test
+    public void testRejectsCsv()
+    {
+        assertFormatRejected("csv");
+    }
+
+    @Test
+    public void testRejectsJson()
+    {
+        assertFormatRejected("json");
+    }
+
+    @Test
+    public void testNoFilesAtLocationErrors()
+    {
+        try {
+            computeActual(format("SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet'))", CATALOG, emptyLocation));
+            fail("Expected error on empty location");
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage() != null && e.getMessage().contains(emptyLocation),
+                    "Expected error to mention location, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMultiFileMergeable()
+    {
+        MaterializedResult schema = computeActual(format(
+                "SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet')) ORDER BY n",
+                CATALOG, multiFileMergeableLocation));
+        assertEquals(schema.getRowCount(), 3);
+        assertEquals(schema.getMaterializedRows().get(2).getField(0), 100000000000L);
+    }
+
+    @Test
+    public void testMultiFileIncompatibleFails()
+    {
+        try {
+            computeActual(format(
+                    "SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                    CATALOG, multiFileConflictLocation));
+            fail("Expected merge conflict error");
+        }
+        catch (RuntimeException e) {
+            String message = e.getMessage();
+            assertTrue(message != null && message.contains("'x'"),
+                    "Expected error to name the conflicting column 'x', got: " + message);
+            assertTrue(message != null && (message.contains("a.parquet") || message.contains("b.parquet")),
+                    "Expected error to name one of the offending files, got: " + message);
+        }
+    }
+
+    @Test
+    public void testWhereClauseFilters()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT id, name FROM TABLE(%s.system.read_files('%s', 'parquet')) WHERE id >= 2 ORDER BY id",
+                CATALOG, singleFileLocation));
+        assertEquals(result.getRowCount(), 2);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 2L);
+        assertEquals(result.getMaterializedRows().get(1).getField(0), 3L);
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT count(*), sum(id) FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                CATALOG, singleFileLocation));
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 3L);
+        assertEquals(result.getMaterializedRows().get(0).getField(1), 6L);
+    }
+
+    @Test
+    public void testColumnProjection()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT name FROM TABLE(%s.system.read_files('%s', 'parquet')) ORDER BY name",
+                CATALOG, singleFileLocation));
+        assertEquals(result.getRowCount(), 3);
+        assertEquals(result.getTypes().size(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), "a");
+    }
+
+    @Test
+    public void testRecursiveSubdirectoryListing()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT sum(id) FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                CATALOG, nestedDirectoryLocation));
+        assertEquals(result.getOnlyValue(), 60L);
+    }
+
+    @Test
+    public void testHiddenFilesSkipped()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT count(*) FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                CATALOG, hiddenFilesLocation));
+        assertEquals(result.getOnlyValue(), 2L);
+    }
+
+    @Test
+    public void testNestedTypesRoundTrip()
+    {
+        MaterializedResult result = computeActual(format(
+                "SELECT r.x, r.y, arr[2], m['k1'] FROM TABLE(%s.system.read_files('%s', 'parquet'))",
+                CATALOG, nestedTypesLocation));
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 1L);
+        assertEquals(result.getMaterializedRows().get(0).getField(1), "a");
+        assertEquals(result.getMaterializedRows().get(0).getField(2), 2L);
+        assertEquals(result.getMaterializedRows().get(0).getField(3), 100L);
+    }
+
+    @Test
+    public void testJoinWithRegularTable()
+    {
+        String dimTable = format("%s.%s.join_dim", CATALOG, SCHEMA);
+        try {
+            getQueryRunner().execute(format(
+                    "CREATE TABLE %s AS SELECT * FROM (VALUES (1, 'one'), (2, 'two')) t(id, label)",
+                    dimTable));
+            MaterializedResult result = computeActual(format(
+                    "SELECT d.label FROM TABLE(%s.system.read_files('%s', 'parquet')) p " +
+                            "JOIN %s d ON p.id = d.id ORDER BY p.id",
+                    CATALOG, singleFileLocation, dimTable));
+            assertEquals(result.getRowCount(), 2);
+            assertEquals(result.getMaterializedRows().get(0).getField(0), "one");
+            assertEquals(result.getMaterializedRows().get(1).getField(0), "two");
+        }
+        finally {
+            getQueryRunner().execute(format("DROP TABLE IF EXISTS %s", dimTable));
+        }
+    }
+
+    @Test
+    public void testMaxFileCountCapsScanRows()
+    {
+        MaterializedResult capped = computeActual(format(
+                "SELECT count(*) FROM TABLE(%s.system.read_files('%s', 'parquet', 1))",
+                CATALOG, threeFileLocation));
+        assertEquals(capped.getOnlyValue(), 1L);
+
+        MaterializedResult uncapped = computeActual(format(
+                "SELECT count(*) FROM TABLE(%s.system.read_files('%s', 'parquet', 3))",
+                CATALOG, threeFileLocation));
+        assertEquals(uncapped.getOnlyValue(), 3L);
+    }
+
+    @Test
+    public void testBadLocationError()
+    {
+        String bogus = "file:///tmp/this_path_should_not_exist_" + System.nanoTime() + "/";
+        try {
+            computeActual(format("SELECT * FROM TABLE(%s.system.read_files('%s', 'parquet'))", CATALOG, bogus));
+            fail("Expected error on bogus location");
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage() != null && e.getMessage().contains(bogus),
+                    "Expected error to mention the bad location, got: " + e.getMessage());
+        }
+    }
+
+    private void assertFormatRejected(String formatString)
+    {
+        try {
+            computeActual(format("SELECT * FROM TABLE(%s.system.read_files('%s', '%s'))", CATALOG, singleFileLocation, formatString));
+            fail("Expected format rejection for: " + formatString);
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage() != null && e.getMessage().toUpperCase().contains("PARQUET"),
+                    "Expected error to mention PARQUET as supported format, got: " + e.getMessage());
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/functions/schema/TestParquetSchemaExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/functions/schema/TestParquetSchemaExtractor.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.schema;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.parquet.FileParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.functions.schema.ParquetSchemaExtractor.extractFromDataSource;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
+import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestParquetSchemaExtractor
+{
+    private static final TypeManager TYPE_MANAGER = FUNCTION_AND_TYPE_MANAGER;
+
+    private java.nio.file.Path tempDir;
+
+    private static ColumnMetadata col(String name, Type type, boolean nullable)
+    {
+        return ColumnMetadata.builder().setName(name).setType(type).setNullable(nullable).build();
+    }
+
+    @BeforeClass
+    public void setUp()
+            throws IOException
+    {
+        tempDir = createTempDirectory("parquet-schema-extractor-test");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        if (tempDir != null) {
+            deleteRecursively(tempDir, ALLOW_INSECURE);
+        }
+    }
+
+    @Test
+    public void testFlatRequired()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .addField(Types.required(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("name"))
+                .addField(Types.required(PrimitiveTypeName.DOUBLE).named("value"))
+                .named("root");
+        File file = writeEmptyParquet("flat.parquet", schema);
+
+        List<ColumnMetadata> columns = extract(file);
+        assertEquals(columns, ImmutableList.of(
+                col("id", BIGINT, false),
+                col("name", VARCHAR, false),
+                col("value", DOUBLE, false)));
+    }
+
+    @Test
+    public void testOptionals()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("optional_name"))
+                .named("root");
+        File file = writeEmptyParquet("optionals.parquet", schema);
+
+        List<ColumnMetadata> columns = extract(file);
+        assertEquals(columns.size(), 2);
+        assertEquals(columns.get(0), col("id", BIGINT, false));
+        assertEquals(columns.get(1), col("optional_name", VARCHAR, true));
+    }
+
+    @Test
+    public void testDecimalsAndTemporal()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optional(PrimitiveTypeName.INT64)
+                        .as(LogicalTypeAnnotation.decimalType(4, 18)).named("short_dec"))
+                .addField(Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(16)
+                        .as(LogicalTypeAnnotation.decimalType(10, 38)).named("long_dec"))
+                .addField(Types.optional(PrimitiveTypeName.INT32)
+                        .as(LogicalTypeAnnotation.dateType()).named("d"))
+                .addField(Types.optional(PrimitiveTypeName.INT64)
+                        .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)).named("ts"))
+                .named("root");
+        File file = writeEmptyParquet("decimals_temporal.parquet", schema);
+
+        List<ColumnMetadata> columns = extract(file);
+        assertEquals(columns, ImmutableList.of(
+                col("short_dec", DecimalType.createDecimalType(18, 4), true),
+                col("long_dec", DecimalType.createDecimalType(38, 10), true),
+                col("d", DATE, true),
+                col("ts", TIMESTAMP_WITH_TIME_ZONE, true)));
+    }
+
+    @Test
+    public void testNestedRowArrayMap()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalGroup()
+                        .addField(Types.required(PrimitiveTypeName.INT64).named("a"))
+                        .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("b"))
+                        .named("payload"))
+                .addField(Types.optionalList()
+                        .element(Types.required(PrimitiveTypeName.INT64).named("element"))
+                        .named("arr"))
+                .addField(Types.optionalList()
+                        .element(Types.optionalGroup()
+                                .addField(Types.required(PrimitiveTypeName.INT64).named("a"))
+                                .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("b"))
+                                .named("element"))
+                        .named("arr_row"))
+                .addField(Types.optionalMap()
+                        .key(Types.required(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("key"))
+                        .value(Types.optional(PrimitiveTypeName.INT64).named("value"))
+                        .named("m"))
+                .named("root");
+        File file = writeEmptyParquet("nested.parquet", schema);
+
+        List<ColumnMetadata> columns = extract(file);
+        assertEquals(columns.size(), 4);
+
+        Type expectedPayload = RowType.from(ImmutableList.of(
+                RowType.field("a", BIGINT),
+                RowType.field("b", VARCHAR)));
+        assertEquals(columns.get(0), col("payload", expectedPayload, true));
+        assertEquals(columns.get(1), col("arr", new ArrayType(BIGINT), true));
+        assertEquals(columns.get(2), col("arr_row", new ArrayType(expectedPayload), true));
+
+        Type expectedMap = TYPE_MANAGER.getParameterizedType(
+                StandardTypes.MAP,
+                ImmutableList.of(
+                        TypeSignatureParameter.of(VARCHAR.getTypeSignature()),
+                        TypeSignatureParameter.of(BIGINT.getTypeSignature())));
+        assertEquals(columns.get(3), col("m", expectedMap, true));
+    }
+
+    @Test
+    public void testEmptyValidFileReturnsSchema()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .named("root");
+        File file = writeEmptyParquet("empty.parquet", schema);
+
+        List<ColumnMetadata> columns = extract(file);
+        assertEquals(columns, ImmutableList.of(col("id", BIGINT, false)));
+    }
+
+    @Test
+    public void testCorruptFileThrowsHiveBadData()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .named("root");
+        File valid = writeEmptyParquet("corrupt.parquet", schema);
+        // Drop the trailing 16 bytes (magic + footer length).
+        try (RandomAccessFile raf = new RandomAccessFile(valid, "rw")) {
+            raf.setLength(Math.max(0L, valid.length() - 16));
+        }
+
+        try {
+            extract(valid);
+            fail("Expected PrestoException(HIVE_BAD_DATA)");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), HIVE_BAD_DATA.toErrorCode());
+            assertTrue(e.getMessage().contains(valid.getName()), "message should name the file: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNonParquetFileThrowsHiveBadData()
+            throws IOException
+    {
+        File file = new File(tempDir.toFile(), "not_parquet.bin");
+        Files.write(file.toPath(), "this is not a parquet file, just plain text".getBytes(UTF_8));
+
+        try {
+            extract(file);
+            fail("Expected PrestoException(HIVE_BAD_DATA)");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), HIVE_BAD_DATA.toErrorCode());
+            assertTrue(e.getMessage().contains(file.getName()), "message should name the file: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testReadsOnlyFooterBytes()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("name"))
+                .named("root");
+        // 1000 rows to ensure there's a real body before the footer.
+        File file = writePopulatedParquet("populated.parquet", schema, 1000);
+
+        long fileSize = file.length();
+        try (FileParquetDataSource backing = new FileParquetDataSource(file)) {
+            RecordingDataSource recording = new RecordingDataSource(backing);
+            List<ColumnMetadata> columns = extractFromDataSource(recording, new Path(file.toURI()), fileSize, TYPE_MANAGER);
+            assertEquals(columns.size(), 2);
+
+            // Any read outside the trailing footer-size window must be a data-block read.
+            long footerWindowStart = Math.max(0L, fileSize - 16 * 1024);
+            assertFalse(recording.reads.isEmpty(), "expected at least one read");
+            for (long[] read : recording.reads) {
+                long position = read[0];
+                assertTrue(
+                        position >= footerWindowStart,
+                        String.format("read at position %s falls outside the footer window [%s, %s)", position, footerWindowStart, fileSize));
+            }
+        }
+    }
+
+    @Test
+    public void testExtractEndToEndViaHdfsEnvironment()
+            throws IOException
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.required(PrimitiveTypeName.INT64).named("id"))
+                .named("root");
+        File file = writeEmptyParquet("e2e.parquet", schema);
+
+        ParquetSchemaExtractor extractor = new ParquetSchemaExtractor(TYPE_MANAGER, new FileFormatDataSourceStats());
+        List<ColumnMetadata> columns = extractor.extract(new Path(file.toURI()), HDFS_ENVIRONMENT, SESSION);
+        assertEquals(columns, ImmutableList.of(col("id", BIGINT, false)));
+    }
+
+    private List<ColumnMetadata> extract(File file)
+            throws IOException
+    {
+        try (FileParquetDataSource source = new FileParquetDataSource(file)) {
+            return extractFromDataSource(source, new Path(file.toURI()), file.length(), TYPE_MANAGER);
+        }
+    }
+
+    private File writeEmptyParquet(String name, MessageType schema)
+            throws IOException
+    {
+        File file = new File(tempDir.toFile(), name);
+        if (file.exists() && !file.delete()) {
+            throw new IOException("Could not delete pre-existing file " + file);
+        }
+        Configuration conf = new Configuration();
+        GroupWriteSupport.setSchema(schema, conf);
+        try (ParquetWriter<?> ignored = ExampleParquetWriter.builder(new Path(file.toURI()))
+                .withConf(conf)
+                .withWriteMode(OVERWRITE)
+                .withType(schema)
+                .build()) {
+            // Close without writing rows: emits an empty file with just the schema footer.
+        }
+        return file;
+    }
+
+    private File writePopulatedParquet(String name, MessageType schema, int rows)
+            throws IOException
+    {
+        File file = new File(tempDir.toFile(), name);
+        if (file.exists() && !file.delete()) {
+            throw new IOException("Could not delete pre-existing file " + file);
+        }
+        Configuration conf = new Configuration();
+        GroupWriteSupport.setSchema(schema, conf);
+        try (ParquetWriter<org.apache.parquet.example.data.Group> writer = ExampleParquetWriter.builder(new Path(file.toURI()))
+                .withConf(conf)
+                .withWriteMode(OVERWRITE)
+                .withType(schema)
+                .build()) {
+            org.apache.parquet.example.data.simple.SimpleGroupFactory factory = new org.apache.parquet.example.data.simple.SimpleGroupFactory(schema);
+            for (int i = 0; i < rows; i++) {
+                org.apache.parquet.example.data.Group group = factory.newGroup()
+                        .append("id", (long) i)
+                        .append("name", "row-" + i);
+                writer.write(group);
+            }
+        }
+        return file;
+    }
+
+    private static final class RecordingDataSource
+            implements ParquetDataSource
+    {
+        private final ParquetDataSource delegate;
+        private final List<long[]> reads = new ArrayList<>();
+
+        RecordingDataSource(ParquetDataSource delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ParquetDataSourceId getId()
+        {
+            return delegate.getId();
+        }
+
+        @Override
+        public long getReadBytes()
+        {
+            return delegate.getReadBytes();
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return delegate.getReadTimeNanos();
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer)
+        {
+            reads.add(new long[] {position, buffer.length});
+            delegate.readFully(position, buffer);
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+        {
+            reads.add(new long[] {position, bufferLength});
+            delegate.readFully(position, buffer, bufferOffset, bufferLength);
+        }
+
+        @Override
+        public Optional<ColumnIndex> readColumnIndex(ColumnChunkMetaData column)
+                throws IOException
+        {
+            return delegate.readColumnIndex(column);
+        }
+
+        @Override
+        public Optional<OffsetIndex> readOffsetIndex(ColumnChunkMetaData column)
+                throws IOException
+        {
+            return delegate.readOffsetIndex(column);
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            delegate.close();
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/functions/schema/TestSchemaMerger.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/functions/schema/TestSchemaMerger.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.schema;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestSchemaMerger
+{
+    private static final TypeManager TYPE_MANAGER = FUNCTION_AND_TYPE_MANAGER;
+    private static final String FILE_A = "file:///a.parquet";
+    private static final String FILE_B = "file:///b.parquet";
+    private static final String FILE_C = "file:///c.parquet";
+
+    private static ColumnMetadata col(String name, Type type, boolean nullable)
+    {
+        return ColumnMetadata.builder().setName(name).setType(type).setNullable(nullable).build();
+    }
+
+    @Test
+    public void testSingleFilePassthrough()
+    {
+        List<ColumnMetadata> file = ImmutableList.of(col("id", BIGINT, false), col("name", VARCHAR, true));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(file), ImmutableList.of(FILE_A), TYPE_MANAGER);
+        assertEquals(merged, file);
+    }
+
+    @Test
+    public void testIntegerWidening()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("n", INTEGER, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("n", BIGINT, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged, ImmutableList.of(col("n", BIGINT, false)));
+    }
+
+    @Test
+    public void testIntegerChainTinyintToBigint()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("n", TINYINT, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("n", SMALLINT, false));
+        List<ColumnMetadata> fileC = ImmutableList.of(col("n", BIGINT, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(
+                ImmutableList.of(fileA, fileB, fileC),
+                ImmutableList.of(FILE_A, FILE_B, FILE_C),
+                TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), BIGINT);
+    }
+
+    @Test
+    public void testIntegerToDouble()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("v", INTEGER, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("v", DOUBLE, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), DOUBLE);
+    }
+
+    @Test
+    public void testRealToDouble()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("v", REAL, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("v", DOUBLE, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), DOUBLE);
+    }
+
+    @Test
+    public void testDecimalReprecision()
+    {
+        DecimalType a = DecimalType.createDecimalType(10, 2);
+        DecimalType b = DecimalType.createDecimalType(12, 4);
+        List<ColumnMetadata> fileA = ImmutableList.of(col("d", a, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("d", b, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        // integer digits: max(10-2, 12-4) = 8, scale = max(2, 4) = 4 → DECIMAL(12, 4)
+        assertEquals(merged.get(0).getType(), DecimalType.createDecimalType(12, 4));
+    }
+
+    @Test
+    public void testDecimalReprecisionOverflows()
+    {
+        DecimalType a = DecimalType.createDecimalType(38, 0);
+        DecimalType b = DecimalType.createDecimalType(38, 10);
+        List<ColumnMetadata> fileA = ImmutableList.of(col("d", a, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("d", b, false));
+        try {
+            SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+            fail("Expected PrestoException on decimal precision overflow");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), INVALID_FUNCTION_ARGUMENT.toErrorCode());
+            assertTrue(e.getMessage().contains("'d'"), e.getMessage());
+            assertTrue(e.getMessage().contains(FILE_A) && e.getMessage().contains(FILE_B), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testVarcharBoundedWidens()
+    {
+        VarcharType a = VarcharType.createVarcharType(10);
+        VarcharType b = VarcharType.createVarcharType(20);
+        List<ColumnMetadata> fileA = ImmutableList.of(col("s", a, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("s", b, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), VarcharType.createVarcharType(20));
+    }
+
+    @Test
+    public void testVarcharUnboundedPrevails()
+    {
+        VarcharType a = VarcharType.createVarcharType(10);
+        VarcharType b = VarcharType.createUnboundedVarcharType();
+        List<ColumnMetadata> fileA = ImmutableList.of(col("s", a, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("s", b, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), VarcharType.createUnboundedVarcharType());
+    }
+
+    @Test
+    public void testCharWidens()
+    {
+        CharType a = CharType.createCharType(5);
+        CharType b = CharType.createCharType(8);
+        List<ColumnMetadata> fileA = ImmutableList.of(col("c", a, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("c", b, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), CharType.createCharType(8));
+    }
+
+    @Test
+    public void testCaseInsensitiveColumnKey()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("Name", VARCHAR, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("NAME", VARCHAR, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.size(), 1);
+        assertEquals(merged.get(0).getName(), "Name");
+    }
+
+    @Test
+    public void testPresenceMakesNullable()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("id", BIGINT, false), col("name", VARCHAR, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("id", BIGINT, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.size(), 2);
+        assertEquals(merged.get(0).getName(), "id");
+        assertFalse(merged.get(0).isNullable());
+        assertEquals(merged.get(1).getName(), "name");
+        assertTrue(merged.get(1).isNullable());
+    }
+
+    @Test
+    public void testIncomingNullablePropagates()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("id", BIGINT, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("id", BIGINT, true));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertTrue(merged.get(0).isNullable());
+    }
+
+    @Test
+    public void testOrderingFromFirstFileNewColumnsAppend()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("first", BIGINT, false), col("second", BIGINT, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("third", BIGINT, false), col("first", BIGINT, false));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.size(), 3);
+        assertEquals(merged.get(0).getName(), "first");
+        assertEquals(merged.get(1).getName(), "second");
+        assertEquals(merged.get(2).getName(), "third");
+    }
+
+    @Test
+    public void testIncompatibleTypeFails()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("x", BIGINT, false));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("x", VARCHAR, false));
+        try {
+            SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+            fail("Expected PrestoException on type conflict");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), INVALID_FUNCTION_ARGUMENT.toErrorCode());
+            assertTrue(e.getMessage().contains("'x'"), e.getMessage());
+            assertTrue(e.getMessage().contains(FILE_A) && e.getMessage().contains(FILE_B), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRowRecursive()
+    {
+        Type rowA = RowType.from(ImmutableList.of(RowType.field("a", INTEGER), RowType.field("b", VARCHAR)));
+        Type rowB = RowType.from(ImmutableList.of(RowType.field("a", BIGINT), RowType.field("c", VARCHAR)));
+        List<ColumnMetadata> fileA = ImmutableList.of(col("r", rowA, true));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("r", rowB, true));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        Type expected = RowType.from(ImmutableList.of(
+                RowType.field("a", BIGINT),
+                RowType.field("b", VARCHAR),
+                RowType.field("c", VARCHAR)));
+        assertEquals(merged.get(0).getType(), expected);
+    }
+
+    @Test
+    public void testArrayRecursive()
+    {
+        List<ColumnMetadata> fileA = ImmutableList.of(col("arr", new ArrayType(INTEGER), true));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("arr", new ArrayType(BIGINT), true));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        assertEquals(merged.get(0).getType(), new ArrayType(BIGINT));
+    }
+
+    @Test
+    public void testMapRecursive()
+    {
+        Type mapA = TYPE_MANAGER.getParameterizedType(
+                StandardTypes.MAP,
+                ImmutableList.of(TypeSignatureParameter.of(VARCHAR.getTypeSignature()), TypeSignatureParameter.of(INTEGER.getTypeSignature())));
+        Type mapB = TYPE_MANAGER.getParameterizedType(
+                StandardTypes.MAP,
+                ImmutableList.of(TypeSignatureParameter.of(VARCHAR.getTypeSignature()), TypeSignatureParameter.of(BIGINT.getTypeSignature())));
+        List<ColumnMetadata> fileA = ImmutableList.of(col("m", mapA, true));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("m", mapB, true));
+        List<ColumnMetadata> merged = SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+        Type expected = TYPE_MANAGER.getParameterizedType(
+                StandardTypes.MAP,
+                ImmutableList.of(TypeSignatureParameter.of(VARCHAR.getTypeSignature()), TypeSignatureParameter.of(BIGINT.getTypeSignature())));
+        assertEquals(merged.get(0).getType(), expected);
+    }
+
+    @Test
+    public void testNestedConflictMessageNamesPath()
+    {
+        Type rowA = RowType.from(ImmutableList.of(RowType.field("inner", BIGINT)));
+        Type rowB = RowType.from(ImmutableList.of(RowType.field("inner", VARCHAR)));
+        List<ColumnMetadata> fileA = ImmutableList.of(col("outer", rowA, true));
+        List<ColumnMetadata> fileB = ImmutableList.of(col("outer", rowB, true));
+        try {
+            SchemaMerger.merge(ImmutableList.of(fileA, fileB), ImmutableList.of(FILE_A, FILE_B), TYPE_MANAGER);
+            fail("Expected PrestoException on nested type conflict");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), INVALID_FUNCTION_ARGUMENT.toErrorCode());
+            assertTrue(e.getMessage().contains("outer.inner"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testEmptyFilesFails()
+    {
+        try {
+            SchemaMerger.merge(ImmutableList.of(), ImmutableList.of(), TYPE_MANAGER);
+            fail("Expected PrestoException on empty input");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), INVALID_FUNCTION_ARGUMENT.toErrorCode());
+        }
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetToPrestoTypeConverter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetToPrestoTypeConverter.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.JsonLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.ListLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.MapLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Inverse of {@link com.facebook.presto.parquet.writer.ParquetSchemaConverter}: derives a Presto type
+ * tree from a Parquet schema (used by {@code read_files} which has no metastore type to resolve against).
+ *
+ * <p>{@code INT96} → {@code TIMESTAMP}. {@code TIMESTAMP}/{@code TIME} with {@code isAdjustedToUTC=true}
+ * → the {@code WITH TIME ZONE} variant. {@code TIMESTAMP_NANOS} and {@code TIME_NANOS} are rejected —
+ * the reader has no nanosecond-aware decoder and would silently emit values 10^6× too large.
+ */
+public final class ParquetToPrestoTypeConverter
+{
+    private ParquetToPrestoTypeConverter() {}
+
+    public static Type fromParquet(org.apache.parquet.schema.Type parquetType, TypeManager typeManager)
+    {
+        requireNonNull(parquetType, "parquetType is null");
+        requireNonNull(typeManager, "typeManager is null");
+
+        if (parquetType.isPrimitive()) {
+            return fromPrimitive(parquetType.asPrimitiveType());
+        }
+        return fromGroup(parquetType.asGroupType(), typeManager);
+    }
+
+    private static Type fromGroup(GroupType group, TypeManager typeManager)
+    {
+        LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
+        if (annotation instanceof ListLogicalTypeAnnotation) {
+            return fromList(group, typeManager);
+        }
+        if (annotation instanceof MapLogicalTypeAnnotation) {
+            return fromMap(group, typeManager);
+        }
+        return fromStruct(group, typeManager);
+    }
+
+    private static Type fromList(GroupType list, TypeManager typeManager)
+    {
+        // Accept both 3-level (list -> repeated group -> element) and legacy 2-level encodings.
+        if (list.getFieldCount() != 1) {
+            throw new IllegalArgumentException(format("Invalid Parquet LIST type, expected 1 field, got %s: %s", list.getFieldCount(), list));
+        }
+        org.apache.parquet.schema.Type repeated = list.getType(0);
+        Type elementType;
+        if (repeated.isPrimitive() || repeated.asGroupType().getFieldCount() != 1) {
+            elementType = fromParquet(repeated, typeManager);
+        }
+        else {
+            elementType = fromParquet(repeated.asGroupType().getType(0), typeManager);
+        }
+        return new ArrayType(elementType);
+    }
+
+    private static Type fromMap(GroupType map, TypeManager typeManager)
+    {
+        if (map.getFieldCount() != 1) {
+            throw new IllegalArgumentException(format("Invalid Parquet MAP type, expected 1 repeated field, got %s: %s", map.getFieldCount(), map));
+        }
+        GroupType keyValue = map.getType(0).asGroupType();
+        if (keyValue.getFieldCount() != 2) {
+            throw new IllegalArgumentException(format("Invalid Parquet MAP key_value, expected 2 fields, got %s: %s", keyValue.getFieldCount(), keyValue));
+        }
+        Type keyType = fromParquet(keyValue.getType(0), typeManager);
+        Type valueType = fromParquet(keyValue.getType(1), typeManager);
+        return typeManager.getParameterizedType(
+                MAP,
+                ImmutableList.of(
+                        TypeSignatureParameter.of(keyType.getTypeSignature()),
+                        TypeSignatureParameter.of(valueType.getTypeSignature())));
+    }
+
+    private static Type fromStruct(GroupType struct, TypeManager typeManager)
+    {
+        ImmutableList.Builder<RowType.Field> fields = ImmutableList.builder();
+        for (org.apache.parquet.schema.Type field : struct.getFields()) {
+            fields.add(new RowType.Field(java.util.Optional.of(field.getName()), fromParquet(field, typeManager)));
+        }
+        return RowType.from(fields.build());
+    }
+
+    private static Type fromPrimitive(PrimitiveType primitive)
+    {
+        LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+        PrimitiveTypeName name = primitive.getPrimitiveTypeName();
+
+        if (annotation instanceof DecimalLogicalTypeAnnotation) {
+            DecimalLogicalTypeAnnotation decimal = (DecimalLogicalTypeAnnotation) annotation;
+            return DecimalType.createDecimalType(decimal.getPrecision(), decimal.getScale());
+        }
+        if (annotation instanceof DateLogicalTypeAnnotation) {
+            return DATE;
+        }
+        if (annotation instanceof TimestampLogicalTypeAnnotation) {
+            TimestampLogicalTypeAnnotation timestamp = (TimestampLogicalTypeAnnotation) annotation;
+            if (timestamp.getUnit() == TimeUnit.NANOS) {
+                throw new IllegalArgumentException(format("Unsupported Parquet TIMESTAMP unit NANOS: %s", primitive));
+            }
+            return timestamp.isAdjustedToUTC() ? TIMESTAMP_WITH_TIME_ZONE : TIMESTAMP;
+        }
+        if (annotation instanceof TimeLogicalTypeAnnotation) {
+            TimeLogicalTypeAnnotation time = (TimeLogicalTypeAnnotation) annotation;
+            if (time.getUnit() == TimeUnit.NANOS) {
+                throw new IllegalArgumentException(format("Unsupported Parquet TIME unit NANOS: %s", primitive));
+            }
+            return time.isAdjustedToUTC() ? TIME_WITH_TIME_ZONE : TIME;
+        }
+        if (annotation instanceof StringLogicalTypeAnnotation
+                || annotation instanceof EnumLogicalTypeAnnotation
+                || annotation instanceof JsonLogicalTypeAnnotation) {
+            return VARCHAR;
+        }
+        if (annotation instanceof UUIDLogicalTypeAnnotation) {
+            return UUID;
+        }
+        if (annotation instanceof IntLogicalTypeAnnotation) {
+            IntLogicalTypeAnnotation intAnnotation = (IntLogicalTypeAnnotation) annotation;
+            return fromIntAnnotation(intAnnotation.getBitWidth(), intAnnotation.isSigned());
+        }
+
+        switch (name) {
+            case BOOLEAN:
+                return BOOLEAN;
+            case INT32:
+                return INTEGER;
+            case INT64:
+                return BIGINT;
+            case INT96:
+                return TIMESTAMP;
+            case FLOAT:
+                return REAL;
+            case DOUBLE:
+                return DOUBLE;
+            case BINARY:
+                return VARBINARY;
+            case FIXED_LEN_BYTE_ARRAY:
+                return VARBINARY;
+            default:
+                throw new IllegalArgumentException(format("Unsupported Parquet primitive type: %s (name=%s)", primitive, name));
+        }
+    }
+
+    private static Type fromIntAnnotation(int bitWidth, boolean signed)
+    {
+        if (signed) {
+            switch (bitWidth) {
+                case 8:
+                    return TINYINT;
+                case 16:
+                    return SMALLINT;
+                case 32:
+                    return INTEGER;
+                case 64:
+                    return BIGINT;
+                default:
+                    throw new IllegalArgumentException(format("Unsupported signed INT bit width: %s", bitWidth));
+            }
+        }
+        // Unsigned: widen to the next signed type. UINT_64 has no safe widening.
+        switch (bitWidth) {
+            case 8:
+                return SMALLINT;
+            case 16:
+                return INTEGER;
+            case 32:
+                return BIGINT;
+            case 64:
+                throw new IllegalArgumentException("Unsigned 64-bit integer is not supported (no signed Presto type can represent the full range)");
+            default:
+                throw new IllegalArgumentException(format("Unsupported unsigned INT bit width: %s", bitWidth));
+        }
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetToPrestoTypeConverter.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetToPrestoTypeConverter.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.parquet.ParquetToPrestoTypeConverter.fromParquet;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestParquetToPrestoTypeConverter
+{
+    private static final TypeManager TYPE_MANAGER = new ParquetTestTypeManager();
+
+    @Test
+    public void testPrimitives()
+    {
+        assertEquals(convertPrimitive(PrimitiveTypeName.BOOLEAN), BOOLEAN);
+        assertEquals(convertPrimitive(PrimitiveTypeName.INT32), INTEGER);
+        assertEquals(convertPrimitive(PrimitiveTypeName.INT64), BIGINT);
+        assertEquals(convertPrimitive(PrimitiveTypeName.INT96), TIMESTAMP);
+        assertEquals(convertPrimitive(PrimitiveTypeName.FLOAT), REAL);
+        assertEquals(convertPrimitive(PrimitiveTypeName.DOUBLE), DOUBLE);
+        assertEquals(convertPrimitive(PrimitiveTypeName.BINARY), VARBINARY);
+    }
+
+    @Test
+    public void testFixedLenByteArrayDefaultsToVarbinary()
+    {
+        PrimitiveType type = Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(16).named("c");
+        assertEquals(fromParquet(type, TYPE_MANAGER), VARBINARY);
+    }
+
+    @Test
+    public void testString()
+    {
+        PrimitiveType utf8 = Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("c");
+        assertEquals(fromParquet(utf8, TYPE_MANAGER), VARCHAR);
+    }
+
+    @Test
+    public void testEnumAndJsonAreVarchar()
+    {
+        PrimitiveType enumType = Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.enumType()).named("c");
+        PrimitiveType jsonType = Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.jsonType()).named("c");
+        assertEquals(fromParquet(enumType, TYPE_MANAGER), VARCHAR);
+        assertEquals(fromParquet(jsonType, TYPE_MANAGER), VARCHAR);
+    }
+
+    @Test
+    public void testDate()
+    {
+        PrimitiveType type = Types.optional(PrimitiveTypeName.INT32).as(LogicalTypeAnnotation.dateType()).named("c");
+        assertEquals(fromParquet(type, TYPE_MANAGER), DATE);
+    }
+
+    @Test
+    public void testTimestampLocalVariants()
+    {
+        PrimitiveType millis = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MILLIS)).named("c");
+        PrimitiveType micros = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS)).named("c");
+        assertEquals(fromParquet(millis, TYPE_MANAGER), TIMESTAMP);
+        assertEquals(fromParquet(micros, TYPE_MANAGER), TIMESTAMP);
+    }
+
+    @Test
+    public void testTimestampUtcAdjustedMapsToWithTimeZone()
+    {
+        PrimitiveType millisUtc = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)).named("c");
+        PrimitiveType microsUtc = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS)).named("c");
+        assertEquals(fromParquet(millisUtc, TYPE_MANAGER), TIMESTAMP_WITH_TIME_ZONE);
+        assertEquals(fromParquet(microsUtc, TYPE_MANAGER), TIMESTAMP_WITH_TIME_ZONE);
+    }
+
+    @Test
+    public void testTimestampNanosRejected()
+    {
+        PrimitiveType nanos = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.NANOS)).named("c");
+        assertThrows(IllegalArgumentException.class, () -> fromParquet(nanos, TYPE_MANAGER));
+    }
+
+    @Test
+    public void testTime()
+    {
+        PrimitiveType timeMillis = Types.optional(PrimitiveTypeName.INT32)
+                .as(LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.MILLIS)).named("c");
+        PrimitiveType timeMicros = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.MICROS)).named("c");
+        assertEquals(fromParquet(timeMillis, TYPE_MANAGER), TIME);
+        assertEquals(fromParquet(timeMicros, TYPE_MANAGER), TIME);
+    }
+
+    @Test
+    public void testTimeUtcAdjustedMapsToWithTimeZone()
+    {
+        PrimitiveType timeMillisUtc = Types.optional(PrimitiveTypeName.INT32)
+                .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)).named("c");
+        assertEquals(fromParquet(timeMillisUtc, TYPE_MANAGER), TIME_WITH_TIME_ZONE);
+    }
+
+    @Test
+    public void testTimeNanosRejected()
+    {
+        PrimitiveType timeNanos = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timeType(false, LogicalTypeAnnotation.TimeUnit.NANOS)).named("c");
+        assertThrows(IllegalArgumentException.class, () -> fromParquet(timeNanos, TYPE_MANAGER));
+    }
+
+    @Test
+    public void testDecimalShortAndLong()
+    {
+        PrimitiveType shortDecimal = Types.optional(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.decimalType(4, 18)).named("c");
+        PrimitiveType longDecimal = Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+                .length(16)
+                .as(LogicalTypeAnnotation.decimalType(10, 38)).named("c");
+        assertEquals(fromParquet(shortDecimal, TYPE_MANAGER), DecimalType.createDecimalType(18, 4));
+        assertEquals(fromParquet(longDecimal, TYPE_MANAGER), DecimalType.createDecimalType(38, 10));
+    }
+
+    @Test
+    public void testSignedInt()
+    {
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 8, true), TYPE_MANAGER), TINYINT);
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 16, true), TYPE_MANAGER), SMALLINT);
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 32, true), TYPE_MANAGER), INTEGER);
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT64, 64, true), TYPE_MANAGER), BIGINT);
+    }
+
+    @Test
+    public void testUnsignedIntWidens()
+    {
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 8, false), TYPE_MANAGER), SMALLINT);
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 16, false), TYPE_MANAGER), INTEGER);
+        assertEquals(fromParquet(intAnnotated(PrimitiveTypeName.INT32, 32, false), TYPE_MANAGER), BIGINT);
+    }
+
+    @Test
+    public void testUnsignedInt64Unsupported()
+    {
+        PrimitiveType type = intAnnotated(PrimitiveTypeName.INT64, 64, false);
+        assertThrows(IllegalArgumentException.class, () -> fromParquet(type, TYPE_MANAGER));
+    }
+
+    @Test
+    public void testUuid()
+    {
+        PrimitiveType type = Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(16)
+                .as(LogicalTypeAnnotation.uuidType()).named("c");
+        assertEquals(fromParquet(type, TYPE_MANAGER), UUID);
+    }
+
+    @Test
+    public void testRow()
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalGroup()
+                        .addField(Types.required(PrimitiveTypeName.INT64).named("a"))
+                        .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("b"))
+                        .named("payload"))
+                .named("root");
+
+        Type converted = fromParquet(schema.getType("payload"), TYPE_MANAGER);
+        Type expected = RowType.from(ImmutableList.of(
+                RowType.field("a", BIGINT),
+                RowType.field("b", VARCHAR)));
+        assertEquals(converted, expected);
+    }
+
+    @Test
+    public void testArrayOfPrimitive()
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalList()
+                        .element(Types.required(PrimitiveTypeName.INT64).named("element"))
+                        .named("arr"))
+                .named("root");
+
+        Type converted = fromParquet(schema.getType("arr"), TYPE_MANAGER);
+        assertEquals(converted, new ArrayType(BIGINT));
+    }
+
+    @Test
+    public void testArrayOfRow()
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalList()
+                        .element(Types.optionalGroup()
+                                .addField(Types.required(PrimitiveTypeName.INT64).named("a"))
+                                .addField(Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("b"))
+                                .named("element"))
+                        .named("arr_row"))
+                .named("root");
+
+        Type converted = fromParquet(schema.getType("arr_row"), TYPE_MANAGER);
+        Type expected = new ArrayType(RowType.from(ImmutableList.of(
+                RowType.field("a", BIGINT),
+                RowType.field("b", VARCHAR))));
+        assertEquals(converted, expected);
+    }
+
+    @Test
+    public void testMap()
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalMap()
+                        .key(Types.required(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("key"))
+                        .value(Types.optional(PrimitiveTypeName.INT64).named("value"))
+                        .named("m"))
+                .named("root");
+
+        Type converted = fromParquet(schema.getType("m"), TYPE_MANAGER);
+        assertEquals(converted, TYPE_MANAGER.getParameterizedType(
+                StandardTypes.MAP,
+                ImmutableList.of(
+                        TypeSignatureParameter.of(VARCHAR.getTypeSignature()),
+                        TypeSignatureParameter.of(BIGINT.getTypeSignature()))));
+    }
+
+    @Test
+    public void testLegacyTwoLevelList()
+    {
+        MessageType schema = Types.buildMessage()
+                .addField(Types.optionalGroup()
+                        .as(LogicalTypeAnnotation.listType())
+                        .addField(new PrimitiveType(REPEATED, PrimitiveTypeName.INT64, "element"))
+                        .named("legacy_list"))
+                .named("root");
+
+        Type converted = fromParquet(schema.getType("legacy_list"), TYPE_MANAGER);
+        assertEquals(converted, new ArrayType(BIGINT));
+    }
+
+    private static Type convertPrimitive(PrimitiveTypeName name)
+    {
+        Types.PrimitiveBuilder<PrimitiveType> builder = Types.optional(name);
+        if (name == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+            builder = builder.length(16);
+        }
+        return fromParquet(builder.named("c"), TYPE_MANAGER);
+    }
+
+    private static PrimitiveType intAnnotated(PrimitiveTypeName backing, int bitWidth, boolean signed)
+    {
+        return Types.optional(backing).as(LogicalTypeAnnotation.intType(bitWidth, signed)).named("c");
+    }
+
+    /**
+     * Minimal {@link TypeManager} resolving the parameterized types the converter actually emits.
+     */
+    private static final class ParquetTestTypeManager
+            implements TypeManager
+    {
+        @Override
+        public Type getType(TypeSignature signature)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addParametricType(ParametricType parametricType)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addType(Type type)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+        {
+            if (StandardTypes.MAP.equals(baseTypeName)) {
+                Type keyType = typeParameters.get(0).getTypeSignatureOrNamedTypeSignature().map(this::resolve).orElseThrow(IllegalArgumentException::new);
+                Type valueType = typeParameters.get(1).getTypeSignatureOrNamedTypeSignature().map(this::resolve).orElseThrow(IllegalArgumentException::new);
+                return new MapType(keyType, valueType, nativeValueGetter(keyType), nativeValueGetter(valueType));
+            }
+            throw new UnsupportedOperationException("Unsupported parameterized type in test: " + baseTypeName);
+        }
+
+        private Type resolve(TypeSignature signature)
+        {
+            String base = signature.getBase();
+            switch (base) {
+                case StandardTypes.BIGINT:
+                    return BIGINT;
+                case StandardTypes.INTEGER:
+                    return INTEGER;
+                case StandardTypes.SMALLINT:
+                    return SMALLINT;
+                case StandardTypes.TINYINT:
+                    return TINYINT;
+                case StandardTypes.DOUBLE:
+                    return DOUBLE;
+                case StandardTypes.REAL:
+                    return REAL;
+                case StandardTypes.BOOLEAN:
+                    return BOOLEAN;
+                case StandardTypes.DATE:
+                    return DATE;
+                case StandardTypes.TIME:
+                    return TIME;
+                case StandardTypes.TIMESTAMP:
+                    return TIMESTAMP;
+                case StandardTypes.VARCHAR:
+                    return VARCHAR;
+                case StandardTypes.VARBINARY:
+                    return VARBINARY;
+                case StandardTypes.UUID:
+                    return UUID;
+                default:
+                    throw new UnsupportedOperationException("Unsupported base type in test: " + base);
+            }
+        }
+
+        @Override
+        public boolean canCoerce(Type actualType, Type expectedType)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasType(TypeSignature signature)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a Hive connector table function for reading Parquet files directly from a location with schema inferred from file footers, wiring it through synthetic Hive tables and files.

New Features:
- Add a system.read_files table function to the Hive connector that scans Parquet files at a given location with optional file-count cap and inferred schema.
- Support synthetic Hive tables and file lists in Hive metadata, partitioning, and split generation to back connector table functions without metastore tables.

Enhancements:
- Implement Parquet-to-Presto type conversion and a Parquet schema extractor that derive column metadata from Parquet footers only.
- Add a schema merger utility to reconcile and widen column types across multiple Parquet files, including nested types, with detailed error reporting on conflicts.
- Extend Hive connector wiring to expose connector table functions and route read_files handles into a synthetic HiveTableHandle used by the planner and split manager.

Tests:
- Add integration tests for read_files covering CTAS, INSERT, joins, projections, filters, error cases, nested types, directory layouts, and max-file-count behavior.
- Add unit tests for the Parquet schema extractor, Parquet-to-Presto type conversion, schema merger behavior, and read_files format validation.