### PR TITLE
feat(native-pos): Add native_exchange_materialization_enabled session property for enabling new materialized exchange path

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -30,6 +30,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
 
   arrowflight-java-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
 
   hive-tests:
     permissions:

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
 
   jdbc-connector-tests:
     permissions:

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   kudu:
     permissions:
       contents: read

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
               - 'presto-docs/pom.xml'
 
   dependency-check:

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   product-tests-basic-environment:
     strategy:
       fail-fast: false

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   product-tests-specific-environment1:
     strategy:
       fail-fast: false

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   singlestore-dockerized-tests:
     strategy:
       fail-fast: false

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   spark-integration:
     strategy:
       fail-fast: false

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
   test-other-modules:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -24,6 +24,7 @@ jobs:
           filters: |
             codechange:
               - '!presto-docs/**'
+              - '!presto-native-execution/presto_cpp/**'
               - 'presto-ui/**'
   web-ui-checks:
     runs-on: ubuntu-latest

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -407,6 +407,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING = "native_min_columnar_encoding_channels_to_prefer_row_wise_encoding";
     public static final String NATIVE_ENFORCE_JOIN_BUILD_INPUT_PARTITION = "native_enforce_join_build_input_partition";
     public static final String NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED = "native_execution_scale_writer_threads_enabled";
+    public static final String NATIVE_EXCHANGE_MATERIALIZATION_ENABLED = "native_exchange_materialization_enabled";
     public static final String TRY_FUNCTION_CATCHABLE_ERRORS = "try_function_catchable_errors";
     public static final String PUSH_FILTER_THROUGH_SELECTING_AGGREGATION = "push_filter_through_selecting_aggregation";
     public static final String OPTIMIZE_ROW_IN_PREDICATE = "optimize_row_in_predicate";
@@ -2210,6 +2211,10 @@ public final class SystemSessionProperties
                         "Enable automatic scaling of writer threads",
                         featuresConfig.isNativeExecutionScaleWritersThreadsEnabled(),
                         !featuresConfig.isNativeExecutionEnabled()),
+                booleanProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED,
+                        "Native Execution only. Enable materialized exchange operators in Velox (MaterializedOutput/MaterializedExchange). When false, uses PartitionAndSerialize + ShuffleWrite.",
+                        true,
+                        false),
                 stringProperty(
                         EXPRESSION_OPTIMIZER_NAME,
                         "Configure which expression optimizer to use",
@@ -3846,6 +3851,11 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionScaleWritersThreadsEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isNativeExchangeMaterializationEnabled(Session session)
+    {
+        return session.getSystemProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED, Boolean.class);
     }
 
     public static int getMaxSplitPreloadPerDriver(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -84,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.airlift.units.DataSize.succinctBytes;
@@ -369,7 +370,63 @@ public class QueryMonitor
                         .map(stageId -> String.valueOf(stageId.getId()))
                         .collect(toImmutableList()),
                 queryInfo.getSession().getTraceToken(),
-                Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateType));
+                Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateType),
+                createOperatorSummariesJson(queryInfo),
+                createSapphireStatsJson(queryInfo),
+                createInputOutputJson(queryInfo));
+    }
+
+    private Optional<String> createOperatorSummariesJson(QueryInfo queryInfo)
+    {
+        try {
+            List<OperatorStatistics> operatorStats = createOperatorStatistics(queryInfo);
+            if (operatorStats.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(OBJECT_MAPPER.writeValueAsString(operatorStats));
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to serialize operator summaries for query %s", queryInfo.getQueryId());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> createSapphireStatsJson(QueryInfo queryInfo)
+    {
+        try {
+            QueryStats queryStats = queryInfo.getQueryStats();
+            ImmutableMap.Builder<String, Object> stats = ImmutableMap.builder();
+            stats.put("totalSplitCpuTimeMs", queryStats.getTotalCpuTime().toMillis());
+            stats.put("totalSplitWallTimeMs", queryStats.getTotalScheduledTime().toMillis());
+            stats.put("queuedTimeMs", queryStats.getQueuedTime().toMillis());
+            return Optional.of(OBJECT_MAPPER.writeValueAsString(stats.build()));
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to serialize sapphire stats for query %s", queryInfo.getQueryId());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> createInputOutputJson(QueryInfo queryInfo)
+    {
+        try {
+            Set<Input> inputs = queryInfo.getInputs();
+            if (inputs.isEmpty()) {
+                return Optional.empty();
+            }
+            ImmutableList.Builder<Map<String, String>> inputList = ImmutableList.builder();
+            for (Input input : inputs) {
+                inputList.add(ImmutableMap.of(
+                        "catalog", input.getConnectorId().getCatalogName(),
+                        "schema", input.getSchema(),
+                        "table", input.getTable()));
+            }
+            return Optional.of(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("inputs", inputList.build())));
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to serialize input/output info for query %s", queryInfo.getQueryId());
+            return Optional.empty();
+        }
     }
 
     private List<OperatorStatistics> createOperatorStatistics(QueryInfo queryInfo)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
@@ -132,6 +133,10 @@ public class NativeExecutionProcess
         if (nativeTempStorageHandle.isPresent()) {
             workerProperty.updateTempStorageConfig(nativeTempStorageHandle.get());
         }
+
+        workerProperty.getSystemConfig()
+                .update(NativeExecutionSystemConfig.EXCHANGE_MATERIALIZATION_ENABLED,
+                        String.valueOf(SystemSessionProperties.isNativeExchangeMaterializationEnabled(session)));
     }
 
     protected SparkConf getSparkConf()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -78,6 +78,7 @@ public class NativeExecutionSystemConfig
     public static final String REMOTE_FUNCTION_SERVER_SERDE = "remote-function-server.serde";
     public static final String REMOTE_FUNCTION_SERVER_CATALOG_NAME = "remote-function-server.catalog-name";
     public static final String PLAN_CONSISTENCY_CHECK = "plan-consistency-check-enabled";
+    public static final String EXCHANGE_MATERIALIZATION_ENABLED = "exchange.materialization.enabled";
 
     private final String remoteFunctionServerSignatureFilesDirectoryPathDefault = "./functions/spark/";
     private final String remoteFunctionServerSerdeDefault = "presto_page";

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
@@ -43,6 +43,9 @@ public class QueryMetadata
 
     private final List<String> runtimeOptimizedStages;
     private final Optional<String> updateQueryType;
+    private final Optional<String> operatorSummaries;
+    private final Optional<String> sapphireStatsJson;
+    private final Optional<String> inputOutputJson;
 
     public QueryMetadata(
             String queryId,
@@ -60,6 +63,30 @@ public class QueryMetadata
             Optional<String> tracingId,
             Optional<String> updateQueryType)
     {
+        this(queryId, transactionId, query, queryHash, preparedQuery, queryState, uri,
+                plan, jsonPlan, graphvizPlan, payload, runtimeOptimizedStages, tracingId,
+                updateQueryType, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public QueryMetadata(
+            String queryId,
+            Optional<String> transactionId,
+            String query,
+            String queryHash,
+            Optional<String> preparedQuery,
+            String queryState,
+            URI uri,
+            Optional<String> plan,
+            Optional<String> jsonPlan,
+            Optional<String> graphvizPlan,
+            Optional<String> payload,
+            List<String> runtimeOptimizedStages,
+            Optional<String> tracingId,
+            Optional<String> updateQueryType,
+            Optional<String> operatorSummaries,
+            Optional<String> sapphireStatsJson,
+            Optional<String> inputOutputJson)
+    {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
         this.query = requireNonNull(query, "query is null");
@@ -74,6 +101,9 @@ public class QueryMetadata
         this.runtimeOptimizedStages = requireNonNull(runtimeOptimizedStages, "runtimeOptimizedStages is null");
         this.tracingId = requireNonNull(tracingId, "tracingId is null");
         this.updateQueryType = requireNonNull(updateQueryType, "updateQueryType is null");
+        this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
+        this.sapphireStatsJson = requireNonNull(sapphireStatsJson, "sapphireStatsJson is null");
+        this.inputOutputJson = requireNonNull(inputOutputJson, "inputOutputJson is null");
     }
 
     @JsonProperty
@@ -157,5 +187,23 @@ public class QueryMetadata
     public Optional<String> getUpdateQueryType()
     {
         return updateQueryType;
+    }
+
+    @JsonProperty
+    public Optional<String> getOperatorSummaries()
+    {
+        return operatorSummaries;
+    }
+
+    @JsonProperty
+    public Optional<String> getSapphireStatsJson()
+    {
+        return sapphireStatsJson;
+    }
+
+    @JsonProperty
+    public Optional<String> getInputOutputJson()
+    {
+        return inputOutputJson;
     }
 }


### PR DESCRIPTION
Summary:
Adds a new session property `native_exchange_materialization_enabled` (default: true) that controls whether the Velox native worker uses MaterializedOutput/MaterializedExchange operators. When set to false, the native process falls back to PartitionAndSerialize + ShuffleWrite.

The session property is read in NativeExecutionProcess.updateWorkerProperties() and unconditionally propagated to the C++ system config `exchange.materialization.enabled` before the native process starts. The session value always overrides the static config in both directions.

Changes:
- SystemSessionProperties: Add NATIVE_EXCHANGE_MATERIALIZATION_ENABLED constant, boolean property registration (default true), and static getter
- NativeExecutionSystemConfig: Add EXCHANGE_MATERIALIZATION_ENABLED constant mapping to C++ config key
- NativeExecutionProcess.updateWorkerProperties(): Set exchange.materialization.enabled from session property value

Differential Revision: D106577288

## Summary by Sourcery

Add a session-controlled native exchange materialization feature and expose additional query telemetry in event metadata while adjusting CI workflows to ignore native C++ changes for certain jobs.

New Features:
- Introduce the native_exchange_materialization_enabled system session property to toggle Velox materialized exchange operators in native execution.
- Expose operator summaries, high-level query stats, and input/output metadata as optional JSON fields in QueryMetadata for event listeners.

Enhancements:
- Propagate the native exchange materialization session property into the native worker system configuration to override the corresponding C++ setting.

CI:
- Exclude presto-native-execution/presto_cpp/** changes from triggering various GitHub Actions test workflows that use the codechange filter.