### PR TITLE
ci: Advance velox

### DIFF
--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -79,9 +79,7 @@ jobs:
           # Install glog/gflags because they are not installed from homebrew.
           install_gflags
           install_glog
-          install_protobuf
-          # install_protobuf already installed abseil; disable reinstall for subsequent callers.
-          install_abseil() { :; }
+          brew install protobuf@21
 
           # Velox deps needed by proxygen, a presto dependency.
           install_boost
@@ -100,6 +98,7 @@ jobs:
           install_presto_deps
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
+          brew link --force protobuf@21
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
         if: |

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -79,6 +79,9 @@ jobs:
           # Install glog/gflags because they are not installed from homebrew.
           install_gflags
           install_glog
+          install_protobuf
+          # install_protobuf already installed abseil; disable reinstall for subsequent callers.
+          install_abseil() { :; }
 
           # Velox deps needed by proxygen, a presto dependency.
           install_boost
@@ -97,7 +100,6 @@ jobs:
           install_presto_deps
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
-          brew link --force protobuf@21
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
         if: |


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Advance the Velox dependency and update the macOS CI workflow to install required protobuf dependencies.

CI:
- Update the macOS Prestocpp build workflow to install protobuf as part of Velox-related dependencies.

Chores:
- Bump the Velox submodule/reference used by presto-native-execution.