### PR TITLE
feat(plugin-iceberg): Add support for iceberg.target-max-file-size

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -342,10 +342,10 @@ Property Name                                           Description             
                                                         is required if the iceberg.catalog.type is ``hadoop``.
                                                         Otherwise, it will be ignored.
 
-``iceberg.file-format``                                 The storage file format for Iceberg tables. The available     ``PARQUET``                        Yes                 No, write is not supported yet
+``iceberg.file-format``                                 The storage file format for Iceberg tables. The available     ``PARQUET``                        Yes                 No, write is not supported
                                                         values are ``PARQUET`` and ``ORC``.
 
-``iceberg.compression-codec``                           The compression codec to use when writing files. The          ``ZSTD``                           Yes                 No, write is not supported yet
+``iceberg.compression-codec``                           The compression codec to use when writing files. The          ``ZSTD``                           Yes                 No, write is not supported
                                                         available values are ``NONE``, ``SNAPPY``, ``GZIP``,
                                                         ``LZ4``, and ``ZSTD``.
                                                         
@@ -353,7 +353,7 @@ Property Name                                           Description             
                                                         ``iceberg.file-format=ORC``.
 
 
-``iceberg.max-partitions-per-writer``                   The maximum number of partitions handled per writer.          ``100``                            Yes                 No, write is not supported yet
+``iceberg.max-partitions-per-writer``                   The maximum number of partitions handled per writer.          ``100``                            Yes                 No, write is not supported
 
 ``iceberg.minimum-assigned-split-weight``               A decimal value in the range (0, 1] is used as a minimum      ``0.05``                           Yes                 Yes
                                                         for weights assigned to each split. A low value may improve
@@ -403,19 +403,26 @@ Property Name                                           Description             
 
 ``iceberg.split-manager-threads``                       Number of threads to use for generating Iceberg splits.       ``Number of available processors`` Yes                 Yes, only needed on coordinator
 
-``iceberg.metadata-previous-versions-max``              The maximum number of old metadata files to keep in           ``100``                            Yes                 No, write is not supported yet
+``iceberg.metadata-previous-versions-max``              The maximum number of old metadata files to keep in           ``100``                            Yes                 No, write is not supported
                                                         current metadata log.
 
-``iceberg.metadata-delete-after-commit``                Set to ``true`` to delete the oldest metadata files after     ``false``                          Yes                 No, write is not supported yet
+``iceberg.metadata-delete-after-commit``                Set to ``true`` to delete the oldest metadata files after     ``false``                          Yes                 No, write is not supported
                                                         each commit.
 
-``iceberg.metrics-max-inferred-column``                 The maximum number of columns for which metrics               ``100``                            Yes                 No, write is not supported yet
+``iceberg.metrics-max-inferred-column``                 The maximum number of columns for which metrics               ``100``                            Yes                 No, write is not supported
                                                         are collected.
 ``iceberg.max-statistics-file-cache-size``              Maximum size in bytes that should be consumed by the          ``256MB``                          Yes                 Yes, only needed on coordinator
                                                         statistics file cache.
 
 ``iceberg.aggregate-push-down-enabled``                 Controls whether to push down aggregate (MIN/MAX/COUNT) to    ``true``                           Yes                 Yes
                                                         Iceberg based on data file stats.
+
+``iceberg.target-max-file-size``                        Target maximum size of written files; the actual size may     ``1GB``                            Yes                 No, write is not supported
+                                                        be larger. This property accepts values in the format of a
+                                                        number immediately followed by a unit (``40kB``,
+                                                        ``256MB``, ``1GB``). Supported units are: ``B`` (bytes),
+                                                        ``kB`` (kilobytes), ``MB`` (megabytes), ``GB`` (gigabytes),
+                                                        ``TB`` (terabytes), ``PB`` (petabytes).
 ======================================================= ============================================================= ================================== =================== =============================================
 
 Table Properties
@@ -438,10 +445,10 @@ The following table properties are available, which are specific to the Presto I
 ========================================================   ===============================================================   ===================== =================== =============================================
 Property Name                                              Description                                                       Default               Presto Java Support Presto C++ Support
 ========================================================   ===============================================================   ===================== =================== =============================================
-``commit.retry.num-retries``                               Determines the number of attempts for committing the metadata     ``4``                 Yes                 No, write is not supported yet
+``commit.retry.num-retries``                               Determines the number of attempts for committing the metadata     ``4``                 Yes                 No, write is not supported
                                                            in case of concurrent upsert requests, before failing.
 
-``format-version``                                         Optionally specifies the format version of the Iceberg            ``2``                 Yes                 No, write is not supported yet
+``format-version``                                         Optionally specifies the format version of the Iceberg            ``2``                 Yes                 No, write is not supported
                                                            specification to use for new tables, either ``1`` or ``2``.
 
 ``location``                                               Optionally specifies the file system location URI for                                   Yes                 Yes
@@ -455,29 +462,29 @@ Property Name                                              Description          
                                                            for a table scan. Generated splits may still be larger or
                                                            smaller than this value. Must be specified in bytes.
 
-``write.data.path``                                        Optionally specifies the file system location URI for                                   Yes                 No, write is not supported yet
+``write.data.path``                                        Optionally specifies the file system location URI for                                   Yes                 No, write is not supported
                                                            storing the data and delete files of the table. This only
                                                            applies to files written after this property is set. Files
                                                            previously written aren't relocated to reflect this
                                                            parameter.
 
-``write.delete.mode``                                      Optionally specifies the write delete mode of the Iceberg         ``merge-on-read``     Yes                 No, write is not supported yet
+``write.delete.mode``                                      Optionally specifies the write delete mode of the Iceberg         ``merge-on-read``     Yes                 No, write is not supported
                                                            specification to use for new tables, either ``copy-on-write``
                                                            or ``merge-on-read``.
 
-``write.format.default``                                   Optionally specifies the format of table data files,              ``PARQUET``           Yes                 No, write is not supported yet
+``write.format.default``                                   Optionally specifies the format of table data files,              ``PARQUET``           Yes                 No, write is not supported
                                                            either ``PARQUET`` or ``ORC``.
 
-``write.metadata.previous-versions-max``                   Optionally specifies the max number of old metadata files to      ``100``               Yes                 No, write is not supported yet
+``write.metadata.previous-versions-max``                   Optionally specifies the max number of old metadata files to      ``100``               Yes                 No, write is not supported
                                                            keep in current metadata log.
 
-``write.metadata.delete-after-commit.enabled``             Set to ``true`` to delete the oldest metadata file after          ``false``             Yes                 No, write is not supported yet
+``write.metadata.delete-after-commit.enabled``             Set to ``true`` to delete the oldest metadata file after          ``false``             Yes                 No, write is not supported
                                                            each commit.
 
-``write.metadata.metrics.max-inferred-column-defaults``    Optionally specifies the maximum number of columns for which      ``100``               Yes                 No, write is not supported yet
+``write.metadata.metrics.max-inferred-column-defaults``    Optionally specifies the maximum number of columns for which      ``100``               Yes                 No, write is not supported
                                                            metrics are collected.
 
-``write.update.mode``                                      Optionally specifies the write update mode of the Iceberg         ``merge-on-read``     Yes                 No, write is not supported yet
+``write.update.mode``                                      Optionally specifies the write update mode of the Iceberg         ``merge-on-read``     Yes                 No, write is not supported
                                                            specification to use for new tables, either ``copy-on-write``
                                                            or ``merge-on-read``.
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -572,6 +572,13 @@ Session properties set behavior changes for queries executed within the given se
        ``iceberg.rows-for-metadata-optimization-threshold`` in the current session.
      - Yes
      - Yes
+   * - .. _iceberg-sess-target-max-file-size:
+
+       ``iceberg.target_max_file_size``
+     - Overrides the behavior of the connector property
+       ``iceberg.target-max-file-size`` in the current session.
+     - Yes
+     - No
    * - .. _iceberg-sess-target-split-size-bytes:
 
        ``iceberg.target_split_size_bytes``

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -81,6 +81,7 @@ public class IcebergConfig
     private int materializedViewMaxChangedPartitions = 100;
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
     private boolean aggregatePushDownEnabled = true;
+    private DataSize targetMaxFileSize = succinctDataSize(1, DataSize.Unit.GIGABYTE);
 
     @NotNull
     public FileFormat getFileFormat()
@@ -556,6 +557,20 @@ public class IcebergConfig
     public IcebergConfig setAggregatePushDownEnabled(boolean aggregatePushDownEnabled)
     {
         this.aggregatePushDownEnabled = aggregatePushDownEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getTargetMaxFileSize()
+    {
+        return targetMaxFileSize;
+    }
+
+    @Config("iceberg.target-max-file-size")
+    @ConfigDescription("Target maximum size of written files; the actual size may be larger")
+    public IcebergConfig setTargetMaxFileSize(DataSize targetMaxFileSize)
+    {
+        this.targetMaxFileSize = targetMaxFileSize;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.hadoop.HadoopFileIO;
 import java.util.EnumSet;
 import java.util.List;
 
+import static com.facebook.airlift.units.DataSize.Unit.GIGABYTE;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static com.facebook.airlift.units.DataSize.succinctDataSize;
 import static com.facebook.presto.hive.HiveCompressionCodec.ZSTD;
@@ -81,7 +82,7 @@ public class IcebergConfig
     private int materializedViewMaxChangedPartitions = 100;
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
     private boolean aggregatePushDownEnabled = true;
-    private DataSize targetMaxFileSize = succinctDataSize(1, DataSize.Unit.GIGABYTE);
+    private DataSize targetMaxFileSize = succinctDataSize(1, GIGABYTE);
 
     @NotNull
     public FileFormat getFileFormat()
@@ -566,10 +567,14 @@ public class IcebergConfig
         return targetMaxFileSize;
     }
 
+    @Min(1)
     @Config("iceberg.target-max-file-size")
     @ConfigDescription("Target maximum size of written files; the actual size may be larger")
     public IcebergConfig setTargetMaxFileSize(DataSize targetMaxFileSize)
     {
+        if (targetMaxFileSize.toBytes() < 1) {
+            throw new IllegalArgumentException("iceberg.target-max-file-size must be at least 1 byte");
+        }
         this.targetMaxFileSize = targetMaxFileSize;
         return this;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -228,9 +228,11 @@ public class IcebergPageSink
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        for (WriteContext context : writers) {
+        for (int i = 0; i < writers.size(); i++) {
+            WriteContext context = writers.get(i);
             if (context != null) {
                 closeWriter(context);
+                writers.set(i, null);
             }
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -111,8 +111,11 @@ public class IcebergPageSink
     private final FileFormat fileFormat;
     private final PagePartitioner pagePartitioner;
     private final Table table;
+    private final long targetMaxFileSize;
 
     private final List<WriteContext> writers = new ArrayList<>();
+    private final List<WriteContext> closedWriters = new ArrayList<>();
+    private final Collection<Slice> commitTasks = new ArrayList<>();
 
     private long writtenBytes;
     private long systemMemoryUsage;
@@ -138,9 +141,11 @@ public class IcebergPageSink
             FileFormat fileFormat,
             int maxOpenWriters,
             List<SortField> sortOrder,
-            SortParameters sortParameters)
+            SortParameters sortParameters,
+            long targetMaxFileSize)
     {
         requireNonNull(inputColumns, "inputColumns is null");
+        this.targetMaxFileSize = targetMaxFileSize;
         this.table = requireNonNull(table, "table is null");
         this.outputSchema = table.schema();
         this.partitionSpec = table.spec();
@@ -223,28 +228,16 @@ public class IcebergPageSink
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        Collection<Slice> commitTasks = new ArrayList<>();
-
         for (WriteContext context : writers) {
-            context.getWriter().commit();
-
-            CommitTaskData task = new CommitTaskData(
-                    context.getPath().toString(),
-                    context.writer.getFileSizeInBytes(),
-                    new MetricsWrapper(context.writer.getMetrics()),
-                    partitionSpec.specId(),
-                    context.getPartitionData().map(PartitionData::toJson),
-                    fileFormat,
-                    null,
-                    DATA);
-
-            commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
+            if (context != null) {
+                closeWriter(context);
+            }
         }
 
-        writtenBytes = writers.stream()
+        writtenBytes = closedWriters.stream()
                 .mapToLong(writer -> writer.getWriter().getWrittenBytes())
                 .sum();
-        validationCpuNanos = writers.stream()
+        validationCpuNanos = closedWriters.stream()
                 .mapToLong(writer -> writer.getWriter().getValidationCpuNanos())
                 .sum();
 
@@ -256,6 +249,19 @@ public class IcebergPageSink
     {
         RuntimeException error = null;
         for (WriteContext context : writers) {
+            try {
+                if (context != null) {
+                    context.getWriter().rollback();
+                }
+            }
+            catch (Throwable t) {
+                if (error == null) {
+                    error = new RuntimeException("Exception during rollback");
+                }
+                error.addSuppressed(t);
+            }
+        }
+        for (WriteContext context : closedWriters) {
             try {
                 if (context != null) {
                     context.getWriter().rollback();
@@ -332,6 +338,10 @@ public class IcebergPageSink
 
             writtenBytes += (writer.getWrittenBytes() - currentWritten);
             systemMemoryUsage += (writer.getSystemMemoryUsage() - currentMemory);
+            if (writer.getWrittenBytes() >= targetMaxFileSize) {
+                closeWriter(writers.get(index));
+                writers.set(index, null);
+            }
         }
     }
 
@@ -390,8 +400,30 @@ public class IcebergPageSink
             }
         }
         verify(writers.size() == pagePartitioner.getMaxIndex() + 1);
-        verify(!writers.contains(null));
         return writerIndexes;
+    }
+
+    private void closeWriter(WriteContext writeContext)
+    {
+        long currentWritten = writeContext.getWriter().getWrittenBytes();
+        long currentMemory = writeContext.getWriter().getSystemMemoryUsage();
+        writeContext.getWriter().commit();
+        writtenBytes += (writeContext.getWriter().getWrittenBytes() - currentWritten);
+        systemMemoryUsage += (writeContext.getWriter().getSystemMemoryUsage() - currentMemory);
+
+        CommitTaskData task = new CommitTaskData(
+                writeContext.getPath().toString(),
+                writeContext.getWriter().getFileSizeInBytes(),
+                new MetricsWrapper(writeContext.getWriter().getMetrics()),
+                partitionSpec.specId(),
+                writeContext.getPartitionData().map(PartitionData::toJson),
+                fileFormat,
+                null,
+                DATA);
+
+        commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
+
+        closedWriters.add(writeContext);
     }
 
     private WriteContext createWriter(Optional<PartitionData> partitionData, Path outputPath)
@@ -525,6 +557,11 @@ public class IcebergPageSink
         public Optional<PartitionData> getPartitionData()
         {
             return partitionData;
+        }
+
+        public long getWrittenBytes()
+        {
+            return writer.getWrittenBytes();
         }
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -558,11 +558,6 @@ public class IcebergPageSink
         {
             return partitionData;
         }
-
-        public long getWrittenBytes()
-        {
-            return writer.getWrittenBytes();
-        }
     }
 
     private static class PagePartitioner

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -53,6 +53,7 @@ public class IcebergPageSinkProvider
     private final IcebergFileWriterFactory fileWriterFactory;
     private final PageIndexerFactory pageIndexerFactory;
     private final SortParameters sortParameters;
+    private final IcebergConfig icebergConfig;
 
     @Inject
     public IcebergPageSinkProvider(
@@ -60,13 +61,15 @@ public class IcebergPageSinkProvider
             JsonCodec<CommitTaskData> jsonCodec,
             IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory,
-            SortParameters sortParameters)
+            SortParameters sortParameters,
+            IcebergConfig icebergConfig)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.sortParameters = sortParameters;
+        this.icebergConfig = requireNonNull(icebergConfig, "icebergConfig is null");
     }
 
     @Override
@@ -108,7 +111,8 @@ public class IcebergPageSinkProvider
                 tableHandle.getFileFormat(),
                 getMaxPartitionsPerWriter(session),
                 tableHandle.getSortOrder(),
-                sortParameters);
+                sortParameters,
+                icebergConfig.getTargetMaxFileSize().toBytes());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -53,7 +53,6 @@ public class IcebergPageSinkProvider
     private final IcebergFileWriterFactory fileWriterFactory;
     private final PageIndexerFactory pageIndexerFactory;
     private final SortParameters sortParameters;
-    private final IcebergConfig icebergConfig;
 
     @Inject
     public IcebergPageSinkProvider(
@@ -61,15 +60,13 @@ public class IcebergPageSinkProvider
             JsonCodec<CommitTaskData> jsonCodec,
             IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory,
-            SortParameters sortParameters,
-            IcebergConfig icebergConfig)
+            SortParameters sortParameters)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.sortParameters = sortParameters;
-        this.icebergConfig = requireNonNull(icebergConfig, "icebergConfig is null");
     }
 
     @Override
@@ -112,7 +109,7 @@ public class IcebergPageSinkProvider
                 getMaxPartitionsPerWriter(session),
                 tableHandle.getSortOrder(),
                 sortParameters,
-                icebergConfig.getTargetMaxFileSize().toBytes());
+                IcebergSessionProperties.getTargetMaxFileSize(session).toBytes());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -214,6 +214,7 @@ public class IcebergPageSourceProvider
     private final PageIndexerFactory pageIndexerFactory;
     private final int maxOpenPartitions;
     private final SortParameters sortParameters;
+    private final long targetMaxFileSize;
 
     @Inject
     public IcebergPageSourceProvider(
@@ -244,6 +245,7 @@ public class IcebergPageSourceProvider
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
         this.maxOpenPartitions = icebergConfig.getMaxPartitionsPerWriter();
+        this.targetMaxFileSize = icebergConfig.getTargetMaxFileSize().toBytes();
         this.sortParameters = requireNonNull(sortParameters, "sortParameters is null");
     }
 
@@ -937,7 +939,8 @@ public class IcebergPageSourceProvider
                 split.getFileFormat(),
                 maxOpenPartitions,
                 table.getSortOrder(),
-                sortParameters);
+                sortParameters,
+                targetMaxFileSize);
 
         ConnectorPageSource dataSource = new IcebergUpdateablePageSource(
                 tableSchema,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -214,7 +214,6 @@ public class IcebergPageSourceProvider
     private final PageIndexerFactory pageIndexerFactory;
     private final int maxOpenPartitions;
     private final SortParameters sortParameters;
-    private final long targetMaxFileSize;
 
     @Inject
     public IcebergPageSourceProvider(
@@ -245,7 +244,6 @@ public class IcebergPageSourceProvider
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
         this.maxOpenPartitions = icebergConfig.getMaxPartitionsPerWriter();
-        this.targetMaxFileSize = icebergConfig.getTargetMaxFileSize().toBytes();
         this.sortParameters = requireNonNull(sortParameters, "sortParameters is null");
     }
 
@@ -940,7 +938,7 @@ public class IcebergPageSourceProvider
                 maxOpenPartitions,
                 table.getSortOrder(),
                 sortParameters,
-                targetMaxFileSize);
+                IcebergSessionProperties.getTargetMaxFileSize(session).toBytes());
 
         ConnectorPageSource dataSource = new IcebergUpdateablePageSource(
                 tableSchema,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -78,6 +78,7 @@ public final class IcebergSessionProperties
     public static final String MATERIALIZED_VIEW_MAX_CHANGED_PARTITIONS = "materialized_view_max_changed_partitions";
     public static final String MATERIALIZED_VIEW_DEFAULT_MAX_SNAPSHOTS_PER_REFRESH = "materialized_view_default_max_snapshots_per_refresh";
     public static final String AGGREGATE_PUSH_DOWN_ENABLED = "aggregate_push_down_enabled";
+    public static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -271,7 +272,23 @@ public final class IcebergSessionProperties
                         AGGREGATE_PUSH_DOWN_ENABLED,
                         "Controls whether to push down aggregate (MIN/MAX/COUNT) to Iceberg based on data file stats",
                         icebergConfig.isAggregatePushDownEnabled(),
-                        false));
+                        false))
+                .add(new PropertyMetadata<>(
+                        TARGET_MAX_FILE_SIZE,
+                        "Target maximum size of written files; the actual size may be larger",
+                        createUnboundedVarcharType(),
+                        DataSize.class,
+                        icebergConfig.getTargetMaxFileSize(),
+                        false,
+                        value -> {
+                            DataSize dataSize = DataSize.valueOf((String) value);
+                            if (dataSize.toBytes() < 1) {
+                                throw new PrestoException(INVALID_SESSION_PROPERTY,
+                                        format("Invalid value for %s: %s. It must be at least 1 byte.", TARGET_MAX_FILE_SIZE, dataSize));
+                            }
+                            return dataSize;
+                        },
+                        DataSize::toString));
 
         nessieConfig.ifPresent((config) -> propertiesBuilder
                 .add(stringProperty(
@@ -448,5 +465,10 @@ public final class IcebergSessionProperties
     public static boolean isAggregatePushDownEnabled(ConnectorSession session)
     {
         return session.getProperty(AGGREGATE_PUSH_DOWN_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getTargetMaxFileSize(ConnectorSession session)
+    {
+        return session.getProperty(TARGET_MAX_FILE_SIZE, DataSize.class);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.airlift.units.DataSize.Unit.GIGABYTE;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static com.facebook.airlift.units.DataSize.succinctDataSize;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
@@ -78,7 +79,8 @@ public class TestIcebergConfig
                 .setMaterializedViewDefaultStorageSchema(null)
                 .setMaterializedViewMaxChangedPartitions(100)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0)
-                .setAggregatePushDownEnabled(true));
+                .setAggregatePushDownEnabled(true)
+                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE)));
     }
 
     @Test
@@ -119,6 +121,7 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-view-max-changed-partitions", "2000")
                 .put("iceberg.materialized-view-default-max-snapshots-per-refresh", "10")
                 .put("iceberg.aggregate-push-down-enabled", "false")
+                .put("iceberg.target-max-file-size", "512MB")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -155,7 +158,8 @@ public class TestIcebergConfig
                 .setMaterializedViewDefaultStorageSchema("_mv_storage")
                 .setMaterializedViewMaxChangedPartitions(2000)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10)
-                .setAggregatePushDownEnabled(false);
+                .setAggregatePushDownEnabled(false)
+                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
@@ -21,7 +21,10 @@ import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.OptionalInt;
+
 import static com.facebook.presto.SystemSessionProperties.TASK_WRITER_COUNT;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -43,24 +46,21 @@ public class TestIcebergTargetMaxFileSize
     @Test
     public void testTargetMaxFileSize()
     {
-        String tableName = "test_target_max_file_size_" + System.currentTimeMillis();
+        // Note: This test uses estimates (> 10 files) to test the default multi-worker scenario
+        // without modifying worker count, split sizes, or other parameters that would make
+        // the file count deterministic. The 40kB target file size should create significantly
+        // more files than the default 1GB, demonstrating that the configuration is working.
+        String tableName = "test_target_max_file_size_" + randomTableSuffix();
 
         try {
             // Create table with small target file size (40kB configured in connector properties)
-            Session session = Session.builder(getSession())
-                    .setSystemProperty(TASK_WRITER_COUNT, "1")
-                    .build();
-
-            assertUpdate(session,
-                    String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
+            assertUpdate(String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
                     60175);
 
-            // Verify data is correct
             MaterializedResult countResult = computeActual(
                     String.format("SELECT count(*) FROM %s", tableName));
             assertEquals(countResult.getOnlyValue(), 60175L);
 
-            // Check number of files created
             MaterializedResult fileCountResult = computeActual(
                     String.format("SELECT count(*) FROM \"%s$files\"", tableName));
             long fileCount = (Long) fileCountResult.getOnlyValue();
@@ -74,8 +74,8 @@ public class TestIcebergTargetMaxFileSize
             MaterializedResult fileSizes = computeActual(
                     String.format("SELECT file_size_in_bytes FROM \"%s$files\"", tableName));
 
-            long targetSize = 40 * 1024; // 40kB
-            long maxAllowedSize = targetSize * 10; // Allow up to 10x the target size
+            long targetSize = 40 * 1024;
+            long maxAllowedSize = targetSize * 10;
             for (MaterializedRow row : fileSizes.getMaterializedRows()) {
                 long fileSize = (Long) row.getField(0);
                 assertTrue(fileSize > 0 && fileSize <= maxAllowedSize,
@@ -92,31 +92,28 @@ public class TestIcebergTargetMaxFileSize
     @Test
     public void testTargetMaxFileSizeWithPartitioning()
     {
-        String tableName = "test_target_max_file_size_partitioned_" + System.currentTimeMillis();
+        // Note: This test uses estimates (> 10 files) to test the default multi-worker scenario
+        // with partitioning, without modifying worker count, split sizes, or other parameters
+        // that would make the file count deterministic. The 40kB target file size should create
+        // significantly more files than the default 1GB, demonstrating that the configuration
+        // is working across partitions.
+        String tableName = "test_target_max_file_size_partitioned_" + randomTableSuffix();
 
         try {
             // Create partitioned table with small file size limit (40kB configured in connector properties)
-            Session session = Session.builder(getSession())
-                    .setSystemProperty(TASK_WRITER_COUNT, "1")
-                    .build();
-
-            assertUpdate(session,
-                    String.format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, suppkey BIGINT, " +
+            assertUpdate(String.format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, suppkey BIGINT, " +
                             "linenumber INTEGER, quantity DOUBLE, extendedprice DOUBLE, discount DOUBLE, " +
                             "tax DOUBLE, returnflag VARCHAR, linestatus VARCHAR, shipdate DATE, " +
                             "commitdate DATE, receiptdate DATE, shipinstruct VARCHAR, shipmode VARCHAR, " +
                             "comment VARCHAR) WITH (partitioning = ARRAY['returnflag'])", tableName));
 
-            assertUpdate(session,
-                    String.format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName),
+            assertUpdate(String.format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName),
                     60175);
 
-            // Verify data
             MaterializedResult countResult = computeActual(
                     String.format("SELECT count(*) FROM %s", tableName));
             assertEquals(countResult.getOnlyValue(), 60175L);
 
-            // Check total number of files
             MaterializedResult totalFilesResult = computeActual(
                     String.format("SELECT count(*) FROM \"%s$files\"", tableName));
             long totalFiles = (Long) totalFilesResult.getOnlyValue();
@@ -131,7 +128,7 @@ public class TestIcebergTargetMaxFileSize
                     String.format("SELECT file_size_in_bytes FROM \"%s$files\"", tableName));
 
             long targetSize = 40 * 1024; // 40kB
-            long maxAllowedSize = targetSize * 10; // Allow up to 10x the target size
+            long maxAllowedSize = targetSize * 10;
             for (MaterializedRow row : fileSizes.getMaterializedRows()) {
                 long fileSize = (Long) row.getField(0);
                 assertTrue(fileSize > 0 && fileSize <= maxAllowedSize,
@@ -140,7 +137,273 @@ public class TestIcebergTargetMaxFileSize
             }
         }
         finally {
-            // Cleanup
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testDefaultTargetMaxFileSizeUnpartitioned()
+            throws Exception
+    {
+        // Create a query runner with default 1GB target size and single worker
+        QueryRunner defaultQueryRunner = IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setNodeCount(OptionalInt.of(1))
+                .build().getQueryRunner();
+
+        try {
+            String tableName = "test_default_unpartitioned_" + randomTableSuffix();
+
+            try {
+                // With default 1GB target size, TASK_WRITER_COUNT=1, and single worker
+                Session session = Session.builder(defaultQueryRunner.getDefaultSession())
+                        .setSystemProperty(TASK_WRITER_COUNT, "1")
+                        .build();
+
+                defaultQueryRunner.execute(session,
+                        String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName));
+
+                MaterializedResult countResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM %s", tableName));
+                assertEquals(countResult.getOnlyValue(), 60175L);
+
+                MaterializedResult fileCountResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+                long fileCount = (Long) fileCountResult.getOnlyValue();
+
+                // With default 1GB limit, TASK_WRITER_COUNT=1, and single worker,
+                // tpch.tiny.lineitem (~1.68MB) should create exactly 1 file
+                assertEquals(fileCount, 1L,
+                        String.format("Expected exactly 1 file with default 1GB limit, single worker, and TASK_WRITER_COUNT=1, got %d", fileCount));
+            }
+            finally {
+                defaultQueryRunner.execute(String.format("DROP TABLE IF EXISTS %s", tableName));
+            }
+        }
+        finally {
+            defaultQueryRunner.close();
+        }
+    }
+
+    @Test
+    public void testDefaultTargetMaxFileSizePartitioned()
+            throws Exception
+    {
+        // Create a query runner with default 1GB target size and single worker
+        QueryRunner defaultQueryRunner = IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setNodeCount(OptionalInt.of(1))
+                .build().getQueryRunner();
+
+        try {
+            String tableName = "test_default_partitioned_" + randomTableSuffix();
+
+            try {
+                // With default 1GB target size, TASK_WRITER_COUNT=1, and single worker
+                Session session = Session.builder(defaultQueryRunner.getDefaultSession())
+                        .setSystemProperty(TASK_WRITER_COUNT, "1")
+                        .build();
+
+                defaultQueryRunner.execute(session,
+                        String.format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, suppkey BIGINT, " +
+                                "linenumber INTEGER, quantity DOUBLE, extendedprice DOUBLE, discount DOUBLE, " +
+                                "tax DOUBLE, returnflag VARCHAR, linestatus VARCHAR, shipdate DATE, " +
+                                "commitdate DATE, receiptdate DATE, shipinstruct VARCHAR, shipmode VARCHAR, " +
+                                "comment VARCHAR) WITH (partitioning = ARRAY['returnflag'])", tableName));
+
+                defaultQueryRunner.execute(session,
+                        String.format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName));
+
+                MaterializedResult countResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM %s", tableName));
+                assertEquals(countResult.getOnlyValue(), 60175L);
+
+                MaterializedResult partitionCountResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(DISTINCT returnflag) FROM %s", tableName));
+                long partitionCount = (Long) partitionCountResult.getOnlyValue();
+
+                MaterializedResult totalFilesResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+                long totalFiles = (Long) totalFilesResult.getOnlyValue();
+
+                // With default 1GB limit, TASK_WRITER_COUNT=1, and single worker,
+                // we should have exactly 1 file per partition (tpch.tiny.lineitem has 3 distinct returnflag values: A, N, R)
+                assertEquals(totalFiles, partitionCount,
+                        String.format("Expected exactly %d files (1 per partition) with default 1GB limit, single worker, and TASK_WRITER_COUNT=1, got %d",
+                                partitionCount, totalFiles));
+            }
+            finally {
+                defaultQueryRunner.execute(String.format("DROP TABLE IF EXISTS %s", tableName));
+            }
+        }
+        finally {
+            defaultQueryRunner.close();
+        }
+    }
+
+    @Test
+    public void testSessionPropertyOverridesDefault()
+    {
+        String tableName = "test_session_overrides_default_" + randomTableSuffix();
+
+        try {
+            // Use smaller page/block sizes with 900kB target file size for deterministic file splitting
+            // This overrides the default 40kB config property
+            Session session = Session.builder(getSession())
+                    .setSystemProperty(TASK_WRITER_COUNT, "1")
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "2kB")
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_page_size", "1kB")
+                    .setCatalogSessionProperty("iceberg", "target_max_file_size", "900kB")
+                    .build();
+
+            assertUpdate(session,
+                    String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    60175);
+
+            MaterializedResult countResult = computeActual(session,
+                    String.format("SELECT count(*) FROM %s", tableName));
+            assertEquals(countResult.getOnlyValue(), 60175L);
+
+            MaterializedResult fileCountResult = computeActual(session,
+                    String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+            long fileCount = (Long) fileCountResult.getOnlyValue();
+
+            // With 900kB session property (overriding 40kB config),
+            // tpch.tiny.lineitem (~1.68MB) should create exactly 2 files
+            assertEquals(fileCount, 2L,
+                    String.format("Expected exactly 2 files with 900kB session property, got %d", fileCount));
+        }
+        finally {
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testSessionPropertyWithoutConfigProperty()
+            throws Exception
+    {
+        // Create a query runner with NO config property (default 1GB)
+        QueryRunner defaultQueryRunner = IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setNodeCount(OptionalInt.of(1))
+                .build().getQueryRunner();
+
+        try {
+            String tableName = "test_session_no_config_" + randomTableSuffix();
+
+            try {
+                // Use smaller page/block sizes with 900kB target file size for deterministic file splitting
+                // This overrides the default 1GB config
+                Session session = Session.builder(defaultQueryRunner.getDefaultSession())
+                        .setSystemProperty(TASK_WRITER_COUNT, "1")
+                        .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "2kB")
+                        .setCatalogSessionProperty("iceberg", "parquet_writer_page_size", "1kB")
+                        .setCatalogSessionProperty("iceberg", "target_max_file_size", "900kB")
+                        .build();
+
+                defaultQueryRunner.execute(session,
+                        String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName));
+
+                MaterializedResult countResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM %s", tableName));
+                assertEquals(countResult.getOnlyValue(), 60175L);
+
+                MaterializedResult fileCountResult = defaultQueryRunner.execute(
+                        String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+                long fileCount = (Long) fileCountResult.getOnlyValue();
+
+                // With 900kB session property (overriding default 1GB),
+                // tpch.tiny.lineitem (~1.68MB) should create exactly 2 files
+                assertEquals(fileCount, 2L,
+                        String.format("Expected exactly 2 files with 900kB session property, got %d", fileCount));
+            }
+            finally {
+                defaultQueryRunner.execute(String.format("DROP TABLE IF EXISTS %s", tableName));
+            }
+        }
+        finally {
+            defaultQueryRunner.close();
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Could not coerce value '-1B' to DataSize.*iceberg.target-max-file-size.*")
+    public void testNegativeConfigProperty()
+            throws Exception
+    {
+        // Create a query runner with negative config property value
+        // This should fail during initialization because DataSize.valueOf() rejects negative values
+        QueryRunner negativeConfigRunner = IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setExtraConnectorProperties(ImmutableMap.of(
+                        "iceberg.target-max-file-size", "-1B"))
+                .build().getQueryRunner();
+
+        try {
+            negativeConfigRunner.close();
+        }
+        finally {
+            negativeConfigRunner.close();
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*iceberg.target-max-file-size must be at least 1 byte.*")
+    public void testZeroConfigProperty()
+            throws Exception
+    {
+        // Create a query runner with zero config property value
+        // This should fail during initialization due to custom validation in setter
+        QueryRunner zeroConfigRunner = IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setExtraConnectorProperties(ImmutableMap.of(
+                        "iceberg.target-max-file-size", "0B"))
+                .build().getQueryRunner();
+
+        try {
+            zeroConfigRunner.close();
+        }
+        finally {
+            zeroConfigRunner.close();
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*iceberg.target_max_file_size is invalid: -1B.*")
+    public void testNegativeSessionProperty()
+    {
+        String tableName = "test_negative_session_" + randomTableSuffix();
+
+        try {
+            // Try to set negative session property value
+            Session session = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "target_max_file_size", "-1B")
+                    .build();
+
+            // This should fail when the session property is validated
+            assertUpdate(session,
+                    String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    60175);
+        }
+        finally {
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Invalid value for target_max_file_size.*must be at least 1 byte.*")
+    public void testZeroSessionProperty()
+    {
+        String tableName = "test_zero_session_" + randomTableSuffix();
+
+        try {
+            // Try to set zero session property value
+            Session session = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "target_max_file_size", "0B")
+                    .build();
+
+            // This should fail when the session property is validated
+            assertUpdate(session,
+                    String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    60175);
+        }
+        finally {
             assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
         }
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.TASK_WRITER_COUNT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestIcebergTargetMaxFileSize
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(CatalogType.HIVE)
+                .setExtraConnectorProperties(ImmutableMap.of(
+                        "iceberg.target-max-file-size", "40kB"))
+                .build().getQueryRunner();
+    }
+
+    @Test
+    public void testTargetMaxFileSize()
+    {
+        String tableName = "test_target_max_file_size_" + System.currentTimeMillis();
+
+        try {
+            // Create table with small target file size (40kB configured in connector properties)
+            Session session = Session.builder(getSession())
+                    .setSystemProperty(TASK_WRITER_COUNT, "1")
+                    .build();
+
+            assertUpdate(session,
+                    String.format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    60175);
+
+            // Verify data is correct
+            MaterializedResult countResult = computeActual(
+                    String.format("SELECT count(*) FROM %s", tableName));
+            assertEquals(countResult.getOnlyValue(), 60175L);
+
+            // Check number of files created
+            MaterializedResult fileCountResult = computeActual(
+                    String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+            long fileCount = (Long) fileCountResult.getOnlyValue();
+
+            // With 40kB limit, we should create significantly more files than default
+            // tpch.tiny.lineitem is about 2.4MB, so we expect at least 10 files
+            assertTrue(fileCount > 10,
+                    String.format("Expected > 10 files with 40kB limit, got %d", fileCount));
+
+            // Verify file sizes are reasonable (not much larger than target)
+            MaterializedResult fileSizes = computeActual(
+                    String.format("SELECT file_size_in_bytes FROM \"%s$files\"", tableName));
+
+            long targetSize = 40 * 1024; // 40kB
+            long maxAllowedSize = targetSize * 10; // Allow up to 10x the target size
+            for (MaterializedRow row : fileSizes.getMaterializedRows()) {
+                long fileSize = (Long) row.getField(0);
+                assertTrue(fileSize > 0 && fileSize <= maxAllowedSize,
+                        String.format("File size %d bytes is outside expected range (1 to %d bytes)",
+                                fileSize, maxAllowedSize));
+            }
+        }
+        finally {
+            // Cleanup
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testTargetMaxFileSizeWithPartitioning()
+    {
+        String tableName = "test_target_max_file_size_partitioned_" + System.currentTimeMillis();
+
+        try {
+            // Create partitioned table with small file size limit (40kB configured in connector properties)
+            Session session = Session.builder(getSession())
+                    .setSystemProperty(TASK_WRITER_COUNT, "1")
+                    .build();
+
+            assertUpdate(session,
+                    String.format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, suppkey BIGINT, " +
+                            "linenumber INTEGER, quantity DOUBLE, extendedprice DOUBLE, discount DOUBLE, " +
+                            "tax DOUBLE, returnflag VARCHAR, linestatus VARCHAR, shipdate DATE, " +
+                            "commitdate DATE, receiptdate DATE, shipinstruct VARCHAR, shipmode VARCHAR, " +
+                            "comment VARCHAR) WITH (partitioning = ARRAY['returnflag'])", tableName));
+
+            assertUpdate(session,
+                    String.format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName),
+                    60175);
+
+            // Verify data
+            MaterializedResult countResult = computeActual(
+                    String.format("SELECT count(*) FROM %s", tableName));
+            assertEquals(countResult.getOnlyValue(), 60175L);
+
+            // Check total number of files
+            MaterializedResult totalFilesResult = computeActual(
+                    String.format("SELECT count(*) FROM \"%s$files\"", tableName));
+            long totalFiles = (Long) totalFilesResult.getOnlyValue();
+
+            // Should have multiple files across partitions
+            // With partitioning and 40kB limit, we expect even more files than the non-partitioned case
+            assertTrue(totalFiles > 10,
+                    String.format("Expected > 10 total files with 40kB limit and partitioning, got %d", totalFiles));
+
+            // Verify file sizes are reasonable
+            MaterializedResult fileSizes = computeActual(
+                    String.format("SELECT file_size_in_bytes FROM \"%s$files\"", tableName));
+
+            long targetSize = 40 * 1024; // 40kB
+            long maxAllowedSize = targetSize * 10; // Allow up to 10x the target size
+            for (MaterializedRow row : fileSizes.getMaterializedRows()) {
+                long fileSize = (Long) row.getField(0);
+                assertTrue(fileSize > 0 && fileSize <= maxAllowedSize,
+                        String.format("File size %d bytes is outside expected range (1 to %d bytes)",
+                                fileSize, maxAllowedSize));
+            }
+        }
+        finally {
+            // Cleanup
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTargetMaxFileSize.java
@@ -338,12 +338,7 @@ public class TestIcebergTargetMaxFileSize
                         "iceberg.target-max-file-size", "-1B"))
                 .build().getQueryRunner();
 
-        try {
-            negativeConfigRunner.close();
-        }
-        finally {
-            negativeConfigRunner.close();
-        }
+        negativeConfigRunner.close();
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*iceberg.target-max-file-size must be at least 1 byte.*")
@@ -358,12 +353,7 @@ public class TestIcebergTargetMaxFileSize
                         "iceberg.target-max-file-size", "0B"))
                 .build().getQueryRunner();
 
-        try {
-            zeroConfigRunner.close();
-        }
-        finally {
-            zeroConfigRunner.close();
-        }
+        zeroConfigRunner.close();
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*iceberg.target_max_file_size is invalid: -1B.*")


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add support for iceberg.target-max-file-size.

Because files are only rolled over at page boundaries, the configured value is treated as a target rather than a strict upper bound.

Note: Iceberg's default target file size is 512 MB (write.target-file-size-bytes).

Reference:
https://iceberg.apache.org/docs/latest/configuration/#write-properties

Adapted from:

trinodb/trino#10957

Additionally, the logic for closing writers has been updated. Previously, writers were closed in getWriterIndexes() at the beginning of a page write. Writers are now closed at the end of writePage(), after the number of written bytes has been calculated, allowing file size decisions to be based on the actual bytes written.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Internally, we encountered upload failures when generated Iceberg files exceeded AWS's 5 GB upload limit. This change adds support for iceberg.target-max-file-size, allowing users to configure the approximate maximum size of output files.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
The default target file size is now 1 GB.

## Test Plan
<!---Please fill in how you tested your change-->
Added TestIcebergMaxFileSize to verify file rollover behavior when iceberg.target-max-file-size is configured.
Modified other test cases to account for additional iceberg config.
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add configurable target maximum file size for Iceberg writes and enforce writer rollover based on this limit.

New Features:
- Introduce the iceberg.target-max-file-size configuration property with a default target file size of 1 GB for Iceberg output files.

Enhancements:
- Update Iceberg page sink and related providers to track writer state and roll over files when the target maximum file size is reached, including proper commit and abort handling.

Tests:
- Add integration tests to validate file rollover behavior and file sizes with small configured target-max-file-size, including partitioned and non-partitioned tables.