### PR TITLE
feat(plugin-iceberg): Add support for iceberg write-default

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2036,8 +2036,9 @@ ADD COLUMN with DEFAULT (Iceberg V3)
 
     ``ADD COLUMN DEFAULT`` read support is available in both **Presto Java** and **Presto C++** (Prestissimo).
     Both engines execute the DDL, store the default in Iceberg metadata, and inject the ``initial-default``
-    value during reads for historical rows. Write-time handling of ``write-default`` is not supported
-    in either engine.
+    value during reads for historical rows. In addition, **Presto Java** supports write-time handling of
+    ``write-default`` for omitted columns during ``INSERT`` into Iceberg V3 tables. **Presto C++** does not
+    support this behavior.
 
 Iceberg Format Version 3 supports default column values for schema evolution. When a column is
 added with a ``DEFAULT`` clause, Presto sets both the ``initial-default`` and ``write-default``
@@ -2067,9 +2068,9 @@ ALTER COLUMN SET DEFAULT (Iceberg V3)
 
 .. note::
 
-    ``ALTER COLUMN SET DEFAULT`` currently only updates the Iceberg metadata (``write-default`` field).
-    **INSERT support for write-default is not implemented** — inserts will not automatically use
-    the write-default value.
+    ``ALTER COLUMN SET DEFAULT`` updates the Iceberg metadata (``write-default`` field).
+    In **Presto Java**, subsequent ``INSERT`` statements use the ``write-default`` value for omitted
+    columns. **Presto C++** does not yet support write-default materialization during ``INSERT``.
 
 Iceberg Format Version 3 allows updating the ``write-default`` value for an existing column without
 modifying the ``initial-default``. This is useful for schema evolution and maintaining compatibility
@@ -2087,8 +2088,10 @@ Example — Update the ``write-default`` for the ``country`` column::
 
      ALTER TABLE iceberg.web.orders ALTER COLUMN country SET DEFAULT 'US';
 
-After this statement, the Iceberg metadata is updated, but **INSERT operations do not yet use the
-write-default value automatically**. This functionality will be added in a future release.
+After this statement, the Iceberg metadata is updated. In **Presto Java**, subsequent ``INSERT``
+operations use the ``write-default`` value for omitted columns, while explicit ``NULL`` values are
+preserved as ``NULL``. In **Presto C++**, ``INSERT`` operations do not yet use the ``write-default``
+value automatically.
 
 This feature requires Iceberg Format Version 3. Attempting to use ``ALTER COLUMN SET DEFAULT`` on
 a table with format version 2 or lower will result in an error.

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5944,7 +5944,7 @@ public class TestHiveIntegrationSmokeTest
                 .execute(session, transactionSession -> {
                     QualifiedObjectName objectName = new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName);
                     Optional<TableHandle> handle = metadata.getMetadataResolver(transactionSession).getTableHandle(objectName);
-                    InsertTableHandle insertTableHandle = metadata.beginInsert(transactionSession, handle.get());
+                    InsertTableHandle insertTableHandle = metadata.beginInsert(transactionSession, handle.get(), ImmutableList.of());
                     HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) insertTableHandle.getConnectorHandle();
 
                     metadata.finishInsert(transactionSession, insertTableHandle, ImmutableList.of(), ImmutableList.of());

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -802,7 +802,11 @@
                         <ignoredNonTestScopedDependency>org.apache.httpcomponents.core5:httpcore5</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.amazonaws:aws-java-sdk-s3</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.amazonaws:aws-java-sdk-core</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>org.apache.parquet:parquet-hadoop</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
+                    <ignoredUnusedDeclaredDependencies>
+                        <ignoredUnusedDeclaredDependency>com.facebook.presto:presto-memory-context</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
                     <!--                    <ignoredUsedUndeclaredDependencies>-->
                     <!--                        &lt;!&ndash; Ignore these because they are picked up as false-positives when configuring logging in the IcebergQueryRunner &ndash;&gt;-->
                     <!--                        <dependency>org.glassfish.jersey.core:jersey-common:jar</dependency>-->

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -802,11 +802,7 @@
                         <ignoredNonTestScopedDependency>org.apache.httpcomponents.core5:httpcore5</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.amazonaws:aws-java-sdk-s3</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.amazonaws:aws-java-sdk-core</ignoredNonTestScopedDependency>
-                        <ignoredNonTestScopedDependency>org.apache.parquet:parquet-hadoop</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
-                    <ignoredUnusedDeclaredDependencies>
-                        <ignoredUnusedDeclaredDependency>com.facebook.presto:presto-memory-context</ignoredUnusedDeclaredDependency>
-                    </ignoredUnusedDeclaredDependencies>
                     <!--                    <ignoredUsedUndeclaredDependencies>-->
                     <!--                        &lt;!&ndash; Ignore these because they are picked up as false-positives when configuring logging in the IcebergQueryRunner &ndash;&gt;-->
                     <!--                        <dependency>org.glassfish.jersey.core:jersey-common:jar</dependency>-->

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -698,7 +698,7 @@ public abstract class IcebergAbstractMetadata
         return finishInsert(session, (IcebergOutputTableHandle) tableHandle, fragments);
     }
 
-    protected ConnectorInsertTableHandle beginIcebergTableInsert(ConnectorSession session, IcebergTableHandle table, Table icebergTable)
+    protected ConnectorInsertTableHandle beginIcebergTableInsert(ConnectorSession session, IcebergTableHandle table, Table icebergTable, List<String> insertColumnNames)
     {
         validateBranchExists(table, icebergTable);
         return new IcebergInsertTableHandle(
@@ -712,7 +712,8 @@ public abstract class IcebergAbstractMetadata
                 getCompressionCodec(session),
                 icebergTable.properties(),
                 getSupportedSortFields(icebergTable.schema(), icebergTable.sortOrder()),
-                Optional.empty());
+                Optional.empty(),
+                insertColumnNames);
     }
 
     public static List<SortField> getSupportedSortFields(Schema schema, SortOrder sortOrder)
@@ -1351,14 +1352,14 @@ public abstract class IcebergAbstractMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<String> insertColumnNames)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         verify(table.getIcebergTableName().getTableType() == DATA, "only the data table can have data inserted");
         Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         validateTableMode(session, icebergTable);
 
-        return beginIcebergTableInsert(session, table, icebergTable);
+        return beginIcebergTableInsert(session, table, icebergTable, insertColumnNames);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -78,6 +78,7 @@ public class IcebergColumnHandle
     private final ColumnIdentity columnIdentity;
     private final Type type;
     private final Optional<String> defaultValue;
+    private final Optional<String> writeDefaultValue;
 
     @JsonCreator
     public IcebergColumnHandle(
@@ -86,23 +87,30 @@ public class IcebergColumnHandle
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("columnType") ColumnType columnType,
             @JsonProperty("requiredSubfields") List<Subfield> requiredSubfields,
-            @JsonProperty("defaultValue") Optional<String> defaultValue)
+            @JsonProperty("defaultValue") Optional<String> defaultValue,
+            @JsonProperty("writeDefaultValue") Optional<String> writeDefaultValue)
     {
         super(columnIdentity.getName(), comment, columnType, requiredSubfields);
 
         this.columnIdentity = requireNonNull(columnIdentity, "columnIdentity is null");
         this.type = requireNonNull(type, "type is null");
         this.defaultValue = requireNonNull(defaultValue, "defaultValue is null");
+        this.writeDefaultValue = requireNonNull(writeDefaultValue, "writeDefaultValue is null");
     }
 
     public IcebergColumnHandle(ColumnIdentity columnIdentity, Type type, Optional<String> comment, ColumnType columnType)
     {
-        this(columnIdentity, type, comment, columnType, ImmutableList.of(), Optional.empty());
+        this(columnIdentity, type, comment, columnType, ImmutableList.of(), Optional.empty(), Optional.empty());
     }
 
     public IcebergColumnHandle(ColumnIdentity columnIdentity, Type type, Optional<String> comment, ColumnType columnType, Optional<String> defaultValue)
     {
-        this(columnIdentity, type, comment, columnType, ImmutableList.of(), defaultValue);
+        this(columnIdentity, type, comment, columnType, ImmutableList.of(), defaultValue, Optional.empty());
+    }
+
+    public IcebergColumnHandle(ColumnIdentity columnIdentity, Type type, Optional<String> comment, ColumnType columnType, Optional<String> defaultValue, Optional<String> writeDefaultValue)
+    {
+        this(columnIdentity, type, comment, columnType, ImmutableList.of(), defaultValue, writeDefaultValue);
     }
 
     @JsonProperty
@@ -127,6 +135,12 @@ public class IcebergColumnHandle
     public Optional<String> getDefaultValue()
     {
         return defaultValue;
+    }
+
+    @JsonProperty
+    public Optional<String> getWriteDefaultValue()
+    {
+        return writeDefaultValue;
     }
 
     @JsonIgnore
@@ -161,13 +175,13 @@ public class IcebergColumnHandle
             return this;
         }
 
-        return new IcebergColumnHandle(columnIdentity, type, getComment(), getColumnType(), subfields, defaultValue);
+        return new IcebergColumnHandle(columnIdentity, type, getComment(), getColumnType(), subfields, defaultValue, writeDefaultValue);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(columnIdentity, type, getComment(), getColumnType(), getRequiredSubfields(), defaultValue);
+        return Objects.hash(columnIdentity, type, getComment(), getColumnType(), getRequiredSubfields(), defaultValue, writeDefaultValue);
     }
 
     @Override
@@ -185,7 +199,8 @@ public class IcebergColumnHandle
                 Objects.equals(this.getComment(), other.getComment()) &&
                 Objects.equals(this.getColumnType(), other.getColumnType()) &&
                 Objects.equals(this.getRequiredSubfields(), other.getRequiredSubfields()) &&
-                Objects.equals(this.defaultValue, other.defaultValue);
+                Objects.equals(this.defaultValue, other.defaultValue) &&
+                Objects.equals(this.writeDefaultValue, other.writeDefaultValue);
     }
 
     @Override
@@ -262,12 +277,17 @@ public class IcebergColumnHandle
         if (column.initialDefault() != null) {
             defaultValue = Optional.of(String.valueOf(column.initialDefault()));
         }
+        Optional<String> writeDefaultValue = Optional.empty();
+        if (column.writeDefault() != null) {
+            writeDefaultValue = Optional.of(String.valueOf(column.writeDefault()));
+        }
         return new IcebergColumnHandle(
                 createColumnIdentity(column),
                 toPrestoType(column.type(), typeManager),
                 Optional.ofNullable(column.doc()),
                 columnType,
-                defaultValue);
+                defaultValue,
+                writeDefaultValue);
     }
 
     public static Subfield getPushedDownSubfield(IcebergColumnHandle column)
@@ -294,6 +314,7 @@ public class IcebergColumnHandle
                 Optional.of("nested column pushdown"),
                 SYNTHESIZED,
                 requiredSubfields,
+                Optional.empty(),
                 Optional.empty());
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -23,10 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 public class IcebergInsertTableHandle
         extends IcebergWritableTableHandle
         implements ConnectorInsertTableHandle
 {
+    private final List<String> insertedColumns;
+
     public IcebergInsertTableHandle(
             String schemaName,
             IcebergTableName tableName,
@@ -41,7 +45,43 @@ public class IcebergInsertTableHandle
             Optional<SchemaTableName> materializedViewName)
     {
         this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
-                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false);
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, List.of());
+    }
+
+    public IcebergInsertTableHandle(
+            String schemaName,
+            IcebergTableName tableName,
+            PrestoIcebergSchema schema,
+            PrestoIcebergPartitionSpec partitionSpec,
+            List<IcebergColumnHandle> inputColumns,
+            String outputPath,
+            FileFormat fileFormat,
+            HiveCompressionCodec compressionCodec,
+            Map<String, String> storageProperties,
+            List<SortField> sortOrder,
+            Optional<SchemaTableName> materializedViewName,
+            List<String> insertedColumns)
+    {
+        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, insertedColumns);
+    }
+
+    public IcebergInsertTableHandle(
+            String schemaName,
+            IcebergTableName tableName,
+            PrestoIcebergSchema schema,
+            PrestoIcebergPartitionSpec partitionSpec,
+            List<IcebergColumnHandle> inputColumns,
+            String outputPath,
+            FileFormat fileFormat,
+            HiveCompressionCodec compressionCodec,
+            Map<String, String> storageProperties,
+            List<SortField> sortOrder,
+            Optional<SchemaTableName> materializedViewName,
+            boolean fullRefreshRequired)
+    {
+        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, fullRefreshRequired, List.of());
     }
 
     @JsonCreator
@@ -57,7 +97,8 @@ public class IcebergInsertTableHandle
             @JsonProperty("storageProperties") Map<String, String> storageProperties,
             @JsonProperty("sortOrder") List<SortField> sortOrder,
             @JsonProperty("materializedViewName") Optional<SchemaTableName> materializedViewName,
-            @JsonProperty("fullRefreshRequired") boolean fullRefreshRequired)
+            @JsonProperty("fullRefreshRequired") boolean fullRefreshRequired,
+            @JsonProperty("insertedColumns") List<String> insertedColumns)
     {
         super(
                 schemaName,
@@ -72,5 +113,12 @@ public class IcebergInsertTableHandle
                 sortOrder,
                 materializedViewName,
                 fullRefreshRequired);
+        this.insertedColumns = List.copyOf(requireNonNull(insertedColumns, "insertedColumns is null"));
+    }
+
+    @JsonProperty
+    public List<String> getInsertedColumns()
+    {
+        return insertedColumns;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Map;
@@ -113,7 +114,7 @@ public class IcebergInsertTableHandle
                 sortOrder,
                 materializedViewName,
                 fullRefreshRequired);
-        this.insertedColumns = List.copyOf(requireNonNull(insertedColumns, "insertedColumns is null"));
+        this.insertedColumns = ImmutableList.copyOf(requireNonNull(insertedColumns, "insertedColumns is null"));
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.BigintType;
@@ -42,6 +43,7 @@ import com.facebook.presto.spi.PageIndexer;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -62,7 +64,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,7 +72,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static com.facebook.presto.common.type.Decimals.readBigDecimal;
-import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
 import static com.facebook.presto.iceberg.FileContent.DATA;
@@ -155,7 +155,7 @@ public class IcebergPageSink
         this.targetMaxFileSize = targetMaxFileSize;
         requireNonNull(insertedColumns, "insertedColumns is null");
         this.inputColumns = ImmutableList.copyOf(inputColumns);
-        this.insertedColumns = new HashSet<>(insertedColumns);
+        this.insertedColumns = ImmutableSet.copyOf(insertedColumns);
         this.table = requireNonNull(table, "table is null");
         this.outputSchema = table.schema();
         this.partitionSpec = table.spec();
@@ -402,34 +402,8 @@ public class IcebergPageSink
 
     private Block fillBlockWithDefault(Block block, IcebergColumnHandle column)
     {
-        BlockBuilder blockBuilder = column.getType().createBlockBuilder(null, block.getPositionCount());
         Object writeDefaultValue = deserializeIcebergValue(column.getType(), column.getWriteDefaultValue().get(), column.getName());
-        for (int position = 0; position < block.getPositionCount(); position++) {
-            if (!block.isNull(position)) {
-                column.getType().appendTo(block, position, blockBuilder);
-                continue;
-            }
-
-            writeDefaultValue(column, blockBuilder, writeDefaultValue);
-        }
-
-        return blockBuilder.build();
-    }
-
-    private void writeDefaultValue(IcebergColumnHandle column, BlockBuilder blockBuilder, Object value)
-    {
-        Type type = column.getType();
-        if (value == null) {
-            blockBuilder.appendNull();
-            return;
-        }
-
-        if (type instanceof DecimalType && ((DecimalType) type).isShort() && value instanceof Number) {
-            type.writeLong(blockBuilder, ((Number) value).longValue());
-            return;
-        }
-
-        writeNativeValue(type, blockBuilder, value);
+        return RunLengthEncodedBlock.create(column.getType(), writeDefaultValue, block.getPositionCount());
     }
 
     private int[] getWriterIndexes(Page page)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -62,13 +62,16 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static com.facebook.presto.common.type.Decimals.readBigDecimal;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
 import static com.facebook.presto.iceberg.FileContent.DATA;
@@ -76,6 +79,7 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METAD
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.Z_ORDER;
+import static com.facebook.presto.iceberg.IcebergUtil.deserializeIcebergValue;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumnsForWrite;
 import static com.facebook.presto.iceberg.PartitionTransforms.getColumnTransform;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -112,6 +116,8 @@ public class IcebergPageSink
     private final PagePartitioner pagePartitioner;
     private final Table table;
     private final long targetMaxFileSize;
+    private final List<IcebergColumnHandle> inputColumns;
+    private final Set<String> insertedColumns;
 
     private final List<WriteContext> writers = new ArrayList<>();
     private final List<WriteContext> closedWriters = new ArrayList<>();
@@ -136,6 +142,7 @@ public class IcebergPageSink
             HdfsEnvironment hdfsEnvironment,
             HdfsContext hdfsContext,
             List<IcebergColumnHandle> inputColumns,
+            List<String> insertedColumns,
             JsonCodec<CommitTaskData> jsonCodec,
             ConnectorSession session,
             FileFormat fileFormat,
@@ -146,6 +153,9 @@ public class IcebergPageSink
     {
         requireNonNull(inputColumns, "inputColumns is null");
         this.targetMaxFileSize = targetMaxFileSize;
+        requireNonNull(insertedColumns, "insertedColumns is null");
+        this.inputColumns = ImmutableList.copyOf(inputColumns);
+        this.insertedColumns = new HashSet<>(insertedColumns);
         this.table = requireNonNull(table, "table is null");
         this.outputSchema = table.schema();
         this.partitionSpec = table.spec();
@@ -294,6 +304,7 @@ public class IcebergPageSink
 
     private void writePage(Page page)
     {
+        Page pageWithWriteDefaults = fillWriteDefaults(page);
         int[] writerIndexes = getWriterIndexes(page);
 
         // position count for each writer
@@ -325,7 +336,7 @@ public class IcebergPageSink
             }
 
             // if write is partitioned across multiple writers, filter page using dictionary blocks
-            Page pageForWriter = page;
+            Page pageForWriter = pageWithWriteDefaults;
             if (positions.length != page.getPositionCount()) {
                 verify(positions.length == counts[index]);
                 pageForWriter = pageForWriter.getPositions(positions, 0, positions.length);
@@ -345,6 +356,80 @@ public class IcebergPageSink
                 writers.set(index, null);
             }
         }
+    }
+
+    private Page fillWriteDefaults(Page page)
+    {
+        Block[] blocks = new Block[page.getChannelCount()];
+        boolean pageChanged = false;
+
+        for (int channel = 0; channel < page.getChannelCount(); channel++) {
+            Block block = page.getBlock(channel);
+            if (channel >= inputColumns.size()) {
+                blocks[channel] = block;
+                continue;
+            }
+            IcebergColumnHandle column = inputColumns.get(channel);
+
+            boolean shouldApplyWriteDefault = shouldApplyWriteDefault(column, block);
+            if (!shouldApplyWriteDefault) {
+                blocks[channel] = block;
+                continue;
+            }
+
+            blocks[channel] = fillBlockWithDefault(block, column);
+            pageChanged = true;
+        }
+
+        if (!pageChanged) {
+            return page;
+        }
+
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    private boolean shouldApplyWriteDefault(IcebergColumnHandle column, Block block)
+    {
+        return isOmittedInsertColumn(column) &&
+                column.getWriteDefaultValue().isPresent() &&
+                block.mayHaveNull();
+    }
+
+    private boolean isOmittedInsertColumn(IcebergColumnHandle column)
+    {
+        return !insertedColumns.isEmpty() && !insertedColumns.contains(column.getName());
+    }
+
+    private Block fillBlockWithDefault(Block block, IcebergColumnHandle column)
+    {
+        BlockBuilder blockBuilder = column.getType().createBlockBuilder(null, block.getPositionCount());
+        Object writeDefaultValue = deserializeIcebergValue(column.getType(), column.getWriteDefaultValue().get(), column.getName());
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (!block.isNull(position)) {
+                column.getType().appendTo(block, position, blockBuilder);
+                continue;
+            }
+
+            writeDefaultValue(column, blockBuilder, writeDefaultValue);
+        }
+
+        return blockBuilder.build();
+    }
+
+    private void writeDefaultValue(IcebergColumnHandle column, BlockBuilder blockBuilder, Object value)
+    {
+        Type type = column.getType();
+        if (value == null) {
+            blockBuilder.appendNull();
+            return;
+        }
+
+        if (type instanceof DecimalType && ((DecimalType) type).isShort() && value instanceof Number) {
+            type.writeLong(blockBuilder, ((Number) value).longValue());
+            return;
+        }
+
+        writeNativeValue(type, blockBuilder, value);
     }
 
     private int[] getWriterIndexes(Page page)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -305,7 +305,7 @@ public class IcebergPageSink
     private void writePage(Page page)
     {
         Page pageWithWriteDefaults = fillWriteDefaults(page);
-        int[] writerIndexes = getWriterIndexes(page);
+        int[] writerIndexes = getWriterIndexes(pageWithWriteDefaults);
 
         // position count for each writer
         int[] sizes = new int[writers.size()];

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -28,12 +28,14 @@ import com.facebook.presto.spi.PageSinkContext;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
 import jakarta.inject.Inject;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.LocationProvider;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,7 +80,7 @@ public class IcebergPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkContext pageSinkContext)
     {
-        return createPageSink(session, (IcebergWritableTableHandle) insertTableHandle);
+        return createPageSink(session, (IcebergInsertTableHandle) insertTableHandle);
     }
 
     @Override
@@ -88,6 +90,16 @@ public class IcebergPageSinkProvider
     }
 
     private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle)
+    {
+        return createPageSink(session, tableHandle, ImmutableList.of());
+    }
+
+    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergInsertTableHandle tableHandle)
+    {
+        return createPageSink(session, tableHandle, tableHandle.getInsertedColumns());
+    }
+
+    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, List<String> insertedColumns)
     {
         HdfsContext hdfsContext = new HdfsContext(session, tableHandle.getSchemaName(), tableHandle.getTableName().getTableName());
         Schema schema = toIcebergSchema(tableHandle.getSchema());
@@ -103,6 +115,7 @@ public class IcebergPageSinkProvider
                 hdfsEnvironment,
                 hdfsContext,
                 tableHandle.getInputColumns(),
+                insertedColumns,
                 jsonCodec,
                 session,
                 tableHandle.getFileFormat(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -256,8 +256,7 @@ public class IcebergPageSourceProvider
             List<IcebergColumnHandle> regularColumns,
             TupleDomain<IcebergColumnHandle> effectivePredicate,
             FileFormatDataSourceStats fileFormatDataSourceStats,
-            ParquetMetadataSource parquetMetadataSource,
-            Schema tableSchema)
+            ParquetMetadataSource parquetMetadataSource)
     {
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
@@ -374,7 +373,7 @@ public class IcebergPageSourceProvider
                     }
                     else {
                         internalFields.add(Optional.empty());
-                        getInitialDefaultValue(tableSchema, column)
+                        getInitialDefaultValue(column)
                                 .ifPresent(value -> defaultValues.put(column.getId(), value));
                     }
                 }
@@ -382,7 +381,7 @@ public class IcebergPageSourceProvider
                     Optional<org.apache.parquet.schema.Type> parquetField = getColumnType(parquetIdToField, fileSchema, column);
                     if (!parquetField.isPresent()) {
                         internalFields.add(Optional.empty());
-                        getInitialDefaultValue(tableSchema, column)
+                        getInitialDefaultValue(column)
                                 .ifPresent(value -> defaultValues.put(column.getId(), value));
                     }
                     else {
@@ -489,8 +488,7 @@ public class IcebergPageSourceProvider
             StripeMetadataSourceFactory stripeMetadataSourceFactory,
             FileFormatDataSourceStats stats,
             Optional<EncryptionInformation> encryptionInformation,
-            DwrfEncryptionProvider dwrfEncryptionProvider,
-            Schema tableSchema)
+            DwrfEncryptionProvider dwrfEncryptionProvider)
     {
         OrcDataSource orcDataSource = null;
         try {
@@ -588,7 +586,7 @@ public class IcebergPageSourceProvider
                             column.getComment(),
                             column.getRequiredSubfields(),
                             Optional.empty()));
-                    getInitialDefaultValue(tableSchema, column)
+                    getInitialDefaultValue(column)
                             .ifPresent(value -> defaultValues.put(column.getId(), value));
                 }
 
@@ -889,8 +887,7 @@ public class IcebergPageSourceProvider
                         split.getFileFormat(),
                         columnList,
                         icebergLayout.getValidPredicate(),
-                        splitContext.isCacheable(),
-                        tableSchema);
+                        splitContext.isCacheable());
 
         IcebergPartitionInsertingPageSource partitionInsertingPageSource = new IcebergPartitionInsertingPageSource(
                 delegateColumns,
@@ -1040,7 +1037,7 @@ public class IcebergPageSourceProvider
                     }
                 }
 
-                try (ConnectorPageSource pageSource = openDeletes(session, schema, delete, deleteColumns, deleteDomain)) {
+                try (ConnectorPageSource pageSource = openDeletes(session, delete, deleteColumns, deleteDomain)) {
                     readPositionDeletes(pageSource, targetPath, deletedRows);
                 }
                 catch (IOException e) {
@@ -1058,7 +1055,7 @@ public class IcebergPageSourceProvider
                         .map(id -> IcebergColumnHandle.create(schema.findField(id), typeManager, IcebergColumnHandle.ColumnType.REGULAR))
                         .collect(toImmutableList());
 
-                try (ConnectorPageSource pageSource = openDeletes(session, schema, delete, columns, TupleDomain.all())) {
+                try (ConnectorPageSource pageSource = openDeletes(session, delete, columns, TupleDomain.all())) {
                     filters.add(readEqualityDeletes(pageSource, columns, storeDeleteFilePath ? delete.path() : null));
                 }
                 catch (IOException e) {
@@ -1079,7 +1076,6 @@ public class IcebergPageSourceProvider
 
     private ConnectorPageSource openDeletes(
             ConnectorSession session,
-            Schema schema,
             DeleteFile delete,
             List<IcebergColumnHandle> columns,
             TupleDomain<IcebergColumnHandle> tupleDomain)
@@ -1093,8 +1089,7 @@ public class IcebergPageSourceProvider
                 delete.format(),
                 columns,
                 tupleDomain,
-                false,
-                schema)
+                false)
                 .getDelegate();
     }
 
@@ -1107,8 +1102,7 @@ public class IcebergPageSourceProvider
             FileFormat fileFormat,
             List<IcebergColumnHandle> dataColumns,
             TupleDomain<IcebergColumnHandle> predicate,
-            boolean isCacheable,
-            Schema tableSchema)
+            boolean isCacheable)
     {
         switch (fileFormat) {
             case PARQUET:
@@ -1122,8 +1116,7 @@ public class IcebergPageSourceProvider
                         dataColumns,
                         predicate,
                         fileFormatDataSourceStats,
-                        parquetMetadataSource,
-                        tableSchema);
+                        parquetMetadataSource);
             case ORC:
                 OrcReaderOptions readerOptions = OrcReaderOptions.builder()
                         .withMaxMergeDistance(getOrcMaxMergeDistance(session))
@@ -1155,25 +1148,19 @@ public class IcebergPageSourceProvider
                         stripeMetadataSourceFactory,
                         fileFormatDataSourceStats,
                         Optional.empty(),
-                        dwrfEncryptionProvider,
-                        tableSchema);
+                        dwrfEncryptionProvider);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }
 
-    private static Optional<Object> getInitialDefaultValue(Schema tableSchema, IcebergColumnHandle column)
+    private static Optional<Object> getInitialDefaultValue(IcebergColumnHandle column)
     {
         if (!column.hasDefaultValue()) {
             return Optional.empty();
         }
-        Types.NestedField field = tableSchema.findField(column.getId());
-        if (field != null && field.initialDefault() != null) {
-            String defaultValueString = String.valueOf(field.initialDefault());
-            return Optional.of(IcebergUtil.deserializeIcebergValue(
-                    column.getType(),
-                    defaultValueString,
-                    column.getName()));
-        }
-        return Optional.empty();
+        return Optional.of(IcebergUtil.deserializeIcebergValue(
+                column.getType(),
+                column.getDefaultValue().get(),
+                column.getName()));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -153,7 +153,6 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_COLUM
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_MISSING_DATA;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.MERGE_PARTITION_DATA;
 import static com.facebook.presto.iceberg.IcebergOrcColumn.ROOT_COLUMN_ID;
-import static com.facebook.presto.iceberg.IcebergUtil.deserializePartitionValue;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getLocationProvider;
 import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTable;
@@ -257,7 +256,8 @@ public class IcebergPageSourceProvider
             List<IcebergColumnHandle> regularColumns,
             TupleDomain<IcebergColumnHandle> effectivePredicate,
             FileFormatDataSourceStats fileFormatDataSourceStats,
-            ParquetMetadataSource parquetMetadataSource)
+            ParquetMetadataSource parquetMetadataSource,
+            Schema tableSchema)
     {
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
@@ -389,8 +389,36 @@ public class IcebergPageSourceProvider
                 }
             }
 
+            ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
+            for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
+                IcebergColumnHandle column = regularColumns.get(columnIndex);
+                if (column.getColumnType() == IcebergColumnHandle.ColumnType.SYNTHESIZED &&
+                        !column.isUpdateRowIdColumn() && !column.isMergeTargetTableRowIdColumn()) {
+                    Subfield pushedDownSubfield = getPushedDownSubfield(column);
+                    List<String> nestedColumnPath = nestedColumnPath(pushedDownSubfield);
+                    Optional<ColumnIO> columnIO = findNestedColumnIO(lookupColumnByName(messageColumnIO, pushedDownSubfield.getRootName()), nestedColumnPath);
+                    if (!columnIO.isPresent()) {
+                        getInitialDefaultValue(tableSchema, column)
+                                .ifPresent(value -> defaultValues.put(column.getId(), value));
+                    }
+                }
+                else {
+                    Optional<org.apache.parquet.schema.Type> parquetField = getColumnType(parquetIdToField, fileSchema, column);
+                    if (!parquetField.isPresent()) {
+                        getInitialDefaultValue(tableSchema, column)
+                                .ifPresent(value -> defaultValues.put(column.getId(), value));
+                    }
+                }
+            }
+
+            ConnectorPageSource pageSource = new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), rowPositionColumnIndex, namesBuilder.build(), new RuntimeStats());
+            Map<Integer, Object> defaults = defaultValues.build();
+            if (!defaults.isEmpty()) {
+                pageSource = new IcebergDefaultValuePageSource(pageSource, regularColumns, defaults);
+            }
+
             return new ConnectorPageSourceWithRowPositions(
-                    new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), rowPositionColumnIndex, namesBuilder.build(), new RuntimeStats()),
+                    pageSource,
                     startRowPosition,
                     endRowPosition);
         }
@@ -477,7 +505,8 @@ public class IcebergPageSourceProvider
             StripeMetadataSourceFactory stripeMetadataSourceFactory,
             FileFormatDataSourceStats stats,
             Optional<EncryptionInformation> encryptionInformation,
-            DwrfEncryptionProvider dwrfEncryptionProvider)
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            Schema tableSchema)
     {
         OrcDataSource orcDataSource = null;
         try {
@@ -522,6 +551,7 @@ public class IcebergPageSourceProvider
                     MODIFICATION_TIME_NOT_SET);
 
             List<HiveColumnHandle> physicalColumnHandles = new ArrayList<>(regularColumns.size());
+            ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
             ImmutableList.Builder<TupleDomainOrcPredicate.ColumnReference<HiveColumnHandle>> columnReferences = ImmutableList.builder();
 
@@ -574,6 +604,8 @@ public class IcebergPageSourceProvider
                             column.getComment(),
                             column.getRequiredSubfields(),
                             Optional.empty()));
+                    getInitialDefaultValue(tableSchema, column)
+                            .ifPresent(value -> defaultValues.put(column.getId(), value));
                 }
 
                 if (column.isRowPositionColumn()) {
@@ -627,19 +659,25 @@ public class IcebergPageSourceProvider
                     systemMemoryUsage,
                     INITIAL_BATCH_SIZE);
 
+            ConnectorPageSource pageSource = new OrcBatchPageSource(
+                    recordReader,
+                    orcDataSource,
+                    physicalColumnHandles,
+                    typeManager,
+                    systemMemoryUsage,
+                    stats,
+                    runtimeStats,
+                    rowPositionColumnIndex,
+                    // Iceberg doesn't support row IDs
+                    new byte[0],
+                    "");
+            Map<Integer, Object> defaults = defaultValues.build();
+            if (!defaults.isEmpty()) {
+                pageSource = new IcebergDefaultValuePageSource(pageSource, regularColumns, defaults);
+            }
+
             return new ConnectorPageSourceWithRowPositions(
-                    new OrcBatchPageSource(
-                            recordReader,
-                            orcDataSource,
-                            physicalColumnHandles,
-                            typeManager,
-                            systemMemoryUsage,
-                            stats,
-                            runtimeStats,
-                            rowPositionColumnIndex,
-                            // Iceberg doesn't support row IDs
-                            new byte[0],
-                            ""),
+                    pageSource,
                     Optional.empty(),
                     Optional.empty());
         }
@@ -830,20 +868,10 @@ public class IcebergPageSourceProvider
 
         // TODO: pushdownFilter for icebergLayout
         HdfsContext hdfsContext = new HdfsContext(session, table.getSchemaName(), table.getIcebergTableName().getTableName());
-        Function<List<IcebergColumnHandle>, ConnectorPageSourceWithRowPositions> partitionPageSourceDelegate =
-                (columnList) -> createDataPageSource(
-                        session,
-                        hdfsContext,
-                        new Path(split.getPath()),
-                        split.getStart(),
-                        split.getLength(),
-                        split.getFileFormat(),
-                        columnList,
-                        icebergLayout.getValidPredicate(),
-                        splitContext.isCacheable());
+
+        List<IcebergColumnHandle> delegateColumns = columnsToReadFromStorage.stream().collect(toImmutableList());
 
         ImmutableMap.Builder<Integer, Object> metadataValues = ImmutableMap.builder();
-        ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
         for (IcebergColumnHandle icebergColumn : icebergColumns) {
             if (icebergColumn.isPathColumn()) {
                 metadataValues.put(icebergColumn.getColumnIdentity().getId(), utf8Slice(split.getPath()));
@@ -865,20 +893,21 @@ public class IcebergPageSourceProvider
                     }
                 }
             }
-            else if (icebergColumn.hasDefaultValue()) {
-                Types.NestedField field = tableSchema.findField(icebergColumn.getId());
-                if (field != null && field.initialDefault() != null) {
-                    String defaultValueString = String.valueOf(field.initialDefault());
-                    Object prestoValue = deserializePartitionValue(
-                            icebergColumn.getType(),
-                            defaultValueString,
-                            icebergColumn.getName());
-                    defaultValues.put(icebergColumn.getId(), prestoValue);
-                }
-            }
         }
 
-        List<IcebergColumnHandle> delegateColumns = columnsToReadFromStorage.stream().collect(toImmutableList());
+        Function<List<IcebergColumnHandle>, ConnectorPageSourceWithRowPositions> partitionPageSourceDelegate =
+                (columnList) -> createDataPageSource(
+                        session,
+                        hdfsContext,
+                        new Path(split.getPath()),
+                        split.getStart(),
+                        split.getLength(),
+                        split.getFileFormat(),
+                        columnList,
+                        icebergLayout.getValidPredicate(),
+                        splitContext.isCacheable(),
+                        tableSchema);
+
         IcebergPartitionInsertingPageSource partitionInsertingPageSource = new IcebergPartitionInsertingPageSource(
                 delegateColumns,
                 metadataValues.build(),
@@ -935,6 +964,7 @@ public class IcebergPageSourceProvider
                 hdfsEnvironment,
                 hdfsContext,
                 getColumns(tableSchema, partitionSpec, typeManager),
+                ImmutableList.of(),
                 jsonCodec,
                 session,
                 split.getFileFormat(),
@@ -961,10 +991,6 @@ public class IcebergPageSourceProvider
 
         if (split.getChangelogSplitInfo().isPresent()) {
             dataSource = new ChangelogPageSource(dataSource, split.getChangelogSplitInfo().get(), (List<IcebergColumnHandle>) (List<?>) desiredColumns, icebergColumns);
-        }
-        // Wrap with default value page source if there are columns with defaults
-        if (!defaultValues.build().isEmpty()) {
-            dataSource = new IcebergDefaultValuePageSource(dataSource, icebergColumns, defaultValues.build());
         }
         return dataSource;
     }
@@ -1030,7 +1056,7 @@ public class IcebergPageSourceProvider
                     }
                 }
 
-                try (ConnectorPageSource pageSource = openDeletes(session, delete, deleteColumns, deleteDomain)) {
+                try (ConnectorPageSource pageSource = openDeletes(session, schema, delete, deleteColumns, deleteDomain)) {
                     readPositionDeletes(pageSource, targetPath, deletedRows);
                 }
                 catch (IOException e) {
@@ -1048,7 +1074,7 @@ public class IcebergPageSourceProvider
                         .map(id -> IcebergColumnHandle.create(schema.findField(id), typeManager, IcebergColumnHandle.ColumnType.REGULAR))
                         .collect(toImmutableList());
 
-                try (ConnectorPageSource pageSource = openDeletes(session, delete, columns, TupleDomain.all())) {
+                try (ConnectorPageSource pageSource = openDeletes(session, schema, delete, columns, TupleDomain.all())) {
                     filters.add(readEqualityDeletes(pageSource, columns, storeDeleteFilePath ? delete.path() : null));
                 }
                 catch (IOException e) {
@@ -1069,6 +1095,7 @@ public class IcebergPageSourceProvider
 
     private ConnectorPageSource openDeletes(
             ConnectorSession session,
+            Schema schema,
             DeleteFile delete,
             List<IcebergColumnHandle> columns,
             TupleDomain<IcebergColumnHandle> tupleDomain)
@@ -1082,7 +1109,8 @@ public class IcebergPageSourceProvider
                 delete.format(),
                 columns,
                 tupleDomain,
-                false)
+                false,
+                schema)
                 .getDelegate();
     }
 
@@ -1095,7 +1123,8 @@ public class IcebergPageSourceProvider
             FileFormat fileFormat,
             List<IcebergColumnHandle> dataColumns,
             TupleDomain<IcebergColumnHandle> predicate,
-            boolean isCacheable)
+            boolean isCacheable,
+            Schema tableSchema)
     {
         switch (fileFormat) {
             case PARQUET:
@@ -1109,7 +1138,8 @@ public class IcebergPageSourceProvider
                         dataColumns,
                         predicate,
                         fileFormatDataSourceStats,
-                        parquetMetadataSource);
+                        parquetMetadataSource,
+                        tableSchema);
             case ORC:
                 OrcReaderOptions readerOptions = OrcReaderOptions.builder()
                         .withMaxMergeDistance(getOrcMaxMergeDistance(session))
@@ -1141,8 +1171,25 @@ public class IcebergPageSourceProvider
                         stripeMetadataSourceFactory,
                         fileFormatDataSourceStats,
                         Optional.empty(),
-                        dwrfEncryptionProvider);
+                        dwrfEncryptionProvider,
+                        tableSchema);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
+    }
+
+    private static Optional<Object> getInitialDefaultValue(Schema tableSchema, IcebergColumnHandle column)
+    {
+        if (!column.hasDefaultValue()) {
+            return Optional.empty();
+        }
+        Types.NestedField field = tableSchema.findField(column.getId());
+        if (field != null && field.initialDefault() != null) {
+            String defaultValueString = String.valueOf(field.initialDefault());
+            return Optional.of(IcebergUtil.deserializeIcebergValue(
+                    column.getType(),
+                    defaultValueString,
+                    column.getName()));
+        }
+        return Optional.empty();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -356,6 +356,8 @@ public class IcebergPageSourceProvider
             ImmutableList.Builder<Type> prestoTypes = ImmutableList.builder();
             ImmutableList.Builder<Optional<Field>> internalFields = ImmutableList.builder();
             OptionalInt rowPositionColumnIndex = OptionalInt.empty();
+            ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
+
             for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
                 IcebergColumnHandle column = regularColumns.get(columnIndex);
                 namesBuilder.add(column.getName());
@@ -372,12 +374,16 @@ public class IcebergPageSourceProvider
                     }
                     else {
                         internalFields.add(Optional.empty());
+                        getInitialDefaultValue(tableSchema, column)
+                                .ifPresent(value -> defaultValues.put(column.getId(), value));
                     }
                 }
                 else {
                     Optional<org.apache.parquet.schema.Type> parquetField = getColumnType(parquetIdToField, fileSchema, column);
                     if (!parquetField.isPresent()) {
                         internalFields.add(Optional.empty());
+                        getInitialDefaultValue(tableSchema, column)
+                                .ifPresent(value -> defaultValues.put(column.getId(), value));
                     }
                     else {
                         internalFields.add(constructField(column.getType(), messageColumnIO.getChild(parquetField.get().getName())));
@@ -386,28 +392,6 @@ public class IcebergPageSourceProvider
                 if (column.isRowPositionColumn()) {
                     checkArgument(rowPositionColumnIndex.isEmpty(), "Requesting more than 1 row number columns is not allowed.");
                     rowPositionColumnIndex = OptionalInt.of(columnIndex);
-                }
-            }
-
-            ImmutableMap.Builder<Integer, Object> defaultValues = ImmutableMap.builder();
-            for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
-                IcebergColumnHandle column = regularColumns.get(columnIndex);
-                if (column.getColumnType() == IcebergColumnHandle.ColumnType.SYNTHESIZED &&
-                        !column.isUpdateRowIdColumn() && !column.isMergeTargetTableRowIdColumn()) {
-                    Subfield pushedDownSubfield = getPushedDownSubfield(column);
-                    List<String> nestedColumnPath = nestedColumnPath(pushedDownSubfield);
-                    Optional<ColumnIO> columnIO = findNestedColumnIO(lookupColumnByName(messageColumnIO, pushedDownSubfield.getRootName()), nestedColumnPath);
-                    if (!columnIO.isPresent()) {
-                        getInitialDefaultValue(tableSchema, column)
-                                .ifPresent(value -> defaultValues.put(column.getId(), value));
-                    }
-                }
-                else {
-                    Optional<org.apache.parquet.schema.Type> parquetField = getColumnType(parquetIdToField, fileSchema, column);
-                    if (!parquetField.isPresent()) {
-                        getInitialDefaultValue(tableSchema, column)
-                                .ifPresent(value -> defaultValues.put(column.getId(), value));
-                    }
                 }
             }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
@@ -34,7 +34,7 @@ import static com.facebook.presto.common.Utils.nativeValueToBlock;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.isMetadataColumnId;
-import static com.facebook.presto.iceberg.IcebergUtil.deserializePartitionValue;
+import static com.facebook.presto.iceberg.IcebergUtil.deserializeIcebergValue;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -111,7 +111,7 @@ public class IcebergPartitionInsertingPageSource
                     Type type = column.getType();
                     if (partitionKeys.containsKey(column.getId())) {
                         HivePartitionKey icebergPartition = partitionKeys.get(column.getId());
-                        Object prefilledValue = deserializePartitionValue(type, icebergPartition.getValue().orElse(null), column.getName());
+                        Object prefilledValue = deserializeIcebergValue(type, icebergPartition.getValue().orElse(null), column.getName());
                         return nativeValueToBlock(type, prefilledValue);
                     }
                     else if (column.getColumnType() == PARTITION_KEY) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
@@ -116,7 +116,11 @@ public class IcebergPartitionInsertingPageSource
                     }
                     else if (column.getColumnType() == PARTITION_KEY) {
                         // Partition key with no value. This can happen after partition evolution
-                        return nativeValueToBlock(type, null);
+                        Object prefilledValue = null;
+                        if (column.getDefaultValue().isPresent()) {
+                            prefilledValue = deserializeIcebergValue(type, column.getDefaultValue().get(), column.getName());
+                        }
+                        return nativeValueToBlock(type, prefilledValue);
                     }
                     else if (isMetadataColumnId(column.getId())) {
                         return nativeValueToBlock(type, metadataValues.get(column.getColumnIdentity().getId()));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -684,7 +684,7 @@ public final class IcebergUtil
     {
         verifyPartitionTypeSupported(partitionName, prestoType);
 
-        Object partitionValue = deserializePartitionValue(prestoType, partitionStringValue, partitionName);
+        Object partitionValue = deserializeIcebergValue(prestoType, partitionStringValue, partitionName);
         return partitionValue == null ? NullableValue.asNull(prestoType) : NullableValue.of(prestoType, partitionValue);
     }
 
@@ -816,7 +816,7 @@ public final class IcebergUtil
         return new Schema(Types.StructType.of(icebergColumns).asStructType().fields());
     }
 
-    public static Object deserializePartitionValue(Type type, String valueString, String name)
+    public static Object deserializeIcebergValue(Type type, String valueString, String name)
     {
         if (valueString == null) {
             return null;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -968,7 +968,11 @@ public final class IcebergUtil
             Object value = partition.get(index, javaClass);
 
             if (value == null) {
-                partitionKeys.put(field.fieldId(), new HivePartitionKey(colName, Optional.empty()));
+                HivePartitionKey partitionValue = new HivePartitionKey(colName, Optional.empty());
+                partitionKeys.put(field.fieldId(), partitionValue);
+                if (field.transform().isIdentity()) {
+                    partitionKeys.put(sourceId, partitionValue);
+                }
             }
             else {
                 HivePartitionKey partitionValue;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -534,6 +534,129 @@ public class TestIcebergV3
         }
     }
 
+    @Test
+    public void testInsertWithWriteDefault()
+    {
+        String tableName = "test_insert_with_write_default";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+            // Add a column with default value
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN country VARCHAR DEFAULT 'US'");
+            // Verify the default is set
+            Table table = loadTable(tableName);
+            assertEquals(table.schema().findField("country").initialDefault(), "US");
+            assertEquals(table.schema().findField("country").writeDefault(), "US");
+            // Insert without specifying the country column - should use write-default
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (1, 'Alice')", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'Alice', 'US')");
+            // Change the write-default (initial-default remains 'US')
+            assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN country SET DEFAULT 'UK'");
+            table = loadTable(tableName);
+            assertEquals(table.schema().findField("country").initialDefault(), "US");
+            assertEquals(table.schema().findField("country").writeDefault(), "UK");
+            // Insert again without specifying country - should use new write-default 'UK'
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (2, 'Bob')", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'US'), (2, 'Bob', 'UK')");
+            // Insert with explicit value - should override default
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'Charlie', 'CA')", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'US'), (2, 'Bob', 'UK'), (3, 'Charlie', 'CA')");
+            // Set write-default to NULL
+            assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN country SET DEFAULT NULL");
+            table = loadTable(tableName);
+            assertEquals(table.schema().findField("country").initialDefault(), "US");
+            assertNull(table.schema().findField("country").writeDefault());
+            // Insert without specifying country - should preserve materialized NULL, not initial-default
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (4, 'Dave')", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'Alice', 'US'), (2, 'Bob', 'UK'), (3, 'Charlie', 'CA'), (4, 'Dave', NULL)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testInsertWithExplicitNullOverridesWriteDefault()
+    {
+        String tableName = "test_insert_explicit_null_overrides_write_default";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN status VARCHAR DEFAULT 'ACTIVE'");
+
+            assertUpdate("INSERT INTO " + tableName + " (id, status) VALUES (1, NULL)", 1);
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES (2)", 1);
+
+            assertQuery("SELECT id, status FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, NULL), (2, 'ACTIVE')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testInsertWithMultipleWriteDefaultColumns()
+    {
+        String tableName = "test_insert_multiple_write_default_columns";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN country VARCHAR DEFAULT 'US'");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN priority INTEGER DEFAULT 10");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN is_enabled BOOLEAN DEFAULT true");
+
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES (1)", 1);
+            assertUpdate("INSERT INTO " + tableName + " (id, country) VALUES (2, 'UK')", 1);
+
+            assertQuery("SELECT id, country, priority, is_enabled FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'US', 10, true), (2, 'UK', 10, true)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testInsertWithWriteDefaultDifferentDataTypes()
+    {
+        String tableName = "test_insert_write_default_different_types";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN name VARCHAR DEFAULT 'Unknown'");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN score DOUBLE DEFAULT 0.0");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN count BIGINT DEFAULT 0");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN active BOOLEAN DEFAULT false");
+
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES (1)", 1);
+
+            assertQuery("SELECT id, name, score, count, active FROM " + tableName,
+                    "VALUES (1, 'Unknown', 0.0, 0, false)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testInsertWithWriteDefaultOnPartitionedTable()
+    {
+        String tableName = "test_insert_write_default_partitioned_table";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id BIGINT, ds DATE) WITH (\"format-version\" = '3', format = 'PARQUET', partitioning = ARRAY['ds'])");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, DATE '2023-01-01')", 1);
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN region VARCHAR DEFAULT 'US'");
+
+            assertUpdate("INSERT INTO " + tableName + " (id, ds) VALUES (2, DATE '2023-01-02')", 1);
+            assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN region SET DEFAULT 'EU'");
+            assertUpdate("INSERT INTO " + tableName + " (id, ds) VALUES (3, DATE '2023-01-03')", 1);
+
+            assertQuery("SELECT id, ds, region FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, DATE '2023-01-01', 'US'), (2, DATE '2023-01-02', 'US'), (3, DATE '2023-01-03', 'EU')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
     private Table loadTable(String tableName)
     {
         Catalog catalog = CatalogUtil.loadCatalog(

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.io.CloseableIterable;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -569,6 +570,49 @@ public class TestIcebergV3
             assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (4, 'Dave')", 1);
             assertQuery("SELECT * FROM " + tableName + " ORDER BY id",
                     "VALUES (1, 'Alice', 'US'), (2, 'Bob', 'UK'), (3, 'Charlie', 'CA'), (4, 'Dave', NULL)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @DataProvider(name = "withPartitioning")
+    public String[][] withPartitioning()
+    {
+        return new String[][] {
+                {"PARQUET", ""},
+                {"PARQUET", " WITH(partitioning = 'identity')"},
+                {"ORC", ""},
+                {"ORC", " WITH(partitioning = 'identity')"}
+        };
+    }
+    @Test(dataProvider = "withPartitioning")
+    public void testInsertWithPartitionEvolution(String fileFormat, String withPartitioning)
+    {
+        String tableName = "test_insert_with_write_default_" + fileFormat.toLowerCase() + (withPartitioning.isEmpty() ? "_unpartitioned" : "_partitioned");
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES(1, 'Alice'), (2, 'Bob')", 2);
+            // Add a column with default value
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN country VARCHAR DEFAULT 'US'" + withPartitioning);
+            // Verify the default is set
+            Table table = loadTable(tableName);
+            assertEquals(table.schema().findField("country").initialDefault(), "US");
+            assertEquals(table.schema().findField("country").writeDefault(), "US");
+            assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN country SET DEFAULT 'UK'");
+            // Insert without specifying the country column - should use write-default
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (3, 'Carol')", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US'), (3, 'Carol', 'UK')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country = 'US'", "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country = 'UK'", "VALUES(3, 'Carol', 'UK')");
+            assertUpdate("INSERT INTO " + tableName + " (id, name, country) VALUES (4, 'David', NULL), (5, 'Frank', 'FR')", 2);
+            assertQuery("SELECT * FROM " + tableName, "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US'), (3, 'Carol', 'UK'), (4, 'David', NULL), (5, 'Frank', 'FR')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country = 'US'", "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country <> 'US'", "VALUES(3, 'Carol', 'UK'), (5, 'Frank', 'FR')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country = 'UK'", "VALUES(3, 'Carol', 'UK')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country IS NULL", "VALUES(4, 'David', NULL)");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country IS NOT NULL", "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US'), (3, 'Carol', 'UK'), (5, 'Frank', 'FR')");
+            assertQuery("SELECT * FROM " + tableName + " WHERE country in ('US', 'FR', 'CN')", "VALUES(1, 'Alice', 'US'), (2, 'Bob', 'US'), (5, 'Frank', 'FR')");
         }
         finally {
             dropTable(tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestStatisticsUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestStatisticsUtil.java
@@ -322,6 +322,7 @@ public class TestStatisticsUtil
                 Optional.empty(),
                 partitioned ? PARTITION_KEY : REGULAR,
                 ImmutableList.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -600,6 +600,7 @@ public class TestIcebergHiveStatistics
                         ((IcebergColumnHandle) handle).getComment(),
                         REGULAR,
                         handle.getRequiredSubfields(),
+                        Optional.empty(),
                         Optional.empty());
             }
             ColumnStatistics actual = actualStats.get(handle);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
@@ -34,8 +34,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.VerifyException;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -92,7 +94,13 @@ public class TableWriteInfo
             }
             if (target instanceof TableWriterNode.InsertReference) {
                 TableWriterNode.InsertReference insert = (TableWriterNode.InsertReference) target;
-                return Optional.of(new ExecutionWriterTarget.InsertHandle(metadata.beginInsert(session, insert.getHandle()), insert.getSchemaTableName()));
+                // Extract column names from the INSERT statement
+                List<String> insertColumnNames = insert.getOutputColumns()
+                        .map(columns -> columns.stream()
+                                .map(com.facebook.presto.spi.eventlistener.OutputColumnMetadata::getColumnName)
+                                .collect(Collectors.toList()))
+                        .orElse(Collections.emptyList());
+                return Optional.of(new ExecutionWriterTarget.InsertHandle(metadata.beginInsert(session, insert.getHandle(), insertColumnNames), insert.getSchemaTableName()));
             }
             if (target instanceof TableWriterNode.DeleteHandle) {
                 TableWriterNode.DeleteHandle delete = (TableWriterNode.DeleteHandle) target;

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -376,9 +376,9 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames)
     {
-        return delegate.beginInsert(session, tableHandle);
+        return delegate.beginInsert(session, tableHandle, insertColumnNames);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -72,7 +72,6 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_APPLICABLE;
-import static java.util.Collections.emptyList;
 
 public interface Metadata
 {
@@ -337,18 +336,11 @@ public interface Metadata
      *
      * @param session the session
      * @param tableHandle the table handle
-     * @param insertColumnNames the list of column names that are explicitly specified in the INSERT statement
+     * @param insertColumnNames the list of column names that are explicitly specified in the INSERT statement.
+     *                          An empty list indicates no explicit column specification (e.g. INSERT INTO table VALUES ...),
+     *                          which implies inserting into all columns.
      */
     InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames);
-
-    /**
-     * @deprecated Use {@link #beginInsert(Session, TableHandle, List)} instead
-     */
-    @Deprecated
-    default InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
-    {
-        return beginInsert(session, tableHandle, emptyList());
-    }
 
     /**
      * Finish insert query

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -72,6 +72,7 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_APPLICABLE;
+import static java.util.Collections.emptyList;
 
 public interface Metadata
 {
@@ -333,8 +334,21 @@ public interface Metadata
 
     /**
      * Begin insert query
+     *
+     * @param session the session
+     * @param tableHandle the table handle
+     * @param insertColumnNames the list of column names that are explicitly specified in the INSERT statement
      */
-    InsertTableHandle beginInsert(Session session, TableHandle tableHandle);
+    InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames);
+
+    /**
+     * @deprecated Use {@link #beginInsert(Session, TableHandle, List)} instead
+     */
+    @Deprecated
+    default InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    {
+        return beginInsert(session, tableHandle, emptyList());
+    }
 
     /**
      * Finish insert query

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -998,13 +998,16 @@ public class MetadataManager
     }
 
     @Override
-    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, connectorId);
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
         ConnectorTransactionHandle transactionHandle = catalogMetadata.getTransactionHandleFor(connectorId);
-        ConnectorInsertTableHandle handle = metadata.beginInsert(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle());
+        List<String> normalizedColumnNames = insertColumnNames.stream()
+                .map(name -> normalizeIdentifier(session, connectorId.getCatalogName(), name))
+                .collect(toImmutableList());
+        ConnectorInsertTableHandle handle = metadata.beginInsert(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), normalizedColumnNames);
         return new InsertTableHandle(tableHandle.getConnectorId(), transactionHandle, handle);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -305,6 +305,19 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginInsert(session, tableHandle, insertColumnNames);
+        }
+        finally {
+            stats.recordBeginInsertCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    @Deprecated
     public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
     {
         long startTime = System.nanoTime();

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -317,19 +317,6 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
-    @Deprecated
-    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
-    {
-        long startTime = System.nanoTime();
-        try {
-            return delegate.beginInsert(session, tableHandle);
-        }
-        finally {
-            stats.recordBeginInsertCall(System.nanoTime() - startTime);
-        }
-    }
-
-    @Override
     public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         long startTime = System.nanoTime();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -410,12 +410,6 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new UnsupportedOperationException();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -404,6 +404,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<String> insertColumnNames)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -181,6 +181,13 @@ void to_json(json& j, const IcebergColumnHandle& p) {
       "IcebergColumnHandle",
       "String",
       "defaultValue");
+  to_json_key(
+      j,
+      "writeDefaultValue",
+      p.writeDefaultValue,
+      "IcebergColumnHandle",
+      "String",
+      "writeDefaultValue");
 }
 
 void from_json(const json& j, IcebergColumnHandle& p) {
@@ -216,6 +223,13 @@ void from_json(const json& j, IcebergColumnHandle& p) {
       "IcebergColumnHandle",
       "String",
       "defaultValue");
+  from_json_key(
+      j,
+      "writeDefaultValue",
+      p.writeDefaultValue,
+      "IcebergColumnHandle",
+      "String",
+      "writeDefaultValue");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -1414,6 +1428,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "bool",
       "fullRefreshRequired");
+  to_json_key(
+      j,
+      "insertedColumns",
+      p.insertedColumns,
+      "IcebergInsertTableHandle",
+      "List<String>",
+      "insertedColumns");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -1502,6 +1523,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "bool",
       "fullRefreshRequired");
+  from_json_key(
+      j,
+      "insertedColumns",
+      p.insertedColumns,
+      "IcebergInsertTableHandle",
+      "List<String>",
+      "insertedColumns");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -55,6 +55,7 @@ struct IcebergColumnHandle : public ColumnHandle {
   hive::ColumnType columnType = {};
   List<Subfield> requiredSubfields = {};
   std::shared_ptr<String> defaultValue = {};
+  std::shared_ptr<String> writeDefaultValue = {};
 
   IcebergColumnHandle() noexcept;
 
@@ -271,6 +272,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   bool fullRefreshRequired = {};
+  List<String> insertedColumns = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergColumnHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergColumnHandle.hpp.inc
@@ -24,6 +24,7 @@ struct IcebergColumnHandle : public ColumnHandle {
   hive::ColumnType columnType = {};
   List<Subfield> requiredSubfields = {};
   std::shared_ptr<String> defaultValue = {};
+  std::shared_ptr<String> writeDefaultValue = {};
 
   IcebergColumnHandle() noexcept;
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
@@ -29,6 +29,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   bool fullRefreshRequired = {};
+  List<String> insertedColumns = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -548,7 +548,22 @@ public interface ConnectorMetadata
 
     /**
      * Begin insert query
+     *
+     * @param session the session
+     * @param tableHandle the table handle
+     * @param insertColumnNames the list of column names that are explicitly specified in the INSERT statement.
+     *                          This allows connectors to distinguish between columns that are omitted (and should
+     *                          use default values) versus columns that are explicitly set to NULL.
      */
+    default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<String> insertColumnNames)
+    {
+        return beginInsert(session, tableHandle);
+    }
+
+    /**
+     * @deprecated Use {@link #beginInsert(ConnectorSession, ConnectorTableHandle, List)} instead
+     */
+    @Deprecated
     default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support inserts");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -554,6 +554,8 @@ public interface ConnectorMetadata
      * @param insertColumnNames the list of column names that are explicitly specified in the INSERT statement.
      *                          This allows connectors to distinguish between columns that are omitted (and should
      *                          use default values) versus columns that are explicitly set to NULL.
+     *                          An empty list indicates no explicit column specification (e.g. INSERT INTO table VALUES ...),
+     *                          which implies inserting into all columns.
      */
     default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<String> insertColumnNames)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -491,6 +491,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<String> insertColumnNames)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginInsert(session, tableHandle, insertColumnNames);
+        }
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description
Follow-up PR of https://github.com/prestodb/presto/issues/27781 for adding Java write-side support to write Iceberg `write-default` changes for Iceberg Table

## Motivation and Context
Follow-up PR of https://github.com/prestodb/presto/issues/27781 for adding Java write-side support to write Iceberg `write-default` changes for Iceberg Table

## Impact
1. New feature addition for Presto Java for `write-default` support in Iceberg

2. Previously, `IcebergDefaultValuePageSource` was wrapped at the outermost level of `createPageSource()`. At this stage, the page layout had already been modified by IcebergPartitionInsertingPageSource and metadata trackers to include additional columns. This caused channel layout mismatches and casting/indexing exceptions (like UnsupportedOperationException), as the default-value replacement logic expected channels matching the table schema's physical columns.
    So now I have moved the `IcebergDefaultValuePageSource` wrapping down to the lowest file-reader level inside `createParquetPageSource` and `createOrcPageSource`. It now operates exclusively on the physical storage columns (regularColumns) before partition values or delete filters are appended.

3. Updated the `ConnectorMetadata.beginInsert` and the engine's `Metadata.beginInsert` APIs to accept `List<String> insertColumnNames`. This allows the query planner to propagate the set of explicitly targeted columns from the parser down to the connector metadata level. With this information, the `IcebergPageSink` can successfully identify omitted columns and selectively materialize their write-default values, while preserving explicit NULLs for target columns.

## Test Plan
Added relevant tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for iceberg write-default
```

## Summary by Sourcery

Add support in the Iceberg connector for applying column write defaults during inserts and for reading initial default values when data files lack corresponding columns, while pluming insert column metadata through the planner and metadata layers.

New Features:
- Support applying Iceberg column write-default values during INSERT when columns are omitted from the statement, including for multiple data types and partitioned tables.

Bug Fixes:
- Ensure missing physical columns in Parquet and ORC Iceberg files are populated with their initial default values at read time instead of failing or returning nulls.
- Distinguish omitted columns from explicitly NULL columns in INSERT statements so that defaults are not applied when NULL is explicitly provided.

Enhancements:
- Extend Iceberg column handles and insert table handles to carry both initial and write default values and the set of explicitly inserted columns.
- Plumb insert column name information through SPI and metadata layers so connectors can reason about omitted versus specified columns.
- Refine Iceberg value deserialization utilities to be reusable beyond partition values and handle default-value decoding.
- Update Iceberg tests to cover write-default behavior across various types and partitioned tables, and adjust statistics tests for the extended column handle shape.

Build:
- Adjust presto-iceberg module dependency analysis configuration to ignore specific Parquet and memory-context dependencies.

## Summary by Sourcery

Add Iceberg connector support for applying and propagating column default values on both read and write paths, and plumb insert column metadata through the engine to distinguish omitted columns from explicitly provided ones.

New Features:
- Support Iceberg column write-default semantics during INSERT so omitted columns are populated according to their write defaults.
- Carry Iceberg column initial and write default metadata in column and insert table handles across Java and native protocols.

Bug Fixes:
- Populate missing physical columns in Parquet and ORC Iceberg files with their initial default values at read time instead of failing or returning incorrect nulls.
- Fix channel layout issues by applying default-value page source wrapping at the file-reader level rather than after partition and metadata columns are added.
- Enable connectors to distinguish omitted columns from explicitly NULL columns in INSERT statements to avoid misapplying defaults.

Enhancements:
- Refine Iceberg value deserialization utilities for reuse beyond partition keys, including default-value decoding.
- Extend Iceberg page sink and page source wiring to support write defaults without changing existing callers via deprecated beginInsert overloads.
- Update Iceberg statistics tests and helpers to account for the extended column handle shape carrying write default values.

Build:
- Adjust presto-iceberg dependency analysis configuration to ignore specific Parquet and memory-context dependencies.

Tests:
- Add Iceberg V3 tests covering write-default behavior for various data types, multiple defaulted columns, explicit NULL handling, and partitioned tables.