### PR TITLE
test: Add E2E tests for map_top_n_values

### DIFF
--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -598,6 +598,7 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT map_top_n(MAP(ARRAY[CAST(nationkey AS VARCHAR)], ARRAY[comment]), 3) from nation");
         assertQuery("SELECT map_top_n_keys(MAP(ARRAY[orderkey], ARRAY[custkey]), 3) from orders");
         assertQuery("SELECT map_top_n_values(MAP(ARRAY[orderkey], ARRAY[custkey]), 3) from orders");
+        assertQuery("SELECT map_top_n_values(MAP(ARRAY[regionkey], ARRAY[nationkey]), 2, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
         assertQuery("SELECT all_keys_match(MAP(ARRAY[comment], ARRAY[custkey]), k -> length(k) > 5) from orders");
         assertQuery("SELECT any_keys_match(MAP(ARRAY[comment], ARRAY[custkey]), k -> starts_with(k, 'abc')) from orders");
         assertQuery("SELECT any_values_match(MAP(ARRAY[orderkey], ARRAY[totalprice]), k -> abs(k) > 20) from orders");
@@ -621,7 +622,6 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT array_top_n(ARRAY[orderkey], 25, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from orders");
 
         // Map functions
-        assertQuery("SELECT map_top_n_values(MAP(ARRAY[comment], ARRAY[nationkey]), 2, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
         assertQuery("SELECT map_top_n_keys(MAP(ARRAY[regionkey], ARRAY[nationkey]), 5, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
 
         Session sessionWithKeyBasedSampling = Session.builder(getSession())
@@ -652,10 +652,6 @@ public class TestNativeSidecarPlugin
                 ".*Scalar function name not registered: native.default.array_least_frequent.*");
 
         // Map functions
-        assertQueryFails(session,
-                "SELECT map_top_n_values(MAP(ARRAY[comment], ARRAY[nationkey]), 2, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation",
-                ".*Scalar function native\\.default\\.map_top_n_values not registered with arguments.*",
-                true);
         assertQueryFails(session,
                 "SELECT map_top_n_keys(MAP(ARRAY[regionkey], ARRAY[nationkey]), 5, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation",
                 ".*Scalar function native\\.default\\.map_top_n_keys not registered with arguments.*",

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestMapTopNFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestMapTopNFunctions.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+public class TestMapTopNFunctions
+        extends AbstractTestQueryFramework
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .setExtraProperties(ImmutableMap.of("inline-sql-functions", "false"))
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        else {
+            queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        }
+        return queryRunner;
+    }
+
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setExtraProperties(ImmutableMap.of("inline-sql-functions", "true"))
+                .build();
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
+    }
+
+    @Test
+    public void testMapTopNValues()
+    {
+        assertQuery("SELECT TRY(map_top_n_values(c0, BIGINT '6455219767830808341')) FROM (VALUES (MAP(ARRAY[1, 2], ARRAY[ARRAY[1, 3], ARRAY[1, 4]]))) t(c0)");
+        assertQuery("SELECT TRY(map_top_n_values(c0, BIGINT '2')) FROM (VALUES (MAP(ARRAY[1, 2, 3], ARRAY[ARRAY[1, 3], null, ARRAY[1, 4]]))) t(c0)");
+
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[3,2,5,4,1], ARRAY[1,1,1,1,1])), (MAP(ARRAY[3,2,1], ARRAY[1,1,1])), (MAP(ARRAY[2,1], ARRAY[1,1])) ) SELECT map_top_n_values(c0, 3, (x,y) -> x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[3,2,5,4,1], ARRAY[1,1,1,1,1])), (MAP(ARRAY[3,2,1], ARRAY[1,1,1])), (MAP(ARRAY[2,1], ARRAY[1,1])) ) SELECT map_top_n_values(c0, 3, (x,y) -> CAST(IF(x < y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[1,2,3,4,5], ARRAY[1,1,1,1,1])) ) SELECT map_top_n_values(c0, 3, (x, y) -> -x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[1,2,3,4,5], ARRAY[1,1,1,1,1])) ) SELECT map_top_n_values(c0, 3, (x, y) -> CAST(IF(x > y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[-2147483648, 0, 2147483647], ARRAY[1,1,1])) ) SELECT map_top_n_values(c0, 2, (x, y) -> x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[-2147483648, 0, 2147483647], ARRAY[1,1,1])) ) SELECT map_top_n_values(c0, 2, (x, y) -> CAST(IF(x < y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+
+        assertQueryFails(
+                "SELECT map_top_n_values(c0, BIGINT '6455219767830808341') FROM (VALUES (MAP(ARRAY[1, 2], ARRAY[ARRAY[null, null], ARRAY[1, 2]]))) t(c0)",
+                ".* Ordering nulls is not supported Top-level Expression: native\\.default\\.map_top_n_values\\(field, 6455219767830808341:BIGINT\\)");
+    }
+}

--- a/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeMapSqlFunctions.java
+++ b/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeMapSqlFunctions.java
@@ -34,15 +34,4 @@ public class NativeMapSqlFunctions
     {
         return "RETURN IF(n < 0, fail('n must be greater than or equal to 0'), slice(reverse(array_sort(map_keys(input), f)), 1, n))";
     }
-
-    @SqlInvokedScalarFunction(value = "map_top_n_values", deterministic = true, calledOnNullInput = true)
-    @Description("Returns the top N values of the given map sorted using the provided lambda comparator.")
-    @TypeParameter("K")
-    @TypeParameter("V")
-    @SqlParameters({@SqlParameter(name = "input", type = "map(K, V)"), @SqlParameter(name = "n", type = "int"), @SqlParameter(name = "f", type = "function(V, V, int)")})
-    @SqlType("array<V>")
-    public static String mapTopNValuesComparator()
-    {
-        return "RETURN IF(n < 0, fail('n must be greater than or equal to 0'), slice(reverse(array_sort(remove_nulls(map_values(input)), f)) || filter(map_values(input), x -> x is null), 1, n))";
-    }
 }


### PR DESCRIPTION
## Description
Add E2E tests for map_top_n_values

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
As part of https://github.com/facebookincubator/velox/issues/16041

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add end-to-end coverage for native map_top_n_values behavior and align existing sidecar tests with the new testing setup.

Enhancements:
- Remove the inlined SQL-invoked map_top_n_values comparator from the native SQL helpers now that it is covered via native execution paths.

Tests:
- Add native E2E tests comparing map_top_n_values results between native and Java engines across various inputs and custom comparators.
- Update sidecar plugin tests to exercise map_top_n_values only in the overridden inlined SQL-invoked functions configuration.