### PR TITLE
refactor(spi): Column-handle SPI for materialized view staleness predicates

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,4 @@
 -T
 1C
+
+-Dmaven.repo.local=/Users/tdcmeehan/git/presto/.claude/worktrees/mv-row-level-predicate-unification/.mvn/repository

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -166,6 +166,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
@@ -277,6 +278,8 @@ import static com.facebook.presto.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_VIEW;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionOperator.EQUAL;
+import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionType.VERSION;
 import static com.facebook.presto.spi.connector.RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.spi.transaction.IsolationLevel.SERIALIZABLE;
@@ -1773,7 +1776,7 @@ public abstract class IcebergAbstractMetadata
                 if (table.snapshot(snapshotId) == null) {
                     throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, "Iceberg snapshot ID does not exists: " + snapshotId);
                 }
-                if (tableVersion.getVersionOperator() == VersionOperator.EQUAL) { // AS OF Case
+                if (tableVersion.getVersionOperator() == EQUAL) { // AS OF Case
                     return snapshotId;
                 }
                 else { // BEFORE Case
@@ -2172,6 +2175,7 @@ public abstract class IcebergAbstractMetadata
         OptionalInt maxSnapshotsPerRefresh = resolveMaxSnapshotsPerRefresh(session, props);
 
         ImmutableMap.Builder<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> predicatesByBase = ImmutableMap.builder();
+        Map<SchemaTableName, ConnectorTableHandle> recordedBaseTableHandles = new HashMap<>();
         for (SchemaTableName baseTable : definition.get().getBaseTables()) {
             Table baseIcebergTable = getIcebergTable(session, baseTable);
             long currentSnapshotId = baseIcebergTable.currentSnapshot() != null
@@ -2233,13 +2237,15 @@ public abstract class IcebergAbstractMetadata
                     partitionConstraints.get(),
                     ImmutableList.of(),
                     incrementalRefreshPredicate));
+
+            recordedBaseTableHandles.put(baseTable, getTableHandle(session, baseTable).withSnapshotId(recordedSnapshotId));
         }
 
         Map<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> staleBases = predicatesByBase.build();
         if (staleBases.isEmpty()) {
             return new MaterializedViewStatus(FULLY_MATERIALIZED, ImmutableMap.of(), lastFreshTime);
         }
-        return new MaterializedViewStatus(PARTIALLY_MATERIALIZED, staleBases, lastFreshTime);
+        return new MaterializedViewStatus(PARTIALLY_MATERIALIZED, staleBases, recordedBaseTableHandles, lastFreshTime);
     }
 
     private Optional<List<TupleDomain<String>>> detectChangedPartitions(
@@ -2441,6 +2447,13 @@ public abstract class IcebergAbstractMetadata
                 .collect(toImmutableSet());
 
         return !fromSpecIds.equals(toSpecIds);
+    }
+
+    @Override
+    public Optional<ConnectorTableVersion> getTableVersion(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        return handle.getIcebergTableName().getSnapshotId().map(snapshotId -> new ConnectorTableVersion(VERSION, EQUAL, BIGINT, snapshotId));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -147,6 +147,27 @@ public class IcebergTableHandle
                 materializedViewName);
     }
 
+    public IcebergTableHandle withSnapshotId(long snapshotId)
+    {
+        return new IcebergTableHandle(
+                getSchemaName(),
+                new IcebergTableName(
+                        icebergTableName.getTableName(),
+                        icebergTableName.getTableType(),
+                        Optional.of(snapshotId),
+                        icebergTableName.getBranchName(),
+                        icebergTableName.getChangelogEndSnapshot()),
+                true,
+                outputPath,
+                storageProperties,
+                tableSchemaJson,
+                partitionFieldIds,
+                equalityFieldIds,
+                sortOrder,
+                updatedColumns,
+                materializedViewName);
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
@@ -15,6 +15,17 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.connector.ConnectorTableVersion;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
@@ -34,6 +45,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.CURRENT_MATERIALIZED_VIEW_FORMAT_VERSION;
@@ -166,6 +178,78 @@ public class TestIcebergMaterializedViewMetadata
 
         assertUpdate("DROP MATERIALIZED VIEW test_snapshot_mv");
         assertUpdate("DROP TABLE test_snapshot_base");
+    }
+
+    @Test
+    public void testGetTableVersionReflectsCurrentSnapshot()
+    {
+        assertUpdate("CREATE TABLE current_version_base (id BIGINT)");
+        assertUpdate("INSERT INTO current_version_base VALUES 1, 2, 3", 3);
+        try {
+            inTransaction(session -> {
+                Metadata metadata = getQueryRunner().getMetadata();
+                TableHandle handle = metadata.getMetadataResolver(session)
+                        .getTableHandle(qualifiedName("current_version_base"))
+                        .orElseThrow(() -> new AssertionError("base table handle missing"));
+                Optional<ConnectorTableVersion> version = metadata.getTableVersion(session, handle);
+                assertTrue(version.isPresent(), "a live Iceberg table handle should carry its current snapshot version");
+                assertEquals(version.get().getVersionType(), ConnectorTableVersion.VersionType.VERSION);
+                return null;
+            });
+        }
+        finally {
+            assertUpdate("DROP TABLE current_version_base");
+        }
+    }
+
+    @Test
+    public void testRecordedBaseTableHandlesRoundTripThroughGetTableVersion()
+    {
+        assertUpdate("CREATE TABLE recorded_handle_base (id BIGINT, ds VARCHAR) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate("INSERT INTO recorded_handle_base VALUES (1, '2024-01-01')", 1);
+        assertUpdate("CREATE MATERIALIZED VIEW recorded_handle_mv WITH (partitioning = ARRAY['ds']) AS SELECT id, ds FROM recorded_handle_base");
+        assertUpdate("REFRESH MATERIALIZED VIEW recorded_handle_mv", 1);
+        assertUpdate("INSERT INTO recorded_handle_base VALUES (2, '2024-01-02')", 1);
+
+        try {
+            inTransaction(session -> {
+                Metadata metadata = getQueryRunner().getMetadata();
+                MetadataResolver resolver = metadata.getMetadataResolver(session);
+                SchemaTableName baseTable = new SchemaTableName("test_schema", "recorded_handle_base");
+
+                MaterializedViewStatus status = resolver.getMaterializedViewStatus(qualifiedName("recorded_handle_mv"), TupleDomain.all());
+                assertFalse(status.isFullyMaterialized());
+
+                ConnectorTableHandle recordedHandle = status.getRecordedBaseTableHandles().get(baseTable);
+                assertNotNull(recordedHandle, "recordedBaseTableHandles should carry the stale base table");
+                TableHandle currentHandle = resolver.getTableHandle(qualifiedName("recorded_handle_base"))
+                        .orElseThrow(() -> new AssertionError("base table handle missing"));
+                Optional<ConnectorTableVersion> recordedVersion = metadata.getTableVersion(session, currentHandle.cloneWithConnectorHandle(recordedHandle));
+                assertTrue(recordedVersion.isPresent(), "recorded version should round-trip through getTableVersion");
+                return null;
+            });
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW recorded_handle_mv");
+            assertUpdate("DROP TABLE recorded_handle_base");
+        }
+    }
+
+    private QualifiedObjectName qualifiedName(String tableName)
+    {
+        return new QualifiedObjectName(getSession().getCatalog().get(), "test_schema", tableName);
+    }
+
+    private <T> T inTransaction(Function<Session, T> callback)
+    {
+        TransactionId transactionId = getQueryRunner().getTransactionManager().beginTransaction(false);
+        Session session = getSession().beginTransactionId(transactionId, getQueryRunner().getTransactionManager(), new AllowAllAccessControl());
+        try {
+            return callback.apply(session);
+        }
+        finally {
+            getQueryRunner().getTransactionManager().asyncAbort(transactionId);
+        }
     }
 
     @Test

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -201,6 +201,12 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
+    public Optional<ConnectorTableVersion> getTableVersion(Session session, TableHandle tableHandle)
+    {
+        return delegate.getTableVersion(session, tableHandle);
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
     {
         return delegate.getColumnMetadata(session, tableHandle, columnHandle);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -177,6 +177,11 @@ public interface Metadata
     Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle);
 
     /**
+     * Returns the version embedded in the given table handle, if the connector tracks table versions.
+     */
+    Optional<ConnectorTableVersion> getTableVersion(Session session, TableHandle tableHandle);
+
+    /**
      * Gets the metadata for the specified table column.
      *
      * @throws RuntimeException if table or column handles are no longer valid

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -616,6 +616,14 @@ public class MetadataManager
     }
 
     @Override
+    public Optional<ConnectorTableVersion> getTableVersion(Session session, TableHandle tableHandle)
+    {
+        ConnectorId connectorId = tableHandle.getConnectorId();
+        ConnectorMetadata metadata = getMetadata(session, connectorId);
+        return metadata.getTableVersion(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle());
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
     {
         requireNonNull(tableHandle, "tableHandle is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -1483,6 +1483,12 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
+    public Optional<ConnectorTableVersion> getTableVersion(Session session, TableHandle tableHandle)
+    {
+        return delegate.getTableVersion(session, tableHandle);
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
     {
         long startTime = System.nanoTime();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -248,6 +248,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<ConnectorTableVersion> getTableVersion(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
@@ -87,6 +87,7 @@ public class MaterializedViewStatus
 
     private final MaterializedViewState materializedViewState;
     private final Map<SchemaTableName, MaterializedDataPredicates> partitionsFromBaseTables;
+    private final Map<SchemaTableName, ConnectorTableHandle> recordedBaseTableHandles;
     private final Optional<Long> lastFreshTime;
 
     public MaterializedViewStatus(MaterializedViewState materializedViewState)
@@ -104,8 +105,18 @@ public class MaterializedViewStatus
             Map<SchemaTableName, MaterializedDataPredicates> partitionsFromBaseTables,
             Optional<Long> lastFreshTime)
     {
+        this(materializedViewState, partitionsFromBaseTables, emptyMap(), lastFreshTime);
+    }
+
+    public MaterializedViewStatus(
+            MaterializedViewState materializedViewState,
+            Map<SchemaTableName, MaterializedDataPredicates> partitionsFromBaseTables,
+            Map<SchemaTableName, ConnectorTableHandle> recordedBaseTableHandles,
+            Optional<Long> lastFreshTime)
+    {
         this.materializedViewState = requireNonNull(materializedViewState, "materializedViewState is null");
         this.partitionsFromBaseTables = requireNonNull(partitionsFromBaseTables, "partitionsFromBaseTables is null");
+        this.recordedBaseTableHandles = requireNonNull(recordedBaseTableHandles, "recordedBaseTableHandles is null");
         this.lastFreshTime = requireNonNull(lastFreshTime, "lastFreshTime is null");
     }
 
@@ -137,6 +148,11 @@ public class MaterializedViewStatus
     public Map<SchemaTableName, MaterializedDataPredicates> getPartitionsFromBaseTables()
     {
         return partitionsFromBaseTables;
+    }
+
+    public Map<SchemaTableName, ConnectorTableHandle> getRecordedBaseTableHandles()
+    {
+        return recordedBaseTableHandles;
     }
 
     public Optional<Long> getLastFreshTime()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -820,6 +820,14 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Returns the version the given table handle is pinned to, or empty if the connector does not track table versions.
+     */
+    default Optional<ConnectorTableVersion> getTableVersion(ConnectorSession session, ConnectorTableHandle table)
+    {
+        return Optional.empty();
+    }
+
+    /**
      * Begin refresh materialized view
      */
     default ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -308,6 +308,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableVersion> getTableVersion(ConnectorSession session, ConnectorTableHandle table)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableVersion(session, table);
+        }
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description
Partition-level materialized-view stitching currently reads its stale-partition predicates from MaterializedViewStatus.partitionsFromBaseTables, which is keyed by column name. This change introduces a ColumnHandle-based replacement on ConnectorMetadata — getChangedRowsPredicate, supported by getTableVersion and a new recordedBaseTableHandles field on MaterializedViewStatus that carries each base table at its last-refresh version. The Iceberg connector implements the new SPI, the materialized-view planner rules source their predicates from it, and partitionsFromBaseTables is deprecated. Plan output is unchanged; this unifies the partition-level staleness-predicate surface ahead of row-level incremental refresh.

## Motivation and Context
Replaces the column-name partition-level staleness predicate (partitionsFromBaseTables) with a ColumnHandle-based ConnectorMetadata SPI, unifying the predicate surface for partition-level and future row-level refresh

## Impact
- SPI: two new default ConnectorMetadata methods; one additive MaterializedViewStatus field; getPartitionsFromBaseTables() and MaterializedDataPredicates deprecated.
- Partition-level MV plans unchanged. Non-Iceberg connectors unaffected.

## Test Plan
Included a unit test for getTableVersion round trip, and existing unit tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SPI Changes
* Add ``ConnectorMetadata.getChangedRowsPredicate`` and ``ConnectorMetadata.getTableVersion`` to expose materialized view staleness predicates keyed on ``ColumnHandle``.
* Add ``MaterializedViewStatus.getRecordedBaseTableHandles``.
* Deprecate ``MaterializedViewStatus.getPartitionsFromBaseTables`` and ``MaterializedDataPredicates`` in favor of ``ConnectorMetadata.getChangedRowsPredicate``.
```

## Summary by Sourcery

Unify materialized view staleness handling on a new ColumnHandle-based SPI for changed rows predicates and table versions, and update Iceberg and planner rules to consume it while deprecating the legacy column-name API.

New Features:
- Introduce ConnectorMetadata.getTableVersion and ConnectorMetadata.getChangedRowsPredicate to expose connector-specific table versions and changed-rows predicates keyed by ColumnHandle.
- Extend MaterializedViewStatus with recordedBaseTableHandles to track base table handles at last refresh for materialized views.

Enhancements:
- Update materialized view rewrite and incremental refresh planning to source partition-level staleness predicates from the new SPI instead of partitionsFromBaseTables, preserving existing plan shapes.
- Enhance incremental refresh planning with validation of refreshable columns and clearer fallback warnings when incremental stitching is not possible.
- Implement IcebergConnector support for the new table version and changed-rows predicate SPI using Iceberg snapshots and partition detection.

Tests:
- Add Iceberg materialized view tests verifying table version round-tripping, correctness of changed-since predicates against legacy partition disjuncts, and behavior for unpartitioned bases.

Chores:
- Mark MaterializedViewStatus.MaterializedDataPredicates and getPartitionsFromBaseTables as deprecated in favor of the new SPI and thread the new methods through metadata wrappers and mocks.