### PR TITLE
refactor(native): Migrate to PrestoQueryConfig for array_agg.ignore_nulls

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -17,6 +17,7 @@
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "velox/common/compression/Compression.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::presto {
@@ -183,7 +184,9 @@ void updateFromSystemConfigs(
            velox::core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize},
 
       {.prestoSystemConfig = std::string(SystemConfig::kUseLegacyArrayAgg),
-       .veloxConfig = velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls},
+       .veloxConfig = velox::functions::prestosql::PrestoQueryConfig::qualify(
+           velox::functions::prestosql::PrestoQueryConfig::
+               kArrayAggIgnoreNulls)},
 
       {.prestoSystemConfig = std::string{SystemConfig::kTaskWriterCount},
        .veloxConfig = velox::core::QueryConfig::kTaskWriterCount},

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
 
 using namespace facebook::presto;
 using namespace facebook::presto::protocol;
@@ -223,7 +224,8 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
                  config.maxLocalExchangePartitionBufferSize());
            }},
 
-      {.veloxConfigKey = core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+      {.veloxConfigKey = functions::prestosql::PrestoQueryConfig::qualify(
+           functions::prestosql::PrestoQueryConfig::kArrayAggIgnoreNulls),
        .sessionPropertyKey = std::nullopt,
        .systemConfigKey = std::string(SystemConfig::kUseLegacyArrayAgg),
        .sessionValue = "",
@@ -232,7 +234,9 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
            [](const core::QueryConfig& config,
               const std::string& expectedValue) {
              EXPECT_EQ(
-                 expectedValue == "true", config.prestoArrayAggIgnoreNulls());
+                 expectedValue == "true",
+                 functions::prestosql::PrestoQueryConfig{config}
+                     .arrayAggIgnoreNulls());
            }},
 
       {.veloxConfigKey = core::QueryConfig::kMaxOutputBufferSize,
@@ -807,7 +811,8 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
            core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize,
        .systemConfigKey =
            std::string(SystemConfig::kHashProbeBloomFilterPushdownMaxSize)},
-      {.veloxConfigKey = core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+      {.veloxConfigKey = functions::prestosql::PrestoQueryConfig::qualify(
+           functions::prestosql::PrestoQueryConfig::kArrayAggIgnoreNulls),
        .systemConfigKey = std::string(SystemConfig::kUseLegacyArrayAgg)},
       {.veloxConfigKey = core::QueryConfig::kTaskWriterCount,
        .systemConfigKey = std::string(SystemConfig::kTaskWriterCount)},


### PR DESCRIPTION
Replace deprecated `QueryConfig::kPrestoArrayAggIgnoreNulls` and `QueryConfig::prestoArrayAggIgnoreNulls()` with the new `PrestoQueryConfig` API introduced in [Velox #17591](https://github.com/facebookincubator/velox/pull/17591).

The deprecated shims in `QueryConfig` will be removed in a future Velox release.

Advances Velox submodule to include `PrestoQueryConfig`.

## Summary by Sourcery

Migrate Presto array_agg ignore-nulls configuration in the native engine to the new Velox PrestoQueryConfig API and update the Velox submodule accordingly.

Enhancements:
- Replace deprecated QueryConfig-based array_agg ignore-nulls configuration keys and accessors with the new PrestoQueryConfig-qualified key and accessor.
- Align Presto-to-Velox configuration mapping helpers with PrestoQueryConfig for the legacy array_agg setting.

Tests:
- Update Presto-to-Velox query configuration tests to assert behavior via PrestoQueryConfig rather than the deprecated QueryConfig shim.

## Release Notes

```
== NO RELEASE NOTE ==
```
