### PR TITLE
chore: Force modernizer use for all modules up to presto-main-base

### DIFF
--- a/presto-analyzer/pom.xml
+++ b/presto-analyzer/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-built-in-worker-function-tools/pom.xml
+++ b/presto-built-in-worker-function-tools/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-function-namespace-managers-common/pom.xml
+++ b/presto-function-namespace-managers-common/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <artifactId>presto-function-namespace-managers-common</artifactId>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>17</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencyManagement>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-internal-communication/pom.xml
+++ b/presto-internal-communication/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-main-tests/pom.xml
+++ b/presto-main-tests/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <air.test.jvmsize>4g</air.test.jvmsize>
     </properties>
 

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -27,7 +27,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/SslContextProvider.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/SslContextProvider.java
@@ -26,9 +26,9 @@ import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -152,7 +152,7 @@ public class SslContextProvider
         catch (IOException | GeneralSecurityException e) {
             log.debug("Failed to load keystore as PEM, attempting JKS format: {}", e.getMessage());
             keystore = getInstance(getDefaultType());
-            try (InputStream in = new FileInputStream(keystoreFile)) {
+            try (InputStream in = Files.newInputStream(keystoreFile.toPath())) {
                 keystore.load(in, keystorePassword.map(String::toCharArray).orElse(null));
             }
             log.debug("Successfully loaded keystore as JKS format");
@@ -232,7 +232,7 @@ public class SslContextProvider
         if (!loaded) {
             try {
                 log.debug("Attempting to load truststore as JKS format");
-                try (InputStream inputStream = new FileInputStream(trustStorePath)) {
+                try (InputStream inputStream = Files.newInputStream(trustStorePath.toPath())) {
                     trustStore.load(inputStream, trustStorePassword.map(String::toCharArray).orElse(null));
                 }
                 log.debug("Successfully loaded truststore as JKS format");

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <!-- the SPI should have only minimal dependencies -->

--- a/presto-testng-services/pom.xml
+++ b/presto-testng-services/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
-        <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description

Removes the `air.check.skip-modernizer` that was added during the JDK 17 upgrade for modules toward the leaves of the presto dependency tree.

## Motivation and Context

Keep codebase up to date with current JDK standards, reduce debt from previous JDK upgrade

## Impact

N/A

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable modernizer checks for additional modules and update SSL keystore/truststore loading to comply with modern JDK APIs.

Enhancements:
- Replace direct FileInputStream usage with Files.newInputStream when loading SSL key/trust stores to align with modern Java I/O practices.

Build:
- Remove air.check.skip-modernizer properties from multiple module POMs so these modules now participate in modernizer checks during the build.