### PR TITLE
refactor(native-pos): Add State enum and lifecycle state machine to MaterializedOutputBuffer (#27873)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -15,6 +15,7 @@
 #include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
 
 #include <fmt/format.h>
+#include <folly/ExceptionString.h>
 #include <glog/logging.h>
 #include <algorithm>
 #include <cstring>
@@ -23,6 +24,20 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto::operators {
+
+std::string MaterializedOutputBuffer::stateName(State state) {
+  switch (state) {
+    case State::kActive:
+      return "kActive";
+    case State::kDraining:
+      return "kDraining";
+    case State::kClosed:
+      return "kClosed";
+    case State::kAborted:
+      return "kAborted";
+  }
+  return fmt::format("Unknown({})", static_cast<int>(state));
+}
 
 // Stored alongside pool-allocated IOBufs so the free callback can return
 // memory to the correct pool with the correct size.
@@ -35,6 +50,7 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
     int32_t partition,
     std::unique_ptr<folly::IOBuf> rowGroup) {
   std::lock_guard<std::mutex> lock(mutex_);
+  VELOX_CHECK(!closed_, "enqueue called on closed partition");
   auto dataSize = static_cast<int64_t>(rowGroup->computeChainDataLength());
   rowGroups_.push_back(std::move(rowGroup));
   bufferedBytes_ += dataSize;
@@ -98,7 +114,7 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
 }
 
 MaterializedOutputBuffer::~MaterializedOutputBuffer() {
-  if (!finished_.load()) {
+  if (state_ != State::kClosed && state_ != State::kAborted) {
     LOG(WARNING) << "MaterializedOutputBuffer destroyed without calling "
                  << "noMoreData() or abort(). Aborting writer.";
     try {
@@ -132,14 +148,10 @@ void MaterializedOutputBuffer::enqueue(
     std::unique_ptr<folly::IOBuf> rowGroup) {
   VELOX_CHECK_GE(partition, 0);
   VELOX_CHECK_LT(partition, numPartitions_);
-  // During error teardown, abort() may have been called while other
-  // drivers still flush remaining data. Silently drop.
-  if (aborted_.load()) {
+  if (state_ == State::kAborted) {
     return;
   }
-  VELOX_CHECK(
-      !finished_.load(),
-      "enqueue called after finishAndClose when pool is not aborted");
+  VELOX_CHECK_EQ(state_, State::kActive, "enqueue called after noMoreData()");
 
   auto rowGroupBytes = static_cast<int64_t>(rowGroup->computeChainDataLength());
   auto currentBytes = (bufferedBytes_ += rowGroupBytes);
@@ -197,7 +209,9 @@ std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::coalesceRowGroups(
   return coalesced;
 }
 
-int64_t MaterializedOutputBuffer::drainPartition(int32_t partition) {
+int64_t MaterializedOutputBuffer::drainPartition(
+    int32_t partition,
+    bool close) {
   VELOX_CHECK_GE(partition, 0);
   VELOX_CHECK_LT(partition, numPartitions_);
 
@@ -208,6 +222,9 @@ int64_t MaterializedOutputBuffer::drainPartition(int32_t partition) {
     toDrain.swap(partitionBuffers_[partition]->rowGroups_);
     drainedBytes = partitionBuffers_[partition]->bufferedBytes_;
     partitionBuffers_[partition]->bufferedBytes_ = 0;
+    if (close) {
+      partitionBuffers_[partition]->closed_ = true;
+    }
   }
 
   if (!toDrain.empty()) {
@@ -221,76 +238,32 @@ int64_t MaterializedOutputBuffer::drainPartition(int32_t partition) {
   return drainedBytes;
 }
 
-uint64_t MaterializedOutputBuffer::drainAll() {
+uint64_t MaterializedOutputBuffer::close() {
   uint64_t totalDrained = 0;
   for (int32_t i = 0; i < numPartitions_; ++i) {
-    totalDrained += drainPartition(i);
+    totalDrained += drainPartition(i, /*close=*/true);
   }
   return totalDrained;
 }
 
 void MaterializedOutputBuffer::noMoreData() {
-  finishAndClose();
-}
-
-void MaterializedOutputBuffer::abort() {
-  aborted_.store(true);
-  if (finished_.exchange(true)) {
-    return;
-  }
-
-  for (int32_t i = 0; i < numPartitions_; ++i) {
-    std::lock_guard<std::mutex> lock(partitionBuffers_[i]->mutex_);
-    partitionBuffers_[i]->rowGroups_.clear();
-    bufferedBytes_ -= partitionBuffers_[i]->bufferedBytes_;
-    partitionBuffers_[i]->bufferedBytes_ = 0;
-  }
-
-  LOG(INFO)
-      << "MaterializedOutputBuffer: calling writer noMoreData(false) [abort]";
-  writer_->noMoreData(/*success=*/false);
-}
-
-void MaterializedOutputBuffer::setNumDrivers(uint32_t numDrivers) {
-  std::lock_guard<std::mutex> lock(stateMutex_);
-  // Only the first call takes effect — multiple drivers may call this.
-  if (numDrivers_ == 0) {
-    numDrivers_ = numDrivers;
-  }
-}
-
-bool MaterializedOutputBuffer::noMoreDrivers() {
-  bool isLast = false;
-  uint32_t finished = 0;
-  uint32_t total = 0;
-  {
-    std::lock_guard<std::mutex> lock(stateMutex_);
-    ++numFinishedDrivers_;
-    finished = numFinishedDrivers_;
-    total = numDrivers_;
-    isLast = total > 0 && finished >= total;
-  }
-  LOG(INFO) << fmt::format(
-      "MaterializedOutputBuffer noMoreDrivers: {}/{} finished, isLast={}",
-      finished,
-      total,
-      isLast);
-  if (isLast) {
-    finishAndClose();
-  }
-  return isLast;
-}
-
-void MaterializedOutputBuffer::finishAndClose() {
-  if (finished_.exchange(true)) {
+  auto expected = State::kActive;
+  if (!state_.compare_exchange_strong(expected, State::kDraining)) {
     return;
   }
   LOG(INFO) << fmt::format(
-      "MaterializedOutputBuffer finishAndClose: draining, bufferedBytes={}MB",
+      "MaterializedOutputBuffer noMoreData: draining, bufferedBytes={}MB",
       bufferedBytes_ >> 20);
-  drainAll();
+  close();
   LOG(INFO) << "MaterializedOutputBuffer: calling writer noMoreData(true)";
-  writer_->noMoreData(/*success=*/true);
+  try {
+    writer_->noMoreData(/*success=*/true);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "MaterializedOutputBuffer: writer noMoreData(true) failed: "
+               << folly::exceptionStr(e);
+    state_ = State::kAborted;
+    throw;
+  }
   int64_t totalCollects = 0;
   for (int32_t i = 0; i < numPartitions_; ++i) {
     totalCollects += collectCountPerPartition_[i];
@@ -306,6 +279,26 @@ void MaterializedOutputBuffer::finishAndClose() {
       "collectCalls={}, peakBufferedBytes={}MB",
       totalCollects,
       peakBufferedBytes_ >> 20);
+  state_ = State::kClosed;
+}
+
+void MaterializedOutputBuffer::abort() {
+  auto expected = State::kActive;
+  if (!state_.compare_exchange_strong(expected, State::kAborted)) {
+    return;
+  }
+
+  // Free partition buffers.
+  for (int32_t i = 0; i < numPartitions_; ++i) {
+    std::lock_guard<std::mutex> lock(partitionBuffers_[i]->mutex_);
+    partitionBuffers_[i]->rowGroups_.clear();
+    bufferedBytes_ -= partitionBuffers_[i]->bufferedBytes_;
+    partitionBuffers_[i]->bufferedBytes_ = 0;
+  }
+
+  LOG(INFO)
+      << "MaterializedOutputBuffer: calling writer noMoreData(false) [abort]";
+  writer_->noMoreData(/*success=*/false);
 }
 
 folly::F14FastMap<std::string, velox::RuntimeMetric>

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 
+#include <fmt/format.h>
 #include <folly/Synchronized.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
@@ -40,8 +41,22 @@ namespace facebook::presto::operators {
 /// Thread-safe shared buffer between MaterializedOutput operators and a
 /// ShuffleWriter. Multiple MaterializedOutput drivers enqueue concurrently;
 /// the buffer drains to the writer when per-partition thresholds are hit.
+///
+/// Lifecycle state machine:
+///   kActive -> kDraining -> kClosed  (noMoreData: success)
+///   kActive -> kDraining -> kAborted (noMoreData: writer failure)
+///   kActive -> kAborted              (abort: error teardown)
 class MaterializedOutputBuffer {
  public:
+  enum class State : uint8_t {
+    kActive,
+    kDraining,
+    kClosed,
+    kAborted,
+  };
+
+  static std::string stateName(State state);
+
   static constexpr int64_t kDefaultDrainThreshold = 130L * 1024;
 
   // Stat name constants.
@@ -76,15 +91,16 @@ class MaterializedOutputBuffer {
   /// Enqueue a serialized RowGroup for a partition.
   void enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
 
-  /// Drain all partitions.
-  uint64_t drainAll();
-
   /// Signal that no more data will be enqueued. Drains remaining data
   /// and calls writer->noMoreData(true).
   void noMoreData();
 
   /// Abort — clears buffers and calls writer->noMoreData(false).
   void abort();
+
+  State state() const {
+    return state_;
+  }
 
   int64_t bufferedBytes() const {
     return bufferedBytes_;
@@ -94,15 +110,6 @@ class MaterializedOutputBuffer {
   int64_t testingCurrentDrainThreshold() const {
     return partitionDrainThreshold_;
   }
-
-  /// Record the number of drivers. Called by MaterializedOutput before
-  /// task start.
-  void setNumDrivers(uint32_t numDrivers);
-
-  /// Called by each driver when it finishes. Returns true if this was the
-  /// last driver (triggered finishAndClose). The caller can use this to
-  /// attach writer stats to its operator.
-  bool noMoreDrivers();
 
   /// Returns combined writer + buffer stats with typed units
   /// (kBytes, kNone). Only meaningful after close.
@@ -147,15 +154,20 @@ class MaterializedOutputBuffer {
     std::deque<std::unique_ptr<folly::IOBuf>> rowGroups_;
     int64_t bufferedBytes_{0};
     int64_t drainThreshold_{0};
+    // Per-partition safety net: set under the partition lock by
+    // drainPartition(close=true). Guards against data loss if enqueue
+    // races past the global state_ check.
+    bool closed_{false};
     ShuffleWriter* writer_{nullptr};
     MaterializedOutputBuffer* buffer_{nullptr};
   };
 
-  // Drain a specific partition — called from drainAll() during finishAndClose.
-  int64_t drainPartition(int32_t partition);
+  /// Drains buffered data for a partition. If close=true, marks the
+  /// partition closed under its lock.
+  int64_t drainPartition(int32_t partition, bool close = false);
 
-  // Drain all remaining data and close the writer. Called exactly once.
-  void finishAndClose();
+  /// Drains all partitions and marks them closed.
+  uint64_t close();
 
   // Coalesce data into a contiguous buffer and send to the ShuffleWriter.
   void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
@@ -176,19 +188,12 @@ class MaterializedOutputBuffer {
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
   const std::shared_ptr<ShuffleWriter> writer_;
 
-  // Lifecycle flags.
-  std::atomic<bool> finished_{false};
-  std::atomic<bool> aborted_{false};
+  std::atomic<State> state_{State::kActive};
 
   // Per-partition buffers. Each PartitionBuffer has its own mutex that
   // serializes enqueue + drain for that partition.
   std::atomic<int64_t> bufferedBytes_{0};
   std::vector<std::unique_ptr<PartitionBuffer>> partitionBuffers_;
-
-  // stateMutex_ guards driver counts.
-  std::mutex stateMutex_;
-  uint32_t numDrivers_{0};
-  uint32_t numFinishedDrivers_{0};
 
   // Stats counters.
   std::atomic<int64_t> totalDrainedBytes_{0};
@@ -199,3 +204,16 @@ class MaterializedOutputBuffer {
 };
 
 } // namespace facebook::presto::operators
+
+template <>
+struct fmt::formatter<
+    facebook::presto::operators::MaterializedOutputBuffer::State>
+    : formatter<std::string> {
+  auto format(
+      facebook::presto::operators::MaterializedOutputBuffer::State state,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::presto::operators::MaterializedOutputBuffer::stateName(state),
+        ctx);
+  }
+};

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -610,6 +610,79 @@ TEST_F(MaterializedExchangeTest, assertBufferCloseExceptionsArePropagated) {
   cleanupDirectory(tempDir_->getPath());
 }
 
+TEST_F(MaterializedExchangeTest, enqueueAfterNoMoreDataThrows) {
+  const int32_t numPartitions = 2;
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "enqueueAfterClose", 64L << 20, memory::MemoryReclaimer::create());
+
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfo,
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      "test.0.0.0.0",
+      /*maxBufferedBytes=*/1L << 20,
+      rootPool.get());
+
+  auto iobuf = buffer->allocateTrackedIOBuf(1024);
+  std::memset(iobuf->writableData(), 'x', 1024);
+  iobuf->append(1024);
+  buffer->enqueue(0, std::move(iobuf));
+
+  buffer->noMoreData();
+  EXPECT_EQ(buffer->state(), MaterializedOutputBuffer::State::kClosed);
+
+  auto iobuf2 = folly::IOBuf::create(64);
+  std::memset(iobuf2->writableData(), 'y', 64);
+  iobuf2->append(64);
+  VELOX_ASSERT_THROW(
+      buffer->enqueue(0, std::move(iobuf2)),
+      "enqueue called after noMoreData()");
+
+  cleanupDirectory(shuffleDir->getPath());
+}
+
+TEST_F(MaterializedExchangeTest, abortFromActiveState) {
+  const int32_t numPartitions = 2;
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "abortActive", 64L << 20, memory::MemoryReclaimer::create());
+
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfo,
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      "test.0.0.0.0",
+      /*maxBufferedBytes=*/1L << 20,
+      rootPool.get());
+
+  auto iobuf = buffer->allocateTrackedIOBuf(1024);
+  std::memset(iobuf->writableData(), 'x', 1024);
+  iobuf->append(1024);
+  buffer->enqueue(0, std::move(iobuf));
+  EXPECT_GT(buffer->bufferedBytes(), 0);
+
+  buffer->abort();
+  EXPECT_EQ(buffer->state(), MaterializedOutputBuffer::State::kAborted);
+  EXPECT_EQ(buffer->bufferedBytes(), 0);
+
+  // Second abort is a no-op (CAS fails, already kAborted).
+  buffer->abort();
+  EXPECT_EQ(buffer->state(), MaterializedOutputBuffer::State::kAborted);
+
+  // Enqueue after abort is silently dropped (not a crash).
+  auto iobuf2 = folly::IOBuf::create(64);
+  std::memset(iobuf2->writableData(), 'y', 64);
+  iobuf2->append(64);
+  buffer->enqueue(0, std::move(iobuf2));
+
+  cleanupDirectory(shuffleDir->getPath());
+}
+
 } // namespace facebook::presto::operators::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:

Replace the two boolean flags (`finished_`, `aborted_`) with a single `State` enum. The state is the single source of truth for the buffer lifecycle.

## State Machine

```
                  finishAndClose()
    ┌─────────┐   (CAS kActive→kDraining)   ┌──────────┐   closeAllPartitions()   ┌─────────┐
    │ kActive │ ──────────────────────────▶  │ kDraining │  + noMoreData(true)  ──▶ │ kClosed │
    └─────────┘                              └──────────┘                          └─────────┘
         │                                        │
         │  abort()                                │  writer failure
         │  (CAS kActive→kAborted)                 │  (noMoreData throws)
         ▼                                        ▼
    ┌──────────┐                             ┌──────────┐
    │ kAborted │                             │ kAborted │
    └──────────┘                             └──────────┘
```

## Transitions

- `kActive → kDraining`: `finishAndClose()` — all drivers done, begin draining partition buffers via `closeAllPartitions()`.
- `kDraining → kClosed`: After `closeAllPartitions()` completes and `writer->noMoreData(true)` succeeds. Terminal state.
- `kDraining → kAborted`: If `writer->noMoreData(true)` throws. Transitions to `kAborted` before re-throwing so the destructor does not attempt a redundant abort.
- `kActive → kAborted`: `abort()` — error teardown. Clears buffers, calls `writer->noMoreData(false)`. Terminal state.
- Both `finishAndClose()` and `abort()` use CAS on `kActive` to ensure exactly one wins.

## Per-Partition `closed_` Flag

Each `PartitionBuffer` has a `closed_` flag set by `drainPartition(partition, finalDrain=true)` during `closeAllPartitions()`. `VELOX_CHECK` in `PartitionBuffer::enqueue()` fires if data is enqueued after the partition is closed — catches silent data loss from enqueue-after-close.

## Guard Rails

- `enqueue()` checks state: silently drops data in `kAborted` (benign race during error teardown), `VELOX_CHECK` fails in `kDraining`/`kClosed`.
- Destructor: warns and aborts if state is not `kClosed` or `kAborted` (catches forgotten `noMoreData()`/`abort()` calls).

Reviewed By: tanjialiang

Differential Revision: D106414462
