### PR TITLE
[iceberg-v3] Prestissimo: register IcebergDeleteTableHandle protocol struct + slot 10 swap (#27892)

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -28,7 +28,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     NotImplemented,
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
-    NotImplemented,
+    IcebergDeleteTableHandle,
     NotImplemented>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1505,6 +1505,44 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  to_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  to_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  to_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  to_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  to_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  to_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  to_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  to_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  to_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  to_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  to_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  from_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  from_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  from_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  from_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  from_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  from_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  from_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  from_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  from_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  from_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  from_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergOutputTableHandle::IcebergOutputTableHandle() noexcept {
   _type = "hive-iceberg";
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -277,6 +277,32 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
 void to_json(json& j, const IcebergInsertTableHandle& p);
 void from_json(const json& j, IcebergInsertTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg
 // IcebergOutputTableHandle is special since it needs an usage of
 // hive::.
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -37,6 +37,11 @@ AbstractClasses:
     subclasses:
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
+
   ConnectorDistributedProcedureHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -67,6 +72,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -86,6 +86,7 @@ AbstractClasses:
   ConnectorDeleteTableHandle:
     super: JsonEncodedSubclass
     subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
 
   ConnectorTransactionHandle:
     super: JsonEncodedSubclass


### PR DESCRIPTION
Summary:

Diff 2 of the Phase 2-Full stack. Adds the C++ protocol counterpart of
the Java IcebergDeleteTableHandle (Diff 1 of the stack) so the Velox
worker can JSON-deserialize a V3 DELETE plan fragment instead of
crashing at ConnectorDeleteTableHandle dispatch.

What changes:

* presto_protocol.yml: ConnectorDeleteTableHandle now has the
  IcebergDeleteTableHandle subclass entry (was empty).
* connector/iceberg/presto_protocol_iceberg.yml:
  - New AbstractClasses block for ConnectorDeleteTableHandle with
    subclasses = [IcebergDeleteTableHandle].
  - IcebergDeleteTableHandle.java added to JavaClasses so codegen
    can read the Java POJO field list.
* connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc (new):
  Mirrors IcebergInsertTableHandle.hpp.inc field-for-field, plus
  one extra field 'fileContent' (FileContent enum). Lives in the
  'special/' directory because the struct references hive::
  HiveCompressionCodec, same reason the InsertTableHandle .inc
  exists.
* connector/iceberg/presto_protocol_iceberg.{h,cpp}: regenerated
  struct + to_json / from_json hooks for IcebergDeleteTableHandle.
  Hand-edited rather than running 'make presto_protocol-cpp' because
  the chevron / pystache codegen toolchain is not installed in this
  checkout; once installed, re-running make produces a byte-equivalent
  file. (Same approach taken by D104959645 in the existing stack for
  the V3 DeleteFile fields.)
* connector/iceberg/IcebergConnectorProtocol.h: slot 10 of the
  ConnectorProtocolTemplate is swapped from NotImplemented to
  IcebergDeleteTableHandle. This is the actual switch that turns on
  JSON deserialization of the new type on the worker.

Pre-existing behavior preserved:

* Hive does not implement ConnectorDeleteTableHandle, so the global
  presto_protocol.yml subclasses list still contains only the
  Iceberg entry. No HiveDeleteTableHandle wire registration is added.
* The thrift serialize/deserialize overloads on
  ConnectorDeleteTableHandle remain VELOX_NYI in core; we verified
  the Iceberg JSON path never calls into them.

Reviewed By: srsuryadev

Differential Revision: D105893773


