### PR TITLE
feat(planner): Add doNotMerge flag to FilterNode

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -246,10 +246,10 @@ public class IcebergPlanOptimizer
                 return newTableScan;
             }
             else if (predicateNotChangedBySimplification) {
-                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, remainingFilterExpression);
+                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, remainingFilterExpression, filter.isDoNotMerge());
             }
             else {
-                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, filterPredicate);
+                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, filterPredicate, filter.isDoNotMerge());
             }
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -132,6 +132,10 @@ public class EffectivePredicateExtractor
         {
             RowExpression underlyingPredicate = node.getSource().accept(this, context);
 
+            if (node.isDoNotMerge()) {
+                return underlyingPredicate;
+            }
+
             RowExpression predicate = node.getPredicate();
 
             // Remove non-deterministic conjuncts

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -623,7 +623,12 @@ class SubqueryPlanner
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
         {
             FilterNode rewrittenNode = (FilterNode) context.defaultRewrite(node);
-            return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), rewrittenNode.getSource(), replaceExpression(rewrittenNode.getPredicate(), mapping));
+            return new FilterNode(node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    rewrittenNode.getSource(),
+                    replaceExpression(rewrittenNode.getPredicate(), mapping),
+                    node.isDoNotMerge());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
@@ -58,6 +58,10 @@ public class MergeFilters
     {
         FilterNode child = captures.get(CHILD);
 
+        if (parent.isDoNotMerge() || child.isDoNotMerge()) {
+            return Result.empty();
+        }
+
         return Result.ofPlanNode(
                 new FilterNode(
                         parent.getSourceLocation(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -356,6 +356,9 @@ public class TransformCorrelatedInPredicateToJoin
         @Override
         public Optional<Decorrelated> visitFilter(FilterNode node, PlanNode reference)
         {
+            if (node.isDoNotMerge()) {
+                return Optional.empty();
+            }
             Optional<Decorrelated> result = decorrelate(node.getSource());
             return result.map(decorrelated ->
                     new Decorrelated(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -306,7 +306,7 @@ public class OptimizeTopNUsingRowId
             if (node instanceof FilterNode) {
                 FilterNode filterNode = (FilterNode) node;
                 return replaceTableScan(filterNode.getSource(), newTableScan, idAllocator)
-                        .map(newSource -> new FilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate()));
+                        .map(newSource -> new FilterNode(filterNode.getSourceLocation(), idAllocator.getNextId(), newSource, filterNode.getPredicate(), filterNode.isDoNotMerge()));
             }
             if (node instanceof ProjectNode) {
                 ProjectNode projectNode = (ProjectNode) node;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -114,6 +114,10 @@ public class PlanNodeDecorrelator
         @Override
         public Optional<DecorrelationResult> visitFilter(FilterNode node, Void context)
         {
+            if (node.isDoNotMerge()) {
+                return Optional.empty();
+            }
+
             Optional<DecorrelationResult> childDecorrelationResultOptional = Optional.of(new DecorrelationResult(
                     node.getSource(),
                     ImmutableSet.of(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -607,7 +607,7 @@ public class PruneUnreferencedOutputs
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
 
-            return new FilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getPredicate());
+            return new FilterNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getPredicate(), node.isDoNotMerge());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -214,7 +214,12 @@ public class ReplaceConstantVariableReferencesWithConstants
             FilterNode newFilterNode = node;
             if (!rewrittenChild.getConstantExpressionMap().isEmpty()) {
                 predicate = predicate.accept(new ExpressionRewriter(rewrittenChild.getConstantExpressionMap()), null);
-                newFilterNode = new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node.getSource(), predicate);
+                newFilterNode = new FilterNode(node.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        node.getStatsEquivalentPlanNode(),
+                        node.getSource(),
+                        predicate,
+                        node.isDoNotMerge());
             }
 
             return new PlanNodeWithConstant(replaceChildren(newFilterNode, ImmutableList.of(rewrittenChild.getPlanNode())), newConstantMap);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -501,7 +501,8 @@ public class SymbolMapper
                 node.getSourceLocation(),
                 newNodeId,
                 source,
-                map(node.getPredicate()));
+                map(node.getPredicate()),
+                node.isDoNotMerge());
     }
 
     public ProjectNode map(ProjectNode node, PlanNode source, PlanNodeId newNodeId)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -606,7 +606,7 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            return new FilterNode(node.getSourceLocation(), node.getId(), source, canonicalize(node.getPredicate()));
+            return new FilterNode(node.getSourceLocation(), node.getId(), Optional.empty(), source, canonicalize(node.getPredicate()), node.isDoNotMerge());
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeFilters.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -21,6 +23,8 @@ import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
@@ -49,6 +53,63 @@ public class TestMergeFilters
                         p.filter(sqlToRowExpression("b > 44"),
                                 p.filter(sqlToRowExpression("a < 42"),
                                         p.values(p.variable("a"), p.variable("b")))))
+                .matches(filter("(a < 42) AND (b > 44)", values(ImmutableMap.of("a", 0, "b", 1))));
+    }
+
+    @Test
+    public void testSkipMergeWhenChildIsDoNotMerge()
+    {
+        tester().assertThat(new MergeFilters(getFunctionManager()))
+                .on(p -> {
+                    FilterNode child = new FilterNode(
+                            Optional.empty(),
+                            new PlanNodeId("guard-filter"),
+                            Optional.empty(),
+                            p.values(p.variable("a"), p.variable("b")),
+                            sqlToRowExpression("a < 42"),
+                            true);
+                    return p.filter(sqlToRowExpression("b > 44"), child);
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSkipMergeWhenParentIsDoNotMerge()
+    {
+        tester().assertThat(new MergeFilters(getFunctionManager()))
+                .on(p -> {
+                    FilterNode child = new FilterNode(
+                            Optional.empty(),
+                            new PlanNodeId("normal-filter"),
+                            Optional.empty(),
+                            p.values(p.variable("a"), p.variable("b")),
+                            sqlToRowExpression("a < 42"),
+                            false);
+                    return new FilterNode(
+                            Optional.empty(),
+                            new PlanNodeId("guard-filter"),
+                            Optional.empty(),
+                            child,
+                            sqlToRowExpression("b > 44"),
+                            true);
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMergeWhenNeitherIsDoNotMerge()
+    {
+        tester().assertThat(new MergeFilters(getFunctionManager()))
+                .on(p -> {
+                    FilterNode child = new FilterNode(
+                            Optional.empty(),
+                            new PlanNodeId("normal-filter"),
+                            Optional.empty(),
+                            p.values(p.variable("a"), p.variable("b")),
+                            sqlToRowExpression("a < 42"),
+                            false);
+                    return p.filter(sqlToRowExpression("b > 44"), child);
+                })
                 .matches(filter("(a < 42) AND (b > 44)", values(ImmutableMap.of("a", 0, "b", 1))));
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterNode.java
@@ -33,6 +33,7 @@ public final class FilterNode
 {
     private final PlanNode source;
     private final RowExpression predicate;
+    private final boolean doNotMerge;
 
     @JsonCreator
     public FilterNode(
@@ -41,7 +42,7 @@ public final class FilterNode
             @JsonProperty("source") PlanNode source,
             @JsonProperty("predicate") RowExpression predicate)
     {
-        this(sourceLocation, id, Optional.empty(), source, predicate);
+        this(sourceLocation, id, Optional.empty(), source, predicate, false);
     }
 
     public FilterNode(
@@ -51,10 +52,32 @@ public final class FilterNode
             PlanNode source,
             RowExpression predicate)
     {
+        this(sourceLocation, id, statsEquivalentPlanNode, source, predicate, false);
+    }
+
+    public FilterNode(
+            Optional<SourceLocation> sourceLocation,
+            PlanNodeId id,
+            PlanNode source,
+            RowExpression predicate,
+            boolean doNotMerge)
+    {
+        this(sourceLocation, id, Optional.empty(), source, predicate, doNotMerge);
+    }
+
+    public FilterNode(
+            Optional<SourceLocation> sourceLocation,
+            PlanNodeId id,
+            Optional<PlanNode> statsEquivalentPlanNode,
+            PlanNode source,
+            RowExpression predicate,
+            boolean doNotMerge)
+    {
         super(sourceLocation, id, statsEquivalentPlanNode);
 
         this.source = source;
         this.predicate = predicate;
+        this.doNotMerge = doNotMerge;
     }
 
     /**
@@ -65,6 +88,12 @@ public final class FilterNode
     public RowExpression getPredicate()
     {
         return predicate;
+    }
+
+    @JsonProperty
+    public boolean isDoNotMerge()
+    {
+        return doNotMerge;
     }
 
     /**
@@ -97,7 +126,7 @@ public final class FilterNode
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new FilterNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, predicate);
+        return new FilterNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, predicate, doNotMerge);
     }
 
     @Override
@@ -107,7 +136,7 @@ public final class FilterNode
         if (newChildren == null || newChildren.size() != 1) {
             throw new IllegalArgumentException("Expect exactly one child to replace");
         }
-        return new FilterNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), predicate);
+        return new FilterNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), predicate, doNotMerge);
     }
 
     @Override
@@ -127,13 +156,14 @@ public final class FilterNode
             return false;
         }
         FilterNode that = (FilterNode) o;
-        return Objects.equals(source, that.source) &&
+        return doNotMerge == that.doNotMerge &&
+                Objects.equals(source, that.source) &&
                 Objects.equals(predicate, that.predicate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(source, predicate);
+        return Objects.hash(source, predicate, doNotMerge);
     }
 }


### PR DESCRIPTION
## Description

Adds a `doNotMerge` flag to `FilterNode` that prevents optimizer passes from combining its predicate with other filters. When set, `MergeFilters` skips merging, `EffectivePredicateExtractor` does not expose the predicate for inference, and decorrelation bails out rather than pulling the filter apart. All optimizer passes that reconstruct `FilterNode` now preserve the flag.

No optimizer currently sets the flag — this is pure infrastructure for an upcoming correctness fix.

## Motivation and Context

The planner freely merges adjacent filters into a single AND expression and exposes filter predicates for predicate pushdown inference. This is unsafe for guard filters whose purpose is to produce a runtime error (e.g., the scalar subquery cardinality check that calls `fail()` when a subquery returns multiple rows).

When such a guard is merged with other predicates, native execution engines like Velox evaluate top-level conjuncts independently over selectivity vectors and can short-circuit the error away — silently producing wrong results. Similarly, exposing the guard predicate via effective predicate extraction allows downstream optimizers to push predicates below the guard, eliminating rows before the guard observes them.

There was no mechanism for a filter to declare itself unmergeable. This change introduces that mechanism.

## Impact

No functional change. The flag defaults to `false` and no code sets it yet. Existing plan behavior is unchanged.

## Test Plan

- `TestMergeFilters`: new tests verifying merging is skipped when either parent or child has `doNotMerge=true`, and proceeds normally otherwise.
- `TestLocalQueries` (535 tests): full integration pass, no regressions.
- `TestEffectivePredicateExtractor`, `TestPredicatePushdown`, `TestSubqueries`, `TestTransformCorrelatedScalarSubquery`: all pass.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce an opt-out mechanism on FilterNode to prevent certain filters from being merged or decorrelated while preserving existing planner behavior.

Enhancements:
- Extend FilterNode with a serializable doNotMerge flag and propagate it through planner rewrites, symbol mapping, and stats-equivalent handling.
- Update optimizer rules and utilities (MergeFilters, EffectivePredicateExtractor, decorrelators, Iceberg optimizer, TopN-with-RowId optimization, pruning and unaliasing passes) to respect and preserve the doNotMerge flag.

Tests:
- Add planner rule tests to verify MergeFilters skips merging when either parent or child FilterNode is marked doNotMerge and continues to merge otherwise.