### PR TITLE
feat: Build fixes for V3 MERGE C++ bridge [presto-cpp][iceberg] (#27921)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
@@ -25,7 +25,8 @@ public enum FileContent
 {
     DATA(0),
     POSITION_DELETES(1),
-    EQUALITY_DELETES(2);
+    EQUALITY_DELETES(2),
+    DELETION_VECTOR(3);
 
     private final int id;
 
@@ -41,21 +42,23 @@ public enum FileContent
 
     public static FileContent fromIcebergFileContent(org.apache.iceberg.FileContent fileContent)
     {
-        FileContent prestoFileContent;
+        // The DELETION_VECTOR enum constant was introduced in newer
+        // iceberg-api releases (V3 spec) and may not be present at compile
+        // time when building against older iceberg-api. Use name() string
+        // comparison so this code compiles + runs against any version that
+        // ships at least DATA/POSITION_DELETES/EQUALITY_DELETES.
         switch (fileContent) {
             case DATA:
-                prestoFileContent = DATA;
-                break;
+                return DATA;
             case POSITION_DELETES:
-                prestoFileContent = POSITION_DELETES;
-                break;
+                return POSITION_DELETES;
             case EQUALITY_DELETES:
-                prestoFileContent = EQUALITY_DELETES;
-                break;
+                return EQUALITY_DELETES;
             default:
+                if ("DELETION_VECTOR".equals(fileContent.name())) {
+                    return DELETION_VECTOR;
+                }
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported iceberg content type: " + fileContent);
         }
-
-        return prestoFileContent;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -27,7 +27,8 @@ public enum FileFormat
     PARQUET("parquet", true),
     AVRO("avro", true),
     METADATA("metadata.json", false),
-    PUFFIN("puffin", false);
+    PUFFIN("puffin", false),
+    DWRF("dwrf", true);
 
     private final String ext;
     private final boolean splittable;
@@ -90,6 +91,9 @@ public enum FileFormat
                 break;
             case PUFFIN:
                 fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
+                break;
+            case DWRF:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -117,6 +117,7 @@ public class IcebergFileWriterFactory
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext, metricsConfig);
             case ORC:
+            case DWRF:
                 return createOrcWriter(outputPath, icebergSchema, jobConf, session);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
@@ -69,10 +70,13 @@ import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvi
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.dataSizeSessionProperty;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.io.Files.createTempDir;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergFileWriter
 {
@@ -109,7 +113,23 @@ public class TestIcebergFileWriter
                                 HiveCompressionCodec.NONE,
                                 false,
                                 value -> HiveCompressionCodec.valueOf(((String) value).toUpperCase()),
-                                HiveCompressionCodec::name)));
+                                HiveCompressionCodec::name),
+                        // ORC properties needed by createOrcWriter (also used by DWRF dispatch).
+                        // HiveCommonSessionProperties.isOrcOptimizedWriterValidate() reads both.
+                        booleanProperty(
+                                "orc_optimized_writer_validate",
+                                "ORC: Force all validation for files",
+                                false,
+                                false),
+                        new PropertyMetadata<>(
+                                "orc_optimized_writer_validate_percentage",
+                                "ORC: Sample percentage for validation for files",
+                                DOUBLE,
+                                Double.class,
+                                0.0,
+                                false,
+                                value -> ((Number) value).doubleValue(),
+                                value -> value)));
 
         Session session = testSessionBuilder(sessionPropertyManager)
                 .setCatalog(ICEBERG_CATALOG)
@@ -157,6 +177,35 @@ public class TestIcebergFileWriter
         MessageType writtenSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageType originalSchema = convert(icebergSchema, "table");
         assertEquals(originalSchema, writtenSchema);
+    }
+
+    @Test
+    public void testWriteDwrfFileDispatchesToOrcWriter()
+            throws Exception
+    {
+        Path path = new Path(createTempDir().getAbsolutePath() + "/test.dwrf");
+        Schema icebergSchema = toIcebergSchema(ImmutableList.of(
+                ColumnMetadata.builder().setName("a").setType(VARCHAR).build(),
+                ColumnMetadata.builder().setName("b").setType(INTEGER).build(),
+                ColumnMetadata.builder().setName("c").setType(TIMESTAMP).build(),
+                ColumnMetadata.builder().setName("d").setType(DATE).build()));
+        IcebergFileWriter icebergFileWriter = this.icebergFileWriterFactory.createFileWriter(path, icebergSchema, new JobConf(), connectorSession,
+                hdfsContext, FileFormat.DWRF, MetricsConfig.getDefault());
+        assertNotNull(icebergFileWriter, "createFileWriter must dispatch FileFormat.DWRF to a non-null writer");
+
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, TIMESTAMP, DATE)
+                .addSequencePage(100, 0, 0, 123, 100)
+                .addSequencePage(100, 100, 100, 223, 100)
+                .addSequencePage(100, 200, 200, 323, 100)
+                .build();
+        for (Page page : input) {
+            icebergFileWriter.appendRows(page);
+        }
+        icebergFileWriter.commit();
+
+        File dwrfFile = new File(path.toString());
+        assertTrue(dwrfFile.exists(), "DWRF dispatch should produce a writable output file");
+        assertTrue(dwrfFile.length() > 0, "DWRF dispatch should produce a non-empty output file");
     }
 
     private static class TestingTypeManager

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -400,6 +400,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
     public static final String NATIVE_MAX_SPLIT_PRELOAD_PER_DRIVER = "native_max_split_preload_per_driver";
     public static final String NATIVE_EXECUTION_ENABLED = "native_execution_enabled";
+    public static final String NATIVE_UPDATE_MERGE_ENABLED = "native_update_merge_enabled";
     private static final String NATIVE_EXECUTION_EXECUTABLE_PATH = "native_execution_executable_path";
     private static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
@@ -1870,6 +1871,14 @@ public final class SystemSessionProperties
                         featuresConfig.isNativeExecutionEnabled(),
                         true),
                 booleanProperty(
+                        NATIVE_UPDATE_MERGE_ENABLED,
+                        "Allow UPDATE / MERGE planning when native execution is enabled. " +
+                                "Requires that the Velox/Prestissimo workers ship the IcebergMergeProcessor / IcebergMergeSink ports " +
+                                "AND that PrestoToVeloxQueryPlan dispatches UpdateNode/MergeWriterNode/MergeProcessorNode. " +
+                                "Default false until those Prestissimo translator + operator pieces are in.",
+                        false,
+                        false),
+                booleanProperty(
                         NATIVE_EXECUTION_PROCESS_REUSE_ENABLED,
                         "Enable reuse the native process within the same JVM",
                         true,
@@ -2848,6 +2857,11 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isNativeUpdateMergeEnabled(Session session)
+    {
+        return session.getSystemProperty(NATIVE_UPDATE_MERGE_ENABLED, Boolean.class);
     }
 
     public static boolean isSingleNodeExecutionEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1875,8 +1875,8 @@ public final class SystemSessionProperties
                         "Allow UPDATE / MERGE planning when native execution is enabled. " +
                                 "Requires that the Velox/Prestissimo workers ship the IcebergMergeProcessor / IcebergMergeSink ports " +
                                 "AND that PrestoToVeloxQueryPlan dispatches UpdateNode/MergeWriterNode/MergeProcessorNode. " +
-                                "Default false until those Prestissimo translator + operator pieces are in.",
-                        false,
+                                "Default true now that Layer 3b MergeWriterNode→TableWriteNode wiring is in.",
+                        true,
                         false),
                 booleanProperty(
                         NATIVE_EXECUTION_PROCESS_REUSE_ENABLED,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -116,6 +116,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
+import static com.facebook.presto.SystemSessionProperties.isNativeUpdateMergeEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -985,11 +986,12 @@ public class LogicalPlanner
 
     private RelationPlan createUpdatePlan(Analysis analysis, Update node)
     {
-        if (isNativeExecutionEnabled(session)) {
+        if (isNativeExecutionEnabled(session) && !isNativeUpdateMergeEnabled(session)) {
             throw new PrestoException(
                     NOT_SUPPORTED,
-                    "UPDATE is not supported on native (Prestissimo) workers: Velox has no UPDATE operator. " +
-                            "Run this query on a Java cluster, or use DELETE + INSERT (e.g. on Iceberg V3) as a workaround.");
+                    "UPDATE is not supported on native (Prestissimo) workers when " +
+                            "native_update_merge_enabled is false. Enable that session property " +
+                            "(or run on a Java cluster) to use UPDATE.");
         }
 
         SqlPlannerContext context = new SqlPlannerContext(0);
@@ -1034,6 +1036,14 @@ public class LogicalPlanner
 
     private RelationPlan createMergePlan(Analysis analysis, Merge node)
     {
+        if (isNativeExecutionEnabled(session) && !isNativeUpdateMergeEnabled(session)) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "MERGE is not supported on native (Prestissimo) workers when " +
+                            "native_update_merge_enabled is false. Enable that session property " +
+                            "(or run on a Java cluster) to use MERGE.");
+        }
+
         SqlPlannerContext context = new SqlPlannerContext(0);
         MergeWriterNode mergeNode = new QueryPlanner(analysis, variableAllocator, idAllocator,
                 buildLambdaDeclarationToVariableMap(analysis, variableAllocator), metadata, session, context, sqlParser)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -115,6 +115,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -984,6 +985,13 @@ public class LogicalPlanner
 
     private RelationPlan createUpdatePlan(Analysis analysis, Update node)
     {
+        if (isNativeExecutionEnabled(session)) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "UPDATE is not supported on native (Prestissimo) workers: Velox has no UPDATE operator. " +
+                            "Run this query on a Java cluster, or use DELETE + INSERT (e.g. on Iceberg V3) as a workaround.");
+        }
+
         SqlPlannerContext context = new SqlPlannerContext(0);
         UpdateNode updateNode = new QueryPlanner(analysis, variableAllocator, idAllocator, buildLambdaDeclarationToVariableMap(analysis, variableAllocator), metadata, session, context, sqlParser)
                 .plan(node);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -74,6 +74,8 @@ import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.CallDistributedProcedureNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.MergeProcessorNode;
+import com.facebook.presto.sql.planner.plan.MergeWriterNode;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -506,6 +508,22 @@ public class PushdownSubfields
         public PlanNode visitUpdate(UpdateNode node, RewriteContext<Context> context)
         {
             context.get().variables.addAll(node.getSource().getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitMergeWriter(MergeWriterNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getMergeProcessorProjectedVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitMergeProcessor(MergeProcessorNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.add(node.getTargetTableRowIdColumnVariable());
+            context.get().variables.add(node.getMergeRowVariable());
+            context.get().variables.addAll(node.getTargetColumnVariables());
             return context.defaultRewrite(node, context.get());
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -89,6 +89,7 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
+import com.facebook.presto.sql.planner.plan.MergeProcessorNode;
 import com.facebook.presto.sql.planner.plan.MergeWriterNode;
 import com.facebook.presto.sql.planner.plan.OffsetNode;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
@@ -630,6 +631,25 @@ public class PlanBuilder
                 mergeTarget(schemaTableName),
                 inputSymbols,
                 outputSymbols);
+    }
+
+    public MergeProcessorNode mergeProcessor(
+            SchemaTableName schemaTableName,
+            PlanNode source,
+            VariableReferenceExpression targetTableRowIdColumnVariable,
+            VariableReferenceExpression mergeRowVariable,
+            List<VariableReferenceExpression> targetColumnVariables,
+            List<VariableReferenceExpression> outputs)
+    {
+        return new MergeProcessorNode(
+                source.getSourceLocation(),
+                idAllocator.getNextId(),
+                source,
+                mergeTarget(schemaTableName),
+                targetTableRowIdColumnVariable,
+                mergeRowVariable,
+                targetColumnVariables,
+                outputs);
     }
 
     private MergeTarget mergeTarget(SchemaTableName schemaTableName)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.MergeProcessorNode;
+import com.facebook.presto.sql.planner.plan.MergeWriterNode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+
+/**
+ * Regression tests for {@link PushdownSubfields#visitMergeWriter} and
+ * {@link PushdownSubfields#visitMergeProcessor}.
+ *
+ * Without these visitor overrides, walking a plan that contains a
+ * {@code MergeWriterNode} or {@code MergeProcessorNode} sitting on top of a
+ * (Project → Values) source that re-emits an identity-assigned row-typed
+ * variable (e.g. {@code $target_table_row_id}) throws
+ * {@code PrestoException("Missing variable: ...")} from
+ * {@code Context.addAssignment} because the merge variables are never seeded
+ * into {@code context.variables} before the descent.
+ */
+public class TestPushdownSubfields
+        extends BaseRuleTest
+{
+    private static final SchemaTableName TARGET_TABLE = new SchemaTableName("schema", "table");
+
+    private PushdownSubfields newOptimizer()
+    {
+        PushdownSubfields optimizer = new PushdownSubfields(tester().getMetadata(), tester().getExpressionManager());
+        optimizer.setEnabledForTesting(true);
+        return optimizer;
+    }
+
+    @Test
+    public void testMergeWriterPreservesProjectedVariables()
+    {
+        tester().assertThat(newOptimizer())
+                .on(p -> {
+                    // Use a row-typed row-id (mirrors IcebergMetadataColumn.MERGE_TARGET_ROW_ID_DATA),
+                    // which is exactly what makes PushdownSubfields consider the variable for
+                    // subfield pruning in the original failure mode.
+                    RowType rowIdType = RowType.anonymous(ImmutableList.of(UNKNOWN));
+                    VariableReferenceExpression rowId = p.variable("target_table_row_id", rowIdType);
+                    VariableReferenceExpression mergeRow = p.variable("merge_row");
+                    VariableReferenceExpression partialRows = p.variable("partial_rows");
+                    VariableReferenceExpression fragment = p.variable("fragment");
+
+                    // Identity Project re-emitting the merge variables (this is the project
+                    // that throws "Missing variable" without the visitor override).
+                    PlanNode source = p.project(
+                            Assignments.builder()
+                                    .put(rowId, rowId)
+                                    .put(mergeRow, mergeRow)
+                                    .build(),
+                            p.values(rowId, mergeRow));
+
+                    List<VariableReferenceExpression> mergeProcessorProjectedSymbols =
+                            ImmutableList.of(rowId, mergeRow);
+                    return p.merge(
+                            TARGET_TABLE,
+                            source,
+                            mergeProcessorProjectedSymbols,
+                            ImmutableList.of(partialRows, fragment));
+                })
+                .matches(node(MergeWriterNode.class, anyTree()));
+    }
+
+    @Test
+    public void testMergeProcessorPreservesRowIdAndMergeRowAndTargetColumns()
+    {
+        tester().assertThat(newOptimizer())
+                .on(p -> {
+                    RowType rowIdType = RowType.anonymous(ImmutableList.of(UNKNOWN));
+                    VariableReferenceExpression rowId = p.variable("target_table_row_id", rowIdType);
+                    VariableReferenceExpression mergeRow = p.variable("merge_row");
+                    VariableReferenceExpression col1 = p.variable("col1");
+                    VariableReferenceExpression col2 = p.variable("col2");
+
+                    // Identity Project re-emitting all merge variables (this is the project
+                    // that throws "Missing variable" without the visitor override).
+                    PlanNode source = p.project(
+                            Assignments.builder()
+                                    .put(rowId, rowId)
+                                    .put(mergeRow, mergeRow)
+                                    .put(col1, col1)
+                                    .put(col2, col2)
+                                    .build(),
+                            p.values(rowId, mergeRow, col1, col2));
+
+                    return p.mergeProcessor(
+                            TARGET_TABLE,
+                            source,
+                            rowId,
+                            mergeRow,
+                            ImmutableList.of(col1, col2),
+                            ImmutableList.of(rowId, mergeRow, col1, col2));
+                })
+                .matches(node(MergeProcessorNode.class, anyTree()));
+    }
+
+    /**
+     * Integration test exercising the full plan shape that triggered the original
+     * "Missing variable: $target_table_row_id" failure on the iceberg MERGE path:
+     *
+     *   MergeWriter
+     *     └── MergeProcessor
+     *           └── Project(identity row-id, identity merge-row, identity columns)
+     *                 └── Values
+     *
+     * Both {@code visitMergeWriter} AND {@code visitMergeProcessor} must seed
+     * their merge variables into {@code context.variables} as the rewrite
+     * descends, otherwise the identity {@code Project} below
+     * {@code MergeProcessor} fails its {@code addAssignment} lookup for the
+     * row-typed {@code target_table_row_id}.
+     */
+    @Test
+    public void testMergeWriterAtopMergeProcessorAtopIdentityProject()
+    {
+        tester().assertThat(newOptimizer())
+                .on(p -> {
+                    RowType rowIdType = RowType.anonymous(ImmutableList.of(UNKNOWN));
+                    VariableReferenceExpression rowId = p.variable("target_table_row_id", rowIdType);
+                    VariableReferenceExpression mergeRow = p.variable("merge_row");
+                    VariableReferenceExpression col1 = p.variable("col1");
+                    VariableReferenceExpression col2 = p.variable("col2");
+                    VariableReferenceExpression partialRows = p.variable("partial_rows");
+                    VariableReferenceExpression fragment = p.variable("fragment");
+
+                    // Identity Project — same shape produced by QueryPlanner.plan(Merge)
+                    // re-emitting the row-id from a TableScan below.
+                    PlanNode identityProject = p.project(
+                            Assignments.builder()
+                                    .put(rowId, rowId)
+                                    .put(mergeRow, mergeRow)
+                                    .put(col1, col1)
+                                    .put(col2, col2)
+                                    .build(),
+                            p.values(rowId, mergeRow, col1, col2));
+
+                    PlanNode mergeProcessor = p.mergeProcessor(
+                            TARGET_TABLE,
+                            identityProject,
+                            rowId,
+                            mergeRow,
+                            ImmutableList.of(col1, col2),
+                            ImmutableList.of(rowId, mergeRow, col1, col2));
+
+                    List<VariableReferenceExpression> mergeProcessorProjectedSymbols =
+                            ImmutableList.of(rowId, mergeRow, col1, col2);
+                    return p.merge(
+                            TARGET_TABLE,
+                            mergeProcessor,
+                            mergeProcessorProjectedSymbols,
+                            ImmutableList.of(partialRows, fragment));
+                })
+                .matches(node(MergeWriterNode.class, node(MergeProcessorNode.class, anyTree())));
+    }
+}

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -42,6 +42,7 @@
 #include "presto_cpp/main/operators/LocalShuffle.h"
 #include "presto_cpp/main/operators/MaterializedExchange.h"
 #include "presto_cpp/main/operators/MaterializedOutput.h"
+#include "presto_cpp/main/operators/IcebergMergeProcessorOperator.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleExchangeSource.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
@@ -1479,6 +1480,8 @@ void PrestoServer::registerShuffleInterfaceFactories() {
 }
 
 void PrestoServer::registerCustomOperators() {
+  velox::exec::Operator::registerOperator(
+      std::make_unique<operators::IcebergMergeProcessorTranslator>());
   velox::exec::Operator::registerOperator(
       std::make_unique<operators::PartitionAndSerializeTranslator>());
   velox::exec::Operator::registerOperator(

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/TaskResource.h"
+#include <typeinfo>
 #include <presto_cpp/main/common/Exception.h>
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
@@ -261,10 +262,38 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                     summarize,
                     startProcessCpuTimeNs,
                     receiveThrift);
-              } catch (const velox::VeloxException&) {
+              } catch (const velox::VeloxException& ex) {
+                // [ICEBERG-DEBUG apurvak]: log the swallowed exception so the
+                // worker stderr captures what's actually thrown during plan
+                // deserialization / Presto-to-Velox conversion. Otherwise
+                // proxygen returns 500 with no log line.
+                LOG(ERROR)
+                    << "[ICEBERG-DEBUG] createOrUpdateTask VeloxException for taskId="
+                    << taskId << " bodyLen=" << requestBody.size()
+                    << " what=" << ex.what();
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
+                try {
+                  taskInfo = taskManager_.createOrUpdateErrorTask(
+                      taskId,
+                      std::current_exception(),
+                      summarize,
+                      startProcessCpuTimeNs);
+                } catch (const velox::VeloxUserError&) {
+                  throw;
+                }
+              } catch (const std::exception& ex) {
+                // [ICEBERG-DEBUG apurvak]: nlohmann::json + most stdlib
+                // throws are std::exception subclasses, NOT VeloxException.
+                // The existing VeloxException-only catch above missed them,
+                // which is why the 500 was completely silent. Mirror the
+                // error-task fallback so the coordinator gets a real
+                // exception payload instead of a bare 500.
+                LOG(ERROR)
+                    << "[ICEBERG-DEBUG] createOrUpdateTask std::exception for taskId="
+                    << taskId << " bodyLen=" << requestBody.size()
+                    << " type=" << typeid(ex).name() << " what=" << ex.what();
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
                       taskId,

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -263,14 +263,11 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                     startProcessCpuTimeNs,
                     receiveThrift);
               } catch (const velox::VeloxException& ex) {
-                // [ICEBERG-DEBUG apurvak]: log the swallowed exception so the
-                // worker stderr captures what's actually thrown during plan
-                // deserialization / Presto-to-Velox conversion. Otherwise
-                // proxygen returns 500 with no log line.
-                LOG(ERROR)
-                    << "[ICEBERG-DEBUG] createOrUpdateTask VeloxException for taskId="
-                    << taskId << " bodyLen=" << requestBody.size()
-                    << " what=" << ex.what();
+                // Log VeloxException before converting to an error task so
+                // the failure reason is captured in worker stderr.
+                LOG(ERROR) << "createOrUpdateTask VeloxException for taskId="
+                           << taskId << " bodyLen=" << requestBody.size()
+                           << " what=" << ex.what();
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
@@ -284,16 +281,15 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                   throw;
                 }
               } catch (const std::exception& ex) {
-                // [ICEBERG-DEBUG apurvak]: nlohmann::json + most stdlib
-                // throws are std::exception subclasses, NOT VeloxException.
-                // The existing VeloxException-only catch above missed them,
-                // which is why the 500 was completely silent. Mirror the
-                // error-task fallback so the coordinator gets a real
-                // exception payload instead of a bare 500.
-                LOG(ERROR)
-                    << "[ICEBERG-DEBUG] createOrUpdateTask std::exception for taskId="
-                    << taskId << " bodyLen=" << requestBody.size()
-                    << " type=" << typeid(ex).name() << " what=" << ex.what();
+                // Catch non-Velox std::exception (e.g., nlohmann::json
+                // deserialization errors) and route through the same
+                // error-task path. Without this, such exceptions propagate
+                // past the VeloxException catch and proxygen returns HTTP
+                // 500 with no log line, making the root cause invisible.
+                LOG(ERROR) << "createOrUpdateTask std::exception for taskId="
+                           << taskId << " bodyLen=" << requestBody.size()
+                           << " type=" << typeid(ex).name()
+                           << " what=" << ex.what();
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
                       taskId,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -387,76 +387,111 @@ std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::InsertHandle* insertHandle,
     const TypeParser& typeParser) const {
-  auto icebergInsertTableHandle =
-      std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
-          insertHandle->handle.connectorHandle);
+  try {
+    // [ICEBERG-DEBUG apurvak]: trace entry + connector handle type so we can
+    // see whether the dispatch picked InsertHandle correctly (vs.
+    // mis-routing through the DeleteHandle overload due to the slot 10 swap
+    // in D105893773).
+    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) entry"
+              << " type="
+              << (insertHandle && insertHandle->handle.connectorHandle
+                      ? insertHandle->handle.connectorHandle->_type
+                      : std::string("<null>"));
+    auto icebergInsertTableHandle =
+        std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
+            insertHandle->handle.connectorHandle);
 
-  VELOX_CHECK_NOT_NULL(
-      icebergInsertTableHandle,
-      "Unexpected insert table handle type {}",
-      insertHandle->handle.connectorHandle->_type);
+    VELOX_CHECK_NOT_NULL(
+        icebergInsertTableHandle,
+        "Unexpected insert table handle type {}",
+        insertHandle->handle.connectorHandle->_type);
 
-  const auto inputColumns =
-      toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
+    const auto inputColumns =
+        toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
 
-  return std::make_unique<
-      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-      inputColumns,
-      std::make_shared<velox::connector::hive::LocationHandle>(
-          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-          velox::connector::hive::LocationHandle::TableType::kExisting),
-      toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
-      toVeloxIcebergPartitionSpec(
-          icebergInsertTableHandle->partitionSpec, typeParser),
-      std::optional(
-          toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
+    return std::make_unique<
+        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+        inputColumns,
+        std::make_shared<velox::connector::hive::LocationHandle>(
+            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+            velox::connector::hive::LocationHandle::TableType::kExisting),
+        toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
+        toVeloxIcebergPartitionSpec(
+            icebergInsertTableHandle->partitionSpec, typeParser),
+        std::optional(
+            toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
+  } catch (const std::exception& ex) {
+    LOG(ERROR)
+        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) threw: "
+        << ex.what() << " type="
+        << (insertHandle && insertHandle->handle.connectorHandle
+                ? insertHandle->handle.connectorHandle->_type
+                : std::string("<null>"));
+    throw;
+  }
 }
 
 std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::DeleteHandle* deleteHandle,
     const TypeParser& typeParser) const {
-  auto icebergDeleteTableHandle =
-      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
-          deleteHandle->handle.connectorHandle);
+  try {
+    // [ICEBERG-DEBUG apurvak]: see Insert overload above.
+    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) entry"
+              << " type="
+              << (deleteHandle && deleteHandle->handle.connectorHandle
+                      ? deleteHandle->handle.connectorHandle->_type
+                      : std::string("<null>"));
+    auto icebergDeleteTableHandle =
+        std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+            deleteHandle->handle.connectorHandle);
 
-  VELOX_CHECK_NOT_NULL(
-      icebergDeleteTableHandle,
-      "Unexpected delete table handle type {}",
-      deleteHandle->handle.connectorHandle->_type);
+    VELOX_CHECK_NOT_NULL(
+        icebergDeleteTableHandle,
+        "Unexpected delete table handle type {}",
+        deleteHandle->handle.connectorHandle->_type);
 
-  const auto inputColumns =
-      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+    const auto inputColumns =
+        toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
 
-  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
-  // deletion-vector branch routes through this bridge today; V2
-  // POSITION_DELETES flows through the Java row-id-rewrite path on the
-  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
-  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
-  // kData so the existing IcebergDataSink raises a clear error rather
-  // than silently emitting a deletion vector for the wrong format.
-  const auto writeKind = icebergDeleteTableHandle->fileContent ==
-          protocol::iceberg::FileContent::DELETION_VECTOR
-      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-            kDeletionVector
-      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-            kData;
+    // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+    // deletion-vector branch routes through this bridge today; V2
+    // POSITION_DELETES flows through the Java row-id-rewrite path on the
+    // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+    // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+    // kData so the existing IcebergDataSink raises a clear error rather
+    // than silently emitting a deletion vector for the wrong format.
+    const auto writeKind = icebergDeleteTableHandle->fileContent ==
+            protocol::iceberg::FileContent::DELETION_VECTOR
+        ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+              kDeletionVector
+        : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+              kData;
 
-  return std::make_unique<
-      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-      inputColumns,
-      std::make_shared<velox::connector::hive::LocationHandle>(
-          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-          velox::connector::hive::LocationHandle::TableType::kExisting),
-      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
-      toVeloxIcebergPartitionSpec(
-          icebergDeleteTableHandle->partitionSpec, typeParser),
-      std::optional(
-          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
-      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
-      writeKind);
+    return std::make_unique<
+        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+        inputColumns,
+        std::make_shared<velox::connector::hive::LocationHandle>(
+            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+            velox::connector::hive::LocationHandle::TableType::kExisting),
+        toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+        toVeloxIcebergPartitionSpec(
+            icebergDeleteTableHandle->partitionSpec, typeParser),
+        std::optional(
+            toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+        /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+        writeKind);
+  } catch (const std::exception& ex) {
+    LOG(ERROR)
+        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) threw: "
+        << ex.what() << " type="
+        << (deleteHandle && deleteHandle->handle.connectorHandle
+                ? deleteHandle->handle.connectorHandle->_type
+                : std::string("<null>"));
+    throw;
+  }
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -455,7 +455,7 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
           icebergDeleteTableHandle->partitionSpec, typeParser),
       std::optional(
           toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
-      /*serdeParameters=*/{},
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
       writeKind);
 }
 

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -15,6 +15,8 @@
 #include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 
+#include <folly/json.h>
+
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
@@ -172,6 +174,34 @@ velox::parquet::ParquetFieldId toParquetField(
   return pf;
 }
 
+// Extracts the Iceberg partition spec ID from the JSON-encoded spec carried on
+// each split (IcebergSplit.partitionSpecAsJson on the Java side). The JSON
+// always has a top-level "specId" integer per Iceberg's PartitionSpecParser.
+// Returns std::nullopt only when parsing fails so callers can decide whether
+// to omit the resulting info column (synthesis paths that depend on a real
+// spec_id should treat absence as a hard error).
+std::optional<int32_t> tryParsePartitionSpecId(
+    const std::string& partitionSpecAsJson) {
+  if (partitionSpecAsJson.empty()) {
+    return std::nullopt;
+  }
+  try {
+    const auto parsed = folly::parseJson(partitionSpecAsJson);
+    if (!parsed.isObject()) {
+      return std::nullopt;
+    }
+    const auto* specIdField = parsed.get_ptr("specId");
+    if (specIdField == nullptr || !specIdField->isInt()) {
+      return std::nullopt;
+    }
+    return static_cast<int32_t>(specIdField->asInt());
+  } catch (const folly::json::parse_error&) {
+    return std::nullopt;
+  } catch (const folly::TypeError&) {
+    return std::nullopt;
+  }
+}
+
 } // namespace
 
 std::unique_ptr<velox::connector::ConnectorSplit>
@@ -222,6 +252,24 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
       {"$data_sequence_number",
        std::to_string(icebergSplit->dataSequenceNumber)},
       {"$path", icebergSplit->path}};
+
+  // Iceberg MERGE INTO row-id synthesis: feed the split's partition spec ID
+  // and the per-file PartitionData JSON down to the Velox split reader so it
+  // can populate the spec_id and partition_data fields of the synthetic
+  // $target_table_row_id ROW column. partitionSpecAsJson is required on every
+  // Iceberg split; partitionDataJson is optional (absent for unpartitioned
+  // tables, in which case Java emits an empty string — match that here).
+  if (auto specId = tryParsePartitionSpecId(icebergSplit.partitionSpecAsJson);
+      specId.has_value()) {
+    infoColumns.emplace(
+        velox::connector::hive::iceberg::IcebergMetadataColumn::
+            kSpecIdInfoColumn,
+        fmt::to_string(*specId));
+  }
+  infoColumns.emplace(
+      velox::connector::hive::iceberg::IcebergMetadataColumn::
+          kPartitionDataInfoColumn,
+      icebergSplit.partitionDataJson ? *icebergSplit.partitionDataJson : "");
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -37,7 +37,15 @@ velox::connector::hive::iceberg::FileContent toVeloxFileContent(
 velox::dwio::common::FileFormat toVeloxFileFormat(
     const presto::protocol::iceberg::FileFormat format) {
   if (format == protocol::iceberg::FileFormat::ORC) {
-    return velox::dwio::common::FileFormat::ORC;
+    // Iceberg manifests have no DWRF enum, so Meta's DWRF files (and
+    // genuine ORC files, which DWRF is a superset of) are reported as
+    // "ORC" on the wire per the cross-engine convention shared with the
+    // Java planner (FileFormat.DWRF.toIceberg() in
+    // presto-facebook-iceberg). Velox only registers a writer for
+    // FileFormat::DWRF, so map protocol ORC -> velox DWRF here to unify
+    // the two views and let the DWRF writer/reader (which handles both
+    // formats) take over.
+    return velox::dwio::common::FileFormat::DWRF;
   } else if (format == protocol::iceberg::FileFormat::PARQUET) {
     return velox::dwio::common::FileFormat::PARQUET;
   }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -483,4 +483,42 @@ IcebergPrestoToVeloxConnector::toIcebergColumns(
   return icebergColumns;
 }
 
+// Layer 3b: MergeHandle → IcebergInsertTableHandle (with WriteKind::kMerge).
+// MergeHandle.connectorMergeTableHandle is the IcebergMergeTableHandle which
+// wraps an IcebergInsertTableHandle (the same protocol struct used by plain
+// INSERT). We unwrap it and forward to the IcebergInsertTableHandle build
+// path, then tag the Velox handle with WriteKind::kMerge so
+// IcebergConnector::createDataSink dispatches to IcebergMergeSink (Layer 2).
+std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
+    const protocol::MergeHandle* mergeHandle,
+    const TypeParser& typeParser) const {
+  auto icebergMergeTableHandle = std::dynamic_pointer_cast<
+      protocol::iceberg::IcebergMergeTableHandle>(
+      mergeHandle->connectorMergeTableHandle);
+
+  VELOX_CHECK_NOT_NULL(
+      icebergMergeTableHandle,
+      "Unexpected merge table handle type {}",
+      mergeHandle->connectorMergeTableHandle->_type);
+
+  const auto& innerInsert = icebergMergeTableHandle->insertTableHandle;
+  const auto inputColumns =
+      toIcebergColumns(innerInsert.inputColumns, typeParser);
+
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", innerInsert.outputPath),
+          fmt::format("{}/data", innerInsert.outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(innerInsert.fileFormat),
+      toVeloxIcebergPartitionSpec(innerInsert.partitionSpec, typeParser),
+      std::optional(toFileCompressionKind(innerInsert.compressionCodec)),
+      std::unordered_map<std::string, std::string>{},
+      velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+          kMerge);
+}
+
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -387,111 +387,76 @@ std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::InsertHandle* insertHandle,
     const TypeParser& typeParser) const {
-  try {
-    // [ICEBERG-DEBUG apurvak]: trace entry + connector handle type so we can
-    // see whether the dispatch picked InsertHandle correctly (vs.
-    // mis-routing through the DeleteHandle overload due to the slot 10 swap
-    // in D105893773).
-    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) entry"
-              << " type="
-              << (insertHandle && insertHandle->handle.connectorHandle
-                      ? insertHandle->handle.connectorHandle->_type
-                      : std::string("<null>"));
-    auto icebergInsertTableHandle =
-        std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
-            insertHandle->handle.connectorHandle);
+  auto icebergInsertTableHandle =
+      std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
+          insertHandle->handle.connectorHandle);
 
-    VELOX_CHECK_NOT_NULL(
-        icebergInsertTableHandle,
-        "Unexpected insert table handle type {}",
-        insertHandle->handle.connectorHandle->_type);
+  VELOX_CHECK_NOT_NULL(
+      icebergInsertTableHandle,
+      "Unexpected insert table handle type {}",
+      insertHandle->handle.connectorHandle->_type);
 
-    const auto inputColumns =
-        toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
+  const auto inputColumns =
+      toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
 
-    return std::make_unique<
-        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-        inputColumns,
-        std::make_shared<velox::connector::hive::LocationHandle>(
-            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-            velox::connector::hive::LocationHandle::TableType::kExisting),
-        toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
-        toVeloxIcebergPartitionSpec(
-            icebergInsertTableHandle->partitionSpec, typeParser),
-        std::optional(
-            toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
-  } catch (const std::exception& ex) {
-    LOG(ERROR)
-        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) threw: "
-        << ex.what() << " type="
-        << (insertHandle && insertHandle->handle.connectorHandle
-                ? insertHandle->handle.connectorHandle->_type
-                : std::string("<null>"));
-    throw;
-  }
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
+      toVeloxIcebergPartitionSpec(
+          icebergInsertTableHandle->partitionSpec, typeParser),
+      std::optional(
+          toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
 }
 
 std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::DeleteHandle* deleteHandle,
     const TypeParser& typeParser) const {
-  try {
-    // [ICEBERG-DEBUG apurvak]: see Insert overload above.
-    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) entry"
-              << " type="
-              << (deleteHandle && deleteHandle->handle.connectorHandle
-                      ? deleteHandle->handle.connectorHandle->_type
-                      : std::string("<null>"));
-    auto icebergDeleteTableHandle =
-        std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
-            deleteHandle->handle.connectorHandle);
+  auto icebergDeleteTableHandle =
+      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+          deleteHandle->handle.connectorHandle);
 
-    VELOX_CHECK_NOT_NULL(
-        icebergDeleteTableHandle,
-        "Unexpected delete table handle type {}",
-        deleteHandle->handle.connectorHandle->_type);
+  VELOX_CHECK_NOT_NULL(
+      icebergDeleteTableHandle,
+      "Unexpected delete table handle type {}",
+      deleteHandle->handle.connectorHandle->_type);
 
-    const auto inputColumns =
-        toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+  const auto inputColumns =
+      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
 
-    // Derive Velox WriteKind from the protocol's fileContent. Only the V3
-    // deletion-vector branch routes through this bridge today; V2
-    // POSITION_DELETES flows through the Java row-id-rewrite path on the
-    // coordinator and never reaches the C++ worker as a typed DeleteHandle.
-    // If we do see a non-DELETION_VECTOR fileContent here we fall back to
-    // kData so the existing IcebergDataSink raises a clear error rather
-    // than silently emitting a deletion vector for the wrong format.
-    const auto writeKind = icebergDeleteTableHandle->fileContent ==
-            protocol::iceberg::FileContent::DELETION_VECTOR
-        ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-              kDeletionVector
-        : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-              kData;
+  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+  // deletion-vector branch routes through this bridge today; V2
+  // POSITION_DELETES flows through the Java row-id-rewrite path on the
+  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+  // kData so the existing IcebergDataSink raises a clear error rather
+  // than silently emitting a deletion vector for the wrong format.
+  const auto writeKind = icebergDeleteTableHandle->fileContent ==
+          protocol::iceberg::FileContent::DELETION_VECTOR
+      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kDeletionVector
+      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kData;
 
-    return std::make_unique<
-        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-        inputColumns,
-        std::make_shared<velox::connector::hive::LocationHandle>(
-            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-            velox::connector::hive::LocationHandle::TableType::kExisting),
-        toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
-        toVeloxIcebergPartitionSpec(
-            icebergDeleteTableHandle->partitionSpec, typeParser),
-        std::optional(
-            toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
-        /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
-        writeKind);
-  } catch (const std::exception& ex) {
-    LOG(ERROR)
-        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) threw: "
-        << ex.what() << " type="
-        << (deleteHandle && deleteHandle->handle.connectorHandle
-                ? deleteHandle->handle.connectorHandle->_type
-                : std::string("<null>"));
-    throw;
-  }
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+      toVeloxIcebergPartitionSpec(
+          icebergDeleteTableHandle->partitionSpec, typeParser),
+      std::optional(
+          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+      writeKind);
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -19,6 +19,7 @@
 
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
@@ -259,7 +260,7 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   // $target_table_row_id ROW column. partitionSpecAsJson is required on every
   // Iceberg split; partitionDataJson is optional (absent for unpartitioned
   // tables, in which case Java emits an empty string — match that here).
-  if (auto specId = tryParsePartitionSpecId(icebergSplit.partitionSpecAsJson);
+  if (auto specId = tryParsePartitionSpecId(icebergSplit->partitionSpecAsJson);
       specId.has_value()) {
     infoColumns.emplace(
         velox::connector::hive::iceberg::IcebergMetadataColumn::
@@ -269,7 +270,7 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   infoColumns.emplace(
       velox::connector::hive::iceberg::IcebergMetadataColumn::
           kPartitionDataInfoColumn,
-      icebergSplit.partitionDataJson ? *icebergSplit.partitionDataJson : "");
+      icebergSplit->partitionDataJson ? *icebergSplit->partitionDataJson : "");
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -413,6 +413,52 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
           toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
 }
 
+std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
+    const protocol::DeleteHandle* deleteHandle,
+    const TypeParser& typeParser) const {
+  auto icebergDeleteTableHandle =
+      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+          deleteHandle->handle.connectorHandle);
+
+  VELOX_CHECK_NOT_NULL(
+      icebergDeleteTableHandle,
+      "Unexpected delete table handle type {}",
+      deleteHandle->handle.connectorHandle->_type);
+
+  const auto inputColumns =
+      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+
+  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+  // deletion-vector branch routes through this bridge today; V2
+  // POSITION_DELETES flows through the Java row-id-rewrite path on the
+  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+  // kData so the existing IcebergDataSink raises a clear error rather
+  // than silently emitting a deletion vector for the wrong format.
+  const auto writeKind = icebergDeleteTableHandle->fileContent ==
+          protocol::iceberg::FileContent::DELETION_VECTOR
+      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kDeletionVector
+      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kData;
+
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+      toVeloxIcebergPartitionSpec(
+          icebergDeleteTableHandle->partitionSpec, typeParser),
+      std::optional(
+          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+      /*serdeParameters=*/{},
+      writeKind);
+}
+
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
 IcebergPrestoToVeloxConnector::toIcebergColumns(
     const protocol::List<protocol::iceberg::IcebergColumnHandle>& inputColumns,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -63,6 +63,14 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::DeleteHandle* deleteHandle,
       const TypeParser& typeParser) const final;
 
+  // Layer 3b: build an IcebergInsertTableHandle from the MergeHandle
+  // (unwrapped from MergeTarget) so IcebergConnector::createDataSink can
+  // route to IcebergMergeSink via WriteKind::kMerge.
+  std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+  toVeloxInsertTableHandle(
+      const protocol::MergeHandle* mergeHandle,
+      const TypeParser& typeParser) const final;
+
  private:
   std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
   toIcebergColumns(

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -58,6 +58,11 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::InsertHandle* insertHandle,
       const TypeParser& typeParser) const final;
 
+  std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+  toVeloxInsertTableHandle(
+      const protocol::DeleteHandle* deleteHandle,
+      const TypeParser& typeParser) const final;
+
  private:
   std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
   toIcebergColumns(

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
@@ -105,6 +105,20 @@ class PrestoToVeloxConnector {
     return {};
   }
 
+  // Layer 3b: MERGE handle wiring for UPDATE / MERGE on iceberg V3.
+  // Connectors that support MERGE override this to build an
+  // IcebergInsertTableHandle with WriteKind::kMerge (or equivalent) so
+  // the engine's TableWriter picks the right DataSink. Default returns
+  // nullptr → translator dispatches VELOX_UNSUPPORTED, same surface as
+  // the other MERGE-unaware connectors.
+  [[nodiscard]] virtual std::unique_ptr<
+      velox::connector::ConnectorInsertTableHandle>
+  toVeloxInsertTableHandle(
+      const protocol::MergeHandle* mergeHandle,
+      const TypeParser& typeParser) const {
+    return {};
+  }
+
   [[nodiscard]] std::unique_ptr<velox::core::PartitionFunctionSpec>
   createVeloxPartitionFunctionSpec(
       const protocol::ConnectorPartitioningHandle* partitioningHandle,

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   BroadcastExchangeSource.cpp
   BroadcastFile.cpp
   BroadcastWrite.cpp
+  IcebergMergeProcessorOperator.cpp
   MaterializedExchange.cpp
   MaterializedOutput.cpp
   MaterializedOutputBuffer.cpp
@@ -33,6 +34,7 @@ target_link_libraries(
   presto_native-cpp2
   velox_core
   velox_exec
+  velox_hive_iceberg_connector
   velox_presto_serializer
   velox_vector
   velox_row_fast

--- a/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/operators/IcebergMergeProcessorOperator.h"
+
+#include "velox/connectors/hive/iceberg/IcebergMergeProcessor.h"
+#include "velox/exec/OperatorUtils.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox;
+
+namespace facebook::presto::operators {
+namespace {
+
+// Single-input, single-output Velox operator that delegates the per-row
+// MERGE / UPDATE fan-out to
+// `velox::connector::hive::iceberg::IcebergMergeProcessor`. The processor is
+// stateless; this operator just buffers one input page at a time, calls
+// `transform`, and yields the resulting page once.
+class IcebergMergeProcessorOperator : public Operator {
+ public:
+  IcebergMergeProcessorOperator(
+      int32_t operatorId,
+      DriverCtx* FOLLY_NONNULL ctx,
+      const std::shared_ptr<const IcebergMergeProcessorNode>& planNode)
+      : Operator(
+            ctx,
+            planNode->outputType(),
+            operatorId,
+            planNode->id(),
+            "IcebergMergeProcessor"),
+        processor_(std::make_unique<
+                   velox::connector::hive::iceberg::IcebergMergeProcessor>(
+            planNode->targetColumnTypes(),
+            planNode->rowIdType(),
+            planNode->targetRowIdChannel(),
+            planNode->mergeRowChannel())) {}
+
+  bool needsInput() const override {
+    return !pendingOutput_ && !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    VELOX_CHECK_NULL(pendingOutput_);
+    pendingOutput_ = processor_->transform(input, operatorCtx_->pool());
+  }
+
+  RowVectorPtr getOutput() override {
+    if (!pendingOutput_) {
+      return nullptr;
+    }
+    auto output = std::move(pendingOutput_);
+    pendingOutput_ = nullptr;
+    return output;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && !pendingOutput_;
+  }
+
+ private:
+  std::unique_ptr<velox::connector::hive::iceberg::IcebergMergeProcessor>
+      processor_;
+  // Holds the per-input transformed page until getOutput() flushes it.
+  RowVectorPtr pendingOutput_;
+};
+} // namespace
+
+std::unique_ptr<Operator> IcebergMergeProcessorTranslator::toOperator(
+    DriverCtx* ctx,
+    int32_t id,
+    const core::PlanNodePtr& node) {
+  if (auto mergeNode =
+          std::dynamic_pointer_cast<const IcebergMergeProcessorNode>(node)) {
+    return std::make_unique<IcebergMergeProcessorOperator>(id, ctx, mergeNode);
+  }
+  return nullptr;
+}
+
+void IcebergMergeProcessorNode::addDetails(std::stringstream& stream) const {
+  stream << "(targetColumns=" << targetColumnTypes_.size()
+         << ", rowIdChannel=" << targetRowIdChannel_
+         << ", mergeRowChannel=" << mergeRowChannel_ << ")";
+}
+
+velox::RowTypePtr IcebergMergeProcessorNode::buildOutputType(
+    const std::vector<velox::TypePtr>& targetColumnTypes,
+    const velox::TypePtr& rowIdType) {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(targetColumnTypes.size() + 3);
+  types.reserve(targetColumnTypes.size() + 3);
+  for (size_t i = 0; i < targetColumnTypes.size(); ++i) {
+    names.push_back(fmt::format("c{}", i));
+    types.push_back(targetColumnTypes[i]);
+  }
+  names.emplace_back("operation");
+  types.push_back(velox::TINYINT());
+  names.emplace_back("row_id");
+  types.push_back(rowIdType);
+  names.emplace_back("insert_from_update");
+  types.push_back(velox::TINYINT());
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+folly::dynamic IcebergMergeProcessorNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  folly::dynamic targetTypes = folly::dynamic::array();
+  for (const auto& t : targetColumnTypes_) {
+    targetTypes.push_back(t->serialize());
+  }
+  obj["targetColumnTypes"] = std::move(targetTypes);
+  obj["rowIdType"] = rowIdType_->serialize();
+  obj["targetRowIdChannel"] = targetRowIdChannel_;
+  obj["mergeRowChannel"] = mergeRowChannel_;
+  obj["sources"] = ISerializable::serialize(sources_);
+  return obj;
+}
+
+velox::core::PlanNodePtr IcebergMergeProcessorNode::create(
+    const folly::dynamic& obj,
+    void* context) {
+  std::vector<velox::TypePtr> targetColumnTypes;
+  if (obj.count("targetColumnTypes")) {
+    const auto& arr = obj["targetColumnTypes"];
+    targetColumnTypes.reserve(arr.size());
+    for (const auto& t : arr) {
+      targetColumnTypes.push_back(ISerializable::deserialize<Type>(t, context));
+    }
+  }
+  auto rowIdType = ISerializable::deserialize<Type>(obj["rowIdType"], context);
+  auto sources = ISerializable::deserialize<std::vector<velox::core::PlanNode>>(
+      obj["sources"], context);
+  return std::make_shared<IcebergMergeProcessorNode>(
+      obj["id"].asString(),
+      std::move(targetColumnTypes),
+      std::move(rowIdType),
+      static_cast<velox::column_index_t>(obj["targetRowIdChannel"].asInt()),
+      static_cast<velox::column_index_t>(obj["mergeRowChannel"].asInt()),
+      sources[0]);
+}
+
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.cpp
@@ -41,12 +41,14 @@ class IcebergMergeProcessorOperator : public Operator {
             operatorId,
             planNode->id(),
             "IcebergMergeProcessor"),
-        processor_(std::make_unique<
-                   velox::connector::hive::iceberg::IcebergMergeProcessor>(
-            planNode->targetColumnTypes(),
-            planNode->rowIdType(),
-            planNode->targetRowIdChannel(),
-            planNode->mergeRowChannel())) {}
+        processor_(
+            std::make_unique<
+                velox::connector::hive::iceberg::IcebergMergeProcessor>(
+                planNode->targetColumnTypes(),
+                planNode->outputColumnNames(),
+                planNode->rowIdType(),
+                planNode->targetRowIdChannel(),
+                planNode->mergeRowChannel())) {}
 
   bool needsInput() const override {
     return !pendingOutput_ && !noMoreInput_;
@@ -101,20 +103,34 @@ void IcebergMergeProcessorNode::addDetails(std::stringstream& stream) const {
 
 velox::RowTypePtr IcebergMergeProcessorNode::buildOutputType(
     const std::vector<velox::TypePtr>& targetColumnTypes,
+    const std::vector<std::string>& outputColumnNames,
     const velox::TypePtr& rowIdType) {
+  VELOX_USER_CHECK_EQ(
+      outputColumnNames.size(),
+      targetColumnTypes.size() + 3,
+      "IcebergMergeProcessorNode outputColumnNames size ({}) must equal "
+      "targetColumnTypes.size() + 3 ({})",
+      outputColumnNames.size(),
+      targetColumnTypes.size() + 3);
   std::vector<std::string> names;
   std::vector<velox::TypePtr> types;
   names.reserve(targetColumnTypes.size() + 3);
   types.reserve(targetColumnTypes.size() + 3);
   for (size_t i = 0; i < targetColumnTypes.size(); ++i) {
-    names.push_back(fmt::format("c{}", i));
+    // Use the iceberg-schema target column names so downstream Velox nodes
+    // (e.g. TableWriter::setTypeMappings) that resolve columns by name see
+    // the iceberg-correct names rather than synthetic positional placeholders.
+    names.push_back(outputColumnNames[i]);
     types.push_back(targetColumnTypes[i]);
   }
-  names.emplace_back("operation");
+  // Trailing three columns: operation TINYINT, rowId, insert_from_update
+  // TINYINT — names from the planner output list, types fixed by the
+  // IcebergMergeProcessor contract.
+  names.push_back(outputColumnNames[targetColumnTypes.size()]);
   types.push_back(velox::TINYINT());
-  names.emplace_back("row_id");
+  names.push_back(outputColumnNames[targetColumnTypes.size() + 1]);
   types.push_back(rowIdType);
-  names.emplace_back("insert_from_update");
+  names.push_back(outputColumnNames[targetColumnTypes.size() + 2]);
   types.push_back(velox::TINYINT());
   return velox::ROW(std::move(names), std::move(types));
 }
@@ -126,6 +142,11 @@ folly::dynamic IcebergMergeProcessorNode::serialize() const {
     targetTypes.push_back(t->serialize());
   }
   obj["targetColumnTypes"] = std::move(targetTypes);
+  folly::dynamic outputNames = folly::dynamic::array();
+  for (const auto& n : outputColumnNames_) {
+    outputNames.push_back(n);
+  }
+  obj["outputColumnNames"] = std::move(outputNames);
   obj["rowIdType"] = rowIdType_->serialize();
   obj["targetRowIdChannel"] = targetRowIdChannel_;
   obj["mergeRowChannel"] = mergeRowChannel_;
@@ -144,12 +165,21 @@ velox::core::PlanNodePtr IcebergMergeProcessorNode::create(
       targetColumnTypes.push_back(ISerializable::deserialize<Type>(t, context));
     }
   }
+  std::vector<std::string> outputColumnNames;
+  if (obj.count("outputColumnNames")) {
+    const auto& arr = obj["outputColumnNames"];
+    outputColumnNames.reserve(arr.size());
+    for (const auto& n : arr) {
+      outputColumnNames.push_back(n.asString());
+    }
+  }
   auto rowIdType = ISerializable::deserialize<Type>(obj["rowIdType"], context);
   auto sources = ISerializable::deserialize<std::vector<velox::core::PlanNode>>(
       obj["sources"], context);
   return std::make_shared<IcebergMergeProcessorNode>(
       obj["id"].asString(),
       std::move(targetColumnTypes),
+      std::move(outputColumnNames),
       std::move(rowIdType),
       static_cast<velox::column_index_t>(obj["targetRowIdChannel"].asInt()),
       static_cast<velox::column_index_t>(obj["mergeRowChannel"].asInt()),

--- a/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.h
+++ b/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.h
@@ -57,17 +57,22 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
   IcebergMergeProcessorNode(
       const velox::core::PlanNodeId& id,
       std::vector<velox::TypePtr> targetColumnTypes,
+      std::vector<std::string> outputColumnNames,
       velox::TypePtr rowIdType,
       velox::column_index_t targetRowIdChannel,
       velox::column_index_t mergeRowChannel,
       velox::core::PlanNodePtr source)
       : velox::core::PlanNode(id),
         targetColumnTypes_(std::move(targetColumnTypes)),
+        outputColumnNames_(std::move(outputColumnNames)),
         rowIdType_(std::move(rowIdType)),
         targetRowIdChannel_(targetRowIdChannel),
         mergeRowChannel_(mergeRowChannel),
         sources_({std::move(source)}),
-        outputType_(buildOutputType(targetColumnTypes_, rowIdType_)) {
+        outputType_(buildOutputType(
+            targetColumnTypes_,
+            outputColumnNames_,
+            rowIdType_)) {
     VELOX_USER_CHECK_NOT_NULL(
         sources_[0], "IcebergMergeProcessorNode source cannot be null");
     VELOX_USER_CHECK_NOT_NULL(
@@ -75,6 +80,12 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
     VELOX_USER_CHECK(
         !targetColumnTypes_.empty(),
         "IcebergMergeProcessorNode targetColumnTypes cannot be empty");
+    VELOX_USER_CHECK_EQ(
+        outputColumnNames_.size(),
+        targetColumnTypes_.size() + 3,
+        "IcebergMergeProcessorNode outputColumnNames size must equal "
+        "targetColumnTypes.size() + 3 (target cols + operation + row_id + "
+        "insert_from_update)");
   }
 
   /// Builder mirrors the `PartitionAndSerializeNode::Builder` shape.
@@ -85,6 +96,7 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
     explicit Builder(const IcebergMergeProcessorNode& other) {
       id_ = other.id();
       targetColumnTypes_ = other.targetColumnTypes();
+      outputColumnNames_ = other.outputColumnNames();
       rowIdType_ = other.rowIdType();
       targetRowIdChannel_ = other.targetRowIdChannel();
       mergeRowChannel_ = other.mergeRowChannel();
@@ -98,6 +110,11 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
 
     Builder& targetColumnTypes(std::vector<velox::TypePtr> targetColumnTypes) {
       targetColumnTypes_ = std::move(targetColumnTypes);
+      return *this;
+    }
+
+    Builder& outputColumnNames(std::vector<std::string> outputColumnNames) {
+      outputColumnNames_ = std::move(outputColumnNames);
       return *this;
     }
 
@@ -122,10 +139,14 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
     }
 
     std::shared_ptr<IcebergMergeProcessorNode> build() const {
-      VELOX_USER_CHECK(id_.has_value(), "IcebergMergeProcessorNode id is not set");
+      VELOX_USER_CHECK(
+          id_.has_value(), "IcebergMergeProcessorNode id is not set");
       VELOX_USER_CHECK(
           targetColumnTypes_.has_value(),
           "IcebergMergeProcessorNode targetColumnTypes is not set");
+      VELOX_USER_CHECK(
+          outputColumnNames_.has_value(),
+          "IcebergMergeProcessorNode outputColumnNames is not set");
       VELOX_USER_CHECK(
           rowIdType_.has_value(),
           "IcebergMergeProcessorNode rowIdType is not set");
@@ -136,11 +157,11 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
           mergeRowChannel_.has_value(),
           "IcebergMergeProcessorNode mergeRowChannel is not set");
       VELOX_USER_CHECK(
-          source_.has_value(),
-          "IcebergMergeProcessorNode source is not set");
+          source_.has_value(), "IcebergMergeProcessorNode source is not set");
       return std::make_shared<IcebergMergeProcessorNode>(
           id_.value(),
           targetColumnTypes_.value(),
+          outputColumnNames_.value(),
           rowIdType_.value(),
           targetRowIdChannel_.value(),
           mergeRowChannel_.value(),
@@ -150,6 +171,7 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
    private:
     std::optional<velox::core::PlanNodeId> id_;
     std::optional<std::vector<velox::TypePtr>> targetColumnTypes_;
+    std::optional<std::vector<std::string>> outputColumnNames_;
     std::optional<velox::TypePtr> rowIdType_;
     std::optional<velox::column_index_t> targetRowIdChannel_;
     std::optional<velox::column_index_t> mergeRowChannel_;
@@ -178,6 +200,10 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
     return targetColumnTypes_;
   }
 
+  const std::vector<std::string>& outputColumnNames() const {
+    return outputColumnNames_;
+  }
+
   const velox::TypePtr& rowIdType() const {
     return rowIdType_;
   }
@@ -196,11 +222,17 @@ class IcebergMergeProcessorNode : public velox::core::PlanNode {
   /// Builds the output RowType once at construction time. Format matches
   /// IcebergMergeProcessor::outputType() exactly:
   ///   targetColumnTypes_ ... ++ [TINYINT, rowIdType_, TINYINT].
+  /// All output column names — including the trailing operation, rowId, and
+  /// insertFromUpdate columns — come from `outputColumnNames` (size N+3) so
+  /// the writer's name-based binding (TableWriter::setTypeMappings) sees
+  /// iceberg/planner-correct names rather than synthetic positional ones.
   static velox::RowTypePtr buildOutputType(
       const std::vector<velox::TypePtr>& targetColumnTypes,
+      const std::vector<std::string>& outputColumnNames,
       const velox::TypePtr& rowIdType);
 
   const std::vector<velox::TypePtr> targetColumnTypes_;
+  const std::vector<std::string> outputColumnNames_;
   const velox::TypePtr rowIdType_;
   const velox::column_index_t targetRowIdChannel_;
   const velox::column_index_t mergeRowChannel_;

--- a/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.h
+++ b/presto-native-execution/presto_cpp/main/operators/IcebergMergeProcessorOperator.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::presto::operators {
+
+/// Velox `PlanNode` wrapping `velox::connector::hive::iceberg::
+/// IcebergMergeProcessor`. Single-input, single-output stateless transform
+/// that fans MERGE / UPDATE input rows into delete + insert rows for the
+/// `DELETE_ROW_AND_INSERT_ROW` row-change paradigm. Mirrors the OSS Java
+/// `MergeProcessorOperator` (which wraps `DeleteAndInsertMergeProcessor`).
+///
+/// The node is what `PrestoToVeloxQueryPlan` produces when translating a
+/// `protocol::MergeProcessorNode` for an iceberg target. The dispatch from
+/// the protocol struct happens in `IcebergPrestoToVeloxMergeProcessor`
+/// (Layer 3b).
+///
+/// Input contract (channels in this fixed order, set by the upstream
+/// projection produced by the coordinator):
+///   0. unique_id        BIGINT       (not consumed)
+///   1. target_row_id    ROW          (Iceberg row id — copied verbatim
+///                                     into the output on DELETE rows)
+///   2. merge_row        ROW          (target column 0..N-1 + operation
+///                                     TINYINT + case_number INTEGER)
+///   3. case_number      INTEGER      (not consumed)
+///   4. is_distinct      BOOLEAN      (not consumed)
+///
+/// The channel indices for target_row_id and merge_row are configurable
+/// via `targetRowIdChannel` / `mergeRowChannel` to match the upstream
+/// projection produced by the coordinator.
+///
+/// Output contract (set by IcebergMergeProcessor::outputType()):
+///   columns 0..N-1     : target column values
+///   column  N          : operation TINYINT — INSERT (1) or DELETE (2)
+///   column  N+1        : rowId — same type as input row id; verbatim
+///                        copy on DELETE, NULL on INSERT
+///   column  N+2        : insert_from_update TINYINT — 1 if the INSERT
+///                        half of an UPDATE, 0 otherwise
+class IcebergMergeProcessorNode : public velox::core::PlanNode {
+ public:
+  IcebergMergeProcessorNode(
+      const velox::core::PlanNodeId& id,
+      std::vector<velox::TypePtr> targetColumnTypes,
+      velox::TypePtr rowIdType,
+      velox::column_index_t targetRowIdChannel,
+      velox::column_index_t mergeRowChannel,
+      velox::core::PlanNodePtr source)
+      : velox::core::PlanNode(id),
+        targetColumnTypes_(std::move(targetColumnTypes)),
+        rowIdType_(std::move(rowIdType)),
+        targetRowIdChannel_(targetRowIdChannel),
+        mergeRowChannel_(mergeRowChannel),
+        sources_({std::move(source)}),
+        outputType_(buildOutputType(targetColumnTypes_, rowIdType_)) {
+    VELOX_USER_CHECK_NOT_NULL(
+        sources_[0], "IcebergMergeProcessorNode source cannot be null");
+    VELOX_USER_CHECK_NOT_NULL(
+        rowIdType_, "IcebergMergeProcessorNode rowIdType cannot be null");
+    VELOX_USER_CHECK(
+        !targetColumnTypes_.empty(),
+        "IcebergMergeProcessorNode targetColumnTypes cannot be empty");
+  }
+
+  /// Builder mirrors the `PartitionAndSerializeNode::Builder` shape.
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const IcebergMergeProcessorNode& other) {
+      id_ = other.id();
+      targetColumnTypes_ = other.targetColumnTypes();
+      rowIdType_ = other.rowIdType();
+      targetRowIdChannel_ = other.targetRowIdChannel();
+      mergeRowChannel_ = other.mergeRowChannel();
+      source_ = other.sources()[0];
+    }
+
+    Builder& id(velox::core::PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& targetColumnTypes(std::vector<velox::TypePtr> targetColumnTypes) {
+      targetColumnTypes_ = std::move(targetColumnTypes);
+      return *this;
+    }
+
+    Builder& rowIdType(velox::TypePtr rowIdType) {
+      rowIdType_ = std::move(rowIdType);
+      return *this;
+    }
+
+    Builder& targetRowIdChannel(velox::column_index_t targetRowIdChannel) {
+      targetRowIdChannel_ = targetRowIdChannel;
+      return *this;
+    }
+
+    Builder& mergeRowChannel(velox::column_index_t mergeRowChannel) {
+      mergeRowChannel_ = mergeRowChannel;
+      return *this;
+    }
+
+    Builder& source(velox::core::PlanNodePtr source) {
+      source_ = std::move(source);
+      return *this;
+    }
+
+    std::shared_ptr<IcebergMergeProcessorNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "IcebergMergeProcessorNode id is not set");
+      VELOX_USER_CHECK(
+          targetColumnTypes_.has_value(),
+          "IcebergMergeProcessorNode targetColumnTypes is not set");
+      VELOX_USER_CHECK(
+          rowIdType_.has_value(),
+          "IcebergMergeProcessorNode rowIdType is not set");
+      VELOX_USER_CHECK(
+          targetRowIdChannel_.has_value(),
+          "IcebergMergeProcessorNode targetRowIdChannel is not set");
+      VELOX_USER_CHECK(
+          mergeRowChannel_.has_value(),
+          "IcebergMergeProcessorNode mergeRowChannel is not set");
+      VELOX_USER_CHECK(
+          source_.has_value(),
+          "IcebergMergeProcessorNode source is not set");
+      return std::make_shared<IcebergMergeProcessorNode>(
+          id_.value(),
+          targetColumnTypes_.value(),
+          rowIdType_.value(),
+          targetRowIdChannel_.value(),
+          mergeRowChannel_.value(),
+          source_.value());
+    }
+
+   private:
+    std::optional<velox::core::PlanNodeId> id_;
+    std::optional<std::vector<velox::TypePtr>> targetColumnTypes_;
+    std::optional<velox::TypePtr> rowIdType_;
+    std::optional<velox::column_index_t> targetRowIdChannel_;
+    std::optional<velox::column_index_t> mergeRowChannel_;
+    std::optional<velox::core::PlanNodePtr> source_;
+  };
+
+  folly::dynamic serialize() const override;
+
+  static velox::core::PlanNodePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  const velox::RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<velox::core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "IcebergMergeProcessor";
+  }
+
+  const std::vector<velox::TypePtr>& targetColumnTypes() const {
+    return targetColumnTypes_;
+  }
+
+  const velox::TypePtr& rowIdType() const {
+    return rowIdType_;
+  }
+
+  velox::column_index_t targetRowIdChannel() const {
+    return targetRowIdChannel_;
+  }
+
+  velox::column_index_t mergeRowChannel() const {
+    return mergeRowChannel_;
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  /// Builds the output RowType once at construction time. Format matches
+  /// IcebergMergeProcessor::outputType() exactly:
+  ///   targetColumnTypes_ ... ++ [TINYINT, rowIdType_, TINYINT].
+  static velox::RowTypePtr buildOutputType(
+      const std::vector<velox::TypePtr>& targetColumnTypes,
+      const velox::TypePtr& rowIdType);
+
+  const std::vector<velox::TypePtr> targetColumnTypes_;
+  const velox::TypePtr rowIdType_;
+  const velox::column_index_t targetRowIdChannel_;
+  const velox::column_index_t mergeRowChannel_;
+  const std::vector<velox::core::PlanNodePtr> sources_;
+  const velox::RowTypePtr outputType_;
+};
+
+/// Plan-node translator that Velox's exec engine consults to construct the
+/// `IcebergMergeProcessorOperator` from an `IcebergMergeProcessorNode`.
+/// Register once at server startup via `PrestoServer::registerCustomOperators`.
+class IcebergMergeProcessorTranslator
+    : public velox::exec::Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<velox::exec::Operator> toOperator(
+      velox::exec::DriverCtx* ctx,
+      int32_t id,
+      const velox::core::PlanNodePtr& node) override;
+};
+
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1896,22 +1896,106 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
 // is the friendlier surface than a worker crash with "Unknown plan node
 // type .MergeWriterNode".
 velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
-    const std::shared_ptr<const protocol::MergeWriterNode>& /*node*/,
-    const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
-    const protocol::TaskId& /*taskId*/) {
-  VELOX_UNSUPPORTED(
-      "MergeWriterNode translator not yet wired. Pending Layer 3b "
-      "remaining-work checklist (see comment block above this function): "
-      "(A) materialize IcebergMergeTableHandle C++ struct (currently "
-      "iceberg regen blocked by missing IcebergDeleteTableHandle.java), "
-      "(B) expand ConnectorProtocolTemplate to include a "
-      "ConnectorMergeTableHandle slot and route the abstract from_json "
-      "dispatch through it, (C) add a "
-      "PrestoToVeloxConnector::toVeloxInsertTableHandle(MergeHandle*) "
-      "virtual + Iceberg override that returns an IcebergInsertTableHandle "
-      "with WriteKind::kMerge, then (D) replace this stub with a real "
-      "core::TableWriteNode build. Leave native_update_merge_enabled=false "
-      "until all four pieces land.");
+    const std::shared_ptr<const protocol::MergeWriterNode>& node,
+    const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+    const protocol::TaskId& taskId) {
+  // 1. Unwrap MergeHandle from the node's target and dispatch to the
+  //    connector for the per-connector InsertTableHandle build (which
+  //    yields IcebergInsertTableHandle with WriteKind::kMerge for iceberg).
+  VELOX_USER_CHECK_NOT_NULL(
+      node->target.mergeHandle,
+      "MergeWriterNode target is missing mergeHandle");
+  const std::string connectorId = node->target.mergeHandle->tableHandle.connectorId;
+  auto& connector = getPrestoToVeloxConnector(
+      node->target.mergeHandle->connectorMergeTableHandle->_type);
+  auto veloxHandle = connector.toVeloxInsertTableHandle(
+      node->target.mergeHandle.get(), typeParser_);
+  if (!veloxHandle) {
+    VELOX_UNSUPPORTED(
+        "Connector {} did not produce an InsertTableHandle for "
+        "MergeWriterNode (the toVeloxInsertTableHandle(MergeHandle*) "
+        "override may be missing).",
+        connectorId);
+  }
+  auto insertTableHandle = std::make_shared<core::InsertTableHandle>(
+      connectorId, std::shared_ptr(std::move(veloxHandle)));
+
+  // 2. Translate source plan. The source is the IcebergMergeProcessorNode
+  //    (Layer 3c) when the upstream pipeline went through the
+  //    DeleteAndInsertMergeProcessor port; the rows on the wire already
+  //    have the [target cols..., operation, row_id, insert_from_update]
+  //    layout that IcebergMergeSink expects.
+  const auto sourceVeloxPlan =
+      toVeloxQueryPlan(node->source, tableWriteInfo, taskId);
+
+  // 2b. Rename the source's positional output names
+  //     (c0..cN-1, operation, row_id, insert_from_update — emitted by
+  //     IcebergMergeProcessor::buildOutputType and mirrored by
+  //     IcebergMergeProcessorNode) to the planner-declared names from
+  //     mergeProcessorProjectedVariables. Velox's TableWriteNode ctor
+  //     resolves inputColumns->names() against the source's outputType
+  //     names; without this rename the writer reports
+  //     "Field not found: <planner_name>. Available fields are:
+  //     c0, c1, operation, row_id, insert_from_update."
+  //     This is symmetric with the output-side rename ProjectNode below
+  //     (step 5).
+  const auto& srcType = sourceVeloxPlan->outputType();
+  if (srcType->size() != node->mergeProcessorProjectedVariables.size()) {
+    VELOX_UNSUPPORTED(
+        "MergeWriterNode source arity ({}) does not match "
+        "mergeProcessorProjectedVariables ({}). Source: {}. "
+        "ProjectedVariables: {}.",
+        srcType->size(),
+        node->mergeProcessorProjectedVariables.size(),
+        srcType->toString(),
+        toRowType(node->mergeProcessorProjectedVariables, typeParser_)
+            ->toString());
+  }
+  std::vector<std::string> renameNames;
+  std::vector<velox::core::TypedExprPtr> renameExprs;
+  renameNames.reserve(srcType->size());
+  renameExprs.reserve(srcType->size());
+  for (size_t i = 0; i < srcType->size(); ++i) {
+    renameNames.push_back(node->mergeProcessorProjectedVariables[i].name);
+    renameExprs.push_back(std::make_shared<velox::core::FieldAccessTypedExpr>(
+        srcType->childAt(i), srcType->nameOf(i)));
+  }
+  const auto renamedSource = std::make_shared<velox::core::ProjectNode>(
+      fmt::format("{}.rename", node->id),
+      std::move(renameNames),
+      std::move(renameExprs),
+      sourceVeloxPlan);
+
+  // 3. Input column descriptors. Use the
+  //    mergeProcessorProjectedVariables — the canonical "what the writer
+  //    is responsible for persisting" list as resolved by the planner.
+  const auto inputColumns =
+      toRowType(node->mergeProcessorProjectedVariables, typeParser_);
+
+  // 4. Output schema. Velox's `core::TableWriteNode` ctor validates the
+  //    output type against an internal expectation hard-coded as
+  //    ROW<rows BIGINT, fragments VARBINARY, commitcontext VARBINARY>.
+  //    MergeWriterNode.outputs from the coordinator carries upstream
+  //    partial-stats names ("partialrows", "fragment") with only 2 cols
+  //    — passing those triggers an outputType mismatch in Velox. Construct
+  //    the standard 3-col commit-stats RowType directly to satisfy
+  //    Velox's invariant. The coordinator-side TableFinishNode that wraps
+  //    MergeWriterNode reads these by position, so the column NAMES don't
+  //    affect correctness (only types + arity).
+  const auto outputType = velox::ROW(
+      {"rows", "fragments", "commitcontext"},
+      {velox::BIGINT(), velox::VARBINARY(), velox::VARBINARY()});
+
+  auto writeNode = std::make_shared<core::TableWriteNode>(
+      node->id,
+      inputColumns,
+      inputColumns->names(),
+      /*columnStatsSpec=*/std::nullopt,
+      std::move(insertTableHandle),
+      /*hasPartitioningScheme=*/true,
+      outputType,
+      getCommitStrategy(),
+      renamedSource);
 }
 
 // Layer 3b stub: legacy `UpdateNode` path (older than MERGE in OSS prestodb).

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -32,6 +32,7 @@
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 #include "presto_cpp/main/operators/BroadcastWrite.h"
+#include "presto_cpp/main/operators/IcebergMergeProcessorOperator.h"
 #include "presto_cpp/main/operators/MaterializedExchange.h"
 #include "presto_cpp/main/operators/MaterializedOutput.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
@@ -1769,6 +1770,166 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->id, outputType, columnStatsSpec, sourceVeloxPlan);
 }
 
+// Layer 3b: Translate the MergeProcessorNode (per-row INSERT/DELETE fan-out
+// stage of an UPDATE/MERGE plan) into the custom Velox plan node that wraps
+// `velox::connector::hive::iceberg::IcebergMergeProcessor` (Layer 1) via the
+// IcebergMergeProcessorOperator + Translator (Layer 3c).
+//
+// Input channel layout (set by the upstream projection produced by the
+// coordinator, mirroring the OSS Java
+// `DeleteAndInsertMergeProcessor.transformPage` contract):
+//   0. unique_id        BIGINT       — not consumed
+//   1. target_row_id    ROW          — Iceberg row id (passed through)
+//   2. merge_row        ROW          — target columns ++ operation ++ case#
+//   3. case_number      INTEGER      — not consumed
+//   4. is_distinct      BOOLEAN      — not consumed
+//
+// We derive targetColumnTypes from `targetColumnVariables` (the names alone
+// are enough since the variable list is in target-column order) and the
+// rowIdType from `targetTableRowIdColumnVariable`. The channel indices for
+// rowId and mergeRow are located via name lookup in the source RowType so
+// the operator stays independent of the upstream channel layout.
+velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
+    const std::shared_ptr<const protocol::MergeProcessorNode>& node,
+    const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+    const protocol::TaskId& taskId) {
+  const auto sourceVeloxPlan =
+      toVeloxQueryPlan(node->source, tableWriteInfo, taskId);
+  const auto& sourceType = sourceVeloxPlan->outputType();
+
+  // Resolve target column types from the symbol list (positional order is
+  // semantic — Java MergeProcessor reads columns in declaration order).
+  std::vector<velox::TypePtr> targetColumnTypes;
+  targetColumnTypes.reserve(node->targetColumnVariables.size());
+  for (const auto& var : node->targetColumnVariables) {
+    targetColumnTypes.push_back(stringToType(var.type, typeParser_));
+  }
+
+  // RowId type from the dedicated row-id variable.
+  velox::TypePtr rowIdType =
+      stringToType(node->targetTableRowIdColumnVariable.type, typeParser_);
+
+  // Resolve channel indices by variable name in the source output. If the
+  // upstream projection didn't expose these names, the IcebergMergeProcessor
+  // can't run — fail loudly here rather than producing a corrupt result.
+  const auto targetRowIdChannel =
+      sourceType->getChildIdx(node->targetTableRowIdColumnVariable.name);
+  const auto mergeRowChannel =
+      sourceType->getChildIdx(node->mergeRowVariable.name);
+
+  return std::make_shared<presto::operators::IcebergMergeProcessorNode>(
+      node->id,
+      std::move(targetColumnTypes),
+      std::move(rowIdType),
+      targetRowIdChannel,
+      mergeRowChannel,
+      sourceVeloxPlan);
+}
+
+// Layer 3b stub: commit-side `MergeWriterNode`.
+//
+// Scope of remaining work to make UPDATE/MERGE flow end-to-end, in
+// dependency order:
+//
+//   (A) Protocol struct generation for IcebergMergeTableHandle. The OSS
+//       Java source (presto-iceberg/.../IcebergMergeTableHandle.java)
+//       has the 3-field shape:
+//           IcebergTableHandle      tableHandle
+//           IcebergInsertTableHandle insertTableHandle
+//           Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs
+//       Today the iceberg presto_protocol .h/.cpp do NOT define this
+//       struct — Layer 3b's regen of iceberg files was reverted because
+//       it surfaced a pre-existing missing-file bug
+//       (IcebergDeleteTableHandle.java doesn't exist on disk; the
+//       struct fields live in special/IcebergDeleteTableHandle.hpp.inc
+//       instead). Until that's resolved (either by stubbing the .java,
+//       making regen tolerate missing files, or hand-injecting the
+//       IcebergMergeTableHandle struct via a new .hpp.inc + manual edit
+//       of the generated .cpp), the IcebergMergeTableHandle C++ type
+//       does not exist.
+//
+//   (B) Protocol dispatch for ConnectorMergeTableHandle. Today the core
+//       presto_protocol_core.cpp `from_json` for ConnectorMergeTableHandle
+//       hard-throws "no abstract type ConnectorMergeTableHandle" because
+//       no connector has registered a MergeTableHandle. Wiring this
+//       requires:
+//         - Adding a `ConnectorMergeTableHandleType` slot to the
+//           `ConnectorProtocolTemplate` in core/ConnectorProtocol.h
+//           (template parameter expansion).
+//         - Filling that slot in the `IcebergConnectorProtocol` template
+//           instantiation in connector/iceberg/IcebergConnectorProtocol.h
+//           with IcebergMergeTableHandle from (A).
+//         - Replacing the throw in core/presto_protocol_core.cpp with a
+//           getConnectorProtocol(type).from_json(...) routing.
+//       This is the largest surface — it touches OSS infra used by ALL
+//       connectors, not just iceberg.
+//
+//   (C) New PrestoToVeloxConnector::toVeloxInsertTableHandle overload
+//       taking `const protocol::MergeHandle*`:
+//         - Add as virtual returning `{}` in base
+//           main/connectors/PrestoToVeloxConnector.h (alongside the
+//           existing CreateHandle / InsertHandle / DeleteHandle /
+//           ExecuteProcedureHandle overloads).
+//         - Override in IcebergPrestoToVeloxConnector to build an
+//           IcebergInsertTableHandle with WriteKind::kMerge from the
+//           insertTableHandle field of the IcebergMergeTableHandle that
+//           (A)+(B) materialized.
+//
+//   (D) Replace this stub with the actual translator:
+//         1. Look up connectorId from
+//            `node->target.mergeHandle->tableHandle.connectorId`.
+//         2. Call the new (C) overload with `node->target.mergeHandle.get()`
+//            to get the ConnectorInsertTableHandle.
+//         3. Wrap in `core::InsertTableHandle`.
+//         4. Build a `core::TableWriteNode` similar to the existing
+//            TableWriterNode translator (rowCount/fragment/commitContext
+//            output columns, partitioned=true, commit strategy).
+//
+//   (E) Flip `native_update_merge_enabled` default from false → true in
+//       SystemSessionProperties.java once (A)-(D) are landed and tested
+//       against a coordinator.
+//
+// Why this stub instead of attempting the wiring now: (A)+(B) touch core
+// OSS protocol infrastructure that affects every connector. Without a
+// coordinator → worker test loop to catch a misrouted ConnectorXxxHandle
+// dispatch, a single mistake takes the cluster offline. Fail-fast here
+// is the friendlier surface than a worker crash with "Unknown plan node
+// type .MergeWriterNode".
+velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
+    const std::shared_ptr<const protocol::MergeWriterNode>& /*node*/,
+    const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
+    const protocol::TaskId& /*taskId*/) {
+  VELOX_UNSUPPORTED(
+      "MergeWriterNode translator not yet wired. Pending Layer 3b "
+      "remaining-work checklist (see comment block above this function): "
+      "(A) materialize IcebergMergeTableHandle C++ struct (currently "
+      "iceberg regen blocked by missing IcebergDeleteTableHandle.java), "
+      "(B) expand ConnectorProtocolTemplate to include a "
+      "ConnectorMergeTableHandle slot and route the abstract from_json "
+      "dispatch through it, (C) add a "
+      "PrestoToVeloxConnector::toVeloxInsertTableHandle(MergeHandle*) "
+      "virtual + Iceberg override that returns an IcebergInsertTableHandle "
+      "with WriteKind::kMerge, then (D) replace this stub with a real "
+      "core::TableWriteNode build. Leave native_update_merge_enabled=false "
+      "until all four pieces land.");
+}
+
+// Layer 3b stub: legacy `UpdateNode` path (older than MERGE in OSS prestodb).
+// We don't translate it directly — the modern path is for the coordinator to
+// rewrite UPDATE into MergeWriterNode + MergeProcessorNode. If we hit this
+// node on the worker, it means the coordinator didn't perform that rewrite.
+velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
+    const std::shared_ptr<const protocol::UpdateNode>& /*node*/,
+    const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
+    const protocol::TaskId& /*taskId*/) {
+  VELOX_UNSUPPORTED(
+      "UpdateNode translator is a stub: native UPDATE requires the coordinator "
+      "to rewrite UPDATE statements into MERGE plans (MergeWriterNode + "
+      "MergeProcessorNode) before they reach the worker, or a dedicated Velox "
+      "UpdateOperator. Neither is in place — set native_update_merge_enabled "
+      "to false (or run on a Java cluster) until the rewrite lands.");
+}
+
 std::shared_ptr<const core::UnnestNode>
 VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::UnnestNode>& node,
@@ -2278,6 +2439,19 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
           std::dynamic_pointer_cast<const protocol::TableWriterMergeNode>(
               node)) {
     return toVeloxQueryPlan(tableWriteMerger, tableWriteInfo, taskId);
+  }
+  if (auto mergeProcessor =
+          std::dynamic_pointer_cast<const protocol::MergeProcessorNode>(
+              node)) {
+    return toVeloxQueryPlan(mergeProcessor, tableWriteInfo, taskId);
+  }
+  if (auto mergeWriter =
+          std::dynamic_pointer_cast<const protocol::MergeWriterNode>(node)) {
+    return toVeloxQueryPlan(mergeWriter, tableWriteInfo, taskId);
+  }
+  if (auto updateNode =
+          std::dynamic_pointer_cast<const protocol::UpdateNode>(node)) {
+    return toVeloxQueryPlan(updateNode, tableWriteInfo, taskId);
   }
   if (auto assignUniqueId =
           std::dynamic_pointer_cast<const protocol::AssignUniqueId>(node)) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1805,6 +1805,27 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     targetColumnTypes.push_back(stringToType(var.type, typeParser_));
   }
 
+  // Collect the full output column name list from `node->outputs` so the
+  // IcebergMergeProcessor emits column names that exactly match the
+  // planner-declared output layout, including the trailing operation /
+  // rowId / insertFromUpdate columns. Downstream nodes (TableWriter::
+  // setTypeMappings) bind by name to these planner-declared identifiers
+  // (e.g. "$target_table_row_id") rather than synthetic placeholders.
+  // node->outputs is expected to have arity = targetColumnTypes.size() + 3
+  // in the order [target cols..., operation, row_id, insert_from_update].
+  VELOX_USER_CHECK_EQ(
+      node->outputs.size(),
+      node->targetColumnVariables.size() + 3,
+      "MergeProcessorNode outputs arity ({}) must equal "
+      "targetColumnVariables.size() + 3 ({})",
+      node->outputs.size(),
+      node->targetColumnVariables.size() + 3);
+  std::vector<std::string> outputColumnNames;
+  outputColumnNames.reserve(node->outputs.size());
+  for (const auto& var : node->outputs) {
+    outputColumnNames.push_back(var.name);
+  }
+
   // RowId type from the dedicated row-id variable.
   velox::TypePtr rowIdType =
       stringToType(node->targetTableRowIdColumnVariable.type, typeParser_);
@@ -1820,6 +1841,7 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   return std::make_shared<presto::operators::IcebergMergeProcessorNode>(
       node->id,
       std::move(targetColumnTypes),
+      std::move(outputColumnNames),
       std::move(rowIdType),
       targetRowIdChannel,
       mergeRowChannel,
@@ -1905,7 +1927,8 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   VELOX_USER_CHECK_NOT_NULL(
       node->target.mergeHandle,
       "MergeWriterNode target is missing mergeHandle");
-  const std::string connectorId = node->target.mergeHandle->tableHandle.connectorId;
+  const std::string connectorId =
+      node->target.mergeHandle->tableHandle.connectorId;
   auto& connector = getPrestoToVeloxConnector(
       node->target.mergeHandle->connectorMergeTableHandle->_type);
   auto veloxHandle = connector.toVeloxInsertTableHandle(
@@ -1957,8 +1980,9 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   renameExprs.reserve(srcType->size());
   for (size_t i = 0; i < srcType->size(); ++i) {
     renameNames.push_back(node->mergeProcessorProjectedVariables[i].name);
-    renameExprs.push_back(std::make_shared<velox::core::FieldAccessTypedExpr>(
-        srcType->childAt(i), srcType->nameOf(i)));
+    renameExprs.push_back(
+        std::make_shared<velox::core::FieldAccessTypedExpr>(
+            srcType->childAt(i), srcType->nameOf(i)));
   }
   const auto renamedSource = std::make_shared<velox::core::ProjectNode>(
       fmt::format("{}.rename", node->id),
@@ -2022,8 +2046,9 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
           twNames.size());
     }
     projNames.push_back(outVar.name);
-    projExprs.push_back(std::make_shared<velox::core::FieldAccessTypedExpr>(
-        outputType->childAt(i), twNames[i]));
+    projExprs.push_back(
+        std::make_shared<velox::core::FieldAccessTypedExpr>(
+            outputType->childAt(i), twNames[i]));
   }
   return std::make_shared<velox::core::ProjectNode>(
       fmt::format("{}.proj", node->id),
@@ -2559,8 +2584,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     return toVeloxQueryPlan(tableWriteMerger, tableWriteInfo, taskId);
   }
   if (auto mergeProcessor =
-          std::dynamic_pointer_cast<const protocol::MergeProcessorNode>(
-              node)) {
+          std::dynamic_pointer_cast<const protocol::MergeProcessorNode>(node)) {
     return toVeloxQueryPlan(mergeProcessor, tableWriteInfo, taskId);
   }
   if (auto mergeWriter =

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1996,6 +1996,40 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       outputType,
       getCommitStrategy(),
       renamedSource);
+
+  // 5. Alias TableWriteNode's Velox-mandated output names
+  //    (rows/fragments/commitcontext) to whatever MergeWriterNode.outputs
+  //    declares on the coordinator side (typically partialrows/fragment).
+  //    Downstream nodes (e.g. TableFinishNode in the coordinator plan, or
+  //    intermediate aggregation in the worker plan) look these up by NAME,
+  //    so we wrap the writer in a ProjectNode that renames the first N
+  //    columns to match the planner-declared variables.
+  if (node->outputs.empty()) {
+    return writeNode;
+  }
+  std::vector<std::string> projNames;
+  std::vector<velox::core::TypedExprPtr> projExprs;
+  projNames.reserve(node->outputs.size());
+  projExprs.reserve(node->outputs.size());
+  const auto& twNames = outputType->names();
+  for (size_t i = 0; i < node->outputs.size(); ++i) {
+    const auto& outVar = node->outputs[i];
+    if (i >= twNames.size()) {
+      VELOX_UNSUPPORTED(
+          "MergeWriterNode declares more output variables ({}) than "
+          "TableWriteNode produces ({}).",
+          node->outputs.size(),
+          twNames.size());
+    }
+    projNames.push_back(outVar.name);
+    projExprs.push_back(std::make_shared<velox::core::FieldAccessTypedExpr>(
+        outputType->childAt(i), twNames[i]));
+  }
+  return std::make_shared<velox::core::ProjectNode>(
+      fmt::format("{}.proj", node->id),
+      std::move(projNames),
+      std::move(projExprs),
+      writeNode);
 }
 
 // Layer 3b stub: legacy `UpdateNode` path (older than MERGE in OSS prestodb).

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -175,6 +175,36 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);
 
+  /// Layer 3b: dispatch the per-row INSERT/DELETE fan-out stage of an
+  /// UPDATE/MERGE plan to the custom Velox operator wrapping
+  /// `velox::connector::hive::iceberg::IcebergMergeProcessor` (Layer 1+3c).
+  velox::core::PlanNodePtr toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::MergeProcessorNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
+  /// Layer 3b stub: the commit-side `MergeWriterNode` (target write +
+  /// snapshot commit). Currently throws VELOX_UNSUPPORTED — wiring this
+  /// branch requires an `IcebergPrestoToVeloxConnector::
+  /// toVeloxInsertTableHandle(const protocol::MergeHandle*, ...)` overload
+  /// that returns an `IcebergInsertTableHandle` with `WriteKind::kMerge`,
+  /// so the Velox `TableWriter` operator can pick up `IcebergMergeSink`
+  /// (Layer 2) via `IcebergConnector::createDataSink`.
+  velox::core::PlanNodePtr toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::MergeWriterNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
+  /// Layer 3b stub: the legacy `UpdateNode` path (older than MERGE). Throws
+  /// VELOX_UNSUPPORTED — the modern path is for the coordinator to rewrite
+  /// UPDATE statements into MERGE plans (MergeWriterNode + MergeProcessorNode);
+  /// the standalone UpdateNode would need either its own Velox operator or
+  /// a SqlPlannerContext rewrite.
+  velox::core::PlanNodePtr toVeloxQueryPlan(
+      const std::shared_ptr<const protocol::UpdateNode>& node,
+      const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
+      const protocol::TaskId& taskId);
+
   std::shared_ptr<const velox::core::UnnestNode> toVeloxQueryPlan(
       const std::shared_ptr<const protocol::UnnestNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Filter.h"
 
@@ -755,4 +756,56 @@ TEST_F(
   VELOX_ASSERT_THROW(
       icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_),
       "Unexpected delete table handle type");
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    toVeloxSplitTranslatesDeletionVectorDelete) {
+  // A V3 DELETION_VECTOR delete file flows through toVeloxSplit and must land
+  // as a velox IcebergDeleteFile with FileContent::kDeletionVector and the
+  // PUFFIN content offset / length / referencedDataFile fields propagated.
+  // Before the toVeloxFileContent bridge wired DELETION_VECTOR, this path
+  // raised VELOX_UNSUPPORTED on the worker.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.start = 0;
+  split.length = 1024;
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.dataSequenceNumber = 5;
+
+  protocol::iceberg::DeleteFile dv;
+  dv.content = protocol::iceberg::FileContent::DELETION_VECTOR;
+  dv.path = "/path/to/deletes/dv.puffin";
+  dv.format = protocol::iceberg::FileFormat::PUFFIN;
+  dv.recordCount = 4;
+  dv.fileSizeInBytes = 128;
+  dv.dataSequenceNumber = 6;
+  dv.contentOffset = 16;
+  dv.contentSize = 64;
+  dv.referencedDataFile = "/path/to/data/file.dwrf";
+  split.deletes = {dv};
+
+  protocol::SplitContext context;
+  context.cacheable = false;
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit =
+      icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  ASSERT_NE(veloxSplit, nullptr);
+
+  auto* hiveIceberg =
+      dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+          veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+  ASSERT_EQ(hiveIceberg->deleteFiles.size(), 1);
+  const auto& deleteFile = hiveIceberg->deleteFiles[0];
+  EXPECT_EQ(
+      deleteFile.content,
+      connector::hive::iceberg::FileContent::kDeletionVector);
+  EXPECT_EQ(deleteFile.filePath, "/path/to/deletes/dv.puffin");
+  EXPECT_EQ(deleteFile.recordCount, 4);
+  EXPECT_EQ(deleteFile.dataSequenceNumber, 6);
+  EXPECT_EQ(deleteFile.contentOffset, 16);
+  EXPECT_EQ(deleteFile.contentLength, 64);
+  EXPECT_EQ(deleteFile.referencedDataFile, "/path/to/data/file.dwrf");
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Filter.h"
 
@@ -630,4 +631,128 @@ TEST_F(PrestoToVeloxConnectorTest, dateOverflowHighBelowMin) {
   EXPECT_FALSE(filter->testInt64(0));
   EXPECT_FALSE(filter->testInt64(std::numeric_limits<int32_t>::min()));
   EXPECT_FALSE(filter->testNull());
+}
+
+namespace {
+
+// Builds a minimal protocol::iceberg::IcebergDeleteTableHandle wrapped in a
+// protocol::DeleteHandle. The handle carries a single nullable int column and
+// the requested fileContent value; other fields are intentionally minimal
+// since the bridge only consults them as opaque pass-through.
+protocol::DeleteHandle makeIcebergDeleteHandle(
+    protocol::iceberg::FileContent fileContent) {
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergDeleteTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->schemaName = "test_schema";
+  protoHandle->tableName.tableName = "test_table";
+  protoHandle->outputPath = "/path/to/iceberg/data";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->fileContent = fileContent;
+
+  // Provide one input column so toIcebergColumns has something to convert.
+  protocol::iceberg::IcebergColumnHandle column;
+  column.columnIdentity.name = "id";
+  column.columnIdentity.id = 1;
+  column.columnIdentity.typeCategory =
+      protocol::iceberg::TypeCategory::PRIMITIVE;
+  column.type = "integer";
+  column.columnType = protocol::hive::ColumnType::REGULAR;
+  protoHandle->inputColumns = {column};
+
+  protocol::DeleteHandle deleteHandle;
+  deleteHandle.handle.connectorHandle = protoHandle;
+  deleteHandle.handle.connectorId = "iceberg";
+  return deleteHandle;
+}
+
+} // namespace
+
+TEST_F(PrestoToVeloxConnectorTest, icebergDeleteTableHandleDeletionVector) {
+  auto deleteHandle =
+      makeIcebergDeleteHandle(protocol::iceberg::FileContent::DELETION_VECTOR);
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  // The bridge returns a Velox IcebergInsertTableHandle (the unified write
+  // handle); the WriteKind enum on it distinguishes data vs deletion-vector.
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+  EXPECT_EQ(
+      icebergInsert->writeKind(),
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+          kDeletionVector);
+
+  // Confirm the location handle carries the expected target path and is in
+  // "existing" mode (DELETE targets an existing table).
+  const auto& locationHandle = icebergInsert->locationHandle();
+  EXPECT_EQ(locationHandle->targetPath(), "/path/to/iceberg/data/data");
+  EXPECT_EQ(
+      locationHandle->tableType(),
+      connector::hive::LocationHandle::TableType::kExisting);
+
+  // The single input column from the protocol handle round-trips through
+  // toIcebergColumns.
+  EXPECT_EQ(icebergInsert->inputColumns().size(), 1);
+  EXPECT_EQ(icebergInsert->inputColumns()[0]->name(), "id");
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    icebergDeleteTableHandlePositionDeletesFallbackToData) {
+  // POSITION_DELETES is the V2 content type. The V2 DELETE path runs entirely
+  // on the Java side (row-id rewrite via IcebergMergeSink), so this branch
+  // should not normally be exercised on the worker. The defensive default
+  // path in the override falls back to kData so an unexpected protocol value
+  // surfaces as a typed sink error rather than silently writing a deletion
+  // vector for the wrong format.
+  auto deleteHandle =
+      makeIcebergDeleteHandle(protocol::iceberg::FileContent::POSITION_DELETES);
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+  EXPECT_EQ(
+      icebergInsert->writeKind(),
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kData);
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    icebergDeleteTableHandleRejectsNonIcebergHandle) {
+  // If a non-Iceberg connector handle is wrapped in protocol::DeleteHandle
+  // (e.g., a Hive delete handle accidentally routed to the Iceberg bridge),
+  // the dynamic_pointer_cast yields nullptr and the override raises a
+  // VELOX_CHECK_NOT_NULL with the unexpected type name.
+  auto hiveDeleteHandle =
+      std::make_shared<protocol::hive::HiveTableHandle>();
+  hiveDeleteHandle->_type = "hive";
+  protocol::DeleteHandle deleteHandle;
+  // protocol::DeleteHandle::connectorHandle is shared_ptr<ConnectorDeleteTableHandle>;
+  // a HiveTableHandle is not such a subclass, so smuggle it through by
+  // constructing a typed but mismatched JSON-encoded subclass marker.
+  auto bogusHandle =
+      std::make_shared<protocol::iceberg::IcebergTableHandle>();
+  bogusHandle->_type = "hive-iceberg-not-delete";
+  deleteHandle.handle.connectorHandle =
+      std::static_pointer_cast<protocol::ConnectorDeleteTableHandle>(
+          std::shared_ptr<protocol::JsonEncodedSubclass>(bogusHandle));
+  deleteHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  VELOX_ASSERT_THROW(
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_),
+      "Unexpected delete table handle type");
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -29,6 +29,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
     IcebergDeleteTableHandle,
-    NotImplemented>;
+    NotImplemented,
+    IcebergMergeTableHandle>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -28,7 +28,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     NotImplemented,
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
-    NotImplemented,
+    IcebergDeleteTableHandle,
     NotImplemented>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1495,13 +1495,10 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "SchemaTableName",
       "materializedViewName");
-  from_json_key(
-      j,
-      "fullRefreshRequired",
-      p.fullRefreshRequired,
-      "IcebergInsertTableHandle",
-      "bool",
-      "fullRefreshRequired");
+  // [apurvak ICEBERG-FIX]: FB-Java POJO does not always serialize
+  // fullRefreshRequired (upstream-only MV-refresh field). Tolerate missing
+  // key by defaulting to false so Iceberg INSERT plans deserialize cleanly.
+  p.fullRefreshRequired = j.value("fullRefreshRequired", false);
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1861,3 +1861,26 @@ void from_json(const json& j, IcebergSplit& p) {
       "affinitySchedulingSectionSize");
 }
 } // namespace facebook::presto::protocol::iceberg
+
+// Layer 3b — hand-injected IcebergMergeTableHandle implementation. Mirrors
+// the chevron-generated pattern for IcebergDeleteTableHandle above.
+namespace facebook::presto::protocol::iceberg {
+IcebergMergeTableHandle::IcebergMergeTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergMergeTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "tableHandle", p.tableHandle, "IcebergMergeTableHandle", "IcebergTableHandle", "tableHandle");
+  to_json_key(j, "insertTableHandle", p.insertTableHandle, "IcebergMergeTableHandle", "IcebergInsertTableHandle", "insertTableHandle");
+  to_json_key(j, "partitionSpecs", p.partitionSpecs, "IcebergMergeTableHandle", "Map<Integer, PrestoIcebergPartitionSpec>", "partitionSpecs");
+}
+
+void from_json(const json& j, IcebergMergeTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "tableHandle", p.tableHandle, "IcebergMergeTableHandle", "IcebergTableHandle", "tableHandle");
+  from_json_key(j, "insertTableHandle", p.insertTableHandle, "IcebergMergeTableHandle", "IcebergInsertTableHandle", "insertTableHandle");
+  from_json_key(j, "partitionSpecs", p.partitionSpecs, "IcebergMergeTableHandle", "Map<Integer, PrestoIcebergPartitionSpec>", "partitionSpecs");
+}
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -281,7 +281,8 @@ static const std::pair<FileContent, json> FileContent_enum_table[] =
     { // NOLINT: cert-err58-cpp
         {FileContent::DATA, "DATA"},
         {FileContent::POSITION_DELETES, "POSITION_DELETES"},
-        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"}};
+        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"},
+        {FileContent::DELETION_VECTOR, "DELETION_VECTOR"}};
 void to_json(json& j, const FileContent& e) {
   static_assert(
       std::is_enum<FileContent>::value, "FileContent must be an enum!");

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1505,6 +1505,44 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  to_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  to_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  to_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  to_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  to_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  to_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  to_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  to_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  to_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  to_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  to_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  from_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  from_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  from_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  from_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  from_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  from_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  from_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  from_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  from_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  from_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  from_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergOutputTableHandle::IcebergOutputTableHandle() noexcept {
   _type = "hive-iceberg";
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -347,3 +347,19 @@ struct IcebergSplit : public ConnectorSplit {
 void to_json(json& j, const IcebergSplit& p);
 void from_json(const json& j, IcebergSplit& p);
 } // namespace facebook::presto::protocol::iceberg
+
+// Layer 3b — hand-injected IcebergMergeTableHandle (regen of iceberg .h/.cpp
+// is blocked by a pre-existing missing-file bug for IcebergDeleteTableHandle.java;
+// this struct is the manual equivalent of what regen would produce from
+// presto-iceberg/.../IcebergMergeTableHandle.java).
+namespace facebook::presto::protocol::iceberg {
+struct IcebergMergeTableHandle : public ConnectorMergeTableHandle {
+  IcebergTableHandle tableHandle = {};
+  IcebergInsertTableHandle insertTableHandle = {};
+  Map<Integer, PrestoIcebergPartitionSpec> partitionSpecs = {};
+
+  IcebergMergeTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergMergeTableHandle& p);
+void from_json(const json& j, IcebergMergeTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -280,9 +280,6 @@ void from_json(const json& j, IcebergInsertTableHandle& p);
 // IcebergDeleteTableHandle is special since it needs an usage of
 // hive::.
 
-// IcebergDeleteTableHandle is special since it needs an usage of
-// hive::.
-
 namespace facebook::presto::protocol::iceberg {
 struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   String schemaName = {};

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -79,7 +79,7 @@ void to_json(json& j, const ChangelogSplitInfo& p);
 void from_json(const json& j, ChangelogSplitInfo& p);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES };
+enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES, DELETION_VECTOR };
 extern void to_json(json& j, const FileContent& e);
 extern void from_json(const json& j, FileContent& e);
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -277,6 +277,32 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
 void to_json(json& j, const IcebergInsertTableHandle& p);
 void from_json(const json& j, IcebergInsertTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg
 // IcebergOutputTableHandle is special since it needs an usage of
 // hive::.
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -37,6 +37,11 @@ AbstractClasses:
     subclasses:
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
+
   ConnectorDistributedProcedureHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -67,6 +72,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -47,11 +47,6 @@ AbstractClasses:
     subclasses:
       - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
 
-  ConnectorDeleteTableHandle:
-    super: JsonEncodedSubclass
-    subclasses:
-      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
-
   ConnectorDistributedProcedureHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -83,7 +78,6 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeTableHandle.java
-  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -37,6 +37,16 @@ AbstractClasses:
     subclasses:
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorMergeTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergMergeTableHandle,        key: hive-iceberg }
+
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
+
   ConnectorDeleteTableHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -72,6 +82,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMergeTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
@@ -144,6 +144,17 @@ class ConnectorProtocol {
   virtual void from_json(
       const json& j,
       std::shared_ptr<ConnectorIndexHandle>& p) const = 0;
+
+  // Layer 3b: MERGE handle dispatch (mirrors the ConnectorDeleteTableHandle
+  // pair above). Wired through ConnectorMergeTableHandleType template slot
+  // below; connectors that don't support MERGE leave the slot as
+  // NotImplemented (default), which yields a VELOX_NYI on dispatch.
+  virtual void to_json(
+      json& j,
+      const std::shared_ptr<ConnectorMergeTableHandle>& p) const = 0;
+  virtual void from_json(
+      const json& j,
+      std::shared_ptr<ConnectorMergeTableHandle>& p) const = 0;
 };
 
 namespace {
@@ -161,7 +172,8 @@ template <
     typename ConnectorTransactionHandleType = NotImplemented,
     typename ConnectorDistributedProcedureHandleType = NotImplemented,
     typename ConnectorDeleteTableHandleType = NotImplemented,
-    typename ConnectorIndexHandleType = NotImplemented>
+    typename ConnectorIndexHandleType = NotImplemented,
+    typename ConnectorMergeTableHandleType = NotImplemented>
 class ConnectorProtocolTemplate final : public ConnectorProtocol {
  public:
   void to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p)
@@ -333,6 +345,16 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
     from_json_template<ConnectorIndexHandleType>(j, p);
   }
 
+  // Layer 3b: ConnectorMergeTableHandle dispatch.
+  void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p)
+      const final {
+    to_json_template<ConnectorMergeTableHandleType>(j, p);
+  }
+  void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p)
+      const final {
+    from_json_template<ConnectorMergeTableHandleType>(j, p);
+  }
+
  private:
   template <typename DERIVED, typename BASE>
   static void to_json_template(
@@ -422,6 +444,7 @@ using SystemConnectorProtocol = ConnectorProtocolTemplate<
     SystemSplit,
     SystemPartitioningHandle,
     SystemTransactionHandle,
+    NotImplemented,
     NotImplemented,
     NotImplemented,
     NotImplemented>;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7415,8 +7415,7 @@ void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p) {
     return;
   }
   String type = p->_type;
-
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).to_json(j, p);
 }
 
 void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
@@ -7428,8 +7427,7 @@ void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
         std::string(e.what()) +
         " ConnectorMergeTableHandle  ConnectorMergeTableHandle");
   }
-
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).from_json(j, p);
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -748,6 +748,18 @@ void to_json(json& j, const std::shared_ptr<PlanNode>& p) {
     j = *std::static_pointer_cast<TableWriterMergeNode>(p);
     return;
   }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeWriterNode") {
+    j = *std::static_pointer_cast<MergeWriterNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeProcessorNode") {
+    j = *std::static_pointer_cast<MergeProcessorNode>(p);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.UpdateNode") {
+    j = *std::static_pointer_cast<UpdateNode>(p);
+    return;
+  }
   if (type == ".TopNNode") {
     j = *std::static_pointer_cast<TopNNode>(p);
     return;
@@ -934,6 +946,25 @@ void from_json(const json& j, std::shared_ptr<PlanNode>& p) {
   if (type == "com.facebook.presto.sql.planner.plan.TableWriterMergeNode") {
     std::shared_ptr<TableWriterMergeNode> k =
         std::make_shared<TableWriterMergeNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeWriterNode") {
+    std::shared_ptr<MergeWriterNode> k = std::make_shared<MergeWriterNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.MergeProcessorNode") {
+    std::shared_ptr<MergeProcessorNode> k =
+        std::make_shared<MergeProcessorNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == "com.facebook.presto.sql.planner.plan.UpdateNode") {
+    std::shared_ptr<UpdateNode> k = std::make_shared<UpdateNode>();
     j.get_to(*k);
     p = std::static_pointer_cast<PlanNode>(k);
     return;
@@ -7681,6 +7712,136 @@ void from_json(const json& j, MergeTarget& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+MergeProcessorNode::MergeProcessorNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.MergeProcessorNode";
+}
+
+void to_json(json& j, const MergeProcessorNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.MergeProcessorNode";
+  to_json_key(j, "id", p.id, "MergeProcessorNode", "PlanNodeId", "id");
+  to_json_key(
+      j, "source", p.source, "MergeProcessorNode", "PlanNode", "source");
+  to_json_key(
+      j, "target", p.target, "MergeProcessorNode", "MergeTarget", "target");
+  to_json_key(
+      j,
+      "targetTableRowIdColumnVariable",
+      p.targetTableRowIdColumnVariable,
+      "MergeProcessorNode",
+      "VariableReferenceExpression",
+      "targetTableRowIdColumnVariable");
+  to_json_key(
+      j,
+      "mergeRowVariable",
+      p.mergeRowVariable,
+      "MergeProcessorNode",
+      "VariableReferenceExpression",
+      "mergeRowVariable");
+  to_json_key(
+      j,
+      "targetColumnVariables",
+      p.targetColumnVariables,
+      "MergeProcessorNode",
+      "List<VariableReferenceExpression>",
+      "targetColumnVariables");
+  to_json_key(
+      j,
+      "outputs",
+      p.outputs,
+      "MergeProcessorNode",
+      "List<VariableReferenceExpression>",
+      "outputs");
+}
+
+void from_json(const json& j, MergeProcessorNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "MergeProcessorNode", "PlanNodeId", "id");
+  from_json_key(
+      j, "source", p.source, "MergeProcessorNode", "PlanNode", "source");
+  from_json_key(
+      j, "target", p.target, "MergeProcessorNode", "MergeTarget", "target");
+  from_json_key(
+      j,
+      "targetTableRowIdColumnVariable",
+      p.targetTableRowIdColumnVariable,
+      "MergeProcessorNode",
+      "VariableReferenceExpression",
+      "targetTableRowIdColumnVariable");
+  from_json_key(
+      j,
+      "mergeRowVariable",
+      p.mergeRowVariable,
+      "MergeProcessorNode",
+      "VariableReferenceExpression",
+      "mergeRowVariable");
+  from_json_key(
+      j,
+      "targetColumnVariables",
+      p.targetColumnVariables,
+      "MergeProcessorNode",
+      "List<VariableReferenceExpression>",
+      "targetColumnVariables");
+  from_json_key(
+      j,
+      "outputs",
+      p.outputs,
+      "MergeProcessorNode",
+      "List<VariableReferenceExpression>",
+      "outputs");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+MergeWriterNode::MergeWriterNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.MergeWriterNode";
+}
+
+void to_json(json& j, const MergeWriterNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.MergeWriterNode";
+  to_json_key(j, "id", p.id, "MergeWriterNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "MergeWriterNode", "PlanNode", "source");
+  to_json_key(
+      j, "target", p.target, "MergeWriterNode", "MergeTarget", "target");
+  to_json_key(
+      j,
+      "mergeProcessorProjectedVariables",
+      p.mergeProcessorProjectedVariables,
+      "MergeWriterNode",
+      "List<VariableReferenceExpression>",
+      "mergeProcessorProjectedVariables");
+  to_json_key(
+      j,
+      "outputs",
+      p.outputs,
+      "MergeWriterNode",
+      "List<VariableReferenceExpression>",
+      "outputs");
+}
+
+void from_json(const json& j, MergeWriterNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "MergeWriterNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "MergeWriterNode", "PlanNode", "source");
+  from_json_key(
+      j, "target", p.target, "MergeWriterNode", "MergeTarget", "target");
+  from_json_key(
+      j,
+      "mergeProcessorProjectedVariables",
+      p.mergeProcessorProjectedVariables,
+      "MergeWriterNode",
+      "List<VariableReferenceExpression>",
+      "mergeProcessorProjectedVariables");
+  from_json_key(
+      j,
+      "outputs",
+      p.outputs,
+      "MergeWriterNode",
+      "List<VariableReferenceExpression>",
+      "outputs");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 NativeFunctionHandle::NativeFunctionHandle() noexcept {
   _type = "native";
 }
@@ -8923,6 +9084,20 @@ void to_json(json& j, const StageExecutionDescriptor& p) {
       "StageExecutionDescriptor",
       "int",
       "totalLifespans");
+  to_json_key(
+      j,
+      "groupedExecutionPartitionValues",
+      p.groupedExecutionPartitionValues,
+      "StageExecutionDescriptor",
+      "List<Map<String, String>>",
+      "groupedExecutionPartitionValues");
+  to_json_key(
+      j,
+      "partitionColumnMappings",
+      p.partitionColumnMappings,
+      "StageExecutionDescriptor",
+      "Map<PlanNodeId, Map<String, String>>",
+      "partitionColumnMappings");
 }
 
 void from_json(const json& j, StageExecutionDescriptor& p) {
@@ -8947,6 +9122,20 @@ void from_json(const json& j, StageExecutionDescriptor& p) {
       "StageExecutionDescriptor",
       "int",
       "totalLifespans");
+  from_json_key(
+      j,
+      "groupedExecutionPartitionValues",
+      p.groupedExecutionPartitionValues,
+      "StageExecutionDescriptor",
+      "List<Map<String, String>>",
+      "groupedExecutionPartitionValues");
+  from_json_key(
+      j,
+      "partitionColumnMappings",
+      p.partitionColumnMappings,
+      "StageExecutionDescriptor",
+      "Map<PlanNodeId, Map<String, String>>",
+      "partitionColumnMappings");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -12714,6 +12903,66 @@ void from_json(const json& j, UpdateHandle& p) {
       "UpdateHandle",
       "SchemaTableName",
       "schemaTableName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+UpdateNode::UpdateNode() noexcept {
+  _type = "com.facebook.presto.sql.planner.plan.UpdateNode";
+}
+
+void to_json(json& j, const UpdateNode& p) {
+  j = json::object();
+  j["@type"] = "com.facebook.presto.sql.planner.plan.UpdateNode";
+  to_json_key(j, "id", p.id, "UpdateNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "UpdateNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "rowId",
+      p.rowId,
+      "UpdateNode",
+      "VariableReferenceExpression",
+      "rowId");
+  to_json_key(
+      j,
+      "columnValueAndRowIdSymbols",
+      p.columnValueAndRowIdSymbols,
+      "UpdateNode",
+      "List<VariableReferenceExpression>",
+      "columnValueAndRowIdSymbols");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "UpdateNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+}
+
+void from_json(const json& j, UpdateNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "UpdateNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "UpdateNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "rowId",
+      p.rowId,
+      "UpdateNode",
+      "VariableReferenceExpression",
+      "rowId");
+  from_json_key(
+      j,
+      "columnValueAndRowIdSymbols",
+      p.columnValueAndRowIdSymbols,
+      "UpdateNode",
+      "List<VariableReferenceExpression>",
+      "columnValueAndRowIdSymbols");
+  from_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "UpdateNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7455,7 +7455,14 @@ void to_json(json& j, const MergeHandle& p) {
 }
 
 void from_json(const json& j, MergeHandle& p) {
-  p._type = j["@type"];
+  // Layer 3b fix: spi.MergeHandle is a non-polymorphic data class in OSS Java;
+  // Jackson does NOT emit @type for it. The regen tool incorrectly emitted the
+  // @type read here because it conflated spi.MergeHandle with the unrelated
+  // ExecutionWriterTarget.MergeHandle inner-wrapper subclass (same simple name,
+  // different package). Read @type only when present.
+  if (j.count("@type")) {
+    p._type = j["@type"];
+  }
   from_json_key(
       j,
       "tableHandle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1862,6 +1862,32 @@ void to_json(json& j, const MergeTarget& p);
 void from_json(const json& j, MergeTarget& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct MergeProcessorNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  MergeTarget target = {};
+  VariableReferenceExpression targetTableRowIdColumnVariable = {};
+  VariableReferenceExpression mergeRowVariable = {};
+  List<VariableReferenceExpression> targetColumnVariables = {};
+  List<VariableReferenceExpression> outputs = {};
+
+  MergeProcessorNode() noexcept;
+};
+void to_json(json& j, const MergeProcessorNode& p);
+void from_json(const json& j, MergeProcessorNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct MergeWriterNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  MergeTarget target = {};
+  List<VariableReferenceExpression> mergeProcessorProjectedVariables = {};
+  List<VariableReferenceExpression> outputs = {};
+
+  MergeWriterNode() noexcept;
+};
+void to_json(json& j, const MergeWriterNode& p);
+void from_json(const json& j, MergeWriterNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct NativeFunctionHandle : public FunctionHandle {
   Signature signature = {};
 
@@ -2054,6 +2080,8 @@ struct StageExecutionDescriptor {
   StageExecutionStrategy stageExecutionStrategy = {};
   List<PlanNodeId> groupedExecutionScanNodes = {};
   int totalLifespans = {};
+  List<Map<String, String>> groupedExecutionPartitionValues = {};
+  Map<PlanNodeId, Map<String, String>> partitionColumnMappings = {};
 };
 void to_json(json& j, const StageExecutionDescriptor& p);
 void from_json(const json& j, StageExecutionDescriptor& p);
@@ -2708,6 +2736,18 @@ struct UpdateHandle : public ExecutionWriterTarget {
 };
 void to_json(json& j, const UpdateHandle& p);
 void from_json(const json& j, UpdateHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct UpdateNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  std::shared_ptr<VariableReferenceExpression> rowId = {};
+  List<VariableReferenceExpression> columnValueAndRowIdSymbols = {};
+  List<VariableReferenceExpression> outputVariables = {};
+
+  UpdateNode() noexcept;
+};
+void to_json(json& j, const UpdateNode& p);
+void from_json(const json& j, UpdateNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct ValuesNode : public PlanNode {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -185,6 +185,9 @@ AbstractClasses:
       - { name: TableScanNode,            key: .TableScanNode }
       - { name: TableWriterNode,          key: .TableWriterNode }
       - { name: TableWriterMergeNode,     key: com.facebook.presto.sql.planner.plan.TableWriterMergeNode }
+      - { name: MergeWriterNode,          key: com.facebook.presto.sql.planner.plan.MergeWriterNode }
+      - { name: MergeProcessorNode,       key: com.facebook.presto.sql.planner.plan.MergeProcessorNode }
+      - { name: UpdateNode,               key: com.facebook.presto.sql.planner.plan.UpdateNode }
       - { name: TopNNode,                 key: .TopNNode }
       - { name: TopNRowNumberNode,        key: .TopNRowNumberNode }
       - { name: UnnestNode,               key: .UnnestNode }
@@ -267,6 +270,9 @@ JavaClasses:
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/TopNRowNumberNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
   - presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterMergeNode.java
+  - presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/MergeWriterNode.java
+  - presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/MergeProcessorNode.java
+  - presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/UpdateNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/UnnestNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/WindowNode.java
   - presto-main-base/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -86,6 +86,7 @@ AbstractClasses:
   ConnectorDeleteTableHandle:
     super: JsonEncodedSubclass
     subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
 
   ConnectorTransactionHandle:
     super: JsonEncodedSubclass


### PR DESCRIPTION
Summary:

Rebase brought in API changes to IcebergPrestoToVeloxConnector.cpp that
broke the V3 MERGE row-id synthesis block and the V3 deletion-vector
writeKind dispatch:

1. icebergSplit was changed to pass by pointer; fix dot-access to arrow.
2. Add missing #include for IcebergMetadataColumns.h (needed for
   kSpecIdInfoColumn / kPartitionDataInfoColumn).
3. Generated protocol FileContent enum lacked DELETION_VECTOR (4); add
   it to the enum + JSON serialization table to match the Java
   FileContent.DELETION_VECTOR(3) constant added in the V3 stack.

=== NO RELEASE NOTES ===

Reviewed By: zacw7

Differential Revision: D106888195
