### PR TITLE
fix(security): Upgrade commons-configuration2 to 2.15.1 to address CVE-2026-45205

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -45,6 +45,13 @@
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${dep.log4j.version}</version>
             </dependency>
+            <!-- Added to address a vulnerability(CVE-2026-45205) originating from commons-configuration2:jar:2.12.0,which is transitively included through the pinot-spi JAR.
+            This can be removed after upgrading Pinot, since newer Pinot version use the non-vulnerable commons-configuration2:2.15.1. -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.15.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -44,6 +44,13 @@
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${dep.log4j.version}</version>
             </dependency>
+            <!-- Added to address a vulnerability(CVE-2026-45205) originating from commons-configuration2:jar:2.12.0,which is transitively included through the pinot-spi JAR.
+            This can be removed after upgrading Pinot, since newer Pinot version use the non-vulnerable commons-configuration2:2.15.1. -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.15.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description
Upgrade commons-configuration2 to 2.15.1 to address CVE-2026-45205

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
<img width="1048" height="809" alt="Screenshot 2026-05-25 at 9 32 23 PM" src="https://github.com/user-attachments/assets/2038013c-5011-47fc-91f1-17eddde3d061" />
<img width="974" height="742" alt="Screenshot 2026-05-25 at 9 32 37 PM" src="https://github.com/user-attachments/assets/a5c518af-79ca-459d-8687-5ffa2d21982f" />

<img width="1631" height="576" alt="Screenshot 2026-05-25 at 9 32 49 PM" src="https://github.com/user-attachments/assets/0b056070-24ab-4db5-9080-f26319e8e255" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

`== RELEASE NOTES ==`

```
Security Changes
* Upgrade commons-configuration2 in response to `CVE-2026-45205  <https://github.com/advisories/GHSA-337m-mw94-2v6g>`_.

```

