### PR TITLE
feat: IcebergPrestoToVeloxConnector DELETE override (#27893)

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -413,6 +413,52 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
           toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
 }
 
+std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
+    const protocol::DeleteHandle* deleteHandle,
+    const TypeParser& typeParser) const {
+  auto icebergDeleteTableHandle =
+      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+          deleteHandle->handle.connectorHandle);
+
+  VELOX_CHECK_NOT_NULL(
+      icebergDeleteTableHandle,
+      "Unexpected delete table handle type {}",
+      deleteHandle->handle.connectorHandle->_type);
+
+  const auto inputColumns =
+      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+
+  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+  // deletion-vector branch routes through this bridge today; V2
+  // POSITION_DELETES flows through the Java row-id-rewrite path on the
+  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+  // kData so the existing IcebergDataSink raises a clear error rather
+  // than silently emitting a deletion vector for the wrong format.
+  const auto writeKind = icebergDeleteTableHandle->fileContent ==
+          protocol::iceberg::FileContent::DELETION_VECTOR
+      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kDeletionVector
+      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kData;
+
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+      toVeloxIcebergPartitionSpec(
+          icebergDeleteTableHandle->partitionSpec, typeParser),
+      std::optional(
+          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+      /*serdeParameters=*/{},
+      writeKind);
+}
+
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
 IcebergPrestoToVeloxConnector::toIcebergColumns(
     const protocol::List<protocol::iceberg::IcebergColumnHandle>& inputColumns,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -58,6 +58,11 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::InsertHandle* insertHandle,
       const TypeParser& typeParser) const final;
 
+  std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+  toVeloxInsertTableHandle(
+      const protocol::DeleteHandle* deleteHandle,
+      const TypeParser& typeParser) const final;
+
  private:
   std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
   toIcebergColumns(

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -28,7 +28,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     NotImplemented,
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
-    NotImplemented,
+    IcebergDeleteTableHandle,
     NotImplemented>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1505,6 +1505,44 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  to_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  to_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  to_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  to_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  to_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  to_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  to_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  to_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  to_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  to_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  to_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  from_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  from_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  from_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  from_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  from_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  from_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  from_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  from_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  from_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  from_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  from_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergOutputTableHandle::IcebergOutputTableHandle() noexcept {
   _type = "hive-iceberg";
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -277,6 +277,32 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
 void to_json(json& j, const IcebergInsertTableHandle& p);
 void from_json(const json& j, IcebergInsertTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg
 // IcebergOutputTableHandle is special since it needs an usage of
 // hive::.
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -37,6 +37,11 @@ AbstractClasses:
     subclasses:
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
+
   ConnectorDistributedProcedureHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -67,6 +72,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -86,6 +86,7 @@ AbstractClasses:
   ConnectorDeleteTableHandle:
     super: JsonEncodedSubclass
     subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
 
   ConnectorTransactionHandle:
     super: JsonEncodedSubclass


### PR DESCRIPTION
Summary:

Wires the new protocol type from
Diff 2 (IcebergDeleteTableHandle) to the new Velox sink from Diff 3
(IcebergDeletionVectorSink) by adding a toVeloxInsertTableHandle()
override for protocol::DeleteHandle. After this lands, the C++ worker
can convert a Presto DELETE plan into a Velox TableWriteNode that
drives IcebergDeletionVectorSink for V3 deletion vectors.

What changes:

* IcebergPrestoToVeloxConnector.h: declare the 4th override
  (alongside ExecuteProcedureHandle / CreateHandle / InsertHandle).
* IcebergPrestoToVeloxConnector.cpp: implement the override.
  - dynamic_pointer_cast to protocol::iceberg::IcebergDeleteTableHandle.
  - locationHandle TableType = kExisting (deletes target existing
    tables).
  - WriteKind derivation from protocol fileContent:
      DELETION_VECTOR -> kDeletionVector
      anything else   -> kData (defensive fallback so an unexpected
                         fileContent surfaces as a typed sink error
                         rather than silent miswrite).

What's NOT in this diff (deferred):

* Unit tests for the new override path. The plan calls for three
  TEST_F cases in PrestoToVeloxConnectorTest.cpp (simple WHERE,
  IN-clause, range DELETE). Skipping in this session to keep the
  stack landable in one sitting; tests should be added in a
  follow-up before the V3 DELETE rejection in IcebergAbstractMetadata
  is removed (Diff 5 of the stack).

What stays unchanged:

* PrestoToVeloxConnector.h base class: the DeleteHandle*
  default-return-empty override already exists. Virtual dispatch
  picks up our override automatically.
* Registration.cpp: no change needed; IcebergPrestoToVeloxConnector
  is already registered, and the new override is part of the same
  class.

=== NO RELEASE NOTES ===

Reviewed By: srsuryadev

Differential Revision: D105893776


