### PR TITLE
fix(native): Fix CMake link order for presto_server_lib

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -119,8 +119,6 @@ endif()
 # likely due to a conflict between Arrow Thrift from velox_hive_connector and
 # FBThrift libraries. The build issue is fixed by linking velox_hive_connector
 # dependencies first followed by FBThrift.
-target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra ${THRIFT_LIBRARY})
-
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_library(presto_server_remote_function JsonSignatureParser.cpp RemoteFunctionRegisterer.cpp)
 
@@ -132,6 +130,8 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   )
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
+
+target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra ${THRIFT_LIBRARY})
 
 set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK presto_link_job_pool)
 


### PR DESCRIPTION
## Description
Fixed FBThrift duplicate linking issue in presto-native-execution when `PRESTO_ENABLE_REMOTE_FUNCTIONS` is enabled. Reordered library linking in `presto_cpp/main/CMakeLists.txt` to ensure FBThrift libraries are linked transitively through remote function dependencies before being linked directly, preventing duplicate symbol definitions.

## Motivation and Context
When `PRESTO_ENABLE_REMOTE_FUNCTIONS=ON` is enabled, the build fails with the following error:

```
ERROR: something wrong with flag 'thrift_protocol_max_depth' in file 
'fbthrift/thrift/lib/cpp2/protocol/Protocol.cpp'. One possibility: 
file is being linked both statically and dynamically into this executable.
```

Root Cause: FBThrift libraries were being linked twice:

1. Directly via presto_thrift-cpp2 and ${THRIFT_LIBRARY}
2. Transitively through the dependency chain: presto_server_remote_function → velox_functions_remote → velox_functions_remote_thrift_client → FBThrift::thriftcpp2
This caused duplicate symbol definitions for gflags like `thrift_protocol_max_depth`, resulting in a linker error.

Solution: Reordered the linking in `CMakeLists.txt` to link presto_server_remote_function (which brings in FBThrift transitively) before directly linking FBThrift libraries.

## Impact
Build System: Changes library linking order in CMake configuration
No API Changes: No public API or user-facing feature changes
No Performance Impact: Pure build configuration fix
Scope: Only affects builds with PRESTO_ENABLE_REMOTE_FUNCTIONS=ON

## Test Plan
Clean build with remote functions enabled:

```
cd presto-native-execution
rm -rf cmake-build-debug
export EXTRA_CMAKE_FLAGS="-DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON"
make clean
make debug
```

Build completes successfully without duplicate symbol errors

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Reorder presto_server_lib target_link_libraries in CMake to link Thrift libraries after remote function libraries when enabled.

## Summary by Sourcery

Fix CMake linking order for presto_server_lib to avoid duplicate FBThrift linkage when remote functions are enabled.

Bug Fixes:
- Resolve FBThrift duplicate symbol/linking errors in presto-native-execution builds with PRESTO_ENABLE_REMOTE_FUNCTIONS enabled.

Build:
- Adjust presto_server_lib CMake target_link_libraries ordering so remote function dependencies are linked before direct FBThrift libraries.