### PR TITLE
Pushdown certain casts to scan by the PushdownWidenCast rule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/yingsu00/velox.git
+        branch = DateToTimestamp 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/BenchmarkPushDownWidenCast.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/BenchmarkPushDownWidenCast.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_WIDEN_CAST_ENABLED;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.ORDERS;
+
+/**
+ * Microbenchmark comparing query latency with and without the {@code PushDownWidenCast} optimizer.
+ *
+ * <p>Uses a {@link DistributedQueryRunner} backed by Hive in PARQUET format, mirroring the
+ * production path taken by the Velox native worker. The benchmark runs a fixed number of warm-up
+ * and measured iterations for each query/session combination and prints a comparison table to
+ * stdout.
+ *
+ * <p><b>Note:</b> The {@code PushDownWidenCast} optimizer only fires when both
+ * {@code push_down_widen_cast_enabled=true} and {@code native_execution_enabled=true} are set.
+ * The Java Hive connector does not perform type widening during scan, so the optimization is
+ * gated on native execution. Running this benchmark without a Velox native worker will show
+ * ~0% improvement (optimizer does not fire on the Java path).
+ *
+ * <p>Run:
+ * <pre>
+ *   mvn test -pl presto-hive -Dtest=BenchmarkPushDownWidenCast -Dcheckstyle.skip=true
+ * </pre>
+ */
+@Test(singleThreaded = true)
+public class BenchmarkPushDownWidenCast
+{
+    private static final int WARMUP = 3;
+    private static final int MEASURED = 5;
+
+    private DistributedQueryRunner queryRunner;
+    private Session sessionOn;
+    private Session sessionOff;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = (DistributedQueryRunner) HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, LINE_ITEM),
+                ImmutableMap.of(),
+                Optional.empty());
+
+        // Create PARQUET benchmark tables from the loaded TPCH tiny data
+        queryRunner.execute("DROP TABLE IF EXISTS bench_orders_parquet");
+        queryRunner.execute(
+                "CREATE TABLE bench_orders_parquet WITH (format = 'PARQUET') AS " +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderpriority, clerk, " +
+                "       shippriority, comment " +
+                "FROM orders");
+
+        queryRunner.execute("DROP TABLE IF EXISTS bench_orders_parquet_ext");
+        queryRunner.execute(
+                "CREATE TABLE bench_orders_parquet_ext WITH (format = 'PARQUET') AS " +
+                "SELECT orderkey, custkey, " +
+                "       shippriority, " +
+                "       cast(shippriority AS tinyint)  AS tiny_shippriority, " +
+                "       cast(shippriority AS smallint) AS small_shippriority " +
+                "FROM orders");
+
+        queryRunner.execute("DROP TABLE IF EXISTS bench_lineitem_parquet");
+        queryRunner.execute(
+                "CREATE TABLE bench_lineitem_parquet WITH (format = 'PARQUET') AS " +
+                "SELECT orderkey, linenumber, quantity, extendedprice, discount, tax " +
+                "FROM lineitem");
+
+        sessionOff = Session.builder(queryRunner.getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "false")
+                .build();
+
+        sessionOn = Session.builder(queryRunner.getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "true")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.execute("DROP TABLE IF EXISTS bench_orders_parquet");
+            queryRunner.execute("DROP TABLE IF EXISTS bench_orders_parquet_ext");
+            queryRunner.execute("DROP TABLE IF EXISTS bench_lineitem_parquet");
+            queryRunner.close();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Benchmark queries
+    // -----------------------------------------------------------------------
+
+    private static final String Q_SIMPLE_PROJECTION =
+            "SELECT CAST(shippriority AS BIGINT) FROM bench_orders_parquet";
+
+    private static final String Q_AGGREGATION =
+            "SELECT CAST(shippriority AS BIGINT), count(*), sum(CAST(shippriority AS BIGINT)) " +
+            "FROM bench_orders_parquet GROUP BY 1";
+
+    private static final String Q_MULTI_COLUMN =
+            "SELECT " +
+            "    CAST(shippriority AS BIGINT)       AS pri_big, " +
+            "    CAST(tiny_shippriority AS INTEGER) AS tiny_to_int, " +
+            "    CAST(small_shippriority AS BIGINT) AS small_to_big " +
+            "FROM bench_orders_parquet_ext";
+
+    private static final String Q_JOIN =
+            "SELECT o.orderkey, CAST(o.shippriority AS BIGINT), l.linenumber " +
+            "FROM bench_orders_parquet o JOIN bench_lineitem_parquet l ON o.orderkey = l.orderkey";
+
+    // -----------------------------------------------------------------------
+    // Test entry point
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void runBenchmark()
+    {
+        System.out.println();
+        System.out.println("=".repeat(100));
+        System.out.println("BenchmarkPushDownWidenCast  (warmup=" + WARMUP + "  measured=" + MEASURED + ")");
+        System.out.println("NOTE: Full scan-level benefit requires Velox native execution.");
+        System.out.println("      Java-worker savings: elimination of the ProjectNode CAST operator only.");
+        System.out.println("=".repeat(100));
+
+        runCase("simple_projection", Q_SIMPLE_PROJECTION);
+        runCase("aggregation", Q_AGGREGATION);
+        runCase("multi_column_cast", Q_MULTI_COLUMN);
+        runCase("join_with_cast", Q_JOIN);
+
+        System.out.println("=".repeat(100));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private void runCase(String name, String sql)
+    {
+        System.out.printf("%n  %-25s%n", name);
+
+        long offMs = timeQuery(sessionOff, sql);
+        long onMs = timeQuery(sessionOn, sql);
+
+        double pct = offMs > 0 ? 100.0 * (offMs - onMs) / offMs : 0;
+        System.out.printf("    opt=OFF  %5d ms  |  opt=ON  %5d ms  |  improvement %+.1f%%%n",
+                offMs, onMs, pct);
+    }
+
+    /** Runs the query {@code WARMUP+MEASURED} times; returns the median of the measured runs in ms. */
+    private long timeQuery(Session session, String sql)
+    {
+        // warm-up
+        for (int i = 0; i < WARMUP; i++) {
+            MaterializedResult ignored = queryRunner.execute(session, sql);
+        }
+
+        List<Long> durations = new ArrayList<>(MEASURED);
+        for (int i = 0; i < MEASURED; i++) {
+            long t0 = System.currentTimeMillis();
+            MaterializedResult ignored = queryRunner.execute(session, sql);
+            durations.add(System.currentTimeMillis() - t0);
+        }
+
+        return median(durations);
+    }
+
+    private static long median(List<Long> values)
+    {
+        List<Long> sorted = new ArrayList<>(values);
+        sorted.sort(Long::compareTo);
+        return sorted.get(sorted.size() / 2);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPushDownWidenCastHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPushDownWidenCastHiveLogicalPlanner.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_WIDEN_CAST_ENABLED;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * End-to-end tests verifying that {@code PushDownWidenCast} correctly pushes widening type casts
+ * (e.g., INTEGER→BIGINT) into Hive/Parquet {@code TableScanNode}s so that the Velox Parquet
+ * reader can apply the coercion inline during column reading.
+ *
+ * <p>Plan verification checks two properties:
+ * <ol>
+ *   <li>The {@code TableScanNode} that reads an integer-typed column directly outputs a variable
+ *       of the <em>wider</em> type after the optimization fires.</li>
+ *   <li>No {@code ProjectNode} between the scan and the output contains a CAST expression from
+ *       the narrow to the wide type.</li>
+ * </ol>
+ */
+@Test(singleThreaded = true)
+public class TestPushDownWidenCastHiveLogicalPlanner
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, LINE_ITEM),
+                ImmutableMap.of(),
+                Optional.empty());
+    }
+
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return getQueryRunner();
+    }
+
+    // -----------------------------------------------------------------------
+    // Table set-up / tear-down helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates a PARQUET-format table containing representative narrow-type columns:
+     * <ul>
+     *   <li>{@code tiny_col}  — TINYINT</li>
+     *   <li>{@code small_col} — SMALLINT</li>
+     *   <li>{@code int_col}   — INTEGER  (shippriority from orders)</li>
+     *   <li>{@code real_col}  — REAL</li>
+     *   <li>{@code bigint_col}— BIGINT</li>
+     * </ul>
+     */
+    private void createWidenCastTable(QueryRunner queryRunner)
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS widen_cast_test");
+        queryRunner.execute(
+                "CREATE TABLE widen_cast_test WITH (format = 'PARQUET') AS " +
+                "SELECT " +
+                "    orderkey, " +
+                "    cast(shippriority AS tinyint)  AS tiny_col, " +
+                "    cast(shippriority AS smallint) AS small_col, " +
+                "    shippriority                   AS int_col, " +
+                "    cast(totalprice AS real)        AS real_col, " +
+                "    cast(orderkey AS bigint)        AS bigint_col " +
+                "FROM orders LIMIT 1000");
+    }
+
+    private void dropWidenCastTable(QueryRunner queryRunner)
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS widen_cast_test");
+    }
+
+    // -----------------------------------------------------------------------
+    // Session helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Session for plan-structure checks only. Includes {@code native_execution_enabled=true}
+     * so the optimizer fires, but must NOT be used to actually execute queries on the Java path
+     * (the Java connector does not perform type widening during scan).
+     */
+    private Session widenCastEnabledForPlan()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "true")
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .build();
+    }
+
+    // -----------------------------------------------------------------------
+    // Plan inspection helpers
+    // -----------------------------------------------------------------------
+
+    private static TableScanNode findTableScan(Plan plan, String tableName)
+    {
+        return searchFrom(plan.getRoot())
+                .where(node -> isTableScanNode(node, tableName))
+                .findOnlyElement();
+    }
+
+    private static boolean isTableScanNode(PlanNode node, String tableName)
+    {
+        return node instanceof TableScanNode &&
+                ((HiveTableHandle) ((TableScanNode) node).getTable().getConnectorHandle())
+                        .getTableName().equals(tableName);
+    }
+
+    /**
+     * Returns true if any {@code ProjectNode} in the plan contains a widening-cast
+     * {@code CallExpression} (CAST that widens to a wider numeric type) above the given scan.
+     */
+    private static boolean planHasWideningCastProject(Plan plan, String tableName)
+    {
+        return searchFrom(plan.getRoot())
+                .where(node -> node instanceof ProjectNode)
+                .findAll()
+                .stream()
+                .anyMatch(node -> {
+                    ProjectNode project = (ProjectNode) node;
+                    return project.getAssignments().getExpressions().stream()
+                            .anyMatch(TestPushDownWidenCastHiveLogicalPlanner::isWideningCastExpr);
+                });
+    }
+
+    private static boolean isWideningCastExpr(RowExpression expr)
+    {
+        if (!(expr instanceof CallExpression)) {
+            return false;
+        }
+        CallExpression call = (CallExpression) expr;
+        // A CAST expression has display name "CAST" and exactly one argument.
+        if (call.getArguments().size() != 1) {
+            return false;
+        }
+        // Check the argument type is a known narrow numeric type and the output is wider.
+        com.facebook.presto.common.type.Type from = call.getArguments().get(0).getType();
+        com.facebook.presto.common.type.Type to = call.getType();
+        return (from.equals(TINYINT) && (to.equals(SMALLINT) || to.equals(INTEGER) || to.equals(BIGINT)))
+                || (from.equals(SMALLINT) && (to.equals(INTEGER) || to.equals(BIGINT)))
+                || (from.equals(INTEGER) && to.equals(BIGINT))
+                || (from.equals(REAL) && to.equals(DOUBLE));
+    }
+
+    private static boolean scanOutputsType(TableScanNode scan, com.facebook.presto.common.type.Type type)
+    {
+        return scan.getOutputVariables().stream().anyMatch(v -> v.getType().equals(type));
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — plan structure (INTEGER → BIGINT)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testIntegerToBigintCastIsPushedDownToScan()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT CAST(int_col AS BIGINT) FROM widen_cast_test";
+
+            // With optimization: scan must directly output BIGINT; no widening CAST in projects.
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+            assertTrue(scanOutputsType(scanWith, BIGINT),
+                    "Expected scan to output BIGINT after optimization");
+            assertFalse(scanOutputsType(scanWith, INTEGER),
+                    "Expected INTEGER column to be replaced by BIGINT in scan output");
+            assertFalse(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected no widening CAST ProjectNode above scan when optimization is enabled");
+
+            // Without optimization: scan outputs INTEGER; a CAST project must exist.
+            Plan planWithout = plan(sql, getQueryRunner().getDefaultSession());
+            TableScanNode scanWithout = findTableScan(planWithout, "widen_cast_test");
+            assertTrue(scanOutputsType(scanWithout, INTEGER),
+                    "Expected scan to output INTEGER when optimization is disabled");
+            assertTrue(planHasWideningCastProject(planWithout, "widen_cast_test"),
+                    "Expected a widening CAST ProjectNode above scan when optimization is disabled");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    @Test
+    public void testSmallintToIntegerCastIsPushedDownToScan()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT CAST(small_col AS INTEGER) FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+            assertTrue(scanOutputsType(scanWith, INTEGER),
+                    "Expected scan to output INTEGER after SMALLINT->INTEGER push-down");
+            assertFalse(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected no widening CAST in ProjectNode above scan");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    @Test
+    public void testTinyintToBigintCastIsPushedDownToScan()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT CAST(tiny_col AS BIGINT) FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+            assertTrue(scanOutputsType(scanWith, BIGINT),
+                    "Expected scan to output BIGINT after TINYINT->BIGINT push-down");
+            assertFalse(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected no widening CAST in ProjectNode above scan");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    @Test
+    public void testRealToDoubleCastIsPushedDownToScan()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT CAST(real_col AS DOUBLE) FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+            assertTrue(scanOutputsType(scanWith, DOUBLE),
+                    "Expected scan to output DOUBLE after REAL->DOUBLE push-down");
+            assertFalse(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected no widening CAST in ProjectNode above scan");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — negative: non-widening casts must NOT be pushed
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNarrowingCastIsNotPushedDown()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            // BIGINT -> INTEGER is a narrowing cast; must not be pushed.
+            String sql = "SELECT CAST(bigint_col AS INTEGER) FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+            // Scan must still output BIGINT for bigint_col (not replaced).
+            assertTrue(scanOutputsType(scanWith, BIGINT),
+                    "Expected scan to still output BIGINT — narrowing cast must not be pushed");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    @Test
+    public void testOptimizationDisabledByDefault()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT CAST(int_col AS BIGINT) FROM widen_cast_test";
+
+            // Default session has push_down_widen_cast_enabled = false.
+            Plan planDefault = plan(sql, queryRunner.getDefaultSession());
+            TableScanNode scanDefault = findTableScan(planDefault, "widen_cast_test");
+            assertTrue(scanOutputsType(scanDefault, INTEGER),
+                    "Expected scan to output INTEGER with optimization disabled (default)");
+            assertTrue(planHasWideningCastProject(planDefault, "widen_cast_test"),
+                    "Expected CAST ProjectNode above scan with optimization disabled (default)");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — conflict handling (narrow variable used elsewhere in the plan)
+    // -----------------------------------------------------------------------
+
+    /**
+     * When the narrow variable is also passed through the ProjectNode (i.e. used in a second
+     * output column), the optimization is skipped — the plan is unchanged and the scan outputs
+     * only the narrow variable (the CAST remains in the ProjectNode).
+     */
+    @Test
+    public void testConflictIsSkipped()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            // int_col is used in two places: the CAST and the raw column reference.
+            String sql = "SELECT int_col, CAST(int_col AS BIGINT) FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+
+            // The scan must NOT have BIGINT added (conflict → skip).
+            assertFalse(scanOutputsType(scanWith, BIGINT),
+                    "Expected no BIGINT in scan output when narrow var is used elsewhere (conflict case)");
+            assertTrue(scanOutputsType(scanWith, INTEGER),
+                    "Expected INTEGER column to remain in scan output in the conflict case");
+
+            // The CAST must remain in a ProjectNode since the optimization was skipped.
+            assertTrue(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected CAST ProjectNode to remain when optimization is skipped due to conflict");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — multi-column widening in one ProjectNode
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMultipleWideningCastsInSingleProject()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            createWidenCastTable(queryRunner);
+
+            String sql = "SELECT " +
+                    "CAST(tiny_col AS SMALLINT), " +
+                    "CAST(small_col AS BIGINT), " +
+                    "CAST(int_col AS BIGINT), " +
+                    "CAST(real_col AS DOUBLE) " +
+                    "FROM widen_cast_test";
+
+            Plan planWith = plan(sql, widenCastEnabledForPlan());
+            TableScanNode scanWith = findTableScan(planWith, "widen_cast_test");
+
+            // All four widened types should appear directly in scan output.
+            assertTrue(scanOutputsType(scanWith, SMALLINT),
+                    "Expected SMALLINT from TINYINT->SMALLINT push-down");
+            assertTrue(scanOutputsType(scanWith, BIGINT),
+                    "Expected BIGINT from INTEGER->BIGINT push-down");
+            assertTrue(scanOutputsType(scanWith, DOUBLE),
+                    "Expected DOUBLE from REAL->DOUBLE push-down");
+            assertFalse(planHasWideningCastProject(planWith, "widen_cast_test"),
+                    "Expected no widening CAST ProjectNodes above scan");
+        }
+        finally {
+            dropWidenCastTable(queryRunner);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — TPCH orders table (uses existing HiveQueryRunner tables)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Verify push-down works against the TPCH {@code orders} table (ORC/DWRF format) to confirm
+     * the optimizer rule fires independently of file format — format-specific pushdown in the
+     * reader is orthogonal to the planner-level cast elimination.
+     */
+    @Test
+    public void testWideningCastOnTpchOrdersTable()
+    {
+        // orders.shippriority is INTEGER in the TPCH schema.
+        String sql = "SELECT CAST(shippriority AS BIGINT), sum(CAST(shippriority AS BIGINT)) " +
+                "FROM orders GROUP BY 1 ORDER BY 1";
+
+        Plan planWith = plan(sql, widenCastEnabledForPlan());
+        TableScanNode scanWith = findTableScan(planWith, "orders");
+        assertTrue(scanOutputsType(scanWith, BIGINT),
+                "Expected BIGINT in scan output after CAST push-down on orders.shippriority");
+        assertFalse(planHasWideningCastProject(planWith, "orders"),
+                "Expected no CAST ProjectNode above orders scan");
+    }
+
+    @Test
+    public void testWideningCastWithFilterOnOrders()
+    {
+        // Verify the optimization still fires when there is a filter on the table.
+        String sql = "SELECT CAST(shippriority AS BIGINT) FROM orders WHERE orderkey < 1000";
+
+        Plan planWith = plan(sql, widenCastEnabledForPlan());
+        TableScanNode scanWith = findTableScan(planWith, "orders");
+        assertTrue(scanOutputsType(scanWith, BIGINT),
+                "Expected BIGINT scan output even with a filter present");
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -235,6 +235,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_PAYLOAD_JOINS = "optimize_payload_joins";
     public static final String TARGET_RESULT_SIZE = "target_result_size";
     public static final String PUSHDOWN_DEREFERENCE_ENABLED = "pushdown_dereference_enabled";
+    public static final String PUSH_DOWN_WIDEN_CAST_ENABLED = "push_down_widen_cast_enabled";
     public static final String ENABLE_DYNAMIC_FILTERING = "enable_dynamic_filtering";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
@@ -1210,6 +1211,11 @@ public final class SystemSessionProperties
                         PUSHDOWN_DEREFERENCE_ENABLED,
                         "Experimental: enable dereference pushdown",
                         featuresConfig.isPushdownDereferenceEnabled(),
+                        false),
+                booleanProperty(
+                        PUSH_DOWN_WIDEN_CAST_ENABLED,
+                        "Enable push-down of widening integer upcasts and compatible type casts (e.g., INTEGER->BIGINT, DATE->TIMESTAMP) to TableScan",
+                        featuresConfig.isPushDownWidenCastEnabled(),
                         false),
                 new PropertyMetadata<>(
                         INDEX_LOADER_TIMEOUT,
@@ -3105,6 +3111,11 @@ public final class SystemSessionProperties
     public static boolean isPushdownDereferenceEnabled(Session session)
     {
         return session.getSystemProperty(PUSHDOWN_DEREFERENCE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isPushDownWidenCastEnabled(Session session)
+    {
+        return session.getSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, Boolean.class);
     }
 
     public static Duration getIndexLoaderTimeout(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -218,6 +218,7 @@ public class FeaturesConfig
     private boolean retryQueryWithHistoryBasedOptimizationEnabled;
     private boolean treatLowConfidenceZeroEstimationAsUnknownEnabled;
     private boolean pushdownDereferenceEnabled;
+    private boolean pushDownWidenCastEnabled;
     private boolean inlineSqlFunctions = true;
     private boolean checkAccessControlOnUtilizedColumnsOnly = true;
     private boolean checkAccessControlWithSubfields;
@@ -1998,6 +1999,19 @@ public class FeaturesConfig
     public boolean isPushdownDereferenceEnabled()
     {
         return pushdownDereferenceEnabled;
+    }
+
+    @Config("optimizer.push-down-widen-cast-enabled")
+    @ConfigDescription("Enable push-down of widening integer upcasts and compatible type casts (e.g., INTEGER->BIGINT, DATE->TIMESTAMP) to TableScan")
+    public FeaturesConfig setPushDownWidenCastEnabled(boolean pushDownWidenCastEnabled)
+    {
+        this.pushDownWidenCastEnabled = pushDownWidenCastEnabled;
+        return this;
+    }
+
+    public boolean isPushDownWidenCastEnabled()
+    {
+        return pushDownWidenCastEnabled;
     }
 
     @Config("index-loader-timeout")

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -206,6 +206,7 @@ import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PrefilterForLimitingAggregation;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
+import com.facebook.presto.sql.planner.optimizations.PushDownWidenCast;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
@@ -928,7 +929,22 @@ public class PlanOptimizers
                                 new PruneRedundantProjectionAssignments(),
                                 // Re-run RemoveRedundantTableFunctionProcessor after SimplifyPlanWithEmptyInput to optimize empty input tables to empty ValueNode
                                 new RemoveRedundantTableFunctionProcessor())),
-                new PushdownSubfields(metadata, expressionOptimizerManager));
+                new PushdownSubfields(metadata, expressionOptimizerManager),
+                // Push widening casts (e.g., INTEGER->BIGINT, DATE->TIMESTAMP) down to TableScan nodes.
+                // This allows scan operators to apply the type coercion inline during column reading.
+                // Run after PushdownSubfields so subfield pruning has already been applied, and
+                // before predicatePushDown so widened-type predicates can be pushed to scans.
+                new PushDownWidenCast(metadata));
+
+        // After pushing casts to TableScan, clean up identity assignments introduced by PushDownWidenCast
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                estimatedExchangesCostCalculator,
+                ImmutableSet.of(
+                        new InlineProjections(metadata.getFunctionAndTypeManager()),
+                        new RemoveRedundantIdentityProjections())));
 
         builder.add(predicatePushDown); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushDownWidenCast.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushDownWidenCast.java
@@ -1,0 +1,1109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
+import com.facebook.presto.expressions.RowExpressionRewriter;
+import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SortNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
+import static com.facebook.presto.SystemSessionProperties.isPushDownWidenCastEnabled;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Pushes widening type casts as close to the underlying {@link TableScanNode} as possible so the
+ * native (Velox) scan can apply the coercion inline at column-read time, avoiding a separate
+ * per-row CAST operator.
+ *
+ * <h3>Two push modes</h3>
+ *
+ * <p><b>Mode 1 — REPLACE (whole-RHS bare cast).</b> Pattern:
+ * <pre>
+ *   ProjectNode(wideVar := CAST(narrowVar AS T), ...)
+ *     &lt;zero or more transparent intermediate nodes&gt;
+ *       TableScanNode(narrowVar -&gt; columnHandle, ...)
+ * </pre>
+ * The whole RHS of an assignment <em>is</em> the cast and {@code narrowVar} has no other uses.
+ * We swap {@code narrowVar} for {@code wideVar} (same {@code ColumnHandle}) in the scan and turn
+ * the cast assignment into {@code wideVar := wideVar} (cleaned up by {@link
+ * com.facebook.presto.sql.planner.iterative.rule.InlineProjections}).
+ *
+ * <p><b>Mode 2 — ADD (nested subexpression cast).</b> Pattern:
+ * <pre>
+ *   ProjectNode(out := f(CAST(narrowVar AS T), ...), ...)
+ *     &lt;intermediates&gt;
+ *       TableScanNode(narrowVar -&gt; columnHandle, ...)
+ * </pre>
+ * The CAST is nested inside a wrapping expression, and {@code narrowVar} may be used elsewhere
+ * (in this Project, in upstream nodes, in a Filter predicate, etc.). We allocate a fresh
+ * {@code wideVar}, insert a new {@link ProjectNode} <em>directly above the scan</em> that computes
+ * {@code wideVar := CAST(narrowVar AS T)} (the scan itself is untouched), thread {@code wideVar}
+ * up through intermediate nodes as a passthrough, and rewrite every matching {@code CAST(narrowVar
+ * AS T)} subexpression in the top Project to a bare reference to {@code wideVar}.
+ *
+ * <p><b>Why not ADD straight into the scan's assignments?</b> Two reasons converge:
+ * <ul>
+ *   <li>Velox's TableScan operator rejects two outputs mapping to the same column at runtime
+ *       ("Cannot map from same table column to different outputs in table scan; a project node
+ *       should be used instead").</li>
+ *   <li>Several Java planner passes do
+ *       {@code ImmutableBiMap.copyOf(scan.getAssignments()).inverse()} — that fails on
+ *       duplicate {@code ColumnHandle} values.</li>
+ * </ul>
+ * Inserting a fresh Project just above the scan respects both invariants. Velox's own projection
+ * pushdown then fuses the new Project with the scan into a single {@code ScanProject} operator,
+ * so the CAST runs as part of the scan dataflow.
+ *
+ * <h3>Transparent intermediate nodes</h3>
+ *
+ * Both modes descend through these on their way to the {@link TableScanNode}:
+ * <ul>
+ *   <li>{@link FilterNode} — REPLACE skips if the predicate references {@code narrowVar};
+ *       ADD always descends (narrow is preserved).</li>
+ *   <li>{@link SortNode}, {@link TopNNode} — REPLACE skips if {@code narrowVar} is in the
+ *       ordering scheme; ADD always descends.</li>
+ *   <li>{@link LimitNode} — always transparent.</li>
+ *   <li>Intermediate {@link ProjectNode} — must pass {@code narrowVar} through as an identity
+ *       assignment; otherwise the descent bails.</li>
+ *   <li>{@link JoinNode} — REPLACE skips if {@code narrowVar} is in any join clause / filter /
+ *       hash / dynamic-filter variable; ADD descends into whichever side contains
+ *       {@code narrowVar} and adds {@code wideVar} to the join's outputs (respecting the
+ *       all-left-before-all-right invariant).</li>
+ * </ul>
+ *
+ * <h3>Supported widening type pairs</h3>
+ * <ul>
+ *   <li>TINYINT → SMALLINT, INTEGER, BIGINT</li>
+ *   <li>SMALLINT → INTEGER, BIGINT</li>
+ *   <li>INTEGER → BIGINT</li>
+ *   <li>REAL → DOUBLE</li>
+ *   <li>DATE → TIMESTAMP</li>
+ * </ul>
+ *
+ * <h3>Session gating</h3>
+ *
+ * Requires <em>both</em> {@code push_down_widen_cast_enabled=true} AND
+ * {@code native_execution_enabled=true}. The Java scan can't do inline widening, so pushing
+ * for non-native sessions would just move work around without saving anything.
+ */
+public class PushDownWidenCast
+        implements PlanOptimizer
+{
+    private final FunctionResolution functionResolution;
+    private boolean isEnabledForTesting;
+
+    public PushDownWidenCast(Metadata metadata)
+    {
+        requireNonNull(metadata, "metadata is null");
+        this.functionResolution = new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver());
+    }
+
+    @Override
+    public void setEnabledForTesting(boolean isSet)
+    {
+        isEnabledForTesting = isSet;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isEnabledForTesting || (isPushDownWidenCastEnabled(session) && isNativeExecutionEnabled(session));
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(
+            PlanNode plan,
+            Session session,
+            TypeProvider types,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator,
+            WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(types, "types is null");
+
+        if (!isEnabled(session)) {
+            return PlanOptimizerResult.optimizerResult(plan, false);
+        }
+
+        Rewriter rewriter = new Rewriter(functionResolution, variableAllocator, idAllocator);
+        PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
+        return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
+    }
+
+    /**
+     * Walks the plan bottom-up; on each {@link ProjectNode} runs two passes in sequence:
+     * <ol>
+     *   <li>{@link #visitProject} → REPLACE pass: handle bare {@code wideVar := CAST(narrow AS T)}
+     *       assignments by swapping {@code narrow} for {@code wideVar} all the way down to the
+     *       {@link TableScanNode} via {@link #tryPushWidening}.</li>
+     *   <li>{@link #applySubexpressionCastPush} → SUBEXPRESSION pass: handle nested
+     *       {@code CAST(narrow AS T)} inside larger expressions. If {@code narrow} has no other
+     *       uses in the project this also goes through {@link #tryPushWidening} (REPLACE); if
+     *       it does, falls back to {@link #tryPushAddWidening} which injects a new Project just
+     *       above the scan that computes {@code wideVar := CAST(narrow AS T)}, then rewrites the
+     *       subexpression to a bare {@code wideVar} reference.</li>
+     * </ol>
+     */
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        // (fromType -> the set of types we'll widen TO). Anything outside this map is left alone.
+        private static final Map<Type, Set<Type>> WIDENING_CAST_MAP = ImmutableMap.<Type, Set<Type>>builder()
+                .put(TinyintType.TINYINT, ImmutableSet.of(SmallintType.SMALLINT, IntegerType.INTEGER, BigintType.BIGINT))
+                .put(SmallintType.SMALLINT, ImmutableSet.of(IntegerType.INTEGER, BigintType.BIGINT))
+                .put(IntegerType.INTEGER, ImmutableSet.of(BigintType.BIGINT))
+                .put(RealType.REAL, ImmutableSet.of(DoubleType.DOUBLE))
+                .put(DateType.DATE, ImmutableSet.of(TimestampType.TIMESTAMP))
+                .build();
+
+        private final FunctionResolution functionResolution;
+        private final VariableAllocator variableAllocator;
+        private final PlanNodeIdAllocator idAllocator;
+        private boolean planChanged;
+
+        public Rewriter(FunctionResolution functionResolution, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
+        {
+            this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+            // variableAllocator is used by the subexpression Phase to mint fresh wideVar names
+            // that won't collide with existing variables anywhere in the plan.
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
+            // idAllocator hands out a fresh PlanNodeId for each new ProjectNode injected just
+            // above a TableScan during the ADD-style push.
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+        }
+
+        /**
+         * Constructs a {@code CAST(narrow AS wideType)} CallExpression — used by ADD-style push
+         * to build the {@code wideVar := CAST(narrow AS T)} assignment in the synthetic Project
+         * inserted above the scan.
+         */
+        private CallExpression buildWideningCast(VariableReferenceExpression narrow, Type wideType)
+        {
+            return new CallExpression(
+                    "CAST",
+                    functionResolution.lookupCast("CAST", narrow.getType(), wideType),
+                    wideType,
+                    ImmutableList.of(narrow));
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            // Bottom-up: first let the visitor descend into children so nested Projects are
+            // rewritten before we process this one. This means by the time we see `node`, every
+            // ProjectNode below it has already been visited (and possibly transformed).
+            PlanNode rewrittenNode = context.defaultRewrite(node, null);
+            if (!(rewrittenNode instanceof ProjectNode)) {
+                return rewrittenNode;
+            }
+            ProjectNode projectNode = (ProjectNode) rewrittenNode;
+
+            // ----- Phase 1: REPLACE pass for bare-RHS CAST assignments -----
+            // Looking for entries like `wideVar := CAST(narrowVar AS T)` where the WHOLE RHS is the cast.
+            Set<VariableReferenceExpression> sourceOutputSet =
+                    ImmutableSet.copyOf(projectNode.getSource().getOutputVariables());
+            Map<VariableReferenceExpression, VariableReferenceExpression> candidates =
+                    collectAllWideningCasts(projectNode, sourceOutputSet);
+
+            // Thread `currentSource` forward across multiple candidates: each successful push
+            // returns a rewritten subtree which becomes the input for the next candidate's push.
+            PlanNode currentSource = projectNode.getSource();
+            Map<VariableReferenceExpression, VariableReferenceExpression> pushed = new LinkedHashMap<>();
+            for (Map.Entry<VariableReferenceExpression, VariableReferenceExpression> entry : candidates.entrySet()) {
+                VariableReferenceExpression narrowVar = entry.getKey();
+                VariableReferenceExpression wideVar = entry.getValue();
+
+                // REPLACE removes narrowVar from the scan entirely. That's only safe if narrowVar
+                // is not referenced anywhere else in this Project — otherwise the other references
+                // would dangle. (Phase 2 below handles those harder cases via ADD instead.)
+                if (isVariableUsedElsewhere(narrowVar, projectNode)) {
+                    continue;
+                }
+                Optional<PlanNode> result = tryPushWidening(currentSource, narrowVar, wideVar);
+                if (result.isPresent()) {
+                    currentSource = result.get();
+                    pushed.put(narrowVar, wideVar);
+                }
+            }
+            // If REPLACE landed anywhere, build the new top Project whose CAST assignments collapse
+            // to identities (`wideVar := wideVar`); InlineProjections later cleans them up.
+            ProjectNode afterReplace = pushed.isEmpty()
+                    ? projectNode
+                    : buildWideProject(projectNode, currentSource, pushed);
+
+            // ----- Phase 2: subexpression-CAST pass -----
+            // Handles CASTs nested inside larger expressions like `f(CAST(col AS T), ...)`. Allowed
+            // to use ADD semantics when narrow has other uses (REPLACE would dangle in that case).
+            return applySubexpressionCastPush(afterReplace);
+        }
+
+        // =======================================================================
+        // Phase 2: subexpression CAST handling
+        // =======================================================================
+
+        /**
+         * Handles every widening CAST {@code CAST(narrowVar AS T)} in this Project's assignments
+         * that Phase 1 didn't already collapse — both nested CASTs (e.g.
+         * {@code date_format(CAST(d AS TIMESTAMP), '%Y')}) and top-level CASTs that Phase 1
+         * skipped because {@code narrow} had other uses or an intermediate node pinned it. For
+         * each candidate, allocates a fresh {@code wideVar} and either:
+         * <ul>
+         *   <li>REPLACE {@code narrow} with {@code wide} in the scan (via {@link #tryPushWidening})
+         *       when {@code narrow} has no other uses outside the CAST subexpressions, or</li>
+         *   <li>ADD a new Project just above the scan that computes
+         *       {@code wide := CAST(narrow AS T)} (via {@link #tryPushAddWidening}) and thread
+         *       {@code wide} up as a passthrough, leaving the scan untouched.</li>
+         * </ul>
+         * Then rewrites every matching {@code CAST(narrow AS T)} expression in this Project's
+         * assignments — at any depth — to a bare {@code wide} reference.
+         *
+         * <p>If Phase 1 already collapsed an assignment to {@code wide := wide} (identity), that
+         * assignment no longer contains a CAST and isn't matched here.
+         */
+        private ProjectNode applySubexpressionCastPush(ProjectNode projectNode)
+        {
+            Set<VariableReferenceExpression> sourceOutputs =
+                    ImmutableSet.copyOf(projectNode.getSource().getOutputVariables());
+
+            // Step 1: discover candidates. Each unique narrowVar gets one freshly-allocated wideVar
+            // (reused if the same CAST(narrow AS T) appears in multiple assignments).
+            Map<VariableReferenceExpression, VariableReferenceExpression> candidates = new LinkedHashMap<>();
+            for (RowExpression expr : projectNode.getAssignments().getExpressions()) {
+                collectSubexpressionWideningCasts(expr, sourceOutputs, candidates);
+            }
+            if (candidates.isEmpty()) {
+                return projectNode;
+            }
+
+            // Step 2: push each candidate. REPLACE is more aggressive (removes narrow from the
+            // scan) so we prefer it when it's safe; otherwise — or if REPLACE fails because an
+            // intermediate node pins narrow — we fall back to ADD which preserves narrow at the
+            // cost of computing the cast in a synthetic Project just above the scan.
+            PlanNode currentSource = projectNode.getSource();
+            Map<VariableReferenceExpression, VariableReferenceExpression> pushed = new LinkedHashMap<>();
+            for (Map.Entry<VariableReferenceExpression, VariableReferenceExpression> entry : candidates.entrySet()) {
+                VariableReferenceExpression narrow = entry.getKey();
+                VariableReferenceExpression wide = entry.getValue();
+                Optional<PlanNode> result = Optional.empty();
+                if (!narrowVarUsedOutsideTargetCasts(projectNode, narrow)) {
+                    // narrow only used inside CAST subexpressions → try REPLACE first
+                    result = tryPushWidening(currentSource, narrow, wide);
+                }
+                if (!result.isPresent()) {
+                    // narrow needed elsewhere, OR REPLACE bailed (e.g. an intermediate node pins
+                    // narrow) → ADD as a fallback so the cast still moves close to the scan.
+                    result = tryPushAddWidening(currentSource, narrow, wide);
+                }
+                if (result.isPresent()) {
+                    currentSource = result.get();
+                    pushed.put(narrow, wide);
+                }
+            }
+            if (pushed.isEmpty()) {
+                return projectNode;
+            }
+
+            // Step 3: rewrite this Project's assignments — every CAST(narrow AS T) subexpression
+            // becomes a bare wideVar reference. The cast itself moves down into either the scan
+            // (REPLACE) or the synthetic Project above it (ADD).
+            Assignments.Builder newAssignments = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
+                newAssignments.put(entry.getKey(), rewriteSubexpressionCasts(entry.getValue(), pushed));
+            }
+
+            planChanged = true;
+            return new ProjectNode(
+                    projectNode.getSourceLocation(),
+                    projectNode.getId(),
+                    projectNode.getStatsEquivalentPlanNode(),
+                    currentSource,
+                    newAssignments.build(),
+                    projectNode.getLocality());
+        }
+
+        /**
+         * Decides whether {@code narrow} can be removed from the scan (REPLACE) or must be
+         * preserved (ADD). Returns true if {@code narrow} is referenced anywhere in
+         * {@code projectNode}'s assignments outside of {@code CAST(narrow AS T)} subexpressions,
+         * or appears as an output variable (i.e. upstream needs it).
+         *
+         * <p>The visitor walks each assignment but skips the bare-variable argument of any
+         * {@code CAST(narrow AS T)} call — those are the references we're about to rewrite away,
+         * so they don't count as "other uses".
+         */
+        private boolean narrowVarUsedOutsideTargetCasts(ProjectNode projectNode, VariableReferenceExpression narrow)
+        {
+            // narrow is itself an output of this Project → some upstream node references it
+            if (projectNode.getAssignments().getVariables().contains(narrow)) {
+                return true;
+            }
+            boolean[] foundOutside = {false};
+            DefaultRowExpressionTraversalVisitor<Void> visitor = new DefaultRowExpressionTraversalVisitor<Void>()
+            {
+                @Override
+                public Void visitVariableReference(VariableReferenceExpression reference, Void context)
+                {
+                    if (reference.equals(narrow)) {
+                        foundOutside[0] = true;
+                    }
+                    return null;
+                }
+
+                @Override
+                public Void visitCall(CallExpression call, Void context)
+                {
+                    // CAST(narrow AS T) is a "safe" reference — the rewrite will replace it with
+                    // wideVar, so the narrow usage inside this call doesn't count. Don't descend.
+                    if (isWideningCast(call) && call.getArguments().get(0) instanceof VariableReferenceExpression
+                            && call.getArguments().get(0).equals(narrow)) {
+                        return null;
+                    }
+                    // Any other call: descend normally to find references to narrow inside it.
+                    return super.visitCall(call, context);
+                }
+            };
+            for (RowExpression expr : projectNode.getAssignments().getExpressions()) {
+                expr.accept(visitor, null);
+                if (foundOutside[0]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * ADD-style descent: walks down through transparent intermediate nodes to the
+         * {@link TableScanNode} that produces {@code narrowVar}, threading {@code wideVar}
+         * through each node's outputs as a passthrough. At the scan, instead of modifying the
+         * scan's assignments, wraps it in a new {@link ProjectNode} that computes
+         * {@code wideVar := CAST(narrowVar AS T)}.
+         *
+         * <p>Why not put {@code wideVar} into the scan's assignments map directly? Two invariants
+         * say no:
+         * <ul>
+         *   <li>Velox enforces "one variable per column" at the TableScan operator level. Two
+         *       variables mapping to the same column trips a runtime error.</li>
+         *   <li>Several Java planner passes invert the scan's assignments via
+         *       {@code ImmutableBiMap.copyOf(...).inverse()}, which throws on duplicate values.</li>
+         * </ul>
+         * A synthetic Project just above the scan satisfies both — and Velox's own projection
+         * pushdown fuses the result into a single {@code ScanProject} operator at runtime, so the
+         * CAST still executes in the scan dataflow.
+         *
+         * <p>Returns {@code Optional.empty()} if {@code narrowVar} doesn't trace back to a scan
+         * along this descent (e.g. it comes from an aggregation, a join clause variable, or
+         * something we don't know how to step through).
+         */
+        private Optional<PlanNode> tryPushAddWidening(
+                PlanNode subtree,
+                VariableReferenceExpression narrowVar,
+                VariableReferenceExpression wideVar)
+        {
+            if (subtree instanceof TableScanNode) {
+                // Base case: insert a Project above the scan. Pass every scan output through and
+                // add wideVar := CAST(narrowVar AS T) as the only computed assignment.
+                TableScanNode scan = (TableScanNode) subtree;
+                if (!scan.getOutputVariables().contains(narrowVar)) {
+                    return Optional.empty();
+                }
+                Assignments.Builder above = Assignments.builder();
+                for (VariableReferenceExpression v : scan.getOutputVariables()) {
+                    above.put(v, v);
+                }
+                above.put(wideVar, buildWideningCast(narrowVar, wideVar.getType()));
+                return Optional.of(new ProjectNode(
+                        scan.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        scan.getStatsEquivalentPlanNode(),
+                        scan,
+                        above.build(),
+                        ProjectNode.Locality.LOCAL));
+            }
+
+            // Outputs of FilterNode/SortNode/TopNNode/LimitNode are derived from their source, so
+            // replaceChildren() with the rewritten source naturally extends the outputs to include
+            // wideVar. No need to rebuild these nodes' output lists.
+            if (subtree instanceof FilterNode) {
+                FilterNode filter = (FilterNode) subtree;
+                return tryPushAddWidening(filter.getSource(), narrowVar, wideVar)
+                        .map(newSource -> filter.replaceChildren(ImmutableList.of(newSource)));
+            }
+            if (subtree instanceof SortNode) {
+                SortNode sort = (SortNode) subtree;
+                return tryPushAddWidening(sort.getSource(), narrowVar, wideVar)
+                        .map(newSource -> sort.replaceChildren(ImmutableList.of(newSource)));
+            }
+            if (subtree instanceof TopNNode) {
+                TopNNode topN = (TopNNode) subtree;
+                return tryPushAddWidening(topN.getSource(), narrowVar, wideVar)
+                        .map(newSource -> topN.replaceChildren(ImmutableList.of(newSource)));
+            }
+            if (subtree instanceof LimitNode) {
+                LimitNode limit = (LimitNode) subtree;
+                return tryPushAddWidening(limit.getSource(), narrowVar, wideVar)
+                        .map(newSource -> limit.replaceChildren(ImmutableList.of(newSource)));
+            }
+
+            if (subtree instanceof JoinNode) {
+                JoinNode joinNode = (JoinNode) subtree;
+                // Figure out which side of the join produces narrowVar; descend into THAT side.
+                boolean fromLeft = joinNode.getLeft().getOutputVariables().contains(narrowVar);
+                boolean fromRight = joinNode.getRight().getOutputVariables().contains(narrowVar);
+                if (!fromLeft && !fromRight) {
+                    return Optional.empty();
+                }
+                PlanNode newLeft = joinNode.getLeft();
+                PlanNode newRight = joinNode.getRight();
+                if (fromLeft) {
+                    Optional<PlanNode> r = tryPushAddWidening(joinNode.getLeft(), narrowVar, wideVar);
+                    if (!r.isPresent()) {
+                        return Optional.empty();
+                    }
+                    newLeft = r.get();
+                }
+                else {
+                    Optional<PlanNode> r = tryPushAddWidening(joinNode.getRight(), narrowVar, wideVar);
+                    if (!r.isPresent()) {
+                        return Optional.empty();
+                    }
+                    newRight = r.get();
+                }
+                // JoinNode invariant: all left-input outputs precede all right-input outputs.
+                // Rebuild the output list partitioned by side and insert wideVar at the boundary
+                // (end-of-left if fromLeft, end-of-all if fromRight).
+                Set<VariableReferenceExpression> leftInputSet =
+                        ImmutableSet.copyOf(joinNode.getLeft().getOutputVariables());
+                ImmutableList.Builder<VariableReferenceExpression> outBuilder = ImmutableList.builder();
+                for (VariableReferenceExpression v : joinNode.getOutputVariables()) {
+                    if (leftInputSet.contains(v)) {
+                        outBuilder.add(v);
+                    }
+                }
+                if (fromLeft) {
+                    outBuilder.add(wideVar);
+                }
+                for (VariableReferenceExpression v : joinNode.getOutputVariables()) {
+                    if (!leftInputSet.contains(v)) {
+                        outBuilder.add(v);
+                    }
+                }
+                if (fromRight) {
+                    outBuilder.add(wideVar);
+                }
+                return Optional.of(new JoinNode(
+                        joinNode.getSourceLocation(),
+                        joinNode.getId(),
+                        joinNode.getStatsEquivalentPlanNode(),
+                        joinNode.getType(),
+                        newLeft,
+                        newRight,
+                        joinNode.getCriteria(),
+                        outBuilder.build(),
+                        joinNode.getFilter(),
+                        joinNode.getLeftHashVariable(),
+                        joinNode.getRightHashVariable(),
+                        joinNode.getDistributionType(),
+                        joinNode.getDynamicFilters()));
+            }
+
+            if (subtree instanceof ProjectNode) {
+                ProjectNode project = (ProjectNode) subtree;
+                // For the descent to succeed, this intermediate Project must pass narrowVar
+                // through unchanged (identity assignment). If it has been renamed or computed,
+                // we can't follow it further down.
+                RowExpression narrowAssignment = project.getAssignments().get(narrowVar);
+                if (narrowAssignment == null || !narrowAssignment.equals(narrowVar)) {
+                    return Optional.empty();
+                }
+                Optional<PlanNode> newSourceOpt = tryPushAddWidening(project.getSource(), narrowVar, wideVar);
+                if (!newSourceOpt.isPresent()) {
+                    return Optional.empty();
+                }
+                // Add an identity passthrough wideVar := wideVar so this Project propagates the
+                // newly-added variable upward.
+                Assignments.Builder newAssignments = Assignments.builder();
+                newAssignments.putAll(project.getAssignments());
+                if (!project.getAssignments().getVariables().contains(wideVar)) {
+                    newAssignments.put(wideVar, wideVar);
+                }
+                return Optional.of(new ProjectNode(
+                        project.getSourceLocation(),
+                        project.getId(),
+                        project.getStatsEquivalentPlanNode(),
+                        newSourceOpt.get(),
+                        newAssignments.build(),
+                        project.getLocality()));
+            }
+            return Optional.empty();
+        }
+
+        /**
+         * Walks {@code expr} and records each widening CAST {@code CAST(narrowVar AS T)} whose
+         * argument is a bare variable from the source — both nested CASTs and top-level CAST
+         * assignments. A fresh {@code wideVar} is allocated for each unique {@code narrowVar} the
+         * first time it is seen; subsequent encounters reuse the same wideVar (so multiple
+         * matching CASTs across assignments converge on one widening).
+         *
+         * <p>Phase 2 sees TOP-LEVEL CASTs that Phase 1 already rewrote (which now look like
+         * {@code wide := wide} identity assignments, not CASTs) — those naturally aren't matched.
+         * Top-level CASTs that Phase 1 SKIPPED (because narrow was used elsewhere or pinned by an
+         * intermediate node) DO appear here, and Phase 2 picks them up via the ADD fallback.
+         */
+        private void collectSubexpressionWideningCasts(
+                RowExpression expr,
+                Set<VariableReferenceExpression> availableSourceVars,
+                Map<VariableReferenceExpression, VariableReferenceExpression> narrowToWide)
+        {
+            // Visitor recurses through Call / SpecialForm arguments, matching CAST(narrow AS T)
+            // at any depth (including the very top of `expr`).
+            DefaultRowExpressionTraversalVisitor<Void> visitor = new DefaultRowExpressionTraversalVisitor<Void>()
+            {
+                @Override
+                public Void visitCall(CallExpression call, Void context)
+                {
+                    if (isWideningCast(call) && call.getArguments().get(0) instanceof VariableReferenceExpression) {
+                        VariableReferenceExpression narrow = (VariableReferenceExpression) call.getArguments().get(0);
+                        if (availableSourceVars.contains(narrow) && !narrowToWide.containsKey(narrow)) {
+                            // Allocate a wideVar (the allocator gives it a unique name via
+                            // a _NN suffix when the hint collides).
+                            VariableReferenceExpression wide = variableAllocator.newVariable(
+                                    narrow.getSourceLocation(), narrow.getName(), call.getType());
+                            narrowToWide.put(narrow, wide);
+                        }
+                        // CAST's argument is a bare variable — nothing useful to descend into.
+                        return null;
+                    }
+                    return super.visitCall(call, context);
+                }
+            };
+            expr.accept(visitor, null);
+        }
+
+        /**
+         * Returns {@code expr} with every {@code CAST(narrowVar AS T)} subexpression replaced by
+         * {@code wideVar}, where {@code narrowVar -> wideVar} is in {@code narrowToWide}. Uses
+         * {@link RowExpressionTreeRewriter} so unrelated subexpressions are returned by identity
+         * (returning {@code null} from {@code rewriteCall} delegates to the tree rewriter's
+         * default behavior, which recurses into arguments).
+         */
+        private RowExpression rewriteSubexpressionCasts(
+                RowExpression expr,
+                Map<VariableReferenceExpression, VariableReferenceExpression> narrowToWide)
+        {
+            return RowExpressionTreeRewriter.rewriteWith(new RowExpressionRewriter<Void>()
+            {
+                @Override
+                public RowExpression rewriteCall(CallExpression node, Void ctx, RowExpressionTreeRewriter<Void> tr)
+                {
+                    if (isWideningCast(node) && node.getArguments().get(0) instanceof VariableReferenceExpression) {
+                        VariableReferenceExpression narrow = (VariableReferenceExpression) node.getArguments().get(0);
+                        VariableReferenceExpression wide = narrowToWide.get(narrow);
+                        // The type check guards against rewriting a CAST whose target type doesn't
+                        // match the allocated wideVar (shouldn't happen given how candidates are
+                        // collected, but cheap to be defensive).
+                        if (wide != null && wide.getType().equals(node.getType())) {
+                            return wide;
+                        }
+                    }
+                    return null;
+                }
+            }, expr);
+        }
+
+        // =======================================================================
+        // Phase 1: REPLACE push — substitute narrowVar with wideVar throughout the subtree
+        // =======================================================================
+
+        /**
+         * Recursive descent that pushes the substitution {@code narrowVar → wideVar} all the way
+         * down to the {@link TableScanNode} that produces {@code narrowVar}. On success the scan
+         * is rebuilt with {@code narrowVar} swapped for {@code wideVar} (same {@code ColumnHandle},
+         * different declared type), and every intermediate node is rebuilt to reflect the
+         * substitution in its outputs. Returns {@code Optional.empty()} if any node on the path
+         * can't safely accept the substitution.
+         *
+         * <p><b>Per-node-type guards (only here, not in {@link #tryPushAddWidening}):</b>
+         * <ul>
+         *   <li>{@code FilterNode}: bail if {@code narrowVar} appears in the predicate — after
+         *       REPLACE, the predicate would reference a variable the scan no longer produces.</li>
+         *   <li>{@code SortNode}/{@code TopNNode}: bail if {@code narrowVar} is an ordering key —
+         *       sorting by a type-changed variable would change collation semantics.</li>
+         *   <li>{@code LimitNode}: always transparent — narrowVar isn't referenced inside.</li>
+         *   <li>{@code JoinNode}: see {@link #tryPushThroughJoin} — bail if narrowVar is pinned by
+         *       any join clause / filter / hash / dynamic-filter variable.</li>
+         *   <li>{@code ProjectNode}: see {@link #tryPushThroughIntermediateProject} — bail unless
+         *       narrowVar is an identity passthrough and not referenced elsewhere in the project.</li>
+         * </ul>
+         */
+        private Optional<PlanNode> tryPushWidening(
+                PlanNode subtree,
+                VariableReferenceExpression narrowVar,
+                VariableReferenceExpression wideVar)
+        {
+            if (subtree instanceof TableScanNode) {
+                TableScanNode scan = (TableScanNode) subtree;
+                if (!scan.getOutputVariables().contains(narrowVar)) {
+                    return Optional.empty();
+                }
+                // Rebuild the scan: narrowVar key swapped for wideVar, ColumnHandle reused.
+                return Optional.of(buildReplaceScan(scan, ImmutableMap.of(narrowVar, wideVar)));
+            }
+
+            if (subtree instanceof FilterNode) {
+                FilterNode filter = (FilterNode) subtree;
+                // Predicate uses narrowVar → can't REPLACE; the predicate's reference would dangle.
+                if (containsVariable(narrowVar, filter.getPredicate())) {
+                    return Optional.empty();
+                }
+                return tryPushWidening(filter.getSource(), narrowVar, wideVar)
+                        .map(newSource -> filter.replaceChildren(ImmutableList.of(newSource)));
+            }
+
+            if (subtree instanceof SortNode) {
+                SortNode sort = (SortNode) subtree;
+                // narrowVar is an ordering key → swapping its type changes sort behavior.
+                if (sort.getOrderingScheme().getOrderByVariables().contains(narrowVar)) {
+                    return Optional.empty();
+                }
+                return tryPushWidening(sort.getSource(), narrowVar, wideVar)
+                        .map(newSource -> sort.replaceChildren(ImmutableList.of(newSource)));
+            }
+
+            if (subtree instanceof TopNNode) {
+                TopNNode topN = (TopNNode) subtree;
+                if (topN.getOrderingScheme().getOrderByVariables().contains(narrowVar)) {
+                    return Optional.empty();
+                }
+                return tryPushWidening(topN.getSource(), narrowVar, wideVar)
+                        .map(newSource -> topN.replaceChildren(ImmutableList.of(newSource)));
+            }
+
+            if (subtree instanceof LimitNode) {
+                // Limit is transparent — it doesn't reference any variable internally.
+                LimitNode limit = (LimitNode) subtree;
+                return tryPushWidening(limit.getSource(), narrowVar, wideVar)
+                        .map(newSource -> limit.replaceChildren(ImmutableList.of(newSource)));
+            }
+
+            if (subtree instanceof JoinNode) {
+                return tryPushThroughJoin((JoinNode) subtree, narrowVar, wideVar);
+            }
+
+            if (subtree instanceof ProjectNode) {
+                return tryPushThroughIntermediateProject((ProjectNode) subtree, narrowVar, wideVar);
+            }
+
+            // Aggregations, window functions, semijoins, etc. — we don't know how to step through.
+            return Optional.empty();
+        }
+
+        /**
+         * REPLACE-style descent through an intermediate ProjectNode. For the descent to succeed
+         * the intermediate Project must (a) pass narrowVar through as an identity assignment
+         * (so we know what to rewrite) and (b) not reference narrowVar in any other assignment
+         * (else REPLACE in the scan would orphan those references). Rewrites the identity
+         * assignment {@code narrowVar := narrowVar} to {@code wideVar := wideVar}; other
+         * assignments are untouched.
+         */
+        private Optional<PlanNode> tryPushThroughIntermediateProject(
+                ProjectNode project,
+                VariableReferenceExpression narrowVar,
+                VariableReferenceExpression wideVar)
+        {
+            // Must be an identity passthrough; otherwise we can't follow it down.
+            RowExpression narrowAssignment = project.getAssignments().get(narrowVar);
+            if (narrowAssignment == null || !narrowAssignment.equals(narrowVar)) {
+                return Optional.empty();
+            }
+            // narrow referenced in any other assignment → REPLACE would dangle.
+            if (isVariableUsedElsewhere(narrowVar, project)) {
+                return Optional.empty();
+            }
+
+            Optional<PlanNode> newSourceOpt = tryPushWidening(project.getSource(), narrowVar, wideVar);
+            if (!newSourceOpt.isPresent()) {
+                return Optional.empty();
+            }
+
+            // Rewrite the single narrow→narrow identity to wide→wide; copy everything else verbatim.
+            Assignments.Builder newAssignments = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> e : project.getAssignments().entrySet()) {
+                if (e.getKey().equals(narrowVar)) {
+                    newAssignments.put(wideVar, wideVar);
+                }
+                else {
+                    newAssignments.put(e);
+                }
+            }
+
+            return Optional.of(new ProjectNode(
+                    project.getSourceLocation(),
+                    project.getId(),
+                    project.getStatsEquivalentPlanNode(),
+                    newSourceOpt.get(),
+                    newAssignments.build(),
+                    project.getLocality()));
+        }
+
+        /**
+         * REPLACE-style descent through a JoinNode. Bails if narrowVar is "pinned" by the join —
+         * i.e. referenced by any clause / filter / hash / dynamic-filter variable — because the
+         * replacement would change the type of a variable the join semantics depend on.
+         * Otherwise recurses into the single side that produces narrowVar and rebuilds the join
+         * with narrowVar swapped for wideVar in its declared outputs.
+         */
+        private Optional<PlanNode> tryPushThroughJoin(
+                JoinNode joinNode,
+                VariableReferenceExpression narrowVar,
+                VariableReferenceExpression wideVar)
+        {
+            Set<VariableReferenceExpression> joinPinnedVars = collectJoinPinnedVariables(joinNode);
+            if (joinPinnedVars.contains(narrowVar)) {
+                return Optional.empty();
+            }
+
+            // narrowVar must come from exactly one side (joins don't produce the same variable on
+            // both sides). Recurse into that side only.
+            boolean fromLeft = joinNode.getLeft().getOutputVariables().contains(narrowVar);
+            boolean fromRight = joinNode.getRight().getOutputVariables().contains(narrowVar);
+            if (!fromLeft && !fromRight) {
+                return Optional.empty();
+            }
+
+            PlanNode newLeft = joinNode.getLeft();
+            PlanNode newRight = joinNode.getRight();
+            if (fromLeft) {
+                Optional<PlanNode> newLeftOpt = tryPushWidening(joinNode.getLeft(), narrowVar, wideVar);
+                if (!newLeftOpt.isPresent()) {
+                    return Optional.empty();
+                }
+                newLeft = newLeftOpt.get();
+            }
+            else {
+                Optional<PlanNode> newRightOpt = tryPushWidening(joinNode.getRight(), narrowVar, wideVar);
+                if (!newRightOpt.isPresent()) {
+                    return Optional.empty();
+                }
+                newRight = newRightOpt.get();
+            }
+
+            // REPLACE simply swaps narrowVar for wideVar in-place in the output list — that keeps
+            // left-before-right ordering automatically since we're not adding a new variable.
+            List<VariableReferenceExpression> newJoinOutputs = joinNode.getOutputVariables().stream()
+                    .map(v -> v.equals(narrowVar) ? wideVar : v)
+                    .collect(toImmutableList());
+
+            return Optional.of(new JoinNode(
+                    joinNode.getSourceLocation(),
+                    joinNode.getId(),
+                    joinNode.getStatsEquivalentPlanNode(),
+                    joinNode.getType(),
+                    newLeft,
+                    newRight,
+                    joinNode.getCriteria(),
+                    newJoinOutputs,
+                    joinNode.getFilter(),
+                    joinNode.getLeftHashVariable(),
+                    joinNode.getRightHashVariable(),
+                    joinNode.getDistributionType(),
+                    joinNode.getDynamicFilters()));
+        }
+
+        // =======================================================================
+        // Shared helpers
+        // =======================================================================
+
+        /**
+         * Returns every variable that the join "pins" — i.e. depends on by name AND type — so we
+         * know not to REPLACE any of them. Pinned variables are: equi-join clause sides, every
+         * variable referenced in the (optional) join filter, dynamic-filter probe variables, and
+         * the optional hash variables on either side.
+         */
+        private static Set<VariableReferenceExpression> collectJoinPinnedVariables(JoinNode joinNode)
+        {
+            Set<VariableReferenceExpression> pinned = new HashSet<>();
+
+            for (EquiJoinClause clause : joinNode.getCriteria()) {
+                pinned.add(clause.getLeft());
+                pinned.add(clause.getRight());
+            }
+
+            joinNode.getFilter().ifPresent(filter ->
+                    filter.accept(new DefaultRowExpressionTraversalVisitor<Void>()
+                    {
+                        @Override
+                        public Void visitVariableReference(VariableReferenceExpression reference, Void context)
+                        {
+                            pinned.add(reference);
+                            return null;
+                        }
+                    }, null));
+
+            pinned.addAll(joinNode.getDynamicFilters().values());
+            joinNode.getLeftHashVariable().ifPresent(pinned::add);
+            joinNode.getRightHashVariable().ifPresent(pinned::add);
+
+            return pinned;
+        }
+
+        /**
+         * Collects whole-RHS widening-cast candidates from {@code projectNode}: every assignment
+         * of the form {@code wideVar := CAST(narrowVar AS T)} where {@code narrowVar} is a
+         * variable available in the source and {@code (narrow.type → T)} is a supported widening
+         * pair. The "narrow used elsewhere" safety check happens later in {@link #visitProject},
+         * not here — this method just enumerates candidates.
+         */
+        private Map<VariableReferenceExpression, VariableReferenceExpression> collectAllWideningCasts(
+                ProjectNode projectNode,
+                Set<VariableReferenceExpression> availableSourceVars)
+        {
+            Map<VariableReferenceExpression, VariableReferenceExpression> narrowToWide = new LinkedHashMap<>();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
+                VariableReferenceExpression wideVar = entry.getKey();
+                RowExpression expr = entry.getValue();
+
+                if (!isWideningCast(expr)) {
+                    continue;
+                }
+                RowExpression castInput = ((CallExpression) expr).getArguments().get(0);
+                if (!(castInput instanceof VariableReferenceExpression)) {
+                    // Only handle the simple case where the cast's input is a bare variable.
+                    // Things like CAST(foo(col) AS T) are out of scope.
+                    continue;
+                }
+                VariableReferenceExpression narrowVar = (VariableReferenceExpression) castInput;
+                if (!availableSourceVars.contains(narrowVar)) {
+                    continue;
+                }
+                narrowToWide.put(narrowVar, wideVar);
+            }
+            return narrowToWide;
+        }
+
+        /**
+         * Rebuilds a {@link TableScanNode} with each narrow variable in {@code narrowToWide}
+         * swapped for its wide counterpart. The {@link ColumnHandle} stays the same — only the
+         * variable identity (name + declared type) changes. The native scan reads the column
+         * from disk in its narrow type and produces the wider variable value inline.
+         */
+        private static TableScanNode buildReplaceScan(
+                TableScanNode tableScan,
+                Map<VariableReferenceExpression, VariableReferenceExpression> narrowToWide)
+        {
+            List<VariableReferenceExpression> newOutputVariables = tableScan.getOutputVariables().stream()
+                    .map(v -> narrowToWide.getOrDefault(v, v))
+                    .collect(toImmutableList());
+
+            ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> newAssignments = ImmutableMap.builder();
+            for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : tableScan.getAssignments().entrySet()) {
+                VariableReferenceExpression narrowVar = entry.getKey();
+                if (narrowToWide.containsKey(narrowVar)) {
+                    // Re-key the (narrow → handle) entry under wideVar — handle (the on-disk
+                    // column) is unchanged.
+                    newAssignments.put(narrowToWide.get(narrowVar), entry.getValue());
+                }
+                else {
+                    newAssignments.put(entry);
+                }
+            }
+
+            return new TableScanNode(
+                    tableScan.getSourceLocation(),
+                    tableScan.getId(),
+                    tableScan.getTable(),
+                    newOutputVariables,
+                    newAssignments.build(),
+                    tableScan.getTableConstraints(),
+                    tableScan.getCurrentConstraint(),
+                    tableScan.getEnforcedConstraint(),
+                    tableScan.getCteMaterializationInfo());
+        }
+
+        /**
+         * Builds the new top-level {@code ProjectNode} after a successful REPLACE push. Each
+         * pushed-down {@code CAST(narrowVar AS T)} assignment becomes the identity
+         * {@code wideVar := wideVar}; the wide variable now arrives pre-typed from the rewritten
+         * scan, so the cast is no longer needed. The identity assignment is dead weight in the
+         * plan but easy to clean up — {@link com.facebook.presto.sql.planner.iterative.rule.InlineProjections}
+         * removes it in the next iterative pass.
+         */
+        private ProjectNode buildWideProject(
+                ProjectNode projectNode,
+                PlanNode newSource,
+                Map<VariableReferenceExpression, VariableReferenceExpression> pushed)
+        {
+            Assignments.Builder newProjectAssignments = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
+                VariableReferenceExpression outputVar = entry.getKey();
+                RowExpression expr = entry.getValue();
+
+                if (isWideningCast(expr)) {
+                    RowExpression castInput = ((CallExpression) expr).getArguments().get(0);
+                    if (castInput instanceof VariableReferenceExpression
+                            && pushed.containsKey((VariableReferenceExpression) castInput)) {
+                        // outputVar IS wideVar (we keyed candidates by output → input). After the
+                        // push, the scan produces wideVar directly, so this collapses to identity.
+                        newProjectAssignments.put(outputVar, outputVar);
+                        continue;
+                    }
+                }
+                newProjectAssignments.put(outputVar, expr);
+            }
+
+            planChanged = true;
+            return new ProjectNode(
+                    projectNode.getSourceLocation(),
+                    projectNode.getId(),
+                    projectNode.getStatsEquivalentPlanNode(),
+                    newSource,
+                    newProjectAssignments.build(),
+                    projectNode.getLocality());
+        }
+
+        /** True iff {@code expr} is {@code CAST(arg AS T)} for some supported widening pair. */
+        private boolean isWideningCast(RowExpression expr)
+        {
+            if (!(expr instanceof CallExpression)) {
+                return false;
+            }
+            CallExpression call = (CallExpression) expr;
+            if (!functionResolution.isCastFunction(call.getFunctionHandle())) {
+                return false;
+            }
+            if (call.getArguments().size() != 1) {
+                return false;
+            }
+            Type fromType = call.getArguments().get(0).getType();
+            Type toType = call.getType();
+            Set<Type> wideningTargets = WIDENING_CAST_MAP.get(fromType);
+            return wideningTargets != null && wideningTargets.contains(toType);
+        }
+
+        /**
+         * True iff {@code narrowVar} appears in MORE than one assignment of the project. Counts
+         * by assignment (not occurrence), so a single assignment like {@code CAST(narrow AS T)}
+         * yields count=1 — the expected use that the rule is about to rewrite. count&gt;1 means
+         * narrow is referenced beyond that one spot and REPLACE would dangle.
+         */
+        private boolean isVariableUsedElsewhere(
+                VariableReferenceExpression narrowVar,
+                ProjectNode projectNode)
+        {
+            int usageCount = 0;
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
+                if (containsVariable(narrowVar, entry.getValue())) {
+                    usageCount++;
+                }
+            }
+            return usageCount > 1;
+        }
+
+        /** Visitor-based check: does {@code expression} (anywhere in its tree) reference {@code variable}? */
+        private static boolean containsVariable(VariableReferenceExpression variable, RowExpression expression)
+        {
+            boolean[] found = {false};
+            expression.accept(new DefaultRowExpressionTraversalVisitor<Void>()
+            {
+                @Override
+                public Void visitVariableReference(VariableReferenceExpression reference, Void context)
+                {
+                    if (reference.equals(variable)) {
+                        found[0] = true;
+                    }
+                    return null;
+                }
+            }, null);
+            return found[0];
+        }
+    }
+
+    /**
+     * Returns true if {@code fromType → toType} is one of the widening pairs this optimizer knows
+     * how to push (the public mirror of the private {@code WIDENING_CAST_MAP} inside
+     * {@link Rewriter}).
+     *
+     * <p>Static so connector / scan operator code can ask the same question — e.g. a Hive page
+     * source deciding whether a Java-side scan path can honor a wider declared type.
+     */
+    public static boolean isWideningTypePair(Type fromType, Type toType)
+    {
+        if (fromType.equals(TinyintType.TINYINT)) {
+            return toType.equals(SmallintType.SMALLINT)
+                    || toType.equals(IntegerType.INTEGER)
+                    || toType.equals(BigintType.BIGINT);
+        }
+        if (fromType.equals(SmallintType.SMALLINT)) {
+            return toType.equals(IntegerType.INTEGER) || toType.equals(BigintType.BIGINT);
+        }
+        if (fromType.equals(IntegerType.INTEGER)) {
+            return toType.equals(BigintType.BIGINT);
+        }
+        if (fromType.equals(RealType.REAL)) {
+            return toType.equals(DoubleType.DOUBLE);
+        }
+        if (fromType.equals(DateType.DATE)) {
+            return toType.equals(TimestampType.TIMESTAMP);
+        }
+        return false;
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushDownWidenCast.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushDownWidenCast.java
@@ -1,0 +1,1475 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.CastType;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SortNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_WIDEN_CAST_ENABLED;
+import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PushDownWidenCast}.
+ */
+public class TestPushDownWidenCast
+        extends BasePlanTest
+{
+    private Metadata metadata;
+    private PlanBuilder builder;
+    private TableHandle ordersTableHandle;
+    private TableHandle lineitemTableHandle;
+    private TpchColumnHandle shippriorityColumnHandle;
+
+    @BeforeClass
+    public void setup()
+    {
+        metadata = getQueryRunner().getMetadata();
+        builder = new PlanBuilder(getQueryRunner().getDefaultSession(), new PlanNodeIdAllocator(), metadata);
+        ConnectorId connectorId = getCurrentConnectorId();
+        ordersTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle("orders", 1.0),
+                TestingTransactionHandle.create(),
+                Optional.empty());
+        lineitemTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle("lineitem", 1.0),
+                TestingTransactionHandle.create(),
+                Optional.empty());
+        shippriorityColumnHandle = new TpchColumnHandle("shippriority", INTEGER);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private CallExpression castExpr(VariableReferenceExpression input, com.facebook.presto.common.type.Type toType)
+    {
+        FunctionHandle handle = metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, input.getType(), toType);
+        return new CallExpression("CAST", handle, toType, ImmutableList.of(input));
+    }
+
+    private PlanNode runOptimizer(PlanNode plan, Session session)
+    {
+        // Collect variables directly from the plan we're optimizing — keeps us independent of
+        // the test class's shared builder (which can race with other parallel tests).
+        Set<VariableReferenceExpression> planVars = new java.util.HashSet<>();
+        collectVariables(plan, planVars);
+        ImmutableList<VariableReferenceExpression> snapshot = ImmutableList.copyOf(planVars);
+        return getQueryRunner().inTransaction(session, s -> {
+            s.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(s, catalog));
+            VariableAllocator allocator = new VariableAllocator(snapshot);
+            return new PushDownWidenCast(metadata)
+                    .optimize(plan, s, TypeProvider.empty(), allocator, new PlanNodeIdAllocator(), WarningCollector.NOOP)
+                    .getPlanNode();
+        });
+    }
+
+    private static void collectVariables(PlanNode node, Set<VariableReferenceExpression> out)
+    {
+        out.addAll(node.getOutputVariables());
+        for (PlanNode child : node.getSources()) {
+            collectVariables(child, out);
+        }
+    }
+
+    private Session sessionWithOptimizerEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "true")
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .build();
+    }
+
+    /** Build a scan of orders with shippriority (INTEGER) and an optional extra BIGINT column. */
+    private TableScanNode ordersScan(VariableReferenceExpression... vars)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, com.facebook.presto.spi.ColumnHandle> assignments = ImmutableMap.builder();
+        for (VariableReferenceExpression v : vars) {
+            assignments.put(v, new TpchColumnHandle(v.getName(), v.getType()));
+        }
+        return builder.tableScan(ordersTableHandle, ImmutableList.copyOf(vars), assignments.build());
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> TableScan  (direct pattern)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testBasicIntegerToBigintPushedDown()
+    {
+        VariableReferenceExpression narrowVar = builder.variable("shippriority", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("expr", BIGINT);
+
+        TableScanNode scan = builder.tableScan(
+                ordersTableHandle,
+                ImmutableList.of(narrowVar),
+                ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan),
+                sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideVar), wideVar);
+
+        TableScanNode rs = (TableScanNode) rp.getSource();
+        assertEquals(rs.getOutputVariables(), ImmutableList.of(wideVar));
+        assertEquals(rs.getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testRealToDoublePushedDown()
+    {
+        TpchColumnHandle realCol = new TpchColumnHandle("realcol", REAL);
+        VariableReferenceExpression narrowVar = builder.variable("realcol", REAL);
+        VariableReferenceExpression wideVar = builder.variable("doublecol", DOUBLE);
+
+        TableScanNode scan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, realCol));
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(wideVar, castExpr(narrowVar, DOUBLE)), scan),
+                sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+        assertEquals(((TableScanNode) ((ProjectNode) result).getSource()).getAssignments().get(wideVar), realCol);
+    }
+
+    @Test
+    public void testSmallintToBigintPushedDown()
+    {
+        TpchColumnHandle smallCol = new TpchColumnHandle("smallcol", SMALLINT);
+        VariableReferenceExpression smallVar = builder.variable("smallcol", SMALLINT);
+        VariableReferenceExpression bigVar = builder.variable("bigcol", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(smallVar), ImmutableMap.of(smallVar, smallCol));
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(bigVar, castExpr(smallVar, BIGINT)), scan),
+                sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(bigVar), bigVar);
+    }
+
+    @Test
+    public void testNarrowingCastIsNotPushedDown()
+    {
+        TpchColumnHandle bigintCol = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression bigintVar = builder.variable("orderkey_nd", BIGINT);
+        VariableReferenceExpression intVar = builder.variable("narrowed_nd", INTEGER);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(bigintVar), ImmutableMap.of(bigintVar, bigintCol));
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(intVar, castExpr(bigintVar, INTEGER)), scan),
+                sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertTrue(((ProjectNode) result).getAssignments().get(intVar) instanceof CallExpression,
+                "narrowing cast should NOT be pushed down");
+    }
+
+    @Test
+    public void testNarrowVarUsedElsewherePushedViaAdd()
+    {
+        // Project has BOTH `wide := CAST(narrow AS BIGINT)` AND `pass := narrow`. Phase 1 REPLACE
+        // bails (narrow used in two assignments), but Phase 2 ADD picks it up: a new Project is
+        // injected above the scan that computes wide := CAST(narrow AS BIGINT); the upper Project
+        // rewrites the original CAST to a bare wide reference. narrow stays available for `pass`.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_ue", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("expr_ue", BIGINT);
+        VariableReferenceExpression passVar = builder.variable("pass_ue", INTEGER);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        Assignments a = Assignments.builder()
+                .put(wideVar, castExpr(narrowVar, BIGINT))
+                .put(passVar, narrowVar)
+                .build();
+
+        PlanNode result = runOptimizer(builder.project(a, scan), sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        // Phase 2 allocates a FRESH wideVar (not the original `expr_ue` declared by the test); the
+        // upper Project's `expr_ue := CAST(narrow)` gets rewritten to `expr_ue := <freshWide>`,
+        // and the fresh wide var is computed by the new Project injected above the scan.
+        RowExpression upperWideAssignment = rp.getAssignments().get(wideVar);
+        assertTrue(upperWideAssignment instanceof VariableReferenceExpression,
+                "upper Project's wideVar assignment should be a bare ref to the fresh wideVar");
+        VariableReferenceExpression freshWide = (VariableReferenceExpression) upperWideAssignment;
+        assertEquals(freshWide.getType(), BIGINT);
+        // passthrough unchanged
+        assertEquals(rp.getAssignments().get(passVar), narrowVar);
+
+        // Below sits the synthetic Project that ADD injected, computing freshWide := CAST(narrow).
+        assertTrue(rp.getSource() instanceof ProjectNode);
+        ProjectNode lower = (ProjectNode) rp.getSource();
+        RowExpression freshWideAssignment = lower.getAssignments().get(freshWide);
+        assertTrue(freshWideAssignment instanceof CallExpression
+                && ((CallExpression) freshWideAssignment).getDisplayName().equals("CAST")
+                && ((CallExpression) freshWideAssignment).getArguments().get(0).equals(narrowVar));
+        // Scan is untouched — narrow is still the only variable mapped to the column.
+        assertTrue(lower.getSource() instanceof TableScanNode);
+        TableScanNode rScan = (TableScanNode) lower.getSource();
+        assertEquals(rScan.getAssignments().get(narrowVar), shippriorityColumnHandle);
+        assertEquals(rScan.getAssignments().size(), 1);
+    }
+
+    @Test
+    public void testOptimizerDisabledIsNoOp()
+    {
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_dis", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("expr_dis", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+        ProjectNode project = builder.project(Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan);
+
+        PlanNode result = runOptimizer(project, getQueryRunner().getDefaultSession());
+        assertSame(result, project, "plan should be unchanged when optimizer is disabled");
+    }
+
+    @Test
+    public void testMultipleEligibleCastsAllPushedDown()
+    {
+        TpchColumnHandle colA = new TpchColumnHandle("shippriority", INTEGER);
+        TpchColumnHandle colB = new TpchColumnHandle("smallcol", SMALLINT);
+        VariableReferenceExpression narrowA = builder.variable("a_narrow_m", INTEGER);
+        VariableReferenceExpression narrowB = builder.variable("b_narrow_m", SMALLINT);
+        VariableReferenceExpression wideA = builder.variable("a_wide_m", BIGINT);
+        VariableReferenceExpression wideB = builder.variable("b_wide_m", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowA, narrowB), ImmutableMap.of(narrowA, colA, narrowB, colB));
+
+        Assignments a = Assignments.builder()
+                .put(wideA, castExpr(narrowA, BIGINT))
+                .put(wideB, castExpr(narrowB, BIGINT))
+                .build();
+
+        PlanNode result = runOptimizer(builder.project(a, scan), sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideA), wideA);
+        assertEquals(rp.getAssignments().get(wideB), wideB);
+
+        TableScanNode rs = (TableScanNode) rp.getSource();
+        assertEquals(rs.getAssignments().get(wideA), colA);
+        assertEquals(rs.getAssignments().get(wideB), colB);
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> FilterNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughFilter()
+    {
+        VariableReferenceExpression keyVar = builder.variable("orderkey_f", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_f", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_f", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        // Filter on keyVar — does NOT reference narrowVar
+        FilterNode filter = builder.filter(builder.rowExpression("orderkey_f > 0"), scan);
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), filter);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Cast should have been pushed through the FilterNode to the TableScan
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideVar), wideVar);
+
+        // Filter is still there, but its source is the updated TableScan
+        assertTrue(rp.getSource() instanceof FilterNode);
+        FilterNode rf = (FilterNode) rp.getSource();
+        assertTrue(rf.getSource() instanceof TableScanNode);
+        TableScanNode rs = (TableScanNode) rf.getSource();
+        assertEquals(rs.getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testFilterReferencingNarrowVarFallsBackToAdd()
+    {
+        // Filter references narrowVar → Phase 1 REPLACE bails (would orphan the predicate).
+        // Phase 2 ADD picks up the slack: injects a Project above the scan that computes
+        // wide := CAST(narrow), leaves the scan + filter untouched, and rewrites the upper
+        // Project's CAST to a bare reference to the fresh wideVar.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_fb", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_fb", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        FilterNode filter = builder.filter(builder.rowExpression("shippriority_fb > 0"), scan);
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), filter);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Upper Project: wideVar's CAST replaced by a bare reference to the fresh wide var.
+        ProjectNode rp = (ProjectNode) result;
+        assertTrue(rp.getAssignments().get(wideVar) instanceof VariableReferenceExpression);
+        VariableReferenceExpression freshWide = (VariableReferenceExpression) rp.getAssignments().get(wideVar);
+        // Filter still there, predicate still references narrow.
+        FilterNode rf = (FilterNode) rp.getSource();
+        // Below the filter, a new Project was injected that computes freshWide := CAST(narrow).
+        ProjectNode lower = (ProjectNode) rf.getSource();
+        RowExpression freshWideAssignment = lower.getAssignments().get(freshWide);
+        assertTrue(freshWideAssignment instanceof CallExpression
+                && ((CallExpression) freshWideAssignment).getDisplayName().equals("CAST")
+                && ((CallExpression) freshWideAssignment).getArguments().get(0).equals(narrowVar));
+        // Scan untouched.
+        TableScanNode rScan = (TableScanNode) lower.getSource();
+        assertEquals(rScan.getAssignments().size(), 1);
+        assertEquals(rScan.getAssignments().get(narrowVar), shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> LimitNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughLimit()
+    {
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_l", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_l", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        LimitNode limit = new LimitNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                scan,
+                100,
+                LimitNode.Step.FINAL);
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), limit);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof LimitNode);
+        LimitNode rl = (LimitNode) ((ProjectNode) result).getSource();
+        assertTrue(rl.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rl.getSource()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> SortNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughSort()
+    {
+        VariableReferenceExpression keyVar = builder.variable("orderkey_s", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_s", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_s", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        // Sort by keyVar — does NOT use narrowVar
+        OrderingScheme ordering = new OrderingScheme(
+                ImmutableList.of(new Ordering(keyVar, ASC_NULLS_FIRST)));
+        SortNode sort = new SortNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                scan,
+                ordering,
+                false,
+                ImmutableList.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), sort);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof SortNode);
+        SortNode rs = (SortNode) ((ProjectNode) result).getSource();
+        assertTrue(rs.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rs.getSource()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testSortKeyIsNarrowVarFallsBackToAdd()
+    {
+        // Sort orders by narrowVar → Phase 1 REPLACE bails (would change sort semantics).
+        // Phase 2 ADD pushes: synthetic Project above scan computes wide := CAST(narrow); the
+        // sort still operates on narrow.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_sk", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_sk", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        OrderingScheme ordering = new OrderingScheme(
+                ImmutableList.of(new Ordering(narrowVar, ASC_NULLS_FIRST)));
+        SortNode sort = new SortNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                scan,
+                ordering,
+                false,
+                ImmutableList.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), sort);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        assertTrue(rp.getAssignments().get(wideVar) instanceof VariableReferenceExpression);
+        VariableReferenceExpression freshWide = (VariableReferenceExpression) rp.getAssignments().get(wideVar);
+        SortNode rs = (SortNode) rp.getSource();
+        // Sort still orders by narrow.
+        assertTrue(rs.getOrderingScheme().getOrderByVariables().contains(narrowVar));
+        // New Project below Sort produces freshWide := CAST(narrow).
+        ProjectNode lower = (ProjectNode) rs.getSource();
+        RowExpression freshWideAssignment = lower.getAssignments().get(freshWide);
+        assertTrue(freshWideAssignment instanceof CallExpression
+                && ((CallExpression) freshWideAssignment).getDisplayName().equals("CAST")
+                && ((CallExpression) freshWideAssignment).getArguments().get(0).equals(narrowVar));
+        // Scan untouched.
+        TableScanNode rScan = (TableScanNode) lower.getSource();
+        assertEquals(rScan.getAssignments().get(narrowVar), shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> TopNNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughTopN()
+    {
+        VariableReferenceExpression keyVar = builder.variable("orderkey_tn", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_tn", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_tn", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        OrderingScheme ordering = new OrderingScheme(
+                ImmutableList.of(new Ordering(keyVar, ASC_NULLS_FIRST)));
+        TopNNode topN = new TopNNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                scan,
+                10,
+                ordering,
+                TopNNode.Step.SINGLE);
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), topN);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof TopNNode);
+        TopNNode rtn = (TopNNode) ((ProjectNode) result).getSource();
+        assertTrue(rtn.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rtn.getSource()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> (intermediate) ProjectNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughIntermediateIdentityProject()
+    {
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_ip", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_ip", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        // Intermediate project that just passes narrowVar through (identity)
+        ProjectNode innerProject = builder.project(
+                Assignments.of(narrowVar, narrowVar), scan);
+
+        ProjectNode outerProject = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), innerProject);
+
+        PlanNode result = runOptimizer(outerProject, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideVar), wideVar);
+
+        // The inner project should now pass wideVar through (identity)
+        assertTrue(rp.getSource() instanceof ProjectNode);
+        ProjectNode ri = (ProjectNode) rp.getSource();
+        assertEquals(ri.getAssignments().get(wideVar), wideVar,
+                "inner project identity assignment should be updated to wideVar");
+
+        assertTrue(ri.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) ri.getSource()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testIntermediateProjectComputingNarrowVarPreventsPushDown()
+    {
+        VariableReferenceExpression rawVar = builder.variable("raw_ip", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_ipc", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_ipc", BIGINT);
+
+        // Inner project COMPUTES narrowVar from rawVar (not a passthrough)
+        TpchColumnHandle rawCol = new TpchColumnHandle("orderkey", BIGINT);
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(rawVar), ImmutableMap.of(rawVar, rawCol));
+
+        FunctionHandle castToInt = metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, BIGINT, INTEGER);
+        CallExpression computeNarrow = new CallExpression("CAST", castToInt, INTEGER, ImmutableList.of(rawVar));
+        ProjectNode innerProject = builder.project(Assignments.of(narrowVar, computeNarrow), scan);
+
+        ProjectNode outerProject = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), innerProject);
+
+        PlanNode result = runOptimizer(outerProject, sessionWithOptimizerEnabled());
+
+        // outer CAST should NOT be pushed through the inner project that computes narrowVar
+        assertTrue(result instanceof ProjectNode);
+        assertTrue(((ProjectNode) result).getAssignments().get(wideVar) instanceof CallExpression,
+                "cast should not be pushed when inner project computes the narrow variable");
+    }
+
+    // -----------------------------------------------------------------------
+    // Project -> JoinNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughJoinLeftSide()
+    {
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("o_shippriority", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_shippriority", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, narrowVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, narrowVar, shippriorityColumnHandle));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression lineitemKeyVar = builder.variable("l_orderkey", BIGINT);
+
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(lineitemKeyVar),
+                ImmutableMap.of(lineitemKeyVar, lineitemKey));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, lineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, narrowVar, lineitemKeyVar), // left vars first
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), join);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideVar), wideVar);
+
+        assertTrue(rp.getSource() instanceof JoinNode);
+        JoinNode rj = (JoinNode) rp.getSource();
+        assertTrue(rj.getOutputVariables().contains(wideVar));
+        assertTrue(!rj.getOutputVariables().contains(narrowVar));
+
+        assertTrue(rj.getLeft() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rj.getLeft()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testWideningCastPushedThroughJoinRightSide()
+    {
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey_rs", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        TpchColumnHandle linenumberCol = new TpchColumnHandle("linenumber", INTEGER);
+        VariableReferenceExpression lineitemKeyVar = builder.variable("l_orderkey_rs", BIGINT);
+        VariableReferenceExpression linenumberVar = builder.variable("l_linenumber_rs", INTEGER);
+        VariableReferenceExpression wideLinenumberVar = builder.variable("wide_linenumber_rs", BIGINT);
+
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(lineitemKeyVar, linenumberVar),
+                ImmutableMap.of(lineitemKeyVar, lineitemKey, linenumberVar, linenumberCol));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, lineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, lineitemKeyVar, linenumberVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideLinenumberVar, castExpr(linenumberVar, BIGINT)), join);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideLinenumberVar), wideLinenumberVar);
+
+        JoinNode rj = (JoinNode) ((ProjectNode) result).getSource();
+        assertTrue(rj.getOutputVariables().contains(wideLinenumberVar));
+        assertTrue(!rj.getOutputVariables().contains(linenumberVar));
+        assertEquals(((TableScanNode) rj.getRight()).getAssignments().get(wideLinenumberVar), linenumberCol);
+    }
+
+    @Test
+    public void testJoinKeyVariableFallsBackToAdd()
+    {
+        // narrow is the join's left-side equi-clause variable → REPLACE bails (joins pin clause
+        // variables). ADD pushes: new Project under the join's left side computes wide :=
+        // CAST(narrow); the join keeps using narrow as its key.
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        TpchColumnHandle shippriorityCol = new TpchColumnHandle("shippriority", INTEGER);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey_jk", BIGINT);
+        VariableReferenceExpression shippriorityVar = builder.variable("o_shippriority_jk", INTEGER);
+        VariableReferenceExpression widePriorityVar = builder.variable("wide_priority_jk", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, shippriorityVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, shippriorityVar, shippriorityCol));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression lineitemKeyVar = builder.variable("l_orderkey_jk", BIGINT);
+
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(lineitemKeyVar),
+                ImmutableMap.of(lineitemKeyVar, lineitemKey));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(shippriorityVar, lineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, shippriorityVar, lineitemKeyVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(widePriorityVar, castExpr(shippriorityVar, BIGINT)), join),
+                sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        // CAST replaced with a bare wide-var reference.
+        assertTrue(rp.getAssignments().get(widePriorityVar) instanceof VariableReferenceExpression);
+        // Join still uses shippriorityVar as the equi-clause key (untouched).
+        JoinNode rj = (JoinNode) rp.getSource();
+        assertEquals(rj.getCriteria().get(0).getLeft(), shippriorityVar);
+        // Below the join's left side: a new Project that computes the wide var from narrow.
+        assertTrue(rj.getLeft() instanceof ProjectNode);
+    }
+
+    @Test
+    public void testJoinFilterVariableFallsBackToAdd()
+    {
+        // narrow appears in the join's residual filter → REPLACE bails. ADD pushes; the join's
+        // filter still references narrow.
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        TpchColumnHandle shippriorityCol = new TpchColumnHandle("shippriority", INTEGER);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey_jf", BIGINT);
+        VariableReferenceExpression shippriorityVar = builder.variable("o_shippriority_jf", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_jf", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, shippriorityVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, shippriorityVar, shippriorityCol));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression lineitemKeyVar = builder.variable("l_orderkey_jf", BIGINT);
+
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(lineitemKeyVar),
+                ImmutableMap.of(lineitemKeyVar, lineitemKey));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, lineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, shippriorityVar, lineitemKeyVar),
+                Optional.of(builder.rowExpression("o_shippriority_jf > 0")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        PlanNode result = runOptimizer(
+                builder.project(Assignments.of(wideVar, castExpr(shippriorityVar, BIGINT)), join),
+                sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        // CAST replaced with a bare wide-var reference.
+        assertTrue(rp.getAssignments().get(wideVar) instanceof VariableReferenceExpression);
+        // Join's residual filter unchanged.
+        JoinNode rj = (JoinNode) rp.getSource();
+        assertTrue(rj.getFilter().isPresent());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple intermediate nodes between ProjectNode and TableScanNode
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughFilterThenSort()
+    {
+        // Plan: Project(cast) -> Filter(key > 0) -> Sort(by key) -> TableScan
+        // Semantics: SELECT CAST(shippriority AS BIGINT) FROM
+        //            (SELECT * FROM orders ORDER BY orderkey) WHERE orderkey > 0
+        VariableReferenceExpression keyVar = builder.variable("orderkey_fts", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_fts", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_fts", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        OrderingScheme sortByKey = new OrderingScheme(
+                ImmutableList.of(new Ordering(keyVar, ASC_NULLS_FIRST)));
+        SortNode sort = new SortNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                scan,
+                sortByKey,
+                false,
+                ImmutableList.of());
+
+        // Filter on keyVar — does NOT reference narrowVar
+        FilterNode filter = builder.filter(builder.rowExpression("orderkey_fts > 0"), sort);
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), filter);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Cast is pushed all the way through Filter and Sort to the TableScan
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof FilterNode);
+        FilterNode rf = (FilterNode) ((ProjectNode) result).getSource();
+
+        assertTrue(rf.getSource() instanceof SortNode);
+        SortNode rs = (SortNode) rf.getSource();
+        // Sort ordering key (keyVar) is unchanged
+        assertEquals(rs.getOrderingScheme().getOrderByVariables(), ImmutableList.of(keyVar));
+
+        assertTrue(rs.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rs.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testWideningCastPushedThroughLimitThenFilter()
+    {
+        // Plan: Project(cast) -> Limit(50) -> Filter(key > 0) -> TableScan
+        // Semantics: SELECT CAST(shippriority AS BIGINT) FROM
+        //            (SELECT * FROM orders WHERE orderkey > 0 LIMIT 50)
+        VariableReferenceExpression keyVar = builder.variable("orderkey_ltf", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_ltf", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_ltf", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        // Filter on keyVar — does NOT reference narrowVar
+        FilterNode filter = builder.filter(builder.rowExpression("orderkey_ltf > 0"), scan);
+
+        LimitNode limit = new LimitNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                filter,
+                50,
+                LimitNode.Step.FINAL);
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), limit);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Cast is pushed through Limit and Filter to the TableScan
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof LimitNode);
+        LimitNode rl = (LimitNode) ((ProjectNode) result).getSource();
+        assertEquals(rl.getCount(), 50);
+
+        assertTrue(rl.getSource() instanceof FilterNode);
+        FilterNode rf = (FilterNode) rl.getSource();
+
+        assertTrue(rf.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rf.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testWideningCastPushedThroughTopNThenFilter()
+    {
+        // Plan: Project(cast) -> TopN(10 by key) -> Filter(key > 0) -> TableScan
+        // Semantics: SELECT CAST(shippriority AS BIGINT) FROM
+        //            (SELECT * FROM orders WHERE orderkey > 0 ORDER BY orderkey LIMIT 10)
+        VariableReferenceExpression keyVar = builder.variable("orderkey_tnf", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_tnf", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_tnf", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(keyVar, narrowVar),
+                ImmutableMap.of(
+                        keyVar, new TpchColumnHandle("orderkey", BIGINT),
+                        narrowVar, shippriorityColumnHandle));
+
+        // Filter on keyVar — does NOT reference narrowVar
+        FilterNode filter = builder.filter(builder.rowExpression("orderkey_tnf > 0"), scan);
+
+        OrderingScheme sortByKey = new OrderingScheme(
+                ImmutableList.of(new Ordering(keyVar, ASC_NULLS_FIRST)));
+        TopNNode topN = new TopNNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                filter,
+                10,
+                sortByKey,
+                TopNNode.Step.SINGLE);
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), topN);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Cast is pushed through TopN and Filter to the TableScan
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof TopNNode);
+        TopNNode rtn = (TopNNode) ((ProjectNode) result).getSource();
+        assertEquals(rtn.getCount(), 10);
+        // TopN ordering key (keyVar) is unchanged
+        assertEquals(rtn.getOrderingScheme().getOrderByVariables(), ImmutableList.of(keyVar));
+
+        assertTrue(rtn.getSource() instanceof FilterNode);
+        FilterNode rf = (FilterNode) rtn.getSource();
+
+        assertTrue(rf.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rf.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // PlanNodes above (parent of) the ProjectNode are not affected
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testFilterAboveProjectIsUnaffected()
+    {
+        // Plan: Filter(wideVar > 0) -> Project(wideVar := CAST(narrowVar AS BIGINT)) -> TableScan
+        // The optimizer should push the cast down, and leave the Filter structurally intact.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_abvf", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_abvf", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar),
+                ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan);
+
+        // Filter on the project's output variable (wideVar)
+        FilterNode filter = builder.filter(builder.rowExpression("wide_sp_abvf > 0"), project);
+
+        PlanNode result = runOptimizer(filter, sessionWithOptimizerEnabled());
+
+        // Top-level node is still a FilterNode (not removed or replaced)
+        assertTrue(result instanceof FilterNode);
+        FilterNode rf = (FilterNode) result;
+        // Filter predicate is still a comparison call (wide_sp_abvf > 0), not a plain variable
+        assertTrue(rf.getPredicate() instanceof CallExpression,
+                "filter predicate should remain unchanged");
+
+        // The project directly below has been optimized to an identity assignment
+        assertTrue(rf.getSource() instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) rf.getSource();
+        assertEquals(rp.getAssignments().get(wideVar), wideVar,
+                "project assignment should be identity after cast push-down");
+
+        // The scan now outputs wideVar (BIGINT) directly
+        assertTrue(rp.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rp.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testLimitAboveProjectIsUnaffected()
+    {
+        // Plan: Limit(10) -> Project(wideVar := CAST(narrowVar AS BIGINT)) -> TableScan
+        // The optimizer should push the cast down, and leave the Limit structurally intact.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_abvl", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_abvl", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar),
+                ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan);
+
+        LimitNode limit = new LimitNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                project,
+                10,
+                LimitNode.Step.FINAL);
+
+        PlanNode result = runOptimizer(limit, sessionWithOptimizerEnabled());
+
+        // Top-level node is still a LimitNode with the same count
+        assertTrue(result instanceof LimitNode);
+        assertEquals(((LimitNode) result).getCount(), 10);
+
+        // The project directly below has been optimized to an identity assignment
+        assertTrue(((LimitNode) result).getSource() instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) ((LimitNode) result).getSource();
+        assertEquals(rp.getAssignments().get(wideVar), wideVar,
+                "project assignment should be identity after cast push-down");
+
+        // The scan now outputs wideVar (BIGINT) directly
+        assertTrue(rp.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rp.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testSortAboveProjectIsUnaffected()
+    {
+        // Plan: Sort(wideVar ASC) -> Project(wideVar := CAST(narrowVar AS BIGINT)) -> TableScan
+        // The optimizer should push the cast down, and leave the Sort structurally intact.
+        // The sort on wideVar (BIGINT) produces the same order as sorting CAST(INTEGER->BIGINT).
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_abvs", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_abvs", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar),
+                ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan);
+
+        // Sort on wideVar (the project output)
+        OrderingScheme sortByWide = new OrderingScheme(
+                ImmutableList.of(new Ordering(wideVar, ASC_NULLS_FIRST)));
+        SortNode sort = new SortNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                project,
+                sortByWide,
+                false,
+                ImmutableList.of());
+
+        PlanNode result = runOptimizer(sort, sessionWithOptimizerEnabled());
+
+        // Top-level node is still a SortNode with the same ordering on wideVar
+        assertTrue(result instanceof SortNode);
+        SortNode rs = (SortNode) result;
+        assertEquals(rs.getOrderingScheme().getOrderByVariables(), ImmutableList.of(wideVar),
+                "sort ordering should remain unchanged");
+
+        // The project directly below has been optimized to an identity assignment
+        assertTrue(rs.getSource() instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) rs.getSource();
+        assertEquals(rp.getAssignments().get(wideVar), wideVar,
+                "project assignment should be identity after cast push-down");
+
+        // The scan now outputs wideVar (BIGINT) directly
+        assertTrue(rp.getSource() instanceof TableScanNode);
+        assertEquals(((TableScanNode) rp.getSource()).getAssignments().get(wideVar),
+                shippriorityColumnHandle);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-level: Project -> Filter -> JoinNode -> TableScan
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testWideningCastPushedThroughFilterAndJoin()
+    {
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey_fj", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("o_shippriority_fj", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_sp_fj", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, narrowVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, narrowVar, shippriorityColumnHandle));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression lineitemKeyVar = builder.variable("l_orderkey_fj", BIGINT);
+
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(lineitemKeyVar),
+                ImmutableMap.of(lineitemKeyVar, lineitemKey));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, lineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, narrowVar, lineitemKeyVar), // left vars first
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        // Filter above the join does NOT reference narrowVar
+        FilterNode filter = builder.filter(builder.rowExpression("o_orderkey_fj > 0"), join);
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), filter);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Expect: Project(identity) -> Filter -> Join -> [TableScan(wide), TableScan]
+        assertTrue(result instanceof ProjectNode);
+        assertEquals(((ProjectNode) result).getAssignments().get(wideVar), wideVar);
+
+        assertTrue(((ProjectNode) result).getSource() instanceof FilterNode);
+        FilterNode rf = (FilterNode) ((ProjectNode) result).getSource();
+
+        assertTrue(rf.getSource() instanceof JoinNode);
+        JoinNode rj = (JoinNode) rf.getSource();
+        assertTrue(rj.getOutputVariables().contains(wideVar));
+        assertTrue(!rj.getOutputVariables().contains(narrowVar));
+        assertEquals(((TableScanNode) rj.getLeft()).getAssignments().get(wideVar), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testWideningCastPushedThroughNestedJoins()
+    {
+        // Reproduces the production failure: a CAST sits above an outer join whose
+        // left child is itself a join (e.g. a CTE-internal join), so the narrow
+        // variable is produced by a TableScan two levels below the join the
+        // optimizer first sees.  Pattern:
+        //   Project(CAST(shippriority AS BIGINT))
+        //     OuterJoin (on o_orderkey = lineitem_other_key)
+        //       InnerJoin (on o_orderkey = l_orderkey)
+        //         TableScan(orders: o_orderkey, shippriority)   -- narrowVar lives here
+        //         TableScan(lineitem: l_orderkey)
+        //       TableScan(lineitem: other_orderkey)
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_orderkey_nj", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("o_shippriority_nj", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_shippriority_nj", BIGINT);
+
+        TableScanNode ordersScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, narrowVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, narrowVar, shippriorityColumnHandle));
+
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression innerLineitemKeyVar = builder.variable("l_orderkey_nj", BIGINT);
+        TableScanNode innerLineitemScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(innerLineitemKeyVar),
+                ImmutableMap.of(innerLineitemKeyVar, lineitemKey));
+
+        JoinNode innerJoin = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.LEFT,
+                ordersScan,
+                innerLineitemScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, innerLineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, narrowVar, innerLineitemKeyVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        VariableReferenceExpression outerLineitemKeyVar = builder.variable("l_orderkey_nj_outer", BIGINT);
+        TableScanNode outerLineitemScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(outerLineitemKeyVar),
+                ImmutableMap.of(outerLineitemKeyVar, lineitemKey));
+
+        JoinNode outerJoin = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.LEFT,
+                innerJoin,
+                outerLineitemScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, outerLineitemKeyVar)),
+                ImmutableList.of(ordersKeyVar, narrowVar, innerLineitemKeyVar, outerLineitemKeyVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), outerJoin);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Expect: identity assignment at the top, both joins now produce wideVar,
+        // narrowVar replaced by wideVar all the way down to the orders TableScan.
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+        assertEquals(rp.getAssignments().get(wideVar), wideVar);
+
+        assertTrue(rp.getSource() instanceof JoinNode);
+        JoinNode rOuter = (JoinNode) rp.getSource();
+        assertTrue(rOuter.getOutputVariables().contains(wideVar));
+        assertTrue(!rOuter.getOutputVariables().contains(narrowVar));
+
+        assertTrue(rOuter.getLeft() instanceof JoinNode);
+        JoinNode rInner = (JoinNode) rOuter.getLeft();
+        assertTrue(rInner.getOutputVariables().contains(wideVar));
+        assertTrue(!rInner.getOutputVariables().contains(narrowVar));
+
+        assertTrue(rInner.getLeft() instanceof TableScanNode);
+        TableScanNode rScan = (TableScanNode) rInner.getLeft();
+        assertEquals(rScan.getAssignments().get(wideVar), shippriorityColumnHandle);
+        assertTrue(!rScan.getAssignments().containsKey(narrowVar));
+    }
+
+    // -----------------------------------------------------------------------
+    // Subexpression CAST push (ADD semantics)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubexpressionCastInsideFunctionIsPushed()
+    {
+        // Plan: Project(out := abs(CAST(narrow AS BIGINT))) -> TableScan(narrow:INT)
+        // narrow is used ONLY inside the CAST subexpression — safe to REPLACE narrow with wide
+        // in the scan. Expect scan to produce only wide:BIGINT, and Project to be rewritten to
+        // abs(wide).
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_se", INTEGER);
+        VariableReferenceExpression outVar = builder.variable("out_se", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        RowExpression wrapped = builder.rowExpression("abs(CAST(shippriority_se AS BIGINT))");
+        ProjectNode project = builder.project(Assignments.of(outVar, wrapped), scan);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // Top is still a Project (cast rewritten, not removed since the wrapping function remains).
+        assertTrue(result instanceof ProjectNode);
+        ProjectNode rp = (ProjectNode) result;
+
+        // RHS should now reference the wideVar instead of CAST(...).
+        RowExpression newRhs = rp.getAssignments().get(outVar);
+        assertTrue(newRhs instanceof CallExpression);
+        CallExpression call = (CallExpression) newRhs;
+        assertEquals(call.getDisplayName(), "abs");
+        assertTrue(call.getArguments().get(0) instanceof VariableReferenceExpression,
+                "CAST should be replaced with a bare wide variable reference");
+        VariableReferenceExpression wideRef = (VariableReferenceExpression) call.getArguments().get(0);
+        assertEquals(wideRef.getType(), BIGINT);
+
+        // Source is a TableScan that now produces ONLY the wide variable for the shippriority column.
+        assertTrue(rp.getSource() instanceof TableScanNode);
+        TableScanNode rScan = (TableScanNode) rp.getSource();
+        assertEquals(rScan.getAssignments().get(wideRef), shippriorityColumnHandle);
+        assertTrue(!rScan.getAssignments().containsKey(narrowVar),
+                "narrowVar must be replaced (REPLACE semantics); ADD-style would create a BiMap conflict downstream");
+        assertTrue(rScan.getOutputVariables().contains(wideRef));
+    }
+
+    @Test
+    public void testSubexpressionCastSharedAcrossAssignments()
+    {
+        // Two assignments both contain CAST(narrow AS BIGINT) — they must share the same wideVar.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_sh", INTEGER);
+        VariableReferenceExpression out1 = builder.variable("out1_sh", BIGINT);
+        VariableReferenceExpression out2 = builder.variable("out2_sh", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        RowExpression e1 = builder.rowExpression("abs(CAST(shippriority_sh AS BIGINT))");
+        RowExpression e2 = builder.rowExpression("abs(CAST(shippriority_sh AS BIGINT) + BIGINT '1')");
+        Assignments a = Assignments.builder().put(out1, e1).put(out2, e2).build();
+        ProjectNode project = builder.project(a, scan);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        TableScanNode rScan = (TableScanNode) rp.getSource();
+
+        // Exactly one variable in the scan maps to the shippriority column — the wide one.
+        long entriesForColumn = rScan.getAssignments().entrySet().stream()
+                .filter(e -> e.getValue().equals(shippriorityColumnHandle))
+                .count();
+        assertEquals(entriesForColumn, 1L, "narrowVar replaced; only the wide var maps to the column");
+        assertTrue(!rScan.getAssignments().containsKey(narrowVar));
+
+        // Both RHS expressions now reference that one wide var.
+        VariableReferenceExpression wideArg1 = (VariableReferenceExpression) ((CallExpression) rp.getAssignments().get(out1)).getArguments().get(0);
+        CallExpression absCall = (CallExpression) rp.getAssignments().get(out2);
+        CallExpression plusCall = (CallExpression) absCall.getArguments().get(0);
+        VariableReferenceExpression wideArg2 = (VariableReferenceExpression) plusCall.getArguments().get(0);
+        assertEquals(wideArg1, wideArg2, "both subexpression casts should be rewritten to the same wideVar");
+        assertEquals(rScan.getAssignments().get(wideArg1), shippriorityColumnHandle);
+    }
+
+    @Test
+    public void testTopLevelCastUntouchedByAddPass()
+    {
+        // Sanity: a plain top-level CAST should be handled by the REPLACE pass (existing behaviour),
+        // not by the new ADD pass.  After the rule, the scan should produce only wideVar (no narrow).
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_tl", INTEGER);
+        VariableReferenceExpression wideVar = builder.variable("wide_tl", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        ProjectNode project = builder.project(Assignments.of(wideVar, castExpr(narrowVar, BIGINT)), scan);
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        // REPLACE pass: scan now produces only wideVar, narrow is gone.
+        ProjectNode rp = (ProjectNode) result;
+        TableScanNode rScan = (TableScanNode) rp.getSource();
+        assertTrue(rScan.getAssignments().containsKey(wideVar));
+        assertTrue(!rScan.getAssignments().containsKey(narrowVar),
+                "narrowVar must be removed when REPLACE handles a top-level CAST");
+    }
+
+    @Test
+    public void testSubexpressionCastPushedThroughJoinLeftSide()
+    {
+        // Plan: Project(out := abs(CAST(narrow AS BIGINT))) -> Join -> TableScan(narrow:INT)
+        // narrow is used only in the CAST — safe to REPLACE through the join into the scan.
+        TpchColumnHandle ordersKey = new TpchColumnHandle("orderkey", BIGINT);
+        VariableReferenceExpression ordersKeyVar = builder.variable("o_key_seJ", BIGINT);
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_seJ", INTEGER);
+        VariableReferenceExpression outVar = builder.variable("out_seJ", BIGINT);
+
+        TableScanNode leftScan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(ordersKeyVar, narrowVar),
+                ImmutableMap.of(ordersKeyVar, ordersKey, narrowVar, shippriorityColumnHandle));
+
+        VariableReferenceExpression rightKey = builder.variable("l_key_seJ", BIGINT);
+        TpchColumnHandle lineitemKey = new TpchColumnHandle("orderkey", BIGINT);
+        TableScanNode rightScan = builder.tableScan(lineitemTableHandle,
+                ImmutableList.of(rightKey),
+                ImmutableMap.of(rightKey, lineitemKey));
+
+        JoinNode join = new JoinNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                Optional.empty(),
+                JoinType.INNER,
+                leftScan,
+                rightScan,
+                ImmutableList.of(new EquiJoinClause(ordersKeyVar, rightKey)),
+                ImmutableList.of(ordersKeyVar, narrowVar, rightKey),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        ProjectNode project = builder.project(
+                Assignments.of(outVar, builder.rowExpression("abs(CAST(shippriority_seJ AS BIGINT))")),
+                join);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        JoinNode rj = (JoinNode) rp.getSource();
+        // wideVar replaced narrow throughout: join outputs contain wide, not narrow.
+        VariableReferenceExpression wide = (VariableReferenceExpression)
+                ((CallExpression) rp.getAssignments().get(outVar)).getArguments().get(0);
+        assertTrue(rj.getOutputVariables().contains(wide));
+        assertTrue(!rj.getOutputVariables().contains(narrowVar));
+
+        TableScanNode rLeftScan = (TableScanNode) rj.getLeft();
+        assertEquals(rLeftScan.getAssignments().get(wide), shippriorityColumnHandle);
+        assertTrue(!rLeftScan.getAssignments().containsKey(narrowVar));
+    }
+
+    @Test
+    public void testSubexpressionCastAddedWhenNarrowVarUsedElsewhereInProject()
+    {
+        // narrow is used both as a passthrough AND inside a CAST. The rule cannot REPLACE
+        // (narrow needed elsewhere), so it ADDs wide alongside narrow at the scan. The
+        // four downstream BiMap call-sites are patched to tolerate duplicate ColumnHandles.
+        VariableReferenceExpression narrowVar = builder.variable("shippriority_mu", INTEGER);
+        VariableReferenceExpression passVar = builder.variable("pass_mu", INTEGER);
+        VariableReferenceExpression outVar = builder.variable("out_mu", BIGINT);
+
+        TableScanNode scan = builder.tableScan(ordersTableHandle,
+                ImmutableList.of(narrowVar), ImmutableMap.of(narrowVar, shippriorityColumnHandle));
+
+        Assignments a = Assignments.builder()
+                .put(passVar, narrowVar)
+                .put(outVar, builder.rowExpression("abs(CAST(shippriority_mu AS BIGINT))"))
+                .build();
+        ProjectNode project = builder.project(a, scan);
+
+        PlanNode result = runOptimizer(project, sessionWithOptimizerEnabled());
+
+        ProjectNode rp = (ProjectNode) result;
+        // The rule injects a Project ABOVE the scan that computes wide := CAST(narrow AS T);
+        // the upper Project's RHS is rewritten to abs(wide).
+        VariableReferenceExpression wide = (VariableReferenceExpression)
+                ((CallExpression) rp.getAssignments().get(outVar)).getArguments().get(0);
+        assertEquals(wide.getType(), BIGINT);
+        // Passthrough still references narrow
+        assertEquals(rp.getAssignments().get(passVar), narrowVar);
+
+        // Below the upper Project sits the freshly inserted Project (wide := CAST(narrow))
+        assertTrue(rp.getSource() instanceof ProjectNode);
+        ProjectNode lowerProject = (ProjectNode) rp.getSource();
+        RowExpression wideAssignment = lowerProject.getAssignments().get(wide);
+        assertTrue(wideAssignment instanceof CallExpression
+                && ((CallExpression) wideAssignment).getDisplayName().equals("CAST")
+                && ((CallExpression) wideAssignment).getArguments().get(0).equals(narrowVar),
+                "lower Project should compute wide := CAST(narrow AS BIGINT)");
+
+        // Scan is untouched — narrow remains the only variable mapped to the column.
+        assertTrue(lowerProject.getSource() instanceof TableScanNode);
+        TableScanNode rScan = (TableScanNode) lowerProject.getSource();
+        assertEquals(rScan.getAssignments().get(narrowVar), shippriorityColumnHandle);
+        assertEquals(rScan.getAssignments().size(), 1);
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/BenchmarkNativePushDownWidenCast.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/BenchmarkNativePushDownWidenCast.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_WIDEN_CAST_ENABLED;
+
+/**
+ * Microbenchmark comparing query latency with and without the {@code PushDownWidenCast} optimizer
+ * on the Velox native execution path.
+ *
+ * <p>Requires a built Velox worker binary. Pass the path via JVM argument:
+ * <pre>
+ *   -DPRESTO_SERVER=&lt;path/to/presto_server&gt;
+ *   -DDATA_DIR=&lt;path/to/data_dir&gt;
+ * </pre>
+ *
+ * <p>Run:
+ * <pre>
+ *   mvn test -pl presto-native-execution \
+ *       -Dtest=BenchmarkNativePushDownWidenCast \
+ *       -DPRESTO_SERVER=/path/to/presto_server \
+ *       -DDATA_DIR=/tmp/velox_bench_data \
+ *       -Dcheckstyle.skip=true
+ * </pre>
+ *
+ * <p>With native execution the optimizer pushes widening casts (e.g., INTEGER→BIGINT) into the
+ * {@code TableScanNode} so the Velox Parquet reader applies the coercion inline during column
+ * reading, eliminating the {@code ProjectNode} CAST operator entirely.
+ */
+@Test(singleThreaded = true)
+public class BenchmarkNativePushDownWidenCast
+{
+    private static final int WARMUP = 3;
+    private static final int MEASURED = 5;
+
+    private DistributedQueryRunner queryRunner;
+    private Session sessionOff;
+    private Session sessionOn;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        // HiveQueryRunner asserts DateTimeZone.getDefault() == America/Bahia_Banderas.
+        // Set it here so callers don't need -Duser.timezone on the command line.
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Bahia_Banderas"));
+
+        // Native runner: sets native_execution_enabled=true by default at the server level,
+        // which is inherited as the session default. The PushDownWidenCast optimizer therefore
+        // fires whenever push_down_widen_cast_enabled=true is set in the session.
+        queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat("PARQUET")
+                .build();
+
+        createBenchmarkTablesIfAbsent();
+
+        sessionOff = Session.builder(queryRunner.getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "false")
+                .build();
+
+        // native_execution_enabled is already true by default in this runner.
+        sessionOn = Session.builder(queryRunner.getDefaultSession())
+                .setSystemProperty(PUSH_DOWN_WIDEN_CAST_ENABLED, "true")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Table creation
+    // -----------------------------------------------------------------------
+
+    private void createBenchmarkTablesIfAbsent()
+    {
+        // Use IF NOT EXISTS so repeated runs reuse persisted data in DATA_DIR.
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "bench_orders_parquet")) {
+            queryRunner.execute(
+                    "CREATE TABLE bench_orders_parquet WITH (format = 'PARQUET') AS " +
+                    "SELECT orderkey, custkey, orderstatus, totalprice, orderpriority, clerk, " +
+                    "       shippriority, comment " +
+                    "FROM tpch.tiny.orders");
+        }
+
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "bench_orders_parquet_narrow")) {
+            queryRunner.execute(
+                    "CREATE TABLE bench_orders_parquet_narrow WITH (format = 'PARQUET') AS " +
+                    "SELECT orderkey, custkey, " +
+                    "       shippriority, " +
+                    "       cast(shippriority AS tinyint)  AS tiny_shippriority, " +
+                    "       cast(shippriority AS smallint) AS small_shippriority " +
+                    "FROM tpch.tiny.orders");
+        }
+
+        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "bench_lineitem_parquet")) {
+            queryRunner.execute(
+                    "CREATE TABLE bench_lineitem_parquet WITH (format = 'PARQUET') AS " +
+                    "SELECT orderkey, linenumber, quantity, extendedprice, discount, tax " +
+                    "FROM tpch.tiny.lineitem");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Benchmark queries
+    // -----------------------------------------------------------------------
+
+    private static final String Q_SIMPLE_PROJECTION =
+            "SELECT CAST(shippriority AS BIGINT) FROM bench_orders_parquet";
+
+    private static final String Q_AGGREGATION =
+            "SELECT CAST(shippriority AS BIGINT), count(*), sum(CAST(shippriority AS BIGINT)) " +
+            "FROM bench_orders_parquet GROUP BY 1";
+
+    private static final String Q_MULTI_COLUMN =
+            "SELECT " +
+            "    CAST(shippriority AS BIGINT)              AS pri_big, " +
+            "    CAST(tiny_shippriority AS INTEGER)        AS tiny_to_int, " +
+            "    CAST(small_shippriority AS BIGINT)        AS small_to_big " +
+            "FROM bench_orders_parquet_narrow";
+
+    private static final String Q_JOIN =
+            "SELECT o.orderkey, CAST(o.shippriority AS BIGINT), l.linenumber " +
+            "FROM bench_orders_parquet o JOIN bench_lineitem_parquet l ON o.orderkey = l.orderkey";
+
+    // -----------------------------------------------------------------------
+    // Test entry point
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void runBenchmark()
+    {
+        System.out.println();
+        System.out.println("=".repeat(100));
+        System.out.println("BenchmarkNativePushDownWidenCast  (warmup=" + WARMUP + "  measured=" + MEASURED + ")");
+        System.out.println("Velox native execution — optimizer pushes cast into Parquet reader.");
+        System.out.println("=".repeat(100));
+
+        runCase("simple_projection", Q_SIMPLE_PROJECTION);
+        runCase("aggregation", Q_AGGREGATION);
+        runCase("multi_column_cast", Q_MULTI_COLUMN);
+        runCase("join_with_cast", Q_JOIN);
+
+        System.out.println("=".repeat(100));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private void runCase(String name, String sql)
+    {
+        System.out.printf("%n  %-25s%n", name);
+
+        long offMs = timeQuery(sessionOff, sql);
+        long onMs = timeQuery(sessionOn, sql);
+
+        double pct = offMs > 0 ? 100.0 * (offMs - onMs) / offMs : 0;
+        System.out.printf("    opt=OFF  %5d ms  |  opt=ON  %5d ms  |  improvement %+.1f%%%n",
+                offMs, onMs, pct);
+    }
+
+    /** Runs the query {@code WARMUP+MEASURED} times; returns the median of the measured runs in ms. */
+    private long timeQuery(Session session, String sql)
+    {
+        for (int i = 0; i < WARMUP; i++) {
+            MaterializedResult ignored = queryRunner.execute(session, sql);
+        }
+
+        List<Long> durations = new ArrayList<>(MEASURED);
+        for (int i = 0; i < MEASURED; i++) {
+            long t0 = System.currentTimeMillis();
+            MaterializedResult ignored = queryRunner.execute(session, sql);
+            durations.add(System.currentTimeMillis() - t0);
+        }
+
+        return median(durations);
+    }
+
+    private static long median(List<Long> values)
+    {
+        List<Long> sorted = new ArrayList<>(values);
+        sorted.sort(Long::compareTo);
+        return sorted.get(sorted.size() / 2);
+    }
+}


### PR DESCRIPTION
# Conflicts:
#	presto-native-execution/velox

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a planner optimization that pushes widening casts down to table scans and gate it behind a new configurable session property.

New Features:
- Add PushDownWidenCast optimizer to push supported widening casts (e.g., integer to bigint, date to timestamp, real to double) into TableScan nodes when enabled.
- Expose a configurable feature flag and system session property to control widening-cast pushdown for queries and native execution.

Enhancements:
- Integrate PushDownWidenCast into the logical optimization pipeline alongside subfield and predicate pushdown, followed by cleanup of redundant projections.
- Add comprehensive unit and planner tests to validate cast pushdown behavior across scans, filters, limits, sorts, top-N, joins, and nested plans.
- Introduce micro-benchmarks on both Java and native Hive/Velox paths to compare performance with and without widening-cast pushdown.

Tests:
- Add TestPushDownWidenCast unit test coverage for the new optimizer across diverse plan shapes and join/filter interactions.
- Add TestPushDownWidenCastHiveLogicalPlanner integration tests to verify Hive logical plans push casts into scans and eliminate redundant projections.
- Add BenchmarkPushDownWidenCast and BenchmarkNativePushDownWidenCast benchmarks to measure latency impact of the optimization under representative workloads.