### PR TITLE
fix(security): Upgrade  opentelemetry-api  to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dep.fastutil.version>8.5.2</dep.fastutil.version>
         <dep.datasketches-memory.version>2.2.0</dep.datasketches-memory.version>
         <dep.datasketches-java.version>5.0.1</dep.datasketches-java.version>
-        <dep.io.opentelemetry.version>1.58.0</dep.io.opentelemetry.version>
+        <dep.io.opentelemetry.version>1.62.0</dep.io.opentelemetry.version>
 
         <release.autoPublish>true</release.autoPublish>
     </properties>


### PR DESCRIPTION
## Description
Upgrade  opentelemetry-api  to 1.62.0 to address CVE-2026-45292

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<img width="1340" height="974" alt="Screenshot 2026-05-26 at 6 37 27 PM" src="https://github.com/user-attachments/assets/ad4fcd86-45ca-481a-9b85-9e3f7f870295" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

`== RELEASE NOTES ==`

```
Security Changes
* Upgrade opentelemetry-api  to 1.62.0 in response to `CVE-2026-45292  <https://github.com/advisories/GHSA-fmxf-pm6p-7xgm>`_.

```

## Summary by Sourcery

Upgrade OpenTelemetry API dependency and configure automated dependency updates for the UI package.

Bug Fixes:
- Address a security advisory by bumping the opentelemetry-api dependency from 1.58.0 to 1.62.0.

CI:
- Add Dependabot configuration to automatically create daily update PRs for npm dependencies in the presto-ui project, limited to webpack-cli and labeled as dependencies.