### PR TITLE
fix(native-pos): Move ShuffleWriter and pool creation inside MaterializedOutputBuffer (#27872)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -18,6 +18,9 @@
 #include <glog/logging.h>
 #include <algorithm>
 #include <cstring>
+#include <memory>
+
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto::operators {
 
@@ -53,9 +56,11 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
 
 MaterializedOutputBuffer::MaterializedOutputBuffer(
     int32_t numPartitions,
-    std::shared_ptr<ShuffleWriter> writer,
-    std::shared_ptr<velox::memory::MemoryPool> pool,
+    const std::string& shuffleWriterInfo,
+    ShuffleInterfaceFactory* shuffleWriterFactory,
+    const std::string& taskId,
     int64_t maxBufferedBytes,
+    velox::memory::MemoryPool* pool,
     int64_t partitionDrainThreshold)
     : numPartitions_(numPartitions),
       maxBufferedBytes_(maxBufferedBytes),
@@ -64,17 +69,22 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
               partitionDrainThreshold > 0 ? partitionDrainThreshold
                                           : kDefaultDrainThreshold,
               maxBufferedBytes / numPartitions)),
-      writer_(std::move(writer)),
-      pool_(std::move(pool)),
+      pool_(pool->addLeafChild(
+          fmt::format("materialized_output_buffer.{}", taskId),
+          true,
+          velox::exec::MemoryReclaimer::create())),
+      writer_(
+          shuffleWriterFactory->createWriter(shuffleWriterInfo, pool_.get())),
       collectCountPerPartition_(numPartitions) {
+  VELOX_CHECK_NOT_NULL(pool_, "MemoryPool must be non-null");
+  VELOX_CHECK_NOT_NULL(writer_, "ShuffleWriter must be non-null");
+  VELOX_CHECK_GT(numPartitions, 0, "Must have at least one partition");
   partitionBuffers_.reserve(numPartitions);
   for (int32_t i = 0; i < numPartitions; ++i) {
     partitionBuffers_.push_back(
         std::make_unique<PartitionBuffer>(
             partitionDrainThreshold_, writer_.get(), this));
   }
-  VELOX_CHECK_GT(numPartitions, 0, "Must have at least one partition");
-  VELOX_CHECK_NOT_NULL(writer_, "ShuffleWriter must be non-null");
   LOG(INFO) << fmt::format(
       "MaterializedOutputBuffer: partitions={}, maxBufferedBytes={}MB, "
       "effectiveDrainThreshold={}KB (configured={}KB), pool={}",

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -18,11 +18,14 @@
 #include <mutex>
 #include <vector>
 
+#include <memory>
+
 #include <folly/Synchronized.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::presto::operators {
 
@@ -57,11 +60,15 @@ class MaterializedOutputBuffer {
   static constexpr std::string_view kPeakBufferedBytes =
       "materializedOutputBuffer.peakBufferedBytes";
 
+  /// Creates its own leaf pool under 'parentPool' and the writer from
+  /// the factory.
   MaterializedOutputBuffer(
       int32_t numPartitions,
-      std::shared_ptr<ShuffleWriter> writer,
-      std::shared_ptr<velox::memory::MemoryPool> pool,
+      const std::string& shuffleWriterInfo,
+      ShuffleInterfaceFactory* shuffleWriterFactory,
+      const std::string& taskId,
       int64_t maxBufferedBytes,
+      velox::memory::MemoryPool* pool,
       int64_t partitionDrainThreshold = 0);
 
   ~MaterializedOutputBuffer();
@@ -165,9 +172,9 @@ class MaterializedOutputBuffer {
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
 
-  // Writer and memory pool.
-  const std::shared_ptr<ShuffleWriter> writer_;
+  // Pool created first so the writer can allocate from it.
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
+  const std::shared_ptr<ShuffleWriter> writer_;
 
   // Lifecycle flags.
   std::atomic<bool> finished_{false};

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -132,6 +132,30 @@ class FailingCloseShuffleWriter : public ShuffleWriter {
   std::shared_ptr<ShuffleWriter> delegate_;
 };
 
+// Factory that wraps another factory's writer in FailingCloseShuffleWriter.
+class FailingCloseShuffleFactory : public ShuffleInterfaceFactory {
+ public:
+  explicit FailingCloseShuffleFactory(ShuffleInterfaceFactory* delegate)
+      : delegate_(delegate) {}
+
+  std::shared_ptr<ShuffleReader> createReader(
+      const std::string& serializedShuffleInfo,
+      int32_t partition,
+      velox::memory::MemoryPool* pool) override {
+    return delegate_->createReader(serializedShuffleInfo, partition, pool);
+  }
+
+  std::shared_ptr<ShuffleWriter> createWriter(
+      const std::string& serializedShuffleInfo,
+      velox::memory::MemoryPool* pool) override {
+    return std::make_shared<FailingCloseShuffleWriter>(
+        delegate_->createWriter(serializedShuffleInfo, pool));
+  }
+
+ private:
+  ShuffleInterfaceFactory* delegate_;
+};
+
 } // namespace
 
 class MaterializedExchangeTest : public exec::test::OperatorTestBase {
@@ -194,29 +218,14 @@ class MaterializedExchangeTest : public exec::test::OperatorTestBase {
     auto dataType = asRowType(data[0]->type());
     auto writeInfoStr =
         localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
-    auto writeInfo = LocalShuffleWriteInfo::deserialize(writeInfoStr);
-
-    // Create writer directly with a small per-partition buffer to avoid OOM
-    // in unit tests (the factory default of 256MB is too large for tests with
-    // many partitions).
-    constexpr uint64_t kMaxBytesPerPartition = 1 << 20; // 1MB
-    auto writer = std::make_shared<LocalShuffleWriter>(
-        writeInfo.rootPath,
-        writeInfo.queryId,
-        writeInfo.shuffleId,
-        writeInfo.numPartitions,
-        kMaxBytesPerPartition,
-        writeInfo.sortedShuffle,
-        pool());
-
-    // Create a writer memory pool for MaterializedOutputBuffer, scoped under
-    // the test's root pool to avoid consuming shared arbitrator capacity.
-    auto writerPool = rootPool_->addLeafChild("writerPool");
-
-    // Create the shared MaterializedOutputBuffer.
     constexpr size_t kMaxBufferedBytes = 1 << 20; // 1MB
     auto buffer = std::make_shared<MaterializedOutputBuffer>(
-        numPartitions, writer, writerPool, kMaxBufferedBytes);
+        numPartitions,
+        writeInfoStr,
+        ShuffleInterfaceFactory::factory(shuffleName_),
+        "test.0.0.0.0",
+        kMaxBufferedBytes,
+        rootPool_.get());
 
     // Build partition key expressions on column 0.
     std::vector<core::TypedExprPtr> keys{
@@ -415,20 +424,19 @@ TEST_F(MaterializedExchangeTest, bufferMemoryTracking) {
   // if drain doesn't happen (100 × 10KB × multiple rounds).
   constexpr int64_t kPoolCapacity = 2L * 1024 * 1024;
 
-  auto rootPool =
-      memory::memoryManager()->addRootPool("bufferMemoryTest", kPoolCapacity);
-  auto bufferPool = rootPool->addLeafChild("buffer");
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "bufferMemoryTest", kPoolCapacity, memory::MemoryReclaimer::create());
 
   auto shuffleDir = exec::test::TempDirectoryPath::create();
   auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
-  auto writer = ShuffleInterfaceFactory::factory(shuffleName_)
-                    ->createWriter(writeInfo, pool());
 
   auto buffer = std::make_shared<MaterializedOutputBuffer>(
       numPartitions,
-      std::shared_ptr<ShuffleWriter>(std::move(writer)),
-      std::move(bufferPool),
+      writeInfo,
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      "memtest.0.0.0.0",
       /*maxBufferedBytes=*/100L * 1024 * 1024,
+      rootPool.get(),
       /*partitionDrainThreshold=*/50L * 1024);
 
   // Enqueue 10KB per partition across many rounds. Pool has 2MB, drain
@@ -560,26 +568,18 @@ TEST_F(MaterializedExchangeTest, assertBufferCloseExceptionsArePropagated) {
   auto dataType = asRowType(data->type());
 
   auto writeInfoStr = localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
-  auto writeInfo = LocalShuffleWriteInfo::deserialize(writeInfoStr);
 
-  constexpr uint64_t kMaxBytesPerPartition = 1 << 20;
-  auto realWriter = std::make_shared<LocalShuffleWriter>(
-      writeInfo.rootPath,
-      writeInfo.queryId,
-      writeInfo.shuffleId,
-      writeInfo.numPartitions,
-      kMaxBytesPerPartition,
-      writeInfo.sortedShuffle,
-      pool());
-
-  auto failingWriter =
-      std::make_shared<FailingCloseShuffleWriter>(std::move(realWriter));
-
-  auto writerPool = rootPool_->addLeafChild("writerPool");
+  auto* realFactory = ShuffleInterfaceFactory::factory(shuffleName_);
+  FailingCloseShuffleFactory failingFactory(realFactory);
 
   constexpr size_t kMaxBufferedBytes = 1 << 20;
   auto buffer = std::make_shared<MaterializedOutputBuffer>(
-      numPartitions, failingWriter, writerPool, kMaxBufferedBytes);
+      numPartitions,
+      writeInfoStr,
+      &failingFactory,
+      "failtest.0.0.0.0",
+      kMaxBufferedBytes,
+      rootPool_.get());
 
   std::vector<core::TypedExprPtr> keys{
       std::make_shared<core::FieldAccessTypedExpr>(

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2645,16 +2645,6 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         shuffleFactory,
         "ShuffleInterface factory '{}' not registered",
         shuffleName_);
-    // Add noop memory reclaimer to participate in arbitration protocol.
-    auto shuffleWriterPool = queryCtx_->pool()->addLeafChild(
-        fmt::format("exchange_writer.{}", taskId),
-        true,
-        velox::exec::MemoryReclaimer::create());
-    auto shuffleWriter = shuffleFactory->createWriter(
-        *serializedShuffleWriteInfo_, shuffleWriterPool.get());
-
-    auto sharedWriter =
-        std::shared_ptr<operators::ShuffleWriter>(std::move(shuffleWriter));
     const auto maxBufferedBytes =
         SystemConfig::instance()->exchangeMaterializationOutputBufferMaxBytes();
     const auto drainThreshold =
@@ -2662,9 +2652,11 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
             ->exchangeMaterializationOutputBufferPerPartitionMaxBytes();
     auto buffer = std::make_shared<operators::MaterializedOutputBuffer>(
         partitionedOutputNode->numPartitions(),
-        std::move(sharedWriter),
-        std::move(shuffleWriterPool),
+        *serializedShuffleWriteInfo_,
+        shuffleFactory,
+        taskId,
         maxBufferedBytes,
+        queryCtx_->pool(),
         drainThreshold);
 
     auto materializedOutputNode =


### PR DESCRIPTION
Summary:

Change the `MaterializedOutputBuffer` constructor to accept a `ShuffleInterfaceFactory*` and parent `MemoryPool*` instead of pre-built `ShuffleWriter` and pool. `MaterializedOutputBuffer` now creates its own leaf pool (with a no-op `MemoryReclaimer`) and writer internally. This encapsulates the pool/writer lifecycle and eliminates the need for callers to manage these resources.

The old test constructor is removed. Tests use mock factories (`NoOpShuffleFactory`, `FailingCloseShuffleFactory`) to go through the same production constructor.

Reviewed By: xiaoxmeng

Differential Revision: D106414461

```
== NO RELEASE NOTE ==
```
