### PR TITLE
test: Add end to end tests for khyperloglog scalar functions

### DIFF
--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
@@ -259,13 +259,6 @@ public abstract class AbstractTestArrowFederationNativeQueries
 
     @Override
     @Test(enabled = false)
-    public void testMergeKHyperLogLog()
-    {
-        // type not present under native execution
-    }
-
-    @Override
-    @Test(enabled = false)
     public void testStringFilters()
     {
         // function not available under native execution

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestKHyperLogLogFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestKHyperLogLogFunctions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestKHyperLogLogFunctions;
+import org.testng.annotations.BeforeClass;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder;
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+public class TestKHyperLogLogFunctions
+        extends AbstractTestKHyperLogLogFunctions
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "false"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestKHyperLogLogFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestKHyperLogLogFunctions.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import org.testng.annotations.Test;
+
+public abstract class AbstractTestKHyperLogLogFunctions
+        extends AbstractTestQueryFramework
+{
+    @Test
+    public void testMergeKHyperLogLog()
+    {
+        assertQueryWithSameQueryRunner("select k1, cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
+                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2) group by k1",
+                "select k1, cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
+                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1");
+
+        assertQueryWithSameQueryRunner("select cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
+                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2)",
+                "select cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
+                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2)");
+    }
+
+    @Test
+    public void testKHyperLogLogScalarFunctions()
+    {
+        // khyperloglog_agg(x, y) summarizes x in a MinHash structure and the y values linked to each x in
+        // per-x HyperLogLogs. The sketches below are exact (the number of distinct x is far below the
+        // MinHash size), so the derived scalar functions are deterministic. KHyperLogLog is not a H2 type,
+        // so both sides run on the same Presto query runner and the expected side is an algebraic identity.
+        String sketchA = "select khyperloglog_agg(x, y) khll from (values (1, 10), (2, 20), (3, 30), (4, 40)) t(x, y)";
+        String sketchB = "select khyperloglog_agg(x, y) khll from (values (3, 30), (4, 40), (5, 50), (6, 60)) t(x, y)";
+        String sketchDisjoint = "select khyperloglog_agg(x, y) khll from (values (7, 70), (8, 80), (9, 90), (10, 100)) t(x, y)";
+
+        // cardinality of the MinHash side is the number of distinct x.
+        assertQueryWithSameQueryRunner(
+                "select cardinality(khll) = 4 from (" + sketchA + ")",
+                "select true");
+
+        // intersection_cardinality counts the x values shared by both sketches: A and B share {3, 4}.
+        assertQueryWithSameQueryRunner(
+                "select intersection_cardinality(a.khll, b.khll) = 2 from (" + sketchA + ") a, (" + sketchB + ") b",
+                "select true");
+        // Self-intersection equals the cardinality; disjoint sketches intersect in nothing.
+        assertQueryWithSameQueryRunner(
+                "select intersection_cardinality(a.khll, a.khll) = 4 and intersection_cardinality(a.khll, c.khll) = 0 " +
+                        "from (" + sketchA + ") a, (" + sketchDisjoint + ") c",
+                "select true");
+
+        // jaccard_index is 1 for identical sketches and 0 for disjoint ones.
+        assertQueryWithSameQueryRunner(
+                "select jaccard_index(a.khll, a.khll) = 1.0E0 and jaccard_index(a.khll, c.khll) = 0.0E0 " +
+                        "from (" + sketchA + ") a, (" + sketchDisjoint + ") c",
+                "select true");
+
+        // merge_khll unions an array of sketches; the union of A and B has 6 distinct x ({1..6}).
+        assertQueryWithSameQueryRunner(
+                "select cardinality(merge_khll(array[a.khll, b.khll])) = 6 from (" + sketchA + ") a, (" + sketchB + ") b",
+                "select true");
+        // merge_khll of a null array returns null.
+        assertQueryWithSameQueryRunner(
+                "select cardinality(merge_khll(null)) is null",
+                "select true");
+
+        // Each x is linked to exactly one y, so every x has uniqueness 1 and the histogram puts all mass in bucket 1.
+        assertQueryWithSameQueryRunner(
+                "select uniqueness_distribution(khll)[1] = 1.0E0 from (" + sketchA + ")",
+                "select true");
+        // The one-argument form uses the MinHash size as the histogram size, matching the explicit form.
+        assertQueryWithSameQueryRunner(
+                "select uniqueness_distribution(khll) = uniqueness_distribution(khll, cardinality(khll)) from (" + sketchA + ")",
+                "select true");
+        // histogramSize controls the bucket count; uniqueness above it accumulates in the last bucket.
+        assertQueryWithSameQueryRunner(
+                "select cardinality(uniqueness_distribution(khll, 3)) = 3 from (" + sketchA + ")",
+                "select true");
+
+        // reidentification_potential is the fraction of x whose uniqueness is at or below the threshold.
+        // Every x has uniqueness 1, so it is 1 at threshold 1 and 0 at threshold 0.
+        assertQueryWithSameQueryRunner(
+                "select reidentification_potential(khll, 1) = 1.0E0 and reidentification_potential(khll, 0) = 0.0E0 from (" + sketchA + ")",
+                "select true");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8130,20 +8130,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testMergeKHyperLogLog()
-    {
-        assertQueryWithSameQueryRunner("select k1, cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
-                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2) group by k1",
-                "select k1, cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
-                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1");
-
-        assertQueryWithSameQueryRunner("select cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
-                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2)",
-                "select cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
-                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2)");
-    }
-
-    @Test
     public void testRepeat()
     {
         assertQuery("select repeat(k1, k2), repeat(k1, 5), repeat(3, k2) from (values (3, 2), (5, 4), (2, 4))t(k1, k2)",

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestKHyperLogLogFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestKHyperLogLogFunctions.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+
+public class TestKHyperLogLogFunctions
+        extends AbstractTestKHyperLogLogFunctions
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder().build();
+    }
+}


### PR DESCRIPTION
Extend khyperloglog end to end coverage to the scalar functions documented at functions/khyperloglog: intersection_cardinality, jaccard_index, uniqueness_distribution (both the default and explicit histogramSize forms), reidentification_potential and merge_khll, alongside cardinality and khyperloglog_agg.





## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Extend test coverage for khyperloglog scalar functions across both Java and native engines.

Tests:
- Add end-to-end query tests for khyperloglog scalar functions, including intersection_cardinality, jaccard_index, uniqueness_distribution, reidentification_potential, merge_khll, and cardinality in AbstractTestQueries.
- Introduce native engine tests for khyperloglog scalar functions that compare native results against the Java reference implementation using a shared khyperloglogValues dataset.