### PR TITLE
test: Fix flaky test caused by duplicate table names used concurrently

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -7222,7 +7222,7 @@ public class TestHiveIntegrationSmokeTest
 
         String catalog = getSession().getCatalog().get();
         String schema = getSession().getSchema().get();
-        String table = "test_textfile_custom_delim";
+        String table = "test_textfile_custom_delim_read";
         String path = new Path(tempDir.toURI().toASCIIString()).toString();
 
         String createTableWithCustomSerdeFormat =
@@ -7289,7 +7289,7 @@ public class TestHiveIntegrationSmokeTest
     {
         String catalog = getSession().getCatalog().get();
         String schema = getSession().getSchema().get();
-        String table = "test_textfile_custom_delim";
+        String table = "test_textfile_custom_delim_write";
 
         String createTableWithCustomSerdeFormat =
                 "CREATE TABLE %s.%s.%s (\n" +


### PR DESCRIPTION
## Description

This PR ensures concurrently executed tests use different table names in `TestHiveIntegrationSmokeTest`.

## Motivation and Context

Fix flaky test: https://github.com/prestodb/presto/issues/27895

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Use distinct table names for textfile serde read and write tests in TestHiveIntegrationSmokeTest to prevent interference when tests run concurrently.