### PR TITLE
refactor(native-pos): Remove cooperative backpressure and `useSystemMemory` config

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -241,7 +241,6 @@ SystemConfig::SystemConfig() {
           NUM_PROP(
               kExchangeMaterializationOutputBufferPerPartitionMaxBytes,
               130L * 1024),
-          BOOL_PROP(kExchangeMaterializationOutputBufferUseSystemMemory, false),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           BOOL_PROP(kHttpEnableAccessLog, false),
@@ -799,12 +798,6 @@ int64_t SystemConfig::exchangeMaterializationOutputBufferPerPartitionMaxBytes()
   return optionalProperty<int64_t>(
              kExchangeMaterializationOutputBufferPerPartitionMaxBytes)
       .value_or(130L * 1024);
-}
-
-bool SystemConfig::exchangeMaterializationOutputBufferUseSystemMemory() const {
-  return optionalProperty<bool>(
-             kExchangeMaterializationOutputBufferUseSystemMemory)
-      .value_or(false);
 }
 
 bool SystemConfig::enableSerializedPageChecksum() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -231,7 +231,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLargestSizeClassPages, 256),
           BOOL_PROP(kEnableVeloxTaskLogging, false),
           BOOL_PROP(kEnableVeloxExprSetLogging, false),
-          NUM_PROP(kLocalShuffleMaxPartitionBytes, 268435456),
+          NUM_PROP(kLocalShuffleMaxPartitionBytes, 65536),
           STR_PROP(kShuffleName, ""),
           BOOL_PROP(kExchangeMaterializationEnabled, false),
           NUM_PROP(

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -693,14 +693,6 @@ class SystemConfig : public ConfigBase {
       kExchangeMaterializationOutputBufferPerPartitionMaxBytes{
           "exchange.materialization.output-buffer.per-partition-max-bytes"};
 
-  /// When true, MaterializedOutputBuffer uses a system memory pool (outside
-  /// the arbitrator). When false, uses an operator pool under the query's
-  /// memory hierarchy (visible to the arbitrator).
-  /// Default: false.
-  static constexpr std::string_view
-      kExchangeMaterializationOutputBufferUseSystemMemory{
-          "exchange.materialization.output-buffer.use-system-memory"};
-
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
@@ -1167,8 +1159,6 @@ class SystemConfig : public ConfigBase {
   int64_t exchangeMaterializationOutputBufferMaxBytes() const;
 
   int64_t exchangeMaterializationOutputBufferPerPartitionMaxBytes() const;
-
-  bool exchangeMaterializationOutputBufferUseSystemMemory() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -445,16 +445,7 @@ void MaterializedOutput::flushBatch() {
 
     auto iobuf = buildRowGroup(rows);
 
-    // Enqueue always accepts the data — backpressure is advisory. If the
-    // buffer is full, enqueue returns true and populates a future. We record
-    // the future but continue flushing remaining partitions. The driver
-    // suspends on the next isBlocked() call, not mid-loop. The overshoot
-    // per flush is bounded by targetSizeInBytes_ (1-16MB).
-    ContinueFuture future;
-    if (buffer_->enqueue(partition, std::move(iobuf), &future)) {
-      blockingReason_ = BlockingReason::kWaitForConsumer;
-      future_ = std::move(future);
-    }
+    buffer_->enqueue(partition, std::move(iobuf));
   }
 
   // Reset accumulated state.

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -59,7 +59,6 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
     int64_t partitionDrainThreshold)
     : numPartitions_(numPartitions),
       maxBufferedBytes_(maxBufferedBytes),
-      continueBufferedBytes_(maxBufferedBytes * 9 / 10),
       partitionDrainThreshold_(
           std::min(
               partitionDrainThreshold > 0 ? partitionDrainThreshold
@@ -118,38 +117,15 @@ void MaterializedOutputBuffer::freeTrackedIOBuf(void* buf, void* userData) {
   delete info;
 }
 
-bool MaterializedOutputBuffer::maybeApplyBackpressure(
-    velox::ContinueFuture* future) {
-  if (bufferedBytes_ >= maxBufferedBytes_) {
-    std::lock_guard<std::mutex> lock(stateMutex_);
-    if (bufferedBytes_ >= maxBufferedBytes_) {
-      auto [promise, semiFuture] =
-          velox::makeVeloxContinuePromiseContract("MaterializedOutputBuffer");
-      promises_.push_back(std::move(promise));
-      *future = std::move(semiFuture);
-      ++backpressureCount_;
-      LOG(INFO) << fmt::format(
-          "MaterializedOutputBuffer backpressure: bufferedBytes={}MB >= "
-          "max={}MB, waitingDrivers={}",
-          bufferedBytes_ >> 20,
-          maxBufferedBytes_ >> 20,
-          promises_.size());
-      return true;
-    }
-  }
-  return false;
-}
-
-bool MaterializedOutputBuffer::enqueue(
+void MaterializedOutputBuffer::enqueue(
     int32_t partition,
-    std::unique_ptr<folly::IOBuf> rowGroup,
-    velox::ContinueFuture* future) {
+    std::unique_ptr<folly::IOBuf> rowGroup) {
   VELOX_CHECK_GE(partition, 0);
   VELOX_CHECK_LT(partition, numPartitions_);
   // During error teardown, abort() may have been called while other
   // drivers still flush remaining data. Silently drop.
   if (aborted_.load()) {
-    return false;
+    return;
   }
   VELOX_CHECK(
       !finished_.load(),
@@ -179,19 +155,8 @@ bool MaterializedOutputBuffer::enqueue(
           static_cast<int64_t>(drainCount_),
           bufferedBytes_ >> 20);
     }
-    auto prevTotal = bufferedBytes_.fetch_sub(drainedBytes);
-    if (prevTotal >= continueBufferedBytes_ &&
-        (prevTotal - drainedBytes) < continueBufferedBytes_) {
-      std::vector<velox::ContinuePromise> promises;
-      {
-        std::lock_guard<std::mutex> stateLock(stateMutex_);
-        promises.swap(promises_);
-      }
-      maybeUnblockProducers(promises);
-    }
+    bufferedBytes_.fetch_sub(drainedBytes);
   }
-
-  return maybeApplyBackpressure(future);
 }
 
 void MaterializedOutputBuffer::flushToWriter(
@@ -271,14 +236,6 @@ void MaterializedOutputBuffer::abort() {
     partitionBuffers_[i]->bufferedBytes_ = 0;
   }
 
-  // Unblock any waiting producers.
-  std::vector<velox::ContinuePromise> promises;
-  {
-    std::lock_guard<std::mutex> lock(stateMutex_);
-    promises.swap(promises_);
-  }
-  maybeUnblockProducers(promises);
-
   LOG(INFO)
       << "MaterializedOutputBuffer: calling writer noMoreData(false) [abort]";
   writer_->noMoreData(/*success=*/false);
@@ -314,20 +271,6 @@ bool MaterializedOutputBuffer::noMoreDrivers() {
   return isLast;
 }
 
-void MaterializedOutputBuffer::maybeUnblockProducers(
-    std::vector<velox::ContinuePromise>& promises) {
-  if (!promises.empty()) {
-    LOG(INFO) << fmt::format(
-        "MaterializedOutputBuffer resumed: unblocked {} drivers, "
-        "bufferedBytes={}MB",
-        promises.size(),
-        bufferedBytes_ >> 20);
-  }
-  for (auto& promise : promises) {
-    promise.setValue();
-  }
-}
-
 void MaterializedOutputBuffer::finishAndClose() {
   if (finished_.exchange(true)) {
     return;
@@ -350,8 +293,7 @@ void MaterializedOutputBuffer::finishAndClose() {
       bufferedBytes_ >> 20);
   LOG(INFO) << fmt::format(
       "MaterializedOutputBuffer closed: "
-      "backpressureCount={}, collectCalls={}, peakBufferedBytes={}MB",
-      static_cast<int64_t>(backpressureCount_),
+      "collectCalls={}, peakBufferedBytes={}MB",
       totalCollects,
       peakBufferedBytes_ >> 20);
 }
@@ -361,7 +303,6 @@ folly::F14FastMap<std::string, int64_t> MaterializedOutputBuffer::stats()
   auto writerStats = writer_->stats();
   writerStats[std::string(kTotalDrainedBytes)] = totalDrainedBytes_;
   writerStats[std::string(kDrainCount)] = drainCount_;
-  writerStats[std::string(kBackpressureCount)] = backpressureCount_;
   writerStats[std::string(kCurrentDrainThreshold)] = partitionDrainThreshold_;
   writerStats[std::string(kBufferPoolUsedBytes)] =
       pool_ ? pool_->usedBytes() : 0;

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -21,7 +21,6 @@
 #include <folly/Synchronized.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
-#include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/MemoryPool.h"
 
 namespace facebook::presto::operators {
@@ -30,7 +29,7 @@ namespace facebook::presto::operators {
 ///
 /// Accepts serialized RowGroups per partition from multiple drivers, buffers
 /// them, and drains to the ShuffleWriter when the per-partition threshold is
-/// hit. Supports ContinueFuture-based cooperative backpressure.
+/// hit.
 ///
 /// Memory for buffered RowGroups is tracked through bufferPool_ (a system
 /// pool visible for accounting). The writer uses a separate system pool.
@@ -46,8 +45,6 @@ class MaterializedOutputBuffer {
       "materializedOutputBuffer.totalDrainedBytes";
   static constexpr std::string_view kDrainCount =
       "materializedOutputBuffer.drainCount";
-  static constexpr std::string_view kBackpressureCount =
-      "materializedOutputBuffer.backpressureCount";
   static constexpr std::string_view kCurrentDrainThreshold =
       "materializedOutputBuffer.currentDrainThreshold";
   static constexpr std::string_view kBufferPoolUsedBytes =
@@ -68,12 +65,8 @@ class MaterializedOutputBuffer {
 
   ~MaterializedOutputBuffer();
 
-  /// Enqueue a serialized RowGroup for a partition. If total buffered
-  /// bytes exceeds maxBufferedBytes, populates *future and returns true.
-  bool enqueue(
-      int32_t partition,
-      std::unique_ptr<folly::IOBuf> rowGroup,
-      velox::ContinueFuture* future);
+  /// Enqueue a serialized RowGroup for a partition.
+  void enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
 
   /// Drain all partitions.
   uint64_t drainAll();
@@ -152,9 +145,6 @@ class MaterializedOutputBuffer {
   // Drain a specific partition — called from drainAll() during finishAndClose.
   int64_t drainPartition(int32_t partition);
 
-  // Fulfill promises to unblock producers waiting on backpressure.
-  void maybeUnblockProducers(std::vector<velox::ContinuePromise>& promises);
-
   // Drain all remaining data and close the writer. Called exactly once.
   void finishAndClose();
 
@@ -165,17 +155,12 @@ class MaterializedOutputBuffer {
   std::unique_ptr<folly::IOBuf> coalesceRowGroups(
       std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups);
 
-  // Check if total buffered bytes exceeds the threshold and set up a
-  // ContinueFuture for the caller to block on.
-  bool maybeApplyBackpressure(velox::ContinueFuture* future);
-
   // Free callback for pool-tracked IOBufs.
   static void freeTrackedIOBuf(void* buf, void* userData);
 
   // Immutable config.
   const int32_t numPartitions_;
   const int64_t maxBufferedBytes_;
-  const int64_t continueBufferedBytes_;
   const int64_t partitionDrainThreshold_;
 
   // Writer and memory pool.
@@ -191,16 +176,14 @@ class MaterializedOutputBuffer {
   std::atomic<int64_t> bufferedBytes_{0};
   std::vector<std::unique_ptr<PartitionBuffer>> partitionBuffers_;
 
-  // Backpressure state — stateMutex_ guards promises_ and driver counts.
+  // stateMutex_ guards driver counts.
   std::mutex stateMutex_;
   uint32_t numDrivers_{0};
   uint32_t numFinishedDrivers_{0};
-  std::vector<velox::ContinuePromise> promises_;
 
   // Stats counters.
   std::atomic<int64_t> totalDrainedBytes_{0};
   std::atomic<int64_t> drainCount_{0};
-  std::atomic<int64_t> backpressureCount_{0};
   std::atomic<int64_t> peakBufferedBytes_{0};
   std::atomic<int64_t> lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -442,8 +442,7 @@ TEST_F(MaterializedExchangeTest, bufferMemoryTracking) {
         auto iobuf = buffer->allocateTrackedIOBuf(10 * 1024);
         std::memset(iobuf->writableData(), 'x', 10 * 1024);
         iobuf->append(10 * 1024);
-        velox::ContinueFuture future;
-        buffer->enqueue(p, std::move(iobuf), &future);
+        buffer->enqueue(p, std::move(iobuf));
         ++totalEnqueued;
       } catch (const velox::VeloxRuntimeError&) {
         threw = true;

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2645,17 +2645,11 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         shuffleFactory,
         "ShuffleInterface factory '{}' not registered",
         shuffleName_);
-    const auto useSystemMemory =
-        SystemConfig::instance()
-            ->exchangeMaterializationOutputBufferUseSystemMemory();
-    auto shuffleWriterPool = useSystemMemory
-        ? velox::memory::memoryManager()->addLeafPool(
-              fmt::format("_sys.exchange_writer.{}", taskId))
-        // Add noop memory reclaimer to participate in arbitration protocol.
-        : queryCtx_->pool()->addLeafChild(
-              fmt::format("exchange_writer.{}", taskId),
-              true,
-              velox::exec::MemoryReclaimer::create());
+    // Add noop memory reclaimer to participate in arbitration protocol.
+    auto shuffleWriterPool = queryCtx_->pool()->addLeafChild(
+        fmt::format("exchange_writer.{}", taskId),
+        true,
+        velox::exec::MemoryReclaimer::create());
     auto shuffleWriter = shuffleFactory->createWriter(
         *serializedShuffleWriteInfo_, shuffleWriterPool.get());
 


### PR DESCRIPTION
Summary:
Remove `maybeApplyBackpressure` / `maybeUnblockProducers` and the associated `ContinueFuture`-based flow control from `MaterializedOutputBuffer`. The backpressure mechanism was a no-op in practice because `maxBufferedBytes_` is set to 1GB while the pool capacity is typically 8GB — the pool runs out of capacity and OOMs long before the 1GB backpressure threshold is reached, so the cooperative flow control never activates.

Also remove the `exchange.materialization.output-buffer.use-system-memory` config property. Using a system pool places the exchange writer outside the arbitrator-visible memory hierarchy, making it invisible to memory management. All exchange writer pools should participate in the query memory hierarchy.

Differential Revision: D106168793

```
== NO RELEASE NOTE ==
```


