### PR TITLE
fix(native): Preserve Java aggregation iteration order across protocol

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateBeforeGroupId.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateBeforeGroupId.java
@@ -464,4 +464,41 @@ public class TestPreAggregateBeforeGroupId
                 "Output variable types must preserve original aggregation ordering to avoid " +
                 "type mismatch at PartitionedOutput in Velox native execution");
     }
+
+    @Test
+    public void testAggregationOutputsPreservesInsertionOrder()
+    {
+        // Regression test for #27902: AggregationNode.getAggregationOutputs() is
+        // the explicit list serialized to native workers so they can build the
+        // output schema in Java's order. Names chosen so alphabetical sort
+        // [count_a, sum_x] differs from insertion order [sum_x, count_a]; the
+        // getter must return insertion order. The rule is disabled here -- we
+        // only inspect the input AggregationNode, not the rewrite.
+        tester().assertThat(new PreAggregateBeforeGroupId(getFunctionManager()))
+                .setSystemProperty(PRE_AGGREGATE_BEFORE_GROUPING_SETS, "false")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    AggregationNode aggregationNode = p.aggregation(agg -> agg
+                            .addAggregation(
+                                    p.variable("sum_x", BIGINT),
+                                    p.rowExpression("sum(x)"))
+                            .addAggregation(
+                                    p.variable("count_a", BIGINT),
+                                    p.rowExpression("count(a)"))
+                            .globalGrouping()
+                            .step(AggregationNode.Step.PARTIAL)
+                            .source(p.values(a, x)));
+
+                    List<String> outputNames = aggregationNode.getAggregationOutputs().stream()
+                            .map(VariableReferenceExpression::getName)
+                            .collect(Collectors.toList());
+                    assertEquals(outputNames, ImmutableList.of("sum_x", "count_a"),
+                            "getAggregationOutputs() must return aggregations.keySet() in " +
+                            "LinkedHashMap insertion order so native workers build the " +
+                            "schema in Java's order");
+                    return aggregationNode;
+                })
+                .doesNotFire();
+    }
 }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1084,9 +1084,21 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   std::vector<std::string> aggregateNames;
   std::vector<core::AggregationNode::Aggregate> aggregates;
 
+  // Use aggregationOutputs (Java's LinkedHashMap insertion order) when sent by
+  // the coordinator. Iterating node->aggregations directly is unsafe because
+  // protocol::Map = std::map<VRE, ...> sorts by variable name, which can
+  // diverge from Java's order and shift channel positions at exchange
+  // operators (see prestodb/presto#27902). Fall back to map iteration only
+  // for backward compatibility with older coordinators that don't send the
+  // field (aggregationOutputs is Optional<> in the protocol).
   std::vector<protocol::VariableReferenceExpression> outputVariables;
-  for (const auto& [variable, _] : node->aggregations) {
-    outputVariables.push_back(variable);
+  if (node->aggregationOutputs != nullptr &&
+      !node->aggregationOutputs->empty()) {
+    outputVariables = *node->aggregationOutputs;
+  } else {
+    for (const auto& [variable, _] : node->aggregations) {
+      outputVariables.push_back(variable);
+    }
   }
   toAggregations(
       outputVariables, node->aggregations, aggregates, aggregateNames);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -1018,6 +1018,15 @@ void to_json(json& j, const AggregationNode& p) {
       "aggregations");
   to_json_key(
       j,
+      "aggregationOutputs",
+      p.aggregationOutputs,
+      "AggregationNode",
+      "List<VariableReferenceExpression>",
+      "aggregationOutputs");
+  // to_json_key for std::shared_ptr only emits when the pointer is non-null,
+  // matching the pattern for other Optional<> ExtraFields.
+  to_json_key(
+      j,
       "groupingSets",
       p.groupingSets,
       "AggregationNode",
@@ -1066,6 +1075,17 @@ void from_json(const json& j, AggregationNode& p) {
       "AggregationNode",
       "Map<VariableReferenceExpression, Aggregation>",
       "aggregations");
+  // from_json_key for std::shared_ptr tolerates a missing key, so older
+  // coordinators that predate this field deserialize cleanly with
+  // p.aggregationOutputs left as nullptr; the converter falls back to
+  // iterating `aggregations` in that case.
+  from_json_key(
+      j,
+      "aggregationOutputs",
+      p.aggregationOutputs,
+      "AggregationNode",
+      "List<VariableReferenceExpression>",
+      "aggregationOutputs");
   from_json_key(
       j,
       "groupingSets",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -443,6 +443,7 @@ namespace facebook::presto::protocol {
 struct AggregationNode : public PlanNode {
   std::shared_ptr<PlanNode> source = {};
   Map<VariableReferenceExpression, Aggregation> aggregations = {};
+  std::shared_ptr<List<VariableReferenceExpression>> aggregationOutputs = {};
   GroupingSetDescriptor groupingSets = {};
   List<VariableReferenceExpression> preGroupedVariables = {};
   AggregationNodeStep step = {};

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -39,6 +39,13 @@ ExtraFields:
     FunctionHandle: functionHandle
     List<RowExpression>: arguments
 
+  # Java's LinkedHashMap iteration order for aggregations.keySet(), serialized
+  # so native workers can build the AggregationNode output schema in the same
+  # order. Optional for backward compatibility with coordinators that predate
+  # this field (see prestodb/presto#27902).
+  AggregationNode:
+    Optional<List<VariableReferenceExpression>>: aggregationOutputs
+
   PlanNode:
     PlanNodeId: id
 

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/AggregationNodeTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/AggregationNodeTest.cpp
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
+
+using namespace facebook::presto::protocol;
+
+class AggregationNodeTest : public ::testing::Test {};
+
+namespace {
+VariableReferenceExpression variable(std::string name, std::string type) {
+  VariableReferenceExpression v;
+  v._type = "variable";
+  v.name = std::move(name);
+  v.type = std::move(type);
+  return v;
+}
+} // namespace
+
+// Verifies that protocol::AggregationNode::aggregationOutputs survives a JSON
+// round-trip and preserves the explicit list order. Java sends this field in
+// LinkedHashMap insertion order so native workers can build the
+// AggregationNode output schema in the same order as the Java planner.
+// Without it, iterating node->aggregations (std::map<VRE>, sorted by name)
+// can shift channel positions and cause type mismatches at exchange
+// operators (see prestodb/presto#27902).
+TEST_F(AggregationNodeTest, aggregationOutputsRoundTripPreservesOrder) {
+  // Names chosen so sorted order [count_a, sum_b] differs from insertion
+  // order [sum_b, count_a] -- mirroring the production scenario where
+  // `approx_distinct_*` sorted before `sum_*` while Java inserted sums first.
+  AggregationNode original;
+  original.id = "1";
+  original.aggregationOutputs =
+      std::make_shared<List<VariableReferenceExpression>>(
+          List<VariableReferenceExpression>{
+              variable("sum_b", "double"),
+              variable("count_a", "bigint"),
+          });
+  original.groupingSets.groupingKeys = {};
+  original.groupingSets.groupingSetCount = 1;
+  original.groupingSets.globalGroupingSets = {0};
+  original.step = AggregationNodeStep::PARTIAL;
+
+  json j = original;
+  AggregationNode parsed = j;
+
+  ASSERT_NE(parsed.aggregationOutputs, nullptr);
+  ASSERT_EQ(parsed.aggregationOutputs->size(), 2);
+  EXPECT_EQ((*parsed.aggregationOutputs)[0].name, "sum_b");
+  EXPECT_EQ((*parsed.aggregationOutputs)[0].type, "double");
+  EXPECT_EQ((*parsed.aggregationOutputs)[1].name, "count_a");
+  EXPECT_EQ((*parsed.aggregationOutputs)[1].type, "bigint");
+}
+
+// Verifies backward compatibility: when JSON omits aggregationOutputs (older
+// coordinators), deserialization succeeds and the field is left empty.
+// PrestoToVeloxQueryPlan.cpp falls back to iterating `aggregations` in that
+// case.
+TEST_F(AggregationNodeTest, missingAggregationOutputsIsBackwardCompatible) {
+  std::string str = R"({
+        "@type": ".AggregationNode",
+        "id": "1",
+        "aggregations": {},
+        "groupingSets": {
+          "groupingKeys": [],
+          "groupingSetCount": 1,
+          "globalGroupingSets": [0]
+        },
+        "preGroupedVariables": [],
+        "step": "PARTIAL"
+      })";
+
+  json j = json::parse(str);
+  AggregationNode parsed = j;
+
+  EXPECT_EQ(parsed.aggregationOutputs, nullptr);
+  EXPECT_TRUE(parsed.aggregations.empty());
+}

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 add_executable(
   presto_protocol_test
+  AggregationNodeTest.cpp
   Base64Test.cpp
   CallExpressionTest.cpp
   ConstantExpressionTest.cpp

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
@@ -53,6 +53,7 @@ public final class AggregationNode
     private final Optional<VariableReferenceExpression> groupIdVariable;
     private final Optional<Integer> aggregationId;
     private final List<VariableReferenceExpression> outputs;
+    private final List<VariableReferenceExpression> aggregationOutputs;
 
     @JsonCreator
     public AggregationNode(
@@ -107,9 +108,11 @@ public final class AggregationNode
         checkArgument(preGroupedVariables.isEmpty() || groupingSets.getGroupingKeys().containsAll(preGroupedVariables), "Pre-grouped variables must be a subset of the grouping keys");
         this.preGroupedVariables = unmodifiableList(new ArrayList<>(preGroupedVariables));
 
+        this.aggregationOutputs = unmodifiableList(new ArrayList<>(this.aggregations.keySet()));
+
         ArrayList<VariableReferenceExpression> keys = new ArrayList<>(groupingSets.getGroupingKeys());
         hashVariable.ifPresent(keys::add);
-        keys.addAll(new ArrayList<>(aggregations.keySet()));
+        keys.addAll(aggregationOutputs);
 
         this.outputs = unmodifiableList(keys);
     }
@@ -181,6 +184,20 @@ public final class AggregationNode
     public Map<VariableReferenceExpression, Aggregation> getAggregations()
     {
         return aggregations;
+    }
+
+    // Serializes the aggregation output variables in deterministic Java-side
+    // (LinkedHashMap) iteration order so native workers (Prestissimo) can build
+    // the AggregationNode output schema in the same order. Without this, the
+    // C++ protocol deserializes `aggregations` into std::map<VRE> (sorted by
+    // name), which can diverge from Java's order and cause type mismatches at
+    // exchange operators (see #27902). Marked READ_ONLY because it is derived
+    // from `aggregations` — the JsonCreator constructor reconstructs the same
+    // order from the LinkedHashMap copy of `aggregations`.
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public List<VariableReferenceExpression> getAggregationOutputs()
+    {
+        return aggregationOutputs;
     }
 
     @JsonProperty


### PR DESCRIPTION
## Summary

`protocol::AggregationNode::aggregations` is `std::map<VRE, Aggregation>` on the native side (sorted by variable name); the Java side iterates `LinkedHashMap` insertion order. When the two orders diverge — e.g. `approx_distinct_*` mixed with `sum_*`, alphabetical sort `approx_distinct < sum` but Java inserts `sum`s first — the native `AggregationNode` output schema differs from the Java planner's. Channel positions shift and type mismatches surface at exchange operators:

```
type_->kindEquals(vector.type()) Type mismatch: BIGINT vs. DOUBLE
Operator: LocalPartition(...)
```

#27493 partially addressed this by switching three Java optimizer rules from `HashMap` to `LinkedHashMap` (deterministic insertion order), but did not align Java with the native side's sort. Queries whose variable names happened to sort consistently with their insertion order passed; others still crashed.

This adds an explicit `aggregationOutputs: List<VariableReferenceExpression>` field, populated on the Java side from `aggregations.keySet()` in `LinkedHashMap` order. The native converter uses this list when present and falls back to `std::map` iteration only for older coordinators that don't send the field (so rolling upgrades are safe).

Fixes #27902.

## Changes

- `presto-spi/.../AggregationNode.java`: `@JsonProperty(READ_ONLY) getAggregationOutputs()` — derived from `aggregations`, no constructor change.
- `presto_protocol_core.h`/`.cpp`: `List<VRE> aggregationOutputs` on `protocol::AggregationNode`, with backward-compatible `from_json`.
- `PrestoToVeloxQueryPlan.cpp`: converter uses `aggregationOutputs` when non-empty; falls back to map iteration otherwise.
- Tests: protocol round-trip + backward-compat (`AggregationNodeTest.cpp`); Java getter ordering (`TestPreAggregateBeforeGroupId`).

## Test plan

- [ ] `mvn test -pl presto-main-base -Dtest=TestPreAggregateBeforeGroupId#testAggregationOutputsPreservesInsertionOrder`
- [ ] `presto-native-execution` build + run `presto_protocol_test --gtest_filter="AggregationNodeTest.*"`
- [ ] Existing `TestPreAggregateBeforeGroupId` suite stays green
- [ ] Manually verify a reproducer query (`approx_distinct(...)` + `sum(...)` under `GROUPING SETS` with `optimizer.pre_aggregate_before_grouping_sets=true`) no longer crashes on a Prestissimo cluster

## Release notes

\`\`\`
== RELEASE NOTES ==

Native Execution Changes
* Fix runtime type-mismatch crashes at exchange operators in Prestissimo when aggregation variable names sort differently from their Java allocation order. The protocol now carries an explicit aggregation output ordering so native workers build the AggregationNode output schema in the order the Java planner intended.
\`\`\`

## Summary by Sourcery

Ensure native AggregationNode output schemas follow Java planner aggregation ordering by explicitly propagating aggregation output variables through the protocol and converter.

Bug Fixes:
- Prevent type-mismatch failures in native execution caused by differing aggregation iteration orders between Java and C++.

Enhancements:
- Expose an explicit aggregationOutputs list on AggregationNode in the Java SPI and carry it through the native protocol for deterministic aggregation output ordering.

Tests:
- Add Java and C++ regression tests to verify aggregation output ordering is preserved and that the protocol remains backward compatible when aggregationOutputs is absent.