### PR TITLE
chore(ci): Advance dorny/paths-filter, actions/checkout, actions/setup-java to latest

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -24,7 +24,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       # Checkout the code only if there are changes in the relevant files
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
@@ -124,7 +124,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
@@ -255,7 +255,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false

--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -50,14 +50,14 @@ jobs:
 
     steps:
       # Checkout the code only if there are changes in the relevant files
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
 
       # Set up Java and dependencies for the build environment
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
@@ -124,7 +124,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
@@ -255,7 +255,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
@@ -290,7 +290,7 @@ jobs:
 
       - name: Install OpenJDK8
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           show-progress: false

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           show-progress: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         with:
           show-progress: false
           persist-credentials: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           show-progress: false
           persist-credentials: false
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra latexmk tex-gyre texlive-xetex fonts-freefont-otf xindy
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -44,7 +44,7 @@ jobs:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
@@ -101,7 +101,7 @@ jobs:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -44,12 +44,12 @@ jobs:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
@@ -101,12 +101,12 @@ jobs:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -44,7 +44,7 @@ jobs:
       group: ${{ github.workflow }}-jdbc-connector-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -44,12 +44,12 @@ jobs:
       group: ${{ github.workflow }}-jdbc-connector-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -42,12 +42,12 @@ jobs:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -21,7 +21,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -42,7 +42,7 @@ jobs:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         with:
           show-progress: false
           persist-credentials: false

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -44,7 +44,7 @@ jobs:
       # Checkout PR branch first to get access to the composite action
       - name: Checkout PR branch
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout base branch
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           persist-credentials: false
           ref: ${{ steps.merge-base.outputs.sha }}

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -44,7 +44,7 @@ jobs:
       # Checkout PR branch first to get access to the composite action
       - name: Checkout PR branch
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout base branch
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           ref: ${{ steps.merge-base.outputs.sha }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Set up Java
         if: needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout presto source
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
           show-progress: false
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout presto source
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
           show-progress: false
@@ -198,7 +198,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}

--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout presto source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
           show-progress: false
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout presto source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           fetch-tags: true
           show-progress: false

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -72,7 +72,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           sudo apt-get install -y build-essential git gpg python3 python3-venv
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           ref: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
@@ -268,7 +268,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           ref: ${{ env.RELEASE_TAG}}
           persist-credentials: false
@@ -304,7 +304,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           ref: ${{ env.RELEASE_TAG}}
           persist-credentials: false
@@ -373,7 +373,7 @@ jobs:
           swap-storage: false
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: true
@@ -479,7 +479,7 @@ jobs:
 
     steps:
       - name: Checkout presto
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           repository: ${{ github.repository_owner }}/presto
           path: presto
@@ -490,7 +490,7 @@ jobs:
           persist-credentials: true
 
       - name: Checkout prestodb.github.io
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           repository: ${{ github.repository_owner }}/prestodb.github.io
           path: prestodb.github.io

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -72,7 +72,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
           swap-storage: false
 
       - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -155,7 +155,7 @@ jobs:
           sudo apt-get install -y build-essential git gpg python3 python3-venv
 
       - name: Checkout code
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
@@ -268,7 +268,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG}}
           persist-credentials: false
@@ -304,7 +304,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG}}
           persist-credentials: false
@@ -373,7 +373,7 @@ jobs:
           swap-storage: false
 
       - name: Checkout
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: true
@@ -479,7 +479,7 @@ jobs:
 
     steps:
       - name: Checkout presto
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/presto
           path: presto
@@ -490,7 +490,7 @@ jobs:
           persist-credentials: true
 
       - name: Checkout prestodb.github.io
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/prestodb.github.io
           path: prestodb.github.io

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@v6.0
         with:
           persist-credentials: false
       - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -146,7 +146,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -271,7 +271,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -400,7 +400,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -516,7 +516,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -628,7 +628,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -19,7 +19,7 @@ jobs:
       # For pull requests it's not necessary to checkout the code
       - name: Run changes check for PRs
         if: github.event_name != 'schedule'
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -146,7 +146,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -197,7 +197,7 @@ jobs:
       - name: Install OpenJDK8
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -271,7 +271,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -329,7 +329,7 @@ jobs:
       - name: Install OpenJDK8
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -400,7 +400,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -451,7 +451,7 @@ jobs:
       - name: Install OpenJDK17
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -516,7 +516,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -566,7 +566,7 @@ jobs:
       - name: Install OpenJDK8
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -628,7 +628,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
@@ -678,7 +678,7 @@ jobs:
       - name: Install OpenJDK8
         if: |
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -13,7 +13,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -84,7 +84,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -84,7 +84,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # For pull requests it's not necessary to checkout the code
       - name: Run changes check for PRs
-        uses: dorny/paths-filter@7267a8516b6f92bdb098633497bad573efdbf271
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -43,7 +43,7 @@ jobs:
       group: ${{ github.workflow }}-prestocpp-macos-build-${{ github.event.pull_request.number }}-${{ matrix.os }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: |
           needs.changes.outputs.codechange == 'true'
         with:

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -43,7 +43,7 @@ jobs:
       group: ${{ github.workflow }}-prestocpp-macos-build-${{ github.event.pull_request.number }}-${{ matrix.os }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: |
           needs.changes.outputs.codechange == 'true'
         with:

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -48,12 +48,12 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -21,7 +21,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -47,12 +47,12 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
@@ -114,12 +114,12 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -21,7 +21,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -47,7 +47,7 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
@@ -114,7 +114,7 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -17,7 +17,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -17,11 +17,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -43,7 +43,7 @@ jobs:
       group: ${{ github.workflow }}-singlestore-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -43,7 +43,7 @@ jobs:
       group: ${{ github.workflow }}-singlestore-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
@@ -60,7 +60,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "=== AFTER ==="
           df -h
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -48,12 +48,12 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           tool-cache: true
           swap-storage: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,12 +77,12 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -18,7 +18,7 @@ jobs:
       codechange: ${{ steps.filter.outputs.codechange }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -37,7 +37,7 @@ jobs:
       group: ${{ github.workflow }}-web-ui-checks-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0
         with:
           show-progress: false
           persist-credentials: false

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -37,7 +37,7 @@ jobs:
       group: ${{ github.workflow }}-web-ui-checks-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6.0
+      - uses: actions/checkout@v6
         with:
           show-progress: false
           persist-credentials: false


### PR DESCRIPTION
## Description
- Upgrade dorny/paths-filter to v4.0.1 per https://github.com/dorny/paths-filter/releases. Fixes #27918
- Upgrade actions/checkout to v6.0 per https://github.com/actions/checkout/releases
- Upgrade actions/set-java to v5.2 per https://github.com/actions/setup-java/releases

## Motivation and Context
Node 20 will be deprecated 16-Jun-2026.

## Impact
Now CI jobs will be able to use non-deprecated and futuristic Nodejs 24+

## Test Plan
Ensure CI is all green.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Bump dorny/paths-filter from v3 to v4.0.1 across multiple GitHub Actions workflows to keep CI up to date with supported Node versions.