### PR TITLE
fix(native-pos): Move MaterializedOutputBuffer creation under task mutex to prevent pool name collision

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -23,6 +23,8 @@
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Counters.h"
 #include "presto_cpp/main/common/Utils.h"
+#include "presto_cpp/main/operators/MaterializedOutput.h"
+#include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
 #include "presto_cpp/main/types/PrestoToVeloxSplit.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/file/FileSystems.h"
@@ -586,6 +588,28 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
           static_cast<exec::Consumer>(nullptr),
           prestoTask->id.stageId(),
           spillDiskOpts);
+
+      // Create MaterializedOutputBuffer under task mutex if the plan
+      // uses exchange materialization.
+      if (auto* materializedOutputNode =
+              dynamic_cast<const operators::MaterializedOutputNode*>(
+                  planFragment.planNode.get())) {
+        const auto& shuffleWriterMetadata =
+            materializedOutputNode->shuffleWriterMetadata();
+        auto* shuffleFactory = operators::ShuffleInterfaceFactory::factory(
+            shuffleWriterMetadata.writerFactoryName);
+        VELOX_CHECK_NOT_NULL(
+            shuffleFactory,
+            "ShuffleInterface factory '{}' not registered",
+            shuffleWriterMetadata.writerFactoryName);
+        auto buffer = std::make_shared<operators::MaterializedOutputBuffer>(
+            materializedOutputNode->numPartitions(),
+            shuffleWriterMetadata.writerInfo,
+            shuffleFactory,
+            taskId,
+            newExecTask->queryCtx()->pool());
+        operators::MaterializedOutputBuffer::registerBuffer(taskId, buffer);
+      }
 
       prestoTask->task = std::move(newExecTask);
       prestoTask->info.needsPlan = false;

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -78,8 +78,6 @@ core::PlanNodePtr MaterializedOutputNode::create(
       ? obj["replicateNullsAndAny"].asBool()
       : false;
 
-  // Buffer cannot be deserialized — it is set externally by the plan
-  // converter.
   return std::make_shared<MaterializedOutputNode>(
       deserializePlanNodeId(obj),
       std::move(keyPtrs),
@@ -87,8 +85,8 @@ core::PlanNodePtr MaterializedOutputNode::create(
       std::move(outputType),
       std::move(partitionFunctionSpec),
       replicateNullsAndAny,
-      std::move(source),
-      std::shared_ptr<MaterializedOutputBuffer>{});
+      ShuffleWriterMetadata{},
+      std::move(source));
 }
 
 MaterializedOutput::MaterializedOutput(
@@ -114,7 +112,7 @@ MaterializedOutput::MaterializedOutput(
                                       numDestinations_,
                                       /*localExchange=*/false)),
       replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
-      buffer_(planNode->buffer()),
+      buffer_(MaterializedOutputBuffer::getBuffer(ctx->task->taskId())),
       targetSizeInBytes_(
           std::clamp(
               static_cast<int64_t>(numDestinations_) * kDefaultAvgRowSize,

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -23,6 +23,13 @@
 
 namespace facebook::presto::operators {
 
+/// Metadata needed to create a MaterializedOutputBuffer. Carried on the
+/// plan node so buffer creation can be deferred to task creation time.
+struct ShuffleWriterMetadata {
+  std::string writerInfo;
+  std::string writerFactoryName;
+};
+
 class MaterializedOutputNode : public velox::core::PlanNode {
  public:
   MaterializedOutputNode(
@@ -33,16 +40,16 @@ class MaterializedOutputNode : public velox::core::PlanNode {
       std::shared_ptr<const velox::core::PartitionFunctionSpec>
           partitionFunctionSpec,
       bool replicateNullsAndAny,
-      velox::core::PlanNodePtr source,
-      std::shared_ptr<MaterializedOutputBuffer> buffer)
+      ShuffleWriterMetadata shuffleWriterMetadata,
+      velox::core::PlanNodePtr source)
       : velox::core::PlanNode(id),
         numPartitions_(numPartitions),
         keys_(std::move(keys)),
         outputType_(std::move(outputType)),
         partitionFunctionSpec_(std::move(partitionFunctionSpec)),
         replicateNullsAndAny_(replicateNullsAndAny),
-        sources_{std::move(source)},
-        buffer_(std::move(buffer)) {}
+        shuffleWriterMetadata_(std::move(shuffleWriterMetadata)),
+        sources_{std::move(source)} {}
 
   std::string_view name() const override {
     return "MaterializedOutput";
@@ -56,16 +63,16 @@ class MaterializedOutputNode : public velox::core::PlanNode {
     return keys_;
   }
 
-  MaterializedOutputBuffer* buffer() const {
-    return buffer_.get();
-  }
-
   const auto& partitionFunctionSpec() const {
     return partitionFunctionSpec_;
   }
 
   bool isReplicateNullsAndAny() const {
     return replicateNullsAndAny_;
+  }
+
+  const ShuffleWriterMetadata& shuffleWriterMetadata() const {
+    return shuffleWriterMetadata_;
   }
 
   const velox::RowTypePtr& outputType() const override {
@@ -93,8 +100,8 @@ class MaterializedOutputNode : public velox::core::PlanNode {
   const std::shared_ptr<const velox::core::PartitionFunctionSpec>
       partitionFunctionSpec_;
   const bool replicateNullsAndAny_;
+  const ShuffleWriterMetadata shuffleWriterMetadata_;
   const std::vector<velox::core::PlanNodePtr> sources_;
-  const std::shared_ptr<MaterializedOutputBuffer> buffer_;
 };
 
 class MaterializedOutput : public velox::exec::Operator {
@@ -191,7 +198,7 @@ class MaterializedOutput : public velox::exec::Operator {
   const std::vector<velox::column_index_t> keyChannels_;
   std::unique_ptr<velox::core::PartitionFunction> partitionFunction_;
   const bool replicateNullsAndAny_;
-  MaterializedOutputBuffer* const buffer_;
+  const std::shared_ptr<MaterializedOutputBuffer> buffer_;
 
   // Flush threshold: clamp(numPartitions * kDefaultAvgRowSize, 1MB, 10MB).
   int64_t targetSizeInBytes_;

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -37,6 +37,30 @@
 
 namespace facebook::presto::operators {
 
+folly::Synchronized<
+    folly::F14FastMap<std::string, std::shared_ptr<MaterializedOutputBuffer>>>
+    MaterializedOutputBuffer::buffers_;
+
+void MaterializedOutputBuffer::registerBuffer(
+    const std::string& taskId,
+    std::shared_ptr<MaterializedOutputBuffer> buffer) {
+  buffers_.withWLock(
+      [&](auto& buffers) { buffers.emplace(taskId, std::move(buffer)); });
+}
+
+std::shared_ptr<MaterializedOutputBuffer> MaterializedOutputBuffer::getBuffer(
+    const std::string& taskId) {
+  return buffers_.withRLock(
+      [&](const auto& buffers) -> std::shared_ptr<MaterializedOutputBuffer> {
+        auto it = buffers.find(taskId);
+        return it != buffers.end() ? it->second : nullptr;
+      });
+}
+
+void MaterializedOutputBuffer::removeBuffer(const std::string& taskId) {
+  buffers_.withWLock([&](auto& buffers) { buffers.erase(taskId); });
+}
+
 std::string MaterializedOutputBuffer::stateName(State state) {
   switch (state) {
     case State::kActive:
@@ -108,7 +132,8 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
     ShuffleInterfaceFactory* shuffleWriterFactory,
     const std::string& taskId,
     velox::memory::MemoryPool* pool)
-    : numPartitions_(numPartitions),
+    : taskId_(taskId),
+      numPartitions_(numPartitions),
       maxBufferedBytes_(
           SystemConfig::instance()
               ->exchangeMaterializationOutputBufferMaxBytes()),
@@ -133,6 +158,7 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
 }
 
 MaterializedOutputBuffer::~MaterializedOutputBuffer() {
+  removeBuffer(taskId_);
   if (state_ != State::kClosed && state_ != State::kAborted) {
     LOG(WARNING) << "MaterializedOutputBuffer destroyed without calling "
                  << "noMoreData() or abort(). Aborting writer.";

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -15,13 +15,13 @@
 
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <vector>
 
-#include <memory>
-
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
 #include "velox/common/base/RuntimeMetrics.h"
@@ -134,6 +134,20 @@ class MaterializedOutputBuffer {
 
     MaterializedOutputBuffer* const partitionBuffer_;
   };
+
+  /// Register a buffer in the process-wide registry. Called under the
+  /// prestoTask->mutex in createOrUpdateTaskImpl() to prevent duplicate
+  /// creation from concurrent createTask HTTP requests.
+  static void registerBuffer(
+      const std::string& taskId,
+      std::shared_ptr<MaterializedOutputBuffer> buffer);
+
+  /// Look up an existing buffer by taskId. Returns nullptr if not found.
+  static std::shared_ptr<MaterializedOutputBuffer> getBuffer(
+      const std::string& taskId);
+
+  /// Remove a buffer from the registry. Called during task cleanup.
+  static void removeBuffer(const std::string& taskId);
 
   /// Creates its own leaf pool under 'parentPool' and the writer from
   /// the factory.
@@ -255,6 +269,7 @@ class MaterializedOutputBuffer {
   static void freeTrackedIOBuf(void* buf, void* userData);
 
   // Immutable config.
+  const std::string taskId_;
   const int32_t numPartitions_;
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
@@ -279,6 +294,14 @@ class MaterializedOutputBuffer {
   std::atomic_int64_t reclaimedBytes_{0};
   std::atomic_int64_t lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;
+
+  // Process-wide registry of buffers keyed by taskId, following the same
+  // pattern as Velox OutputBufferManager. Buffer creation is done under
+  // prestoTask->mutex in createOrUpdateTaskImpl() and registered here;
+  // operators look up buffers by taskId at construction time.
+  static folly::Synchronized<
+      folly::F14FastMap<std::string, std::shared_ptr<MaterializedOutputBuffer>>>
+      buffers_;
 };
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(
   GTest::gtest
 )
 
-set_tests_properties(presto_materialized_exchange_test PROPERTIES TIMEOUT 600)
+set_tests_properties(presto_materialized_exchange_test PROPERTIES TIMEOUT 6000)
 
 set_property(TARGET presto_materialized_exchange_test PROPERTY JOB_POOL_LINK presto_link_job_pool)
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -246,14 +246,16 @@ class MaterializedExchangeTest : public exec::test::OperatorTestBase {
         dataType,
         partitionFunctionSpec,
         replicateNullsAndAny,
-        valuesNode,
-        buffer);
+        ShuffleWriterMetadata{},
+        valuesNode);
 
     auto taskId = makeTaskId("write", 0);
+    MaterializedOutputBuffer::registerBuffer(taskId, buffer);
     auto task = makeTask(taskId, exchangeWriteNode, 0);
     task->start(numDrivers);
 
     EXPECT_TRUE(exec::test::waitForTaskCompletion(task.get(), 10'000'000));
+    MaterializedOutputBuffer::removeBuffer(taskId);
 
     // Build expected output: each driver processes the full input.
     std::vector<RowVectorPtr> expected;
@@ -602,15 +604,17 @@ TEST_F(MaterializedExchangeTest, assertBufferCloseExceptionsArePropagated) {
       dataType,
       partitionFunctionSpec,
       false,
-      valuesNode,
-      buffer);
+      ShuffleWriterMetadata{},
+      valuesNode);
 
   auto taskId = makeTaskId("write", 0);
+  MaterializedOutputBuffer::registerBuffer(taskId, buffer);
   auto task = makeTask(taskId, exchangeWriteNode, 0);
   task->start(numDrivers);
 
   EXPECT_TRUE(exec::test::waitForTaskFailure(task.get(), 10'000'000))
       << "Task should fail when buffer noMoreData() throws, not succeed silently";
+  MaterializedOutputBuffer::removeBuffer(taskId);
 
   cleanupDirectory(tempDir_->getPath());
 }

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -22,6 +22,8 @@
 #include "presto_cpp/main/common/tests/MutableConfigs.h"
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
+#include "presto_cpp/main/operators/MaterializedOutput.h"
+#include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -32,6 +34,7 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -1807,6 +1810,78 @@ TEST_P(TaskManagerTest, summarize) {
   taskInfo = taskManager_->deleteTask(taskId, true, true);
   // pipeline stats available when summarize set to false and task is finished
   ASSERT_GT(taskInfo->stats.pipelines.size(), 0);
+}
+
+// Minimal no-op shuffle writer for testing buffer creation without
+// requiring a real shuffle backend.
+namespace {
+class NoOpShuffleWriter : public operators::ShuffleWriter {
+ public:
+  void collect(int32_t, std::string_view, std::string_view) override {}
+  void noMoreData(bool) override {}
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {};
+  }
+};
+
+class NoOpShuffleFactory : public operators::ShuffleInterfaceFactory {
+ public:
+  static constexpr std::string_view kName{"noop_shuffle"};
+
+  std::shared_ptr<operators::ShuffleReader>
+  createReader(const std::string&, int32_t, memory::MemoryPool*) override {
+    return nullptr;
+  }
+
+  std::shared_ptr<operators::ShuffleWriter> createWriter(
+      const std::string&,
+      memory::MemoryPool*) override {
+    return std::make_shared<NoOpShuffleWriter>();
+  }
+};
+} // namespace
+
+TEST_P(TaskManagerTest, duplicateCreateTaskWithMaterializedOutput) {
+  const int32_t numPartitions = 2;
+  operators::ShuffleInterfaceFactory::registerFactory(
+      std::string(NoOpShuffleFactory::kName),
+      std::make_unique<NoOpShuffleFactory>());
+  exec::Operator::registerOperator(
+      std::make_unique<operators::MaterializedOutputTranslator>());
+
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4})});
+  auto dataType = asRowType(data->type());
+
+  auto valuesNode = exec::test::PlanBuilder().values({data}, true).planNode();
+  auto planNode = std::make_shared<operators::MaterializedOutputNode>(
+      "matOut",
+      std::vector<core::TypedExprPtr>{},
+      numPartitions,
+      dataType,
+      std::make_shared<exec::HashPartitionFunctionSpec>(
+          dataType, std::vector<column_index_t>{0}),
+      false,
+      operators::ShuffleWriterMetadata{
+          "{}", std::string(NoOpShuffleFactory::kName)},
+      valuesNode);
+  core::PlanFragment planFragment{planNode};
+
+  protocol::TaskId taskId = "dup_test.0.0.1.0";
+  protocol::TaskUpdateRequest updateRequest;
+
+  // First call creates the task and registers the buffer.
+  auto taskInfo1 = createOrUpdateTask(taskId, updateRequest, planFragment);
+  ASSERT_NE(taskInfo1, nullptr);
+  EXPECT_NE(operators::MaterializedOutputBuffer::getBuffer(taskId), nullptr);
+
+  // Second call with the same taskId is a no-op — no crash.
+  auto taskInfo2 = createOrUpdateTask(taskId, updateRequest, planFragment);
+  ASSERT_NE(taskInfo2, nullptr);
+
+  // Clean up: remove buffer, delete task, wait for cleanup.
+  operators::MaterializedOutputBuffer::removeBuffer(taskId);
+  taskManager_->deleteTask(taskId, false, false);
+  waitForAllOldTasksToBeCleaned(taskManager_.get(), 10'000'000);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2638,18 +2638,10 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
   const bool exchangeMaterializationEnabled =
       SystemConfig::instance()->exchangeMaterializationEnabled();
   if (exchangeMaterializationEnabled && !fragment.outputOrderingScheme) {
-    auto* shuffleFactory =
-        operators::ShuffleInterfaceFactory::factory(shuffleName_);
-    VELOX_CHECK_NOT_NULL(
-        shuffleFactory,
-        "ShuffleInterface factory '{}' not registered",
-        shuffleName_);
-    auto buffer = std::make_shared<operators::MaterializedOutputBuffer>(
-        partitionedOutputNode->numPartitions(),
-        *serializedShuffleWriteInfo_,
-        shuffleFactory,
-        taskId,
-        queryCtx_->pool());
+    VELOX_CHECK(
+        !shuffleName_.empty(),
+        "Shuffle name not provided from 'shuffle.name' property in "
+        "config.properties");
 
     auto materializedOutputNode =
         std::make_shared<operators::MaterializedOutputNode>(
@@ -2659,8 +2651,9 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
             partitionedOutputNode->outputType(),
             partitionedOutputNode->partitionFunctionSpecPtr(),
             partitionedOutputNode->isReplicateNullsAndAny(),
-            partitionedOutputNode->sources()[0],
-            std::move(buffer));
+            operators::ShuffleWriterMetadata{
+                *serializedShuffleWriteInfo_, shuffleName_},
+            partitionedOutputNode->sources()[0]);
 
     planFragment.planNode = std::move(materializedOutputNode);
     return planFragment;


### PR DESCRIPTION
Summary:
## Problem

In extremely rare cases (0.024%, ~4 out of 17,000 queries), when the coordinator retries or duplicates a `createTask` HTTP request, two concurrent requests race through `toVeloxQueryPlan()` — each creating a `MaterializedOutputBuffer` with the same pool name under the shared query root pool. The second call crashes with `"pool already exists"`.

```
                        TaskResource::createOrUpdateBatchTask()
                                      |
                    +----------------------------------+
                    |                                  |
             Request A                           Request B
                    |                                  |
          toVeloxQueryPlan()                 toVeloxQueryPlan()
                    |                                  |
     new MaterializedOutputBuffer()    new MaterializedOutputBuffer()
                    |                                  |
     pool->addLeafChild("mob.taskId")  pool->addLeafChild("mob.taskId")
                    |                                  |
                   OK                         CRASH: "already exists"
                    |                                  |
                    +----------------------------------+
                                      |
                       createOrUpdateTaskImpl()
                                      |
                          prestoTask->mutex  <-- too late
                                      |
                     if (prestoTask->task == nullptr)
                                      |
                         exec::Task::create()
```

The `prestoTask->mutex` deduplicates `exec::Task::create()`, but the pool collision happens before that — during plan conversion.

## Fix

Move `MaterializedOutputBuffer` creation from `toVeloxQueryPlan()` into `createOrUpdateTaskImpl()` under the `prestoTask->mutex`, after `exec::Task::create()`. The plan node (`MaterializedOutputNode`) now carries shuffle params via a `ShuffleWriterMetadata` struct instead of the buffer itself. Operators hold a `shared_ptr<MaterializedOutputBuffer>` (not a raw pointer) looked up by `taskId` from a process-wide registry at construction time.

```
                        TaskResource::createOrUpdateBatchTask()
                                      |
                    +----------------------------------+
                    |                                  |
             Request A                           Request B
                    |                                  |
          toVeloxQueryPlan()                 toVeloxQueryPlan()
                    |                                  |
     MaterializedOutputNode(params)    MaterializedOutputNode(params)
              (no pool created)              (no pool created)
                    |                                  |
                    +----------------------------------+
                                      |
                       createOrUpdateTaskImpl()
                                      |
                          prestoTask->mutex
                                      |
                     if (prestoTask->task == nullptr)
                          |                     |
                  exec::Task::create()    (Request B skipped)
                          |
              new MaterializedOutputBuffer()
                          |
              registerBuffer(taskId, buffer)
                          |
                         OK
```

## Changes

- `ShuffleWriterMetadata` struct added to `MaterializedOutput.h` — groups `shuffleWriterInfo` and `shuffleWriterFactoryName` for transport on the plan node.
- `MaterializedOutputNode` — replaced `shared_ptr<MaterializedOutputBuffer>` member with `ShuffleWriterMetadata`. Buffer is no longer created during plan conversion.
- `MaterializedOutputBuffer` — added static `registerBuffer`/`getBuffer`/`removeBuffer` backed by `folly::Synchronized<F14FastMap>`. Destructor calls `removeBuffer`.
- `MaterializedOutput` operator — holds `shared_ptr<MaterializedOutputBuffer>` (not raw pointer) looked up via `getBuffer(taskId)` at construction time.
- `TaskManager::createOrUpdateTaskImpl()` — after `exec::Task::create()`, under `prestoTask->mutex`, creates the buffer and registers it if the plan root is a `MaterializedOutputNode`.
- `PrestoToVeloxQueryPlan.cpp` — passes `ShuffleWriterMetadata` to the plan node instead of creating the buffer.

## Design

This follows the same pattern as Velox `OutputBufferManager`, which is the 1:1 streaming equivalent of `MaterializedOutputBuffer`:

- `OutputBufferManager` uses a process-wide `folly::Synchronized<unordered_map>` to store output buffers keyed by `taskId`
- Buffer creation happens inside `Task::start()` -> `initializePartitionOutput()` -> `OutputBufferManager::initializeTask()`, after task dedup
- Operators look up the buffer by `taskId` at runtime

`MaterializedOutputBuffer` now follows the same lifecycle:

| Step | OutputBufferManager | MaterializedOutputBuffer |
|------|-------------------|------------------------|
| Registry | `folly::Synchronized<map>` | `folly::Synchronized<F14FastMap>` |
| Creation | `Task::start()` under task lifecycle | `createOrUpdateTaskImpl()` under `prestoTask->mutex` |
| Lookup | `OutputBufferManager::getBuffer(taskId)` | `MaterializedOutputBuffer::getBuffer(taskId)` |
| Cleanup | `OutputBufferManager::removeTask(taskId)` | `MaterializedOutputBuffer::removeBuffer(taskId)` (destructor) |

Reviewed By: xiaoxmeng

Differential Revision: D106850939


```
== NO RELEASE NOTE ==
```