### PR TITLE
test: Add reservoir sample e2e tests

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -1377,6 +1377,62 @@ public abstract class AbstractTestAggregations
                 "SELECT partkey, true FROM lineitem GROUP BY partkey");
     }
 
+    /**
+     * reservoir_sample(initial_sample, initial_processed_count, value, desired_sample_size)
+     * draws a fixed-size sample and returns row(processed_count bigint, sample array(T)).
+     * The sampled elements are chosen at random, so the assertions check deterministic
+     * properties (processed count, sample cardinality, value domain) rather than the
+     * specific elements. Comprehensive correctness lives in TestReservoirSampleAggregation.
+     *
+     * <p>Although this test is declared in presto-tests, it also exercises the native
+     * (Velox) implementation: presto-native-tests/AbstractTestAggregationsNative extends
+     * this class, so the method is inherited and executed against the native query runner.
+     */
+    @Test
+    public void testReservoirSample()
+    {
+        // Single aggregation over orders covering three properties in one scan: processed_count
+        // equals the input row count, the sample is capped at the desired size, and every sampled
+        // element belongs to the input domain (orderkey is positive). Each property is its own
+        // output column so a failure points at the specific property that diverged.
+        assertQuery(
+                "SELECT rs.processed_count, " +
+                        "cardinality(rs.sample), " +
+                        "cardinality(filter(rs.sample, x -> x > 0)) = cardinality(rs.sample) " +
+                        "FROM (SELECT reservoir_sample(NULL, 0, orderkey, 10) AS rs FROM orders) t",
+                "SELECT count(*), 10, true FROM orders");
+
+        // When the input is smaller than the desired size the entire input is kept.
+        assertQuery(
+                "SELECT cardinality(rs.sample) FROM (SELECT reservoir_sample(NULL, 0, orderkey, 100) AS rs FROM (SELECT orderkey FROM orders LIMIT 40) o) t",
+                "SELECT 40");
+
+        // A constant input yields a sample of that constant value; verify the size and contents
+        // rather than the exact array shape.
+        assertQuery(
+                "SELECT cardinality(rs.sample) = 3 AND cardinality(filter(rs.sample, x -> x = 1.0E0)) = 3 FROM (SELECT reservoir_sample(NULL, 0, 1.0E0, 3) AS rs FROM orders) t",
+                "SELECT true");
+
+        // Null values still count toward processed_count (the function is called on null input).
+        assertQuery(
+                "SELECT rs.processed_count FROM (SELECT reservoir_sample(NULL, 0, CASE WHEN orderkey % 2 = 0 THEN orderkey END, 10) AS rs FROM orders) t",
+                "SELECT count(*) FROM orders");
+
+        // A non-empty initial sample with a non-zero initial_processed_count is merged with the new
+        // rows (resume behavior): processed_count accounts for both the seed and the new rows, and
+        // because the combined size does not exceed the desired size the seed elements are retained.
+        assertQuery(
+                "SELECT rs.processed_count = 5 AND cardinality(rs.sample) = 5 " +
+                        "AND contains(rs.sample, 100) AND contains(rs.sample, 200) " +
+                        "FROM (SELECT reservoir_sample(ARRAY[100, 200], 2, x, 5) AS rs FROM (VALUES 1, 2, 3) t(x)) u",
+                "SELECT true");
+
+        // GROUP BY: processed_count per group equals the group's row count.
+        assertQuery(
+                "SELECT orderpriority, rs.processed_count FROM (SELECT orderpriority, reservoir_sample(NULL, 0, orderkey, 5) AS rs FROM orders GROUP BY orderpriority) t",
+                "SELECT orderpriority, count(*) FROM orders GROUP BY orderpriority");
+    }
+
     @Test
     public void testGroupedRow()
     {


### PR DESCRIPTION
## Description
Add e2e aggregation tests verifying reservoir_sample output size, processed_count, null handling, grouping behavior, and deterministic behavior on constant inputs.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Add e2e aggregation tests verifying reservoir_sample output size, processed_count, null handling, grouping behavior, and deterministic behavior on constant inputs.