### PR TITLE
test(native-pos): Reduce `kLocalShuffleMaxPartitionBytes` default to 64KB

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -231,7 +231,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLargestSizeClassPages, 256),
           BOOL_PROP(kEnableVeloxTaskLogging, false),
           BOOL_PROP(kEnableVeloxExprSetLogging, false),
-          NUM_PROP(kLocalShuffleMaxPartitionBytes, 268435456),
+          NUM_PROP(kLocalShuffleMaxPartitionBytes, 65536),
           STR_PROP(kShuffleName, ""),
           BOOL_PROP(kExchangeMaterializationEnabled, false),
           NUM_PROP(


### PR DESCRIPTION
Summary: Reduce `kLocalShuffleMaxPartitionBytes` from 256MB to 64KB. The previous default caused LocalShuffleWriter to buffer an entire 256MB partition before flushing, leading to excessive memory usage when partition counts are high.

Differential Revision: D106168794

## Summary by Sourcery

Enhancements:
- Reduce the default kLocalShuffleMaxPartitionBytes from 256MB to 64KB in the system configuration to limit LocalShuffleWriter buffering.


```
== NO RELEASE NOTE ==
```