### PR TITLE
feat(native-pos): Add native_exchange_materialization_enabled session property to control Velox materialized exchange

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -407,6 +407,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING = "native_min_columnar_encoding_channels_to_prefer_row_wise_encoding";
     public static final String NATIVE_ENFORCE_JOIN_BUILD_INPUT_PARTITION = "native_enforce_join_build_input_partition";
     public static final String NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED = "native_execution_scale_writer_threads_enabled";
+    public static final String NATIVE_EXCHANGE_MATERIALIZATION_ENABLED = "native_exchange_materialization_enabled";
     public static final String TRY_FUNCTION_CATCHABLE_ERRORS = "try_function_catchable_errors";
     public static final String PUSH_FILTER_THROUGH_SELECTING_AGGREGATION = "push_filter_through_selecting_aggregation";
     public static final String OPTIMIZE_ROW_IN_PREDICATE = "optimize_row_in_predicate";
@@ -2210,6 +2211,10 @@ public final class SystemSessionProperties
                         "Enable automatic scaling of writer threads",
                         featuresConfig.isNativeExecutionScaleWritersThreadsEnabled(),
                         !featuresConfig.isNativeExecutionEnabled()),
+                booleanProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED,
+                        "Native Execution only. Enable materialized exchange operators in Velox (MaterializedOutput/MaterializedExchange). When false, uses PartitionAndSerialize + ShuffleWrite.",
+                        false,
+                        false),
                 stringProperty(
                         EXPRESSION_OPTIMIZER_NAME,
                         "Configure which expression optimizer to use",
@@ -3846,6 +3851,11 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionScaleWritersThreadsEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isNativeExchangeMaterializationEnabled(Session session)
+    {
+        return session.getSystemProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED, Boolean.class);
     }
 
     public static int getMaxSplitPreloadPerDriver(Session session)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
@@ -132,6 +133,10 @@ public class NativeExecutionProcess
         if (nativeTempStorageHandle.isPresent()) {
             workerProperty.updateTempStorageConfig(nativeTempStorageHandle.get());
         }
+
+        workerProperty.getSystemConfig()
+                .update(NativeExecutionSystemConfig.EXCHANGE_MATERIALIZATION_ENABLED,
+                        String.valueOf(SystemSessionProperties.isNativeExchangeMaterializationEnabled(session)));
     }
 
     protected SparkConf getSparkConf()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -78,6 +78,7 @@ public class NativeExecutionSystemConfig
     public static final String REMOTE_FUNCTION_SERVER_SERDE = "remote-function-server.serde";
     public static final String REMOTE_FUNCTION_SERVER_CATALOG_NAME = "remote-function-server.catalog-name";
     public static final String PLAN_CONSISTENCY_CHECK = "plan-consistency-check-enabled";
+    public static final String EXCHANGE_MATERIALIZATION_ENABLED = "exchange.materialization.enabled";
 
     private final String remoteFunctionServerSignatureFilesDirectoryPathDefault = "./functions/spark/";
     private final String remoteFunctionServerSerdeDefault = "presto_page";
@@ -121,6 +122,7 @@ public class NativeExecutionSystemConfig
     private final String orderBySpillEnabledDefault = "true";
     private final String maxSpillBytesDefault = String.valueOf(600L << 30);
     private final String planConsistencyCheckEnabled = "true";
+    private final String exchangeMaterializationEnabledDefault = "false";
 
     private final Map<String, String> systemConfigs;
     private final Map<String, String> defaultSystemConfigs;
@@ -187,6 +189,7 @@ public class NativeExecutionSystemConfig
                 .put(ORDER_BY_SPILL_ENABLED, orderBySpillEnabledDefault)
                 .put(MAX_SPILL_BYTES, maxSpillBytesDefault)
                 .put(PLAN_CONSISTENCY_CHECK, planConsistencyCheckEnabled)
+                .put(EXCHANGE_MATERIALIZATION_ENABLED, exchangeMaterializationEnabledDefault)
                 .build();
     }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -80,6 +80,7 @@ public class TestNativeExecutionSystemConfig
                 .put("order-by-spill-enabled", "true")
                 .put("max-spill-bytes", String.valueOf(600L << 30))
                 .put("plan-consistency-check-enabled", "true")
+                .put("exchange.materialization.enabled", "false")
                 .build();
         assertEquals(nativeExecutionSystemConfig.getAllProperties(), expectedConfigs);
 
@@ -124,6 +125,7 @@ public class TestNativeExecutionSystemConfig
                 .put("join-spill-enabled", "false")
                 .put("order-by-spill-enabled", "false")
                 .put("plan-consistency-check-enabled", "false")
+                .put("exchange.materialization.enabled", "true")
                 .put("non-defined-property-key-0", "non-defined-property-value-0")
                 .put("non-defined-property-key-1", "non-defined-property-value-1")
                 .put("non-defined-property-key-2", "non-defined-property-value-2")
@@ -171,6 +173,7 @@ public class TestNativeExecutionSystemConfig
                 .put("join-spill-enabled", "false")
                 .put("order-by-spill-enabled", "false")
                 .put("plan-consistency-check-enabled", "false")
+                .put("exchange.materialization.enabled", "true")
                 .put("non-defined-property-key-0", "non-defined-property-value-0")
                 .put("non-defined-property-key-1", "non-defined-property-value-1")
                 .put("non-defined-property-key-2", "non-defined-property-value-2")


### PR DESCRIPTION
Summary:
Adds a new session property `native_exchange_materialization_enabled` (default: false) that controls whether the Velox native worker uses MaterializedOutput/MaterializedExchange operators in the Presto on Spark native codepath. When set to false, the native process falls back to PartitionAndSerialize + ShuffleWrite.

The session property is read in NativeExecutionProcess.updateWorkerProperties() and unconditionally propagated to the C++ system config `exchange.materialization.enabled` before the native process starts. The session value always overrides the static config in both directions.

Changes:
- SystemSessionProperties: Add NATIVE_EXCHANGE_MATERIALIZATION_ENABLED constant, boolean property registration (default false), and static getter
- NativeExecutionSystemConfig: Add EXCHANGE_MATERIALIZATION_ENABLED constant and default
- NativeExecutionProcess.updateWorkerProperties(): Set exchange.materialization.enabled from session property value
- TestNativeExecutionSystemConfig: Add new property to all test maps


Reviewed By: xiaoxmeng

Differential Revision: D106582232



```
== RELEASE NOTE ==

General Changes
* Add `native_exchange_materialization_enabled` session property (Presto on Spark native codepath only) to control whether Velox native workers use MaterializedOutput/MaterializedExchange operators. When set to `true`, enables materialized exchange; when `false` (default), falls back to PartitionAndSerialize + ShuffleWrite.
```