### PR TITLE
fix(native-pos): Add typed units to MaterializedOutputBuffer runtime stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -480,8 +480,8 @@ bool MaterializedOutput::isFinished() {
 }
 
 void MaterializedOutput::recordBufferStats() {
-  for (const auto& [key, value] : buffer_->stats()) {
-    addRuntimeStat(key, velox::RuntimeCounter(value));
+  for (const auto& [key, metric] : buffer_->stats()) {
+    addRuntimeStat(key, velox::RuntimeCounter(metric.sum, metric.unit));
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -298,23 +298,34 @@ void MaterializedOutputBuffer::finishAndClose() {
       peakBufferedBytes_ >> 20);
 }
 
-folly::F14FastMap<std::string, int64_t> MaterializedOutputBuffer::stats()
-    const {
-  auto writerStats = writer_->stats();
-  writerStats[std::string(kTotalDrainedBytes)] = totalDrainedBytes_;
-  writerStats[std::string(kDrainCount)] = drainCount_;
-  writerStats[std::string(kCurrentDrainThreshold)] = partitionDrainThreshold_;
-  writerStats[std::string(kBufferPoolUsedBytes)] =
-      pool_ ? pool_->usedBytes() : 0;
-  writerStats[std::string(kBufferPoolPeakBytes)] =
-      pool_ ? pool_->peakBytes() : 0;
+folly::F14FastMap<std::string, velox::RuntimeMetric>
+MaterializedOutputBuffer::stats() const {
+  using Unit = velox::RuntimeCounter::Unit;
+  folly::F14FastMap<std::string, velox::RuntimeMetric> result;
+
+  // Writer stats (unknown units from the ShuffleWriter interface).
+  for (const auto& [key, value] : writer_->stats()) {
+    result[key] = velox::RuntimeMetric(value);
+  }
+
+  // Buffer stats with typed units.
   int64_t totalCollects = 0;
   for (int32_t i = 0; i < numPartitions_; ++i) {
     totalCollects += collectCountPerPartition_[i];
   }
-  writerStats[std::string(kTotalCollectCalls)] = totalCollects;
-  writerStats[std::string(kPeakBufferedBytes)] = peakBufferedBytes_;
-  return writerStats;
+  result[std::string(kTotalDrainedBytes)] =
+      velox::RuntimeMetric(totalDrainedBytes_, Unit::kBytes);
+  result[std::string(kDrainCount)] = velox::RuntimeMetric(drainCount_);
+  result[std::string(kCurrentDrainThreshold)] =
+      velox::RuntimeMetric(partitionDrainThreshold_, Unit::kBytes);
+  result[std::string(kBufferPoolUsedBytes)] =
+      velox::RuntimeMetric(pool_ ? pool_->usedBytes() : 0, Unit::kBytes);
+  result[std::string(kBufferPoolPeakBytes)] =
+      velox::RuntimeMetric(pool_ ? pool_->peakBytes() : 0, Unit::kBytes);
+  result[std::string(kTotalCollectCalls)] = velox::RuntimeMetric(totalCollects);
+  result[std::string(kPeakBufferedBytes)] =
+      velox::RuntimeMetric(peakBufferedBytes_, Unit::kBytes);
+  return result;
 }
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -21,6 +21,7 @@
 #include <folly/Synchronized.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/memory/MemoryPool.h"
 
 namespace facebook::presto::operators {
@@ -96,8 +97,9 @@ class MaterializedOutputBuffer {
   /// attach writer stats to its operator.
   bool noMoreDrivers();
 
-  /// Returns combined writer + buffer stats. Only meaningful after close.
-  folly::F14FastMap<std::string, int64_t> stats() const;
+  /// Returns combined writer + buffer stats with typed units
+  /// (kBytes, kNone). Only meaningful after close.
+  folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const;
 
   /// Allocate an IOBuf tracked through pool_. Used by MaterializedOutput
   /// to create RowGroup IOBufs that are visible for memory accounting.


### PR DESCRIPTION
Summary:
Change `MaterializedOutputBuffer::stats()` to return `F14FastMap<string, RuntimeMetric>` instead of `F14FastMap<string, int64_t>`. Each stat now carries its unit:

- `kBytes`: `totalDrainedBytes`, `currentDrainThreshold`, `bufferPoolUsedBytes`, `bufferPoolPeakBytes`, `peakBufferedBytes`, `reclaimedBytes`
- `kNone`: `drainCount`, `totalCollectCalls`, `reclaimCount`

`MaterializedOutput::recordBufferStats()` now passes the unit through to `addRuntimeStat`, so Presto runtime stats display bytes with human-readable formatting (e.g. "512MB" instead of "536870912").

Writer stats from the `ShuffleWriter` interface retain `kNone` (the interface returns raw `int64_t`).

Reviewed By: tanjialiang

Differential Revision: D106259353

```
== NO RELEASE NOTE ==
```
