### PR TITLE
Carry exchange transport types on the Velox PlanFragment

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -388,6 +388,22 @@ std::string toVeloxSerdeKind(protocol::ExchangeEncoding encoding) {
   VELOX_UNSUPPORTED("Unsupported encoding: {}.", fmt::underlying(encoding));
 }
 
+// The coordinator sends ANY when the worker supports UCX transport.
+// In practice ANY means "use the fastest available transport" which is UCX.
+std::string_view toVeloxTransportType(
+    const std::shared_ptr<protocol::TransportType>& t) {
+  if (!t) {
+    return core::TransportKind::kHttp;
+  }
+  switch (*t) {
+    case protocol::TransportType::HTTP:
+      return core::TransportKind::kHttp;
+    case protocol::TransportType::ANY:
+      return core::TransportKind::kUcx;
+  }
+  VELOX_UNSUPPORTED("Unsupported transport type: {}.", fmt::underlying(*t));
+}
+
 std::shared_ptr<core::LocalPartitionNode> buildLocalSystemPartitionNode(
     const std::shared_ptr<const protocol::ExchangeNode>& node,
     core::LocalPartitionNode::Type type,
@@ -2356,6 +2372,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
   core::PlanFragment planFragment;
+  planFragment_ = &planFragment;
 
   // Convert the fragment info first.
   const auto& descriptor = fragment.stageExecutionDescriptor;
@@ -2410,6 +2427,8 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   auto outputType = toRowType(partitioningScheme.outputLayout, typeParser_);
   const auto partitionedOutputNodeId =
       toPartitionedOutputNodeId(fragment.root->id);
+  planFragment.outputTransportTypes[partitionedOutputNodeId] =
+      toVeloxTransportType(fragment.outputTransportType);
 
   if (auto systemPartitioningHandle =
           std::dynamic_pointer_cast<protocol::SystemPartitioningHandle>(
@@ -2561,6 +2580,8 @@ core::PlanNodePtr VeloxInteractiveQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RemoteSourceNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
     const protocol::TaskId& taskId) {
+  planFragment_->inputTransportTypes[node->id] =
+      toVeloxTransportType(node->transportType);
   auto rowType = toRowType(node->outputVariables, typeParser_);
   if (node->orderingScheme) {
     std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
@@ -2718,6 +2739,8 @@ core::PlanNodePtr VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RemoteSourceNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& /* tableWriteInfo */,
     const protocol::TaskId& taskId) {
+  planFragment_->inputTransportTypes[node->id] =
+      toVeloxTransportType(node->transportType);
   auto rowType = toRowType(node->outputVariables, typeParser_);
   // Broadcast exchange source.
   if (node->exchangeType == protocol::ExchangeNodeType::REPLICATE) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -254,6 +254,7 @@ class VeloxQueryPlanConverterBase {
   velox::core::QueryCtx* const queryCtx_;
   VeloxExprConverter exprConverter_;
   TypeParser typeParser_;
+  velox::core::PlanFragment* planFragment_{nullptr};
 };
 
 class VeloxInteractiveQueryPlanConverter : public VeloxQueryPlanConverterBase {

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -92,6 +92,17 @@ const core::ExchangeNode* findExchangeNode(
   return nullptr;
 }
 
+// Returns the transport type annotated for 'nodeId' in 'transportTypes', or
+// TransportKind::kHttp when the node is absent, matching PlanFragment's
+// "a node absent from the map uses kHttp" contract.
+std::string_view transportTypeOrDefault(
+    const folly::F14FastMap<core::PlanNodeId, std::string>& transportTypes,
+    const core::PlanNodeId& nodeId) {
+  const auto it = transportTypes.find(nodeId);
+  return it == transportTypes.end() ? core::TransportKind::kHttp
+                                    : std::string_view{it->second};
+}
+
 } // namespace
 
 class PlanConverterTest : public ::testing::Test {
@@ -337,13 +348,14 @@ TEST_F(PlanConverterTest, transportTypeAbsentDefaultsToHttp) {
       veloxFragment.planNode.get());
   ASSERT_NE(partitionedOutput, nullptr);
   ASSERT_EQ(
-      veloxFragment.outputTransportType(partitionedOutput->id()),
+      transportTypeOrDefault(
+          veloxFragment.outputTransportTypes, partitionedOutput->id()),
       core::TransportKind::kHttp);
 
   auto* exchange = findExchangeNode(veloxFragment.planNode);
   ASSERT_NE(exchange, nullptr);
   ASSERT_EQ(
-      veloxFragment.inputTransportType(exchange->id()),
+      transportTypeOrDefault(veloxFragment.inputTransportTypes, exchange->id()),
       core::TransportKind::kHttp);
 }
 
@@ -365,13 +377,14 @@ TEST_F(PlanConverterTest, transportTypeAny) {
       veloxFragment.planNode.get());
   ASSERT_NE(partitionedOutput, nullptr);
   ASSERT_EQ(
-      veloxFragment.outputTransportType(partitionedOutput->id()),
+      transportTypeOrDefault(
+          veloxFragment.outputTransportTypes, partitionedOutput->id()),
       core::TransportKind::kUcx);
 
   auto* exchange = findExchangeNode(veloxFragment.planNode);
   ASSERT_NE(exchange, nullptr);
   ASSERT_EQ(
-      veloxFragment.inputTransportType(exchange->id()),
+      transportTypeOrDefault(veloxFragment.inputTransportTypes, exchange->id()),
       core::TransportKind::kUcx);
 }
 
@@ -393,12 +406,13 @@ TEST_F(PlanConverterTest, transportTypeHttp) {
       veloxFragment.planNode.get());
   ASSERT_NE(partitionedOutput, nullptr);
   ASSERT_EQ(
-      veloxFragment.outputTransportType(partitionedOutput->id()),
+      transportTypeOrDefault(
+          veloxFragment.outputTransportTypes, partitionedOutput->id()),
       core::TransportKind::kHttp);
 
   auto* exchange = findExchangeNode(veloxFragment.planNode);
   ASSERT_NE(exchange, nullptr);
   ASSERT_EQ(
-      veloxFragment.inputTransportType(exchange->id()),
+      transportTypeOrDefault(veloxFragment.inputTransportTypes, exchange->id()),
       core::TransportKind::kHttp);
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -26,6 +26,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/main/types/tests/TestUtils.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanFragment.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::presto;
@@ -78,6 +79,19 @@ std::shared_ptr<const core::PlanNode> assertToBatchVeloxQueryPlan(
           prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3")
       .planNode;
 }
+const core::ExchangeNode* findExchangeNode(
+    const std::shared_ptr<const core::PlanNode>& node) {
+  if (auto* exchange = dynamic_cast<const core::ExchangeNode*>(node.get())) {
+    return exchange;
+  }
+  for (const auto& source : node->sources()) {
+    if (auto* found = findExchangeNode(source)) {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
 } // namespace
 
 class PlanConverterTest : public ::testing::Test {
@@ -303,4 +317,88 @@ TEST_F(PlanConverterTest, batchPlanConversionExchangeWrite) {
       std::dynamic_pointer_cast<const operators::MaterializedExchangeNode>(
           curNode);
   ASSERT_NE(materializedExchangeNode, nullptr);
+}
+
+TEST_F(PlanConverterTest, transportTypeAbsentDefaultsToHttp) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  ASSERT_FALSE(j.count("outputTransportType"));
+  ASSERT_FALSE(j["root"]["source"]["sources"][0].count("transportType"));
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kHttp);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kHttp);
+}
+
+TEST_F(PlanConverterTest, transportTypeAny) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  j["outputTransportType"] = "ANY";
+  j["root"]["source"]["sources"][0]["transportType"] = "ANY";
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kUcx);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kUcx);
+}
+
+TEST_F(PlanConverterTest, transportTypeHttp) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  j["outputTransportType"] = "HTTP";
+  j["root"]["source"]["sources"][0]["transportType"] = "HTTP";
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kHttp);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kHttp);
 }


### PR DESCRIPTION
## Description

Propagate per-node exchange transport types from the Presto plan into the
converted Velox `PlanFragment`, so that downstream execution can select the
appropriate exchange transport (e.g. HTTP vs. UCX) on a per-node basis.

- `toVeloxTransportType()` maps the protocol transport type to a
  `core::TransportKind` constant (`kHttp`/`kUcx`), returning `std::string_view`.
- The output transport type is recorded in
  `planFragment.outputTransportTypes`, keyed by the `PartitionedOutput` node id.
- Input transport types are recorded in `planFragment.inputTransportTypes`,
  keyed by the `RemoteSource`/`Exchange` node id, via a `planFragment_` pointer
  set during recursive plan conversion.
- Plan converter tests assert the transport types on the converted
  `PlanFragment`.

## Motivation and Context

GPU-accelerated workers can use a faster exchange transport (UCX) than the
default HTTP exchange. Recording the transport type per node on the
`PlanFragment` lets the engine choose the right transport for each exchange
during execution.

## Impact

Native execution plan conversion only. When no transport type is specified,
nodes default to `TransportKind::kHttp`, preserving existing behavior.

## Test Plan

- Unit tests in `PlanConverterTest` covering the absent/default, `ANY`, and
  `HTTP` transport-type cases on the converted `PlanFragment`.
