### PR TITLE
fix(plugin-iceberg): Disable equality delete as join for DELETE/UPDATE

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -79,6 +79,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.common.resourceGroups.QueryType.DELETE;
+import static com.facebook.presto.common.resourceGroups.QueryType.UPDATE;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.iceberg.FileContent.EQUALITY_DELETES;
@@ -137,11 +139,16 @@ public class IcebergEqualityDeleteAsJoin
     {
         int maxDeleteColumns = getDeleteAsJoinRewriteMaxDeleteColumns(session);
         checkArgument(maxDeleteColumns >= 0, "maxDeleteColumns must be non-negative, got %s", maxDeleteColumns);
-        if (!isDeleteToJoinPushdownEnabled(session) || maxDeleteColumns == 0) {
+        if (!isDeleteToJoinPushdownEnabled(session) || maxDeleteColumns == 0 || isDeleteOrUpdateQuery(session)) {
             return maxSubplan;
         }
         return rewriteWith(new DeleteAsJoinRewriter(functionResolution,
                 transactionManager, idAllocator, session, typeManager, variableAllocator), maxSubplan);
+    }
+
+    private boolean isDeleteOrUpdateQuery(ConnectorSession session)
+    {
+        return session.getQueryType().map(t -> t == DELETE || t == UPDATE).orElse(false);
     }
 
     private static class DeleteAsJoinRewriter

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1696,10 +1696,9 @@ public abstract class IcebergDistributedTestBase
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
         assertUpdate(session, "CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
-        Table icebergTable = updateTable(tableName);
-        String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
 
-        writePositionDeleteToNationTable(icebergTable, dataFilePath, 0);
+        assertUpdate(session, "DELETE FROM " + tableName + " WHERE nationkey = 0", 1);
+        Table icebergTable = updateTable(tableName);
         testCheckDeleteFiles(icebergTable, 1, ImmutableList.of(POSITION_DELETES));
         assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 24");
         assertQuery(session, "SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE nationkey != 0");
@@ -1709,7 +1708,8 @@ public abstract class IcebergDistributedTestBase
         assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 19");
         assertQuery(session, "SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1 AND nationkey != 0");
 
-        writePositionDeleteToNationTable(icebergTable, dataFilePath, 7);
+        assertUpdate(session, "DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+        icebergTable = updateTable(tableName);
         testCheckDeleteFiles(icebergTable, 3, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES));
         assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 18");
         assertQuery(session, "SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey != 1 AND nationkey NOT IN (0, 7)");
@@ -1718,6 +1718,16 @@ public abstract class IcebergDistributedTestBase
         testCheckDeleteFiles(icebergTable, 4, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
         assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 13");
         assertQuery(session, "SELECT nationkey FROM " + tableName, "SELECT nationkey FROM nation WHERE regionkey NOT IN (1, 2) AND nationkey NOT IN (0, 7)");
+
+        assertUpdate(session, "UPDATE " + tableName + " SET name = 'ENGLAND' WHERE nationkey = 23", 1);
+        icebergTable = updateTable(tableName);
+        if (fileFormat.equalsIgnoreCase(ORC.toString())) {
+            testCheckDeleteFiles(icebergTable, 6, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+        }
+        else {
+            testCheckDeleteFiles(icebergTable, 5, ImmutableList.of(POSITION_DELETES, POSITION_DELETES, POSITION_DELETES, EQUALITY_DELETES, EQUALITY_DELETES));
+        }
+        assertQuery(session, "SELECT name FROM " + tableName + " WHERE nationkey = 23", "VALUES 'ENGLAND'");
     }
 
     @Test(dataProvider = "equalityDeleteOptions")


### PR DESCRIPTION
## Description
Fixes https://github.com/prestodb/presto/issues/27850

## Impact
No impact

## Test Plan
Added/Modified tests in IcebergDistributedTestBase.java

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Disable the Iceberg equality-delete-as-join optimization for DELETE and UPDATE queries and extend tests to cover position and equality delete behavior for such operations.

Bug Fixes:
- Prevent applying the equality-delete-as-join rewrite when executing DELETE or UPDATE queries on Iceberg tables.

Tests:
- Update Iceberg distributed tests to validate behavior of mixed position and equality deletes, including DELETE and UPDATE statements across different file formats.