### PR TITLE
feat: Add additional predicates to MERGE

### DIFF
--- a/presto-docs/src/main/sphinx/sql/merge.rst
+++ b/presto-docs/src/main/sphinx/sql/merge.rst
@@ -10,11 +10,11 @@ Synopsis
     MERGE INTO target_table [ [ AS ]  target_alias ]
     USING { source_table | query } [ [ AS ] source_alias ]
     ON search_condition
-    WHEN MATCHED THEN
+    WHEN MATCHED [ AND condition ] THEN
         UPDATE SET ( column = expression [, ...] )
-    WHEN MATCHED THEN
+    WHEN MATCHED [ AND condition ] THEN
         DELETE
-    WHEN NOT MATCHED THEN
+    WHEN NOT MATCHED [ AND condition ] THEN
         INSERT [ column_list ]
         VALUES (expression, ...)
 
@@ -32,6 +32,11 @@ When the condition is met, one of the following ``MATCHED`` actions can be taken
 When the condition is not met, the ``NOT MATCHED`` action inserts a new row into the target table. The ``INSERT`` expressions can depend on any field of the source.
 
 A ``MERGE`` statement can contain any combination of ``WHEN MATCHED`` and ``WHEN NOT MATCHED`` clauses. For example, you can use ``WHEN MATCHED THEN DELETE`` together with ``WHEN NOT MATCHED THEN INSERT`` to delete existing matched rows and insert new unmatched rows in a single atomic operation.
+
+Each ``WHEN`` clause may carry an optional additional ``AND condition`` predicate that restricts when that clause fires.
+The predicate is a boolean expression that may reference columns from both the target table and the source relation.
+Clauses are evaluated in textual order; for each input row, the first clause whose ``MATCHED`` / ``NOT MATCHED`` state holds and whose optional ``AND`` predicate is true is the one that fires.
+A row matched by the ``ON`` clause that satisfies no ``WHEN MATCHED`` predicate (and where no predicate-less ``WHEN MATCHED`` clause exists) results in no action for that row; the same is true of source rows that satisfy no ``WHEN NOT MATCHED`` predicate.
 
 The ``MERGE`` command requires each target row to match at most one source row. An exception is raised when a single target table row matches more than one source row.
 If a source row is not matched by the ``WHEN MATCHED`` clause and there is no ``WHEN NOT MATCHED`` clause, the source row is ignored.
@@ -102,6 +107,25 @@ Delete all rows in the target table that match the source. Rows in the target ta
         ON s.product_id = d.product_id
     WHEN MATCHED THEN
         DELETE
+
+Conditional WHEN clauses
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Apply a delta from the source. Update the existing count when the result is positive, delete the row when the result is exactly zero, and insert a new row only when the incoming delta is non-zero.
+Clauses are evaluated in textual order, so the ``UPDATE`` predicate is checked before ``DELETE``.
+
+.. code-block:: text
+
+    MERGE INTO inventory AS t
+        USING incoming AS s
+        ON t.id = s.id
+    WHEN MATCHED AND t.count + s.count_delta > 0 THEN
+        UPDATE SET count = t.count + s.count_delta
+    WHEN MATCHED AND t.count + s.count_delta = 0 THEN
+        DELETE
+    WHEN NOT MATCHED AND s.count_delta <> 0 THEN
+        INSERT (id, count)
+        VALUES (s.id, s.count_delta)
 
 Limitations
 -----------

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -4109,6 +4109,11 @@ public abstract class IcebergDistributedTestBase
                     format("MERGE INTO %s t USING (VALUES (1, 10)) AS s(id, delta) ON t.id = s.id " +
                             "WHEN MATCHED AND count(s.delta) > 0 THEN UPDATE SET value = s.delta", targetTable),
                     ".*MERGE WHEN clause cannot contain aggregations.*");
+
+            assertQueryFails(
+                    format("MERGE INTO %s t USING (VALUES (1, 10)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED AND row_number() OVER (ORDER BY s.delta) > 0 THEN UPDATE SET value = s.delta", targetTable),
+                    ".*MERGE WHEN clause cannot contain aggregations, window functions or grouping operations.*");
         }
         finally {
             assertUpdate("DROP TABLE " + targetTable);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -4016,6 +4016,106 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testMergeWhenClausePredicates()
+    {
+        String targetTable = "merge_when_predicates_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INT, count INT)", targetTable));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 5), (2, 10), (3, 7)", targetTable), 3);
+
+            @Language("SQL") String mergeSql =
+                    format("MERGE INTO %s t USING ", targetTable) +
+                            "(VALUES (1, -3), (2, -10), (3, 0), (4, 8), (5, 0)) AS s(id, count_delta) " +
+                            "ON t.id = s.id " +
+                            "WHEN MATCHED AND t.count + s.count_delta > 0 THEN UPDATE SET count = t.count + s.count_delta " +
+                            "WHEN MATCHED AND t.count + s.count_delta = 0 THEN DELETE " +
+                            "WHEN NOT MATCHED AND s.count_delta <> 0 THEN INSERT (id, count) VALUES (s.id, s.count_delta)";
+
+            assertUpdate(mergeSql, 4);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES (1, 2), (3, 7), (4, 8)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeWhenClauseOrderSensitivity()
+    {
+        String targetTable = "merge_when_order_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INT, status VARCHAR)", targetTable));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'new'), (2, 'new')", targetTable), 2);
+
+            @Language("SQL") String mergeSql =
+                    format("MERGE INTO %s t USING ", targetTable) +
+                            "(VALUES (1, 100), (2, 5)) AS s(id, amount) " +
+                            "ON t.id = s.id " +
+                            "WHEN MATCHED AND s.amount > 50 THEN UPDATE SET status = 'big' " +
+                            "WHEN MATCHED AND s.amount <= 50 THEN UPDATE SET status = 'small'";
+
+            assertUpdate(mergeSql, 2);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES (1, 'big'), (2, 'small')");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeWhenClauseAllPredicatesFailIsNoOp()
+    {
+        String targetTable = "merge_when_noop_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INT, value INT)", targetTable));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 10), (2, 20)", targetTable), 2);
+
+            @Language("SQL") String mergeSql =
+                    format("MERGE INTO %s t USING ", targetTable) +
+                            "(VALUES (1, 100), (3, 0)) AS s(id, delta) " +
+                            "ON t.id = s.id " +
+                            "WHEN MATCHED AND s.delta < 0 THEN UPDATE SET value = t.value + s.delta " +
+                            "WHEN NOT MATCHED AND s.delta <> 0 THEN INSERT (id, value) VALUES (s.id, s.delta)";
+
+            assertUpdate(mergeSql, 0);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES (1, 10), (2, 20)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeWhenClauseAnalyzerErrors()
+    {
+        String targetTable = "merge_when_errors_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INT, value INT)", targetTable));
+
+            assertQueryFails(
+                    format("MERGE INTO %s t USING (VALUES (1, 10)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED AND s.delta + 1 THEN UPDATE SET value = s.delta", targetTable),
+                    ".*The MERGE WHEN condition must evaluate to a boolean.*");
+
+            assertQueryFails(
+                    format("MERGE INTO %s t USING (VALUES (1, 10)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED AND s.nonexistent > 0 THEN UPDATE SET value = s.delta", targetTable),
+                    ".*'s\\.nonexistent' cannot be resolved.*");
+
+            assertQueryFails(
+                    format("MERGE INTO %s t USING (VALUES (1, 10)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED AND count(s.delta) > 0 THEN UPDATE SET value = s.delta", targetTable),
+                    ".*MERGE WHEN clause cannot contain aggregations.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
     public void testMergeCasts()
     {
         String targetTable = "merge_cast_target_" + randomTableSuffix();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -71,6 +71,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_DEREFERENCE_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.predicate.Domain.create;
 import static com.facebook.presto.common.predicate.Domain.multipleValues;
@@ -2695,5 +2696,59 @@ public class TestIcebergLogicalPlanner
     private static Subfield nestedColumn(String column)
     {
         return new Subfield(column);
+    }
+
+    @Test
+    public void testMergeWhenClausePredicateAppearsInPlan()
+    {
+        String targetTable = "merge_plan_when_" + randomTableSuffix();
+        String matchedMarker = "987654321";
+        String notMatchedMarker = "123456789";
+        // PushdownSubfields fails on MERGE's synthetic $target_table_row_id variable.
+        Session sessionWithoutSubfieldPushdown = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "false")
+                .build();
+        try {
+            getQueryRunner().execute(sessionWithoutSubfieldPushdown,
+                    format("CREATE TABLE %s (id INT, value INT)", targetTable));
+
+            @Language("SQL") String withConditions = format(
+                    "MERGE INTO %s t USING (VALUES (1, 5)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED AND s.delta > %s THEN UPDATE SET value = t.value + s.delta " +
+                            "WHEN NOT MATCHED AND s.delta > %s THEN INSERT (id, value) VALUES (s.id, s.delta)",
+                    targetTable, matchedMarker, notMatchedMarker);
+            @Language("SQL") String withoutConditions = format(
+                    "MERGE INTO %s t USING (VALUES (1, 5)) AS s(id, delta) ON t.id = s.id " +
+                            "WHEN MATCHED THEN UPDATE SET value = t.value + s.delta " +
+                            "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.delta)",
+                    targetTable);
+
+            String planWithConditions = planText(withConditions, sessionWithoutSubfieldPushdown);
+            assertTrue(planWithConditions.contains(matchedMarker),
+                    "Plan with WHEN MATCHED predicate should mention marker " + matchedMarker + " but was:\n" + planWithConditions);
+            assertTrue(planWithConditions.contains(notMatchedMarker),
+                    "Plan with WHEN NOT MATCHED predicate should mention marker " + notMatchedMarker + " but was:\n" + planWithConditions);
+
+            String planWithoutConditions = planText(withoutConditions, sessionWithoutSubfieldPushdown);
+            assertTrue(!planWithoutConditions.contains(matchedMarker),
+                    "Plan without WHEN predicates should not mention marker " + matchedMarker + " but was:\n" + planWithoutConditions);
+            assertTrue(!planWithoutConditions.contains(notMatchedMarker),
+                    "Plan without WHEN predicates should not mention marker " + notMatchedMarker + " but was:\n" + planWithoutConditions);
+        }
+        finally {
+            getQueryRunner().execute(sessionWithoutSubfieldPushdown, "DROP TABLE " + targetTable);
+        }
+    }
+
+    private String planText(@Language("SQL") String sql, Session session)
+    {
+        Plan actualPlan = plan(sql, session);
+        return com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan(
+                actualPlan.getRoot(),
+                actualPlan.getTypes(),
+                com.facebook.presto.cost.StatsAndCosts.empty(),
+                getQueryRunner().getMetadata().getFunctionAndTypeManager(),
+                session,
+                0);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
@@ -120,6 +121,7 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -130,6 +132,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -2730,9 +2733,9 @@ public class TestIcebergLogicalPlanner
                     "Plan with WHEN NOT MATCHED predicate should mention marker " + notMatchedMarker + " but was:\n" + planWithConditions);
 
             String planWithoutConditions = planText(withoutConditions, sessionWithoutSubfieldPushdown);
-            assertTrue(!planWithoutConditions.contains(matchedMarker),
+            assertFalse(planWithoutConditions.contains(matchedMarker),
                     "Plan without WHEN predicates should not mention marker " + matchedMarker + " but was:\n" + planWithoutConditions);
-            assertTrue(!planWithoutConditions.contains(notMatchedMarker),
+            assertFalse(planWithoutConditions.contains(notMatchedMarker),
                     "Plan without WHEN predicates should not mention marker " + notMatchedMarker + " but was:\n" + planWithoutConditions);
         }
         finally {
@@ -2743,10 +2746,10 @@ public class TestIcebergLogicalPlanner
     private String planText(@Language("SQL") String sql, Session session)
     {
         Plan actualPlan = plan(sql, session);
-        return com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan(
+        return textLogicalPlan(
                 actualPlan.getRoot(),
                 actualPlan.getTypes(),
-                com.facebook.presto.cost.StatsAndCosts.empty(),
+                StatsAndCosts.empty(),
                 getQueryRunner().getMetadata().getFunctionAndTypeManager(),
                 session,
                 0);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -3545,6 +3545,21 @@ class StatementAnalyzer
 
             for (int caseCounter = 0; caseCounter < merge.getMergeCases().size(); caseCounter++) {
                 MergeCase mergeCase = merge.getMergeCases().get(caseCounter);
+
+                if (mergeCase.getCondition().isPresent()) {
+                    Expression caseCondition = mergeCase.getCondition().get();
+                    ExpressionAnalysis caseConditionAnalysis = analyzeExpression(caseCondition, joinScope);
+                    Type caseConditionType = caseConditionAnalysis.getType(caseCondition);
+                    if (!caseConditionType.equals(BOOLEAN)) {
+                        if (!caseConditionType.equals(UNKNOWN)) {
+                            throw new SemanticException(TYPE_MISMATCH, caseCondition, "The MERGE WHEN condition must evaluate to a boolean: actual type %s", caseConditionType);
+                        }
+                        analysis.addCoercion(caseCondition, BOOLEAN, false);
+                    }
+                    verifyNoAggregateWindowOrGroupingFunctions(analysis.getFunctionHandles(), functionAndTypeResolver, caseCondition, "MERGE WHEN clause");
+                    analysis.recordSubqueries(merge, caseConditionAnalysis);
+                }
+
                 List<String> setColumnNames = lowercaseIdentifierList(mergeCase.getSetColumns());
                 if (mergeCase instanceof MergeUpdate) {
                     allUpdateColumnNames.addAll(setColumnNames);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -555,6 +555,13 @@ public class QueryPlanner
             Expression mergeCondition = mergeCase instanceof MergeInsert ?
                     new IsNullPredicate(targetUniqueIdColumnSymbolReference) : new IsNotNullPredicate(targetUniqueIdColumnSymbolReference);
 
+            if (mergeCase.getCondition().isPresent()) {
+                Expression caseCondition = mergeCase.getCondition().get();
+                joinSubPlan = subqueryPlanner.handleSubqueries(joinSubPlan, caseCondition, mergeStmt, sqlPlannerContext);
+                Expression rewrittenCondition = coerceIfNecessary(analysis, caseCondition, joinSubPlan.rewrite(caseCondition));
+                mergeCondition = LogicalBinaryExpression.and(mergeCondition, rewrittenCondition);
+            }
+
             whenClauses.add(new WhenClause(mergeCondition, new Row(joinResultBuilder.build())));
         }
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -554,11 +554,11 @@ filter
     ;
 
 mergeCase
-    : WHEN MATCHED THEN
+    : WHEN MATCHED (AND condition=expression)? THEN
         UPDATE SET targetColumns+=identifier EQ values+=expression
           (',' targetColumns+=identifier EQ values+=expression)*            #mergeUpdate
-    | WHEN MATCHED THEN DELETE                                              #mergeDelete
-    | WHEN NOT MATCHED THEN
+    | WHEN MATCHED (AND condition=expression)? THEN DELETE                  #mergeDelete
+    | WHEN NOT MATCHED (AND condition=expression)? THEN
         INSERT ('(' columns+=identifier (',' columns+=identifier)* ')')?
         VALUES '(' values+=expression (',' values+=expression)* ')'         #mergeInsert
     ;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -723,7 +723,7 @@ public final class SqlFormatter
         @Override
         protected Void visitMergeInsert(MergeInsert node, Integer indent)
         {
-            appendMergeCaseWhen(false);
+            appendMergeCaseWhen(false, node.getCondition());
             append(indent + 1, "INSERT ");
 
             if (!node.getColumns().isEmpty()) {
@@ -744,7 +744,7 @@ public final class SqlFormatter
         @Override
         protected Void visitMergeUpdate(MergeUpdate node, Integer indent)
         {
-            appendMergeCaseWhen(true);
+            appendMergeCaseWhen(true, node.getCondition());
             append(indent + 1, "UPDATE SET");
 
             boolean first = true;
@@ -763,14 +763,16 @@ public final class SqlFormatter
         @Override
         protected Void visitMergeDelete(MergeDelete node, Integer indent)
         {
-            appendMergeCaseWhen(true);
+            appendMergeCaseWhen(true, node.getCondition());
             append(indent + 1, "DELETE");
             return null;
         }
 
-        private void appendMergeCaseWhen(boolean matched)
+        private void appendMergeCaseWhen(boolean matched, Optional<Expression> condition)
         {
-            builder.append(matched ? "WHEN MATCHED" : "WHEN NOT MATCHED").append(" THEN\n");
+            builder.append(matched ? "WHEN MATCHED" : "WHEN NOT MATCHED");
+            condition.ifPresent(expression -> builder.append(" AND ").append(formatExpression(expression, parameters)));
+            builder.append(" THEN\n");
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -532,6 +532,7 @@ class AstBuilder
     {
         return new MergeInsert(
                 getLocation(context),
+                visitIfPresent(context.condition, Expression.class),
                 visitIdentifiers(context.columns),
                 visit(context.values, Expression.class));
     }
@@ -553,13 +554,13 @@ class AstBuilder
                     (Expression) visit(context.values.get(i))));
         }
 
-        return new MergeUpdate(getLocation(context), assignments.build());
+        return new MergeUpdate(getLocation(context), visitIfPresent(context.condition, Expression.class), assignments.build());
     }
 
     @Override
     public Node visitMergeDelete(SqlBaseParser.MergeDeleteContext context)
     {
-        return new MergeDelete(getLocation(context));
+        return new MergeDelete(getLocation(context), visitIfPresent(context.condition, Expression.class));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -498,6 +498,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitMergeInsert(MergeInsert node, C context)
     {
+        node.getCondition().ifPresent(condition -> process(condition, context));
         node.getColumns().forEach(column -> process(column, context));
         node.getValues().forEach(expression -> process(expression, context));
         return null;
@@ -506,6 +507,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitMergeUpdate(MergeUpdate node, C context)
     {
+        node.getCondition().ifPresent(condition -> process(condition, context));
         node.getAssignments().forEach(assignment -> {
             process(assignment.getTarget(), context);
             process(assignment.getValue(), context);
@@ -516,6 +518,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitMergeDelete(MergeDelete node, C context)
     {
+        node.getCondition().ifPresent(condition -> process(condition, context));
         return null;
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeCase.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeCase.java
@@ -16,12 +16,22 @@ package com.facebook.presto.sql.tree;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 public abstract class MergeCase
         extends Node
 {
-    protected MergeCase(Optional<NodeLocation> location)
+    private final Optional<Expression> condition;
+
+    protected MergeCase(Optional<NodeLocation> location, Optional<Expression> condition)
     {
         super(location);
+        this.condition = requireNonNull(condition, "condition is null");
+    }
+
+    public Optional<Expression> getCondition()
+    {
+        return condition;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeDelete.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeDelete.java
@@ -16,24 +16,37 @@ package com.facebook.presto.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class MergeDelete
         extends MergeCase
 {
     public MergeDelete()
     {
-        this(Optional.empty());
+        this(Optional.empty(), Optional.empty());
     }
 
     public MergeDelete(NodeLocation location)
     {
-        this(Optional.of(location));
+        this(Optional.of(location), Optional.empty());
     }
 
     public MergeDelete(Optional<NodeLocation> location)
     {
-        super(location);
+        this(location, Optional.empty());
+    }
+
+    public MergeDelete(NodeLocation location, Optional<Expression> condition)
+    {
+        this(Optional.of(location), condition);
+    }
+
+    public MergeDelete(Optional<NodeLocation> location, Optional<Expression> condition)
+    {
+        super(location, condition);
     }
 
     @Override
@@ -57,13 +70,15 @@ public class MergeDelete
     @Override
     public List<? extends Node> getChildren()
     {
-        return ImmutableList.of();
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        getCondition().ifPresent(builder::add);
+        return builder.build();
     }
 
     @Override
     public int hashCode()
     {
-        return MergeDelete.class.hashCode();
+        return Objects.hash(MergeDelete.class, getCondition());
     }
 
     @Override
@@ -72,12 +87,19 @@ public class MergeDelete
         if (this == obj) {
             return true;
         }
-        return obj != null && getClass() == obj.getClass();
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        MergeDelete o = (MergeDelete) obj;
+        return Objects.equals(getCondition(), o.getCondition());
     }
 
     @Override
     public String toString()
     {
-        return "MergeDelete{}";
+        return toStringHelper(this)
+                .add("condition", getCondition().orElse(null))
+                .omitNullValues()
+                .toString();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeInsert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeInsert.java
@@ -30,17 +30,27 @@ public class MergeInsert
 
     public MergeInsert(List<Identifier> columns, List<Expression> values)
     {
-        this(Optional.empty(), columns, values);
+        this(Optional.empty(), Optional.empty(), columns, values);
     }
 
     public MergeInsert(NodeLocation location, List<Identifier> columns, List<Expression> values)
     {
-        this(Optional.of(location), columns, values);
+        this(Optional.of(location), Optional.empty(), columns, values);
     }
 
     public MergeInsert(Optional<NodeLocation> location, List<Identifier> columns, List<Expression> values)
     {
-        super(location);
+        this(location, Optional.empty(), columns, values);
+    }
+
+    public MergeInsert(NodeLocation location, Optional<Expression> condition, List<Identifier> columns, List<Expression> values)
+    {
+        this(Optional.of(location), condition, columns, values);
+    }
+
+    public MergeInsert(Optional<NodeLocation> location, Optional<Expression> condition, List<Identifier> columns, List<Expression> values)
+    {
+        super(location, condition);
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.values = ImmutableList.copyOf(requireNonNull(values, "values is null"));
     }
@@ -77,6 +87,7 @@ public class MergeInsert
     public List<? extends Node> getChildren()
     {
         ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        getCondition().ifPresent(builder::add);
         builder.addAll(columns);
         builder.addAll(values);
         return builder.build();
@@ -85,7 +96,7 @@ public class MergeInsert
     @Override
     public int hashCode()
     {
-        return Objects.hash(columns, values);
+        return Objects.hash(getCondition(), columns, values);
     }
 
     @Override
@@ -98,7 +109,8 @@ public class MergeInsert
             return false;
         }
         MergeInsert o = (MergeInsert) obj;
-        return Objects.equals(columns, o.columns) &&
+        return Objects.equals(getCondition(), o.getCondition()) &&
+                Objects.equals(columns, o.columns) &&
                 Objects.equals(values, o.values);
     }
 
@@ -106,6 +118,7 @@ public class MergeInsert
     public String toString()
     {
         return toStringHelper(this)
+                .add("condition", getCondition().orElse(null))
                 .add("columns", columns)
                 .add("values", values)
                 .omitNullValues()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeUpdate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/MergeUpdate.java
@@ -30,17 +30,27 @@ public class MergeUpdate
 
     public MergeUpdate(List<Assignment> assignments)
     {
-        this(Optional.empty(), assignments);
+        this(Optional.empty(), Optional.empty(), assignments);
     }
 
     public MergeUpdate(NodeLocation location, List<Assignment> assignments)
     {
-        this(Optional.of(location), assignments);
+        this(Optional.of(location), Optional.empty(), assignments);
     }
 
     public MergeUpdate(Optional<NodeLocation> location, List<Assignment> assignments)
     {
-        super(location);
+        this(location, Optional.empty(), assignments);
+    }
+
+    public MergeUpdate(NodeLocation location, Optional<Expression> condition, List<Assignment> assignments)
+    {
+        this(Optional.of(location), condition, assignments);
+    }
+
+    public MergeUpdate(Optional<NodeLocation> location, Optional<Expression> condition, List<Assignment> assignments)
+    {
+        super(location, condition);
         this.assignments = ImmutableList.copyOf(requireNonNull(assignments, "assignments is null"));
     }
 
@@ -75,6 +85,7 @@ public class MergeUpdate
     public List<? extends Node> getChildren()
     {
         ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        getCondition().ifPresent(builder::add);
         assignments.forEach(assignment -> {
             builder.add(assignment.getTarget());
             builder.add(assignment.getValue());
@@ -85,7 +96,7 @@ public class MergeUpdate
     @Override
     public int hashCode()
     {
-        return Objects.hash(assignments);
+        return Objects.hash(getCondition(), assignments);
     }
 
     @Override
@@ -98,13 +109,15 @@ public class MergeUpdate
             return false;
         }
         MergeUpdate o = (MergeUpdate) obj;
-        return Objects.equals(assignments, o.assignments);
+        return Objects.equals(getCondition(), o.getCondition()) &&
+                Objects.equals(assignments, o.assignments);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
+                .add("condition", getCondition().orElse(null))
                 .add("assignments", assignments)
                 .omitNullValues()
                 .toString();

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1878,6 +1878,111 @@ public class TestSqlParser
     }
 
     @Test
+    public void testMergeWithConditions()
+    {
+        NodeLocation location = new NodeLocation(1, 1);
+
+        assertStatement("" +
+                        "MERGE INTO product_sales AS s\n" +
+                        "  USING monthly_sales AS ms\n" +
+                        "  ON s.product_id = ms.product_id\n" +
+                        "WHEN MATCHED AND s.sales + ms.sales > 0 THEN\n" +
+                        "  UPDATE SET\n" +
+                        "      sales = sales + ms.sales",
+                new Merge(
+                        location,
+                        new AliasedRelation(location, table(QualifiedName.of("product_sales")), new Identifier("s"), null),
+                        aliased(table(QualifiedName.of("monthly_sales")), "ms"),
+                        equal(nameReference("s", "product_id"), nameReference("ms", "product_id")),
+                        ImmutableList.of(
+                                new MergeUpdate(
+                                        location,
+                                        Optional.of(new ComparisonExpression(
+                                                ComparisonExpression.Operator.GREATER_THAN,
+                                                new ArithmeticBinaryExpression(
+                                                        ArithmeticBinaryExpression.Operator.ADD,
+                                                        nameReference("s", "sales"),
+                                                        nameReference("ms", "sales")),
+                                                new LongLiteral("0"))),
+                                        ImmutableList.of(
+                                                new MergeUpdate.Assignment(new Identifier("sales"), new ArithmeticBinaryExpression(
+                                                        ArithmeticBinaryExpression.Operator.ADD, nameReference("sales"), nameReference("ms", "sales"))))))));
+
+        assertStatement("" +
+                        "MERGE INTO product_sales AS s\n" +
+                        "  USING monthly_sales AS ms\n" +
+                        "  ON s.product_id = ms.product_id\n" +
+                        "WHEN MATCHED AND s.sales + ms.sales = 0 THEN\n" +
+                        "  DELETE",
+                new Merge(
+                        location,
+                        new AliasedRelation(location, table(QualifiedName.of("product_sales")), new Identifier("s"), null),
+                        aliased(table(QualifiedName.of("monthly_sales")), "ms"),
+                        equal(nameReference("s", "product_id"), nameReference("ms", "product_id")),
+                        ImmutableList.of(
+                                new MergeDelete(
+                                        location,
+                                        Optional.of(new ComparisonExpression(
+                                                ComparisonExpression.Operator.EQUAL,
+                                                new ArithmeticBinaryExpression(
+                                                        ArithmeticBinaryExpression.Operator.ADD,
+                                                        nameReference("s", "sales"),
+                                                        nameReference("ms", "sales")),
+                                                new LongLiteral("0")))))));
+
+        assertStatement("" +
+                        "MERGE INTO product_sales AS s\n" +
+                        "  USING monthly_sales AS ms\n" +
+                        "  ON s.product_id = ms.product_id\n" +
+                        "WHEN NOT MATCHED AND ms.sales <> 0 THEN\n" +
+                        "  INSERT (product_id, sales)\n" +
+                        "  VALUES (ms.product_id, ms.sales)",
+                new Merge(
+                        location,
+                        new AliasedRelation(location, table(QualifiedName.of("product_sales")), new Identifier("s"), null),
+                        aliased(table(QualifiedName.of("monthly_sales")), "ms"),
+                        equal(nameReference("s", "product_id"), nameReference("ms", "product_id")),
+                        ImmutableList.of(
+                                new MergeInsert(
+                                        location,
+                                        Optional.of(new ComparisonExpression(
+                                                ComparisonExpression.Operator.NOT_EQUAL,
+                                                nameReference("ms", "sales"),
+                                                new LongLiteral("0"))),
+                                        ImmutableList.of(new Identifier("product_id"), new Identifier("sales")),
+                                        ImmutableList.of(nameReference("ms", "product_id"), nameReference("ms", "sales"))))));
+
+        assertStatement("" +
+                        "MERGE INTO product_sales AS s\n" +
+                        "  USING monthly_sales AS ms\n" +
+                        "  ON s.product_id = ms.product_id\n" +
+                        "WHEN MATCHED AND s.sales + ms.sales > 0 THEN\n" +
+                        "  UPDATE SET\n" +
+                        "      sales = sales + ms.sales\n" +
+                        "WHEN MATCHED THEN\n" +
+                        "  DELETE",
+                new Merge(
+                        location,
+                        new AliasedRelation(location, table(QualifiedName.of("product_sales")), new Identifier("s"), null),
+                        aliased(table(QualifiedName.of("monthly_sales")), "ms"),
+                        equal(nameReference("s", "product_id"), nameReference("ms", "product_id")),
+                        ImmutableList.of(
+                                new MergeUpdate(
+                                        location,
+                                        Optional.of(new ComparisonExpression(
+                                                ComparisonExpression.Operator.GREATER_THAN,
+                                                new ArithmeticBinaryExpression(
+                                                        ArithmeticBinaryExpression.Operator.ADD,
+                                                        nameReference("s", "sales"),
+                                                        nameReference("ms", "sales")),
+                                                new LongLiteral("0"))),
+                                        ImmutableList.of(
+                                                new MergeUpdate.Assignment(new Identifier("sales"), new ArithmeticBinaryExpression(
+                                                        ArithmeticBinaryExpression.Operator.ADD, nameReference("sales"), nameReference("ms", "sales"))))),
+                                new MergeDelete(location))));
+    }
+
+    @Test
     public void testRenameTable()
     {
         assertStatement("ALTER TABLE a RENAME TO b", new RenameTable(QualifiedName.of("a"), QualifiedName.of("b"), false));


### PR DESCRIPTION
## Description
Add SQL-standard optional `AND <predicate>` to each `WHEN [NOT] MATCHED` clause in `MERGE`. Clauses are evaluated in textual order; the first whose predicate is satisfied fires for each row.

## Motivation and Context
The SQL standard and every other major engine (Snowflake, Databricks, Trino, BigQuery) allows an additional boolean predicate per `WHEN` clause, enabling conditional branches like `WHEN MATCHED AND count + count_delta = 0 THEN DELETE`. Presto's grammar rejected these.

## Impact
New SQL syntax. The predicate is optional, so existing MERGE statements are unaffected. No connector SPI changes — predicate is enforced via the existing planner-level `mergeCondition`.

## Test Plan
New unit tests added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for additional predicates on ``WHEN`` clauses in ``MERGE`` (``WHEN MATCHED AND <condition>``, ``WHEN NOT MATCHED AND <condition>``). 
```

## Summary by Sourcery

Support conditional WHEN clauses in MERGE statements and ensure they are parsed, analyzed, planned, and tested across the engine and Iceberg connector.

New Features:
- Allow MERGE WHEN MATCHED and WHEN NOT MATCHED clauses to include boolean predicate conditions.
- Expose MERGE WHEN clause predicates in the logical plan so they can participate in planning and optimization.

Enhancements:
- Extend MERGE AST nodes to carry optional conditions and update traversal, formatting, and equality semantics accordingly.
- Validate MERGE WHEN predicates in the analyzer, including boolean type checking and disallowing aggregates, and incorporate them into the planned merge condition.

Documentation:
- Begin updating MERGE SQL reference documentation to reflect support for conditional WHEN clauses.

Tests:
- Add parser tests for MERGE statements with conditional WHEN clauses and mixed conditional/unconditional cases.
- Add Iceberg integration tests covering MERGE WHEN predicates behavior, clause ordering, no-op scenarios, and analyzer error cases.
- Add a logical planner test to assert that MERGE WHEN predicates appear correctly in the generated plan text.

## Summary by Sourcery

Add support for optional boolean predicates on MERGE WHEN clauses and ensure they are fully integrated across parsing, analysis, planning, and Iceberg.

New Features:
- Allow MERGE WHEN MATCHED and WHEN NOT MATCHED clauses to include optional boolean predicate conditions that control whether the clause applies.

Enhancements:
- Propagate optional WHEN clause predicates through the MERGE AST, traversal, formatting, and equality semantics so they are treated as first-class expressions.
- Validate MERGE WHEN predicates during analysis, including enforcing boolean result types and forbidding aggregates, and compose them into the existing merge condition in the planner.
- Include WHEN clause predicates in the logical plan output to enable inspection and optimization.

Documentation:
- Update MERGE SQL reference documentation to describe support for conditional WHEN clauses.

Tests:
- Extend SQL parser tests to cover MERGE statements with conditional and mixed WHEN clauses.
- Add Iceberg integration tests for MERGE WHEN predicates, including ordering behavior, no-op scenarios, and analyzer error cases.
- Add a logical planner test asserting that MERGE WHEN predicates appear in the generated plan text.