### PR TITLE
fix(optimizer): Inline identity projections through ProjectNode regardless of reference count

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -351,19 +351,25 @@ public class PredicatePushDown
 
         private boolean isInliningCandidate(RowExpression expression, ProjectNode node)
         {
-            // candidate symbols for inlining are
+            // Candidate symbols for inlining are:
             //   1. references to simple constants
-            //   2. references to complex expressions that appear only once
-            // which come from the node, as opposed to an enclosing scope,
-            // and the expression does not contain remote functions.
+            //   2. references to identity projections (variable references) - cheap leaves,
+            //      safe to inline any number of times without duplicating work
+            //   3. references to complex expressions that appear only once, provided the
+            //      expression does not contain remote functions
             Set<VariableReferenceExpression> childOutputSet = ImmutableSet.copyOf(node.getOutputVariables());
             Map<VariableReferenceExpression, Long> dependencies = VariablesExtractor.extractAll(expression).stream()
                     .filter(childOutputSet::contains)
                     .collect(Collectors.groupingBy(identity(), Collectors.counting()));
 
-            return dependencies.entrySet().stream()
-                    .allMatch(entry -> (entry.getValue() == 1 && !node.getAssignments().get(entry.getKey()).accept(new ExternalCallExpressionChecker(functionAndTypeManager), null)) ||
-                            node.getAssignments().get(entry.getKey()) instanceof ConstantExpression);
+            ExternalCallExpressionChecker externalCallChecker = new ExternalCallExpressionChecker(functionAndTypeManager);
+            return dependencies.entrySet().stream().allMatch(entry -> {
+                RowExpression assignment = node.getAssignments().get(entry.getKey());
+                if (assignment instanceof ConstantExpression || assignment instanceof VariableReferenceExpression) {
+                    return true;
+                }
+                return entry.getValue() == 1 && !assignment.accept(externalCallChecker, null);
+            });
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -384,6 +384,28 @@ public class TestPredicatePushdown
                                 tableScan("orders", ImmutableMap.of(
                                         "orderkey", "orderkey")))));
 
+        // Identities referenced multiple times in a disjunction should still be pushed down.
+        // Regression for https://github.com/prestodb/presto/issues/27813 - without this case
+        // a predicate like (col = 'a' OR col IN ('b')) on a partition column is left above
+        // an identity ProjectNode and never reaches connector partition pruning.
+        assertPlan(
+                "WITH t AS (SELECT orderkey x FROM orders) " +
+                        "SELECT * FROM t WHERE x = 1 OR x = 2",
+                anyTree(
+                        filter("orderkey = BIGINT '1' OR orderkey = BIGINT '2'",
+                                tableScan("orders", ImmutableMap.of(
+                                        "orderkey", "orderkey")))));
+
+        // Identities referenced multiple times via a mix of '=' and IN should also be pushed down.
+        // This mirrors the exact predicate shape from issue #27813.
+        assertPlan(
+                "WITH t AS (SELECT orderkey x FROM orders) " +
+                        "SELECT * FROM t WHERE x = 1 OR x IN (2, 3)",
+                anyTree(
+                        filter("orderkey = BIGINT '1' OR orderkey IN (BIGINT '2', BIGINT '3')",
+                                tableScan("orders", ImmutableMap.of(
+                                        "orderkey", "orderkey")))));
+
         // Non-deterministic predicate should not be pushed down
         assertPlan(
                 "WITH t AS (SELECT rand() * orderkey x FROM orders) " +


### PR DESCRIPTION
## Description

When `PredicatePushDown` rewrites a filter through a `ProjectNode`, `isInliningCandidate` decides whether each conjunct of the inherited predicate is safe to inline into the project's assignments. Today a conjunct is considered safe if either every variable it references appears exactly once and the assignment is not a remote function, or the assignment is a `ConstantExpression`.

That misses a common, cheap case: when the assignment is itself just a `VariableReferenceExpression` — i.e. an identity projection. Variable references are leaves with no runtime cost to duplicate, but they fail the "appears only once" check the moment a predicate references the same column more than once, for example `(pt = 'a' OR pt IN ('b'))`. The conjunct then gets stranded in a `FilterNode` above the `ProjectNode` and never reaches the table scan — and so never reaches connector-side partition pruning.

This change adds identity projections as a third always-inline-able case, alongside constants. The existing safety net for complex assignments — appears exactly once *and* not a remote function — is preserved verbatim.

## Motivation and Context

Fixes #27813.

The original report is on a Hive table partitioned by `pt`. A query of the form:

```sql
... WHERE (pt = '2026-05-07' OR pt IN ('2025-09-30')) AND cate4_id IN (SELECT ...)
```

never had its `pt` predicate pushed to partition pruning, so the connector ended up scanning partitions that should have been eliminated. Walking the plan showed the predicate sitting on a `FilterNode` directly above an identity `ProjectNode`. `isInliningCandidate` rejected it because `pt` appears twice across the OR (count = 2, not 1) and the assignment is not a `ConstantExpression`.

The "appears only once" rule exists to prevent duplicating *complex* expressions, where N copies mean N evaluations at runtime. For a leaf — a constant or a plain variable reference — that concern doesn't apply: N copies cost the same as one. So leaves can be inlined freely without violating the original intent of the rule.

## Impact

No public API change, no SQL syntax change.

Optimizer behavior: filters that reference the same column more than once will now push through identity projections instead of being left above them. For partitioned connectors (Hive, Iceberg, etc.) this directly enables partition pruning on disjunctive predicates of the shape in the issue. For non-partitioned scans the effective predicate reaches the connector earlier, which can additionally help with stats-based pruning and predicate-aware scan strategies.

No regression is expected for complex assignments: the original `entry.getValue() == 1 && !external-function` guard still applies to anything that isn't a `ConstantExpression` or `VariableReferenceExpression`.

## Test Plan

Added two regression cases inside the existing `TestPredicatePushdown#testPredicatePushDownOverProjection`:

- `WHERE x = 1 OR x = 2` over an identity projection `x := orderkey` — asserts the predicate lands directly above the table scan, with no surviving `ProjectNode` between them.
- `WHERE x = 1 OR x IN (2, 3)` — same shape as #27813.

The existing negative case in the same test (complex assignment `x := orderkey * 2` referenced twice as `x + x > 1`) continues to assert that complex expressions are *not* inlined when referenced more than once, so the original safety property is unchanged.

Local run:

```
./mvnw -pl presto-main-base -am test -Dtest=TestPredicatePushdown
```

All cases pass.

## Contributor checklist

- [x] Submission complies with the contributing guide (code style, commit standards).
- [x] PR description addresses the issue accurately and concisely; the change references issue #27813.
- [x] No new properties, SQL syntax, or functions added — nothing to document.
- [x] Release note added (see below).
- [x] Adequate tests added.
- [ ] CI passed.
- [x] No new dependencies introduced.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix predicate pushdown through identity projections when the predicate references the same column more than once (e.g. in a disjunction). This enables partition pruning for filters of the form ``col = 'a' OR col IN ('b')`` on partitioned connectors. :pr:`27843 `
```

## Summary by Sourcery

Tests:
- Add regression plans asserting predicates with repeated references to an identity-projected column are pushed down to the table scan, including '=' and IN disjunction shapes.