### PR TITLE
fix(native): Handle expression optimizer failures for UNKNOWN type dispatch

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
+++ b/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
@@ -70,28 +70,27 @@ protocol::RowExpressionOptimizationResult optimizeExpression(
     velox::memory::MemoryPool* pool) {
   protocol::RowExpressionOptimizationResult result;
   const auto expr = prestoToVeloxConverter.toVeloxExpr(input);
-  auto optimized =
-      velox::expression::optimize(expr, queryCtx, pool, kMakeFailExpr);
 
-  if (optimizerLevel == OptimizerLevel::kEvaluated) {
-    try {
+  try {
+    auto optimized =
+        velox::expression::optimize(expr, queryCtx, pool, kMakeFailExpr);
+
+    if (optimizerLevel == OptimizerLevel::kEvaluated) {
       const auto evalResult = tryEvaluateToConstant(optimized, queryCtx, pool);
       optimized = std::make_shared<velox::core::ConstantTypedExpr>(evalResult);
-    } catch (const velox::VeloxException& e) {
-      result.expressionFailureInfo =
-          toNativeSidecarFailureInfo(translateToPrestoException(e));
-      result.optimizedExpression = nullptr;
-      return result;
-    } catch (const std::exception& e) {
-      result.expressionFailureInfo =
-          toNativeSidecarFailureInfo(translateToPrestoException(e));
-      result.optimizedExpression = nullptr;
-      return result;
     }
-  }
 
-  result.optimizedExpression =
-      veloxToPrestoConverter.getRowExpression(optimized);
+    result.optimizedExpression =
+        veloxToPrestoConverter.getRowExpression(optimized);
+  } catch (const velox::VeloxException& e) {
+    result.expressionFailureInfo =
+        toNativeSidecarFailureInfo(translateToPrestoException(e));
+    result.optimizedExpression = nullptr;
+  } catch (const std::exception& e) {
+    result.expressionFailureInfo =
+        toNativeSidecarFailureInfo(translateToPrestoException(e));
+    result.optimizedExpression = nullptr;
+  }
   return result;
 }
 

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -867,6 +867,9 @@ public class TestNativeSidecarPlugin
                         "MAP(ARRAY[5, 7], ARRAY[2, 2]), " +
                         "MAP(), " +
                         "MAP(ARRAY[12, 72], ARRAY[4, 12])");
+
+        // Verify UNKNOWN type expressions produce a structured error instead of crashing the sidecar.
+        assertQueryFails(session, "SELECT array_except(ARRAY[], ARRAY[])", ".*Errors encountered while optimizing expressions\\..*", true);
     }
 
     @Test


### PR DESCRIPTION
## Description
- Widen the try-catch in `ExpressionOptimizer.cpp` to cover `velox::expression::optimize()` in addition to `tryEvaluateToConstant()`
- Previously, exceptions thrown during expression optimization (e.g. Velox type dispatch failures on UNKNOWN type) escaped uncaught and crashed the sidecar process
- Now any `VeloxException` or `std::exception` during optimization is caught and returned as a structured `NativeSidecarFailureInfo` error response

## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/27907.
Uncovered by https://github.com/prestodb/presto/pull/27011.

Velox's type dispatch macros (`VELOX_DYNAMIC_TEMPLATE_TYPE_DISPATCH` etc.) do not handle `TypeKind::UNKNOWN` and throw `VeloxRuntimeError` via `VELOX_FAIL`. This affects ~20 Presto functions (array_except, array_intersect, contains, array_distinct, etc.) when given empty array literals or NULL arrays.

The existing try-catch only wrapped `tryEvaluateToConstant` but the crash occurs earlier in `optimize()` during function resolution. Moving the try-catch to cover the entire optimization pipeline prevents the sidecar from crashing.

## Impact
This fix is narrow and impacts only the correctness of expressions optimized by the native expression optimizer. Other possible fixes were considered and dropped in favor of this:
1. Catch all `VeloxException`s including `VeloxRuntimeError`s in Velox expression optimizer: https://github.com/pramodsatya/velox/commit/8e9f1881af265baa2bddcead0503af069c5676ef
**Pros:** Fix in Velox itself, `makeFailExpr` produces proper failure expression that flows through normally, the sidecar's `toVeloxExpr` → `optimize` → `veloxToPresto` path works end-to-end, returns a structured failure with the error message
**Cons:** Catches broader than intended in Velox (RuntimErrors during constant folding are usually bugs), requires Velox PR

2. Fix each Presto function in Velox to guard against `UNKNOWN` type

**Where:** Each of the ~20 affected functions in `velox/functions/prestosql/`

**What:** Either:
- Switch to `_ALL` macros (requires `UnknownValue` to be hashable — not currently possible for set-based functions)
- Add explicit `if (elementType->isUnknown()) { return special_impl; }` guards before dispatch (like `approx_distinct` and `merge` already do)

**Pros:** Each function handles UNKNOWN correctly at its own level; could even produce correct results for trivial cases (empty arrays)
**Cons:** 20+ function changes, each needs its own logic, large Velox PR, doesn't protect against future functions that forget the guard

## Test Plan
e2e testcase added.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Handle failures from the native expression optimizer without crashing the sidecar and add coverage for UNKNOWN type expressions.

Bug Fixes:
- Catch exceptions thrown during native expression optimization (including UNKNOWN type dispatch failures) and return structured NativeSidecarFailureInfo instead of crashing the sidecar process.

Tests:
- Extend native expression optimizer integration test to verify UNKNOWN-type expressions return a structured error rather than crashing.