### PR TITLE
feat: Prestissimo: wire PUFFIN + EQUALITY_DELETES + DELETION_VECTOR through bridge (#27878)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
@@ -25,7 +25,8 @@ public enum FileContent
 {
     DATA(0),
     POSITION_DELETES(1),
-    EQUALITY_DELETES(2);
+    EQUALITY_DELETES(2),
+    DELETION_VECTOR(3);
 
     private final int id;
 
@@ -51,6 +52,9 @@ public enum FileContent
                 break;
             case EQUALITY_DELETES:
                 prestoFileContent = EQUALITY_DELETES;
+                break;
+            case DELETION_VECTOR:
+                prestoFileContent = DELETION_VECTOR;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported iceberg content type: " + fileContent);

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -30,6 +30,10 @@ velox::connector::hive::iceberg::FileContent toVeloxFileContent(
     return velox::connector::hive::iceberg::FileContent::kData;
   } else if (content == protocol::iceberg::FileContent::POSITION_DELETES) {
     return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
+  } else if (content == protocol::iceberg::FileContent::EQUALITY_DELETES) {
+    return velox::connector::hive::iceberg::FileContent::kEqualityDeletes;
+  } else if (content == protocol::iceberg::FileContent::DELETION_VECTOR) {
+    return velox::connector::hive::iceberg::FileContent::kDeletionVector;
   }
   VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
 }
@@ -40,6 +44,8 @@ velox::dwio::common::FileFormat toVeloxFileFormat(
     return velox::dwio::common::FileFormat::ORC;
   } else if (format == protocol::iceberg::FileFormat::PARQUET) {
     return velox::dwio::common::FileFormat::PARQUET;
+  } else if (format == protocol::iceberg::FileFormat::PUFFIN) {
+    return velox::dwio::common::FileFormat::PUFFIN;
   }
   VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -281,7 +281,8 @@ static const std::pair<FileContent, json> FileContent_enum_table[] =
     { // NOLINT: cert-err58-cpp
         {FileContent::DATA, "DATA"},
         {FileContent::POSITION_DELETES, "POSITION_DELETES"},
-        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"}};
+        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"},
+        {FileContent::DELETION_VECTOR, "DELETION_VECTOR"}};
 void to_json(json& j, const FileContent& e) {
   static_assert(
       std::is_enum<FileContent>::value, "FileContent must be an enum!");

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -79,7 +79,7 @@ void to_json(json& j, const ChangelogSplitInfo& p);
 void from_json(const json& j, ChangelogSplitInfo& p);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES };
+enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES, DELETION_VECTOR };
 extern void to_json(json& j, const FileContent& e);
 extern void from_json(const json& j, FileContent& e);
 } // namespace facebook::presto::protocol::iceberg


### PR DESCRIPTION
Summary:

After D104959645 plumbed the V3 DeleteFile typed fields end-to-end, the
Prestissimo split converter still rejected V3-spec content types and the
PUFFIN file format. Three additive branches:

* toVeloxFileContent: add EQUALITY_DELETES -> kEqualityDeletes
  and DELETION_VECTOR -> kDeletionVector.
* toVeloxFileFormat: add PUFFIN -> velox::dwio::common::FileFormat::PUFFIN
  (D105654940 added the Velox enum entry).
* protocol enum: add DELETION_VECTOR to FileContent (Java enum + generated
  .h/.cpp).

After this, a V3 split with a PUFFIN/DELETION_VECTOR delete file no longer
throws VELOX_UNSUPPORTED at the protocol -> Velox boundary. The Velox
deletion-vector reader (already linked) takes over from there.
=== NO RELEASE NOTES ==

Differential Revision: D106048714


