### PR TITLE
fix: Handle negative user hash codes in router scheduler

### DIFF
--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
@@ -32,7 +32,7 @@ public class UserHashScheduler
     public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         try {
-            return Optional.of(candidates.get(routerRequestInfo.getUser().hashCode() % candidates.size()));
+            return Optional.of(candidates.get(Math.floorMod(routerRequestInfo.getUser().hashCode(), candidates.size())));
         }
         catch (ArithmeticException e) {
             log.warn(e, "Error getting destination for user " + routerRequestInfo.getUser());

--- a/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
@@ -74,7 +74,7 @@ public class TestScheduler
     {
         return new Object[][]
                 {
-                        {"test"}, {"user"}, {"1234"},
+                        {"test"}, {"user"}, {"1234"}, {"OpenAI"},
                 };
     }
 


### PR DESCRIPTION
## Description
Use `Math.floorMod` in `UserHashScheduler` so usernames with negative hash codes still map to a valid candidate index. Also extend the existing scheduler test with a username that produces a negative hash code.

## Motivation and Context
Java's `%` operator preserves the sign of the left operand, so `hashCode() % candidates.size()` can be negative and throw `IndexOutOfBoundsException` for normal usernames.

## Impact
Fixes a router scheduling bug in `USER_HASH` mode. No API or configuration changes.

## Test Plan
- added a regression case to `TestScheduler` using `OpenAI`
- attempted `./mvnw -pl presto-router -am -DskipUI -Dtest=TestScheduler -Dsurefire.failIfNoSpecifiedTests=false test -Dair.check.skip-all -Dmaven.javadoc.skip=true --no-transfer-progress`

## Release Notes
== NO RELEASE NOTE ==
