### PR TITLE
fix(ci): Update release notes check to use raw markdown body

### DIFF
--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened]
 
 env:
-  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.14' }}
+  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.15' }}
 
 jobs:
   check_release_note:
@@ -43,11 +43,11 @@ jobs:
               query($owner: String!, $name: String!, $number: Int!) {
                 repository(owner: $owner, name: $name) {
                   pullRequest(number: $number) {
-                    bodyText
+                    body
                   }
                 }
               }
-            ' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq '.data.repository.pullRequest.bodyText' >> $GITHUB_OUTPUT
+            ' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq '.data.repository.pullRequest.body' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Echo PR Text
         env:


### PR DESCRIPTION
## Description
Bump presto-release-tools to 0.15 and switch the GraphQL query from bodyText to body so the release notes checker receives raw markdown. The new version uses code block delimiters to find the end of the release notes, which prevents failures when the release notes are not the last thing in the PR description (e.g. when automation appends "Differential Revision" lines at the end).


## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/27654

## Impact
the release notes check will no longer fail if the release notes are not the last thing in the PR description.  They will fail if the release notes are not in a code block (which was a requirement before anyway).

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update the GitHub release notes check workflow to consume raw markdown PR bodies using the latest presto-release-tools.

Build:
- Bump presto-release-tools version used in the release-notes-check workflow from 0.14 to 0.15.
- Adjust the GraphQL query in the release-notes-check workflow to use the pull request body field instead of bodyText so raw markdown is passed to the checker.