### PR TITLE
test: Add E2E tests for map_top_n_keys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/jkhaliqi/velox.git

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -90,7 +90,7 @@ public class TestNativeSidecarPlugin
     private static final String REGEX_FUNCTION_NAMESPACE = "native.default.*";
     private static final String REGEX_SESSION_NAMESPACE = "Native Execution only.*";
     private static final long SIDECAR_HTTP_CLIENT_MAX_CONTENT_SIZE_MB = 128;
-    private static final int INLINED_SQL_FUNCTIONS_COUNT = 5;
+    private static final int INLINED_SQL_FUNCTIONS_COUNT = 4;
 
     @Override
     protected void createTables()
@@ -597,6 +597,7 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT map_keys_by_top_n_values(MAP(ARRAY[orderkey], ARRAY[custkey]), 2) from orders");
         assertQuery("SELECT map_top_n(MAP(ARRAY[CAST(nationkey AS VARCHAR)], ARRAY[comment]), 3) from nation");
         assertQuery("SELECT map_top_n_keys(MAP(ARRAY[orderkey], ARRAY[custkey]), 3) from orders");
+        assertQuery("SELECT map_top_n_keys(MAP(ARRAY[regionkey], ARRAY[nationkey]), 5, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
         assertQuery("SELECT map_top_n_values(MAP(ARRAY[orderkey], ARRAY[custkey]), 3) from orders");
         assertQuery("SELECT all_keys_match(MAP(ARRAY[comment], ARRAY[custkey]), k -> length(k) > 5) from orders");
         assertQuery("SELECT any_keys_match(MAP(ARRAY[comment], ARRAY[custkey]), k -> starts_with(k, 'abc')) from orders");
@@ -622,7 +623,6 @@ public class TestNativeSidecarPlugin
 
         // Map functions
         assertQuery("SELECT map_top_n_values(MAP(ARRAY[comment], ARRAY[nationkey]), 2, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
-        assertQuery("SELECT map_top_n_keys(MAP(ARRAY[regionkey], ARRAY[nationkey]), 5, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation");
 
         Session sessionWithKeyBasedSampling = Session.builder(getSession())
                 .setSystemProperty(KEY_BASED_SAMPLING_ENABLED, "true")
@@ -655,10 +655,6 @@ public class TestNativeSidecarPlugin
         assertQueryFails(session,
                 "SELECT map_top_n_values(MAP(ARRAY[comment], ARRAY[nationkey]), 2, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation",
                 ".*Scalar function native\\.default\\.map_top_n_values not registered with arguments.*",
-                true);
-        assertQueryFails(session,
-                "SELECT map_top_n_keys(MAP(ARRAY[regionkey], ARRAY[nationkey]), 5, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) from nation",
-                ".*Scalar function native\\.default\\.map_top_n_keys not registered with arguments.*",
                 true);
     }
 

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestMapTopNFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestMapTopNFunctions.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+public class TestMapTopNFunctions
+        extends AbstractTestQueryFramework
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .setExtraProperties(ImmutableMap.of("inline-sql-functions", "false"))
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        else {
+            queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        }
+        return queryRunner;
+    }
+
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setExtraProperties(ImmutableMap.of("inline-sql-functions", "true"))
+                .build();
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
+    }
+
+    @Test
+    public void testMapTopNKeys()
+    {
+        assertQuery("SELECT TRY(map_top_n_keys(c0, BIGINT '6455219767830808341')) FROM (VALUES (MAP(ARRAY[1, 2], ARRAY[ARRAY[1, null], ARRAY[1, null]]))) t(c0)");
+        assertQuery("SELECT TRY(map_top_n_keys(c0, BIGINT '6455219767830808341')) FROM (VALUES (MAP(ARRAY[1, 2], ARRAY[ARRAY[null, null], ARRAY[1, 2]]))) t(c0)");
+
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[3,2,5,4,1], ARRAY[1,1,1,1,1])), (MAP(ARRAY[3,2,1], ARRAY[1,1,1])), (MAP(ARRAY[2,1], ARRAY[1,1])) ) SELECT map_top_n_keys(c0, 3, (x,y) -> x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[3,2,5,4,1], ARRAY[1,1,1,1,1])), (MAP(ARRAY[3,2,1], ARRAY[1,1,1])), (MAP(ARRAY[2,1], ARRAY[1,1])) ) SELECT map_top_n_keys(c0, 3, (x,y) -> CAST(IF(x < y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[1,2,3,4,5], ARRAY[1,1,1,1,1])) ) SELECT map_top_n_keys(c0, 3, (x, y) -> -x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[1,2,3,4,5], ARRAY[1,1,1,1,1])) ) SELECT map_top_n_keys(c0, 3, (x, y) -> CAST(IF(x > y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+        assertQuery("WITH input(c0) AS ( VALUES (MAP(ARRAY[CAST(-2147483648 AS INTEGER), CAST(0 AS INTEGER), CAST(2147483647 AS INTEGER)], ARRAY[1,1,1])) ) SELECT map_top_n_keys(c0, 2, (x, y) -> x) AS result FROM input",
+                "WITH input(c0) AS ( VALUES (MAP(ARRAY[CAST(-2147483648 AS INTEGER), CAST(0 AS INTEGER), CAST(2147483647 AS INTEGER)], ARRAY[1,1,1])) ) SELECT map_top_n_keys(c0, 2, (x, y) -> CAST(IF(x < y, -1, IF(x = y, 0, 1)) AS INTEGER)) AS result FROM input");
+    }
+}

--- a/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeMapSqlFunctions.java
+++ b/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/NativeMapSqlFunctions.java
@@ -24,17 +24,6 @@ public class NativeMapSqlFunctions
 {
     private NativeMapSqlFunctions() {}
 
-    @SqlInvokedScalarFunction(value = "map_top_n_keys", deterministic = true, calledOnNullInput = true)
-    @Description("Returns the top N keys of the given map sorting its keys using the provided lambda comparator.")
-    @TypeParameter("K")
-    @TypeParameter("V")
-    @SqlParameters({@SqlParameter(name = "input", type = "map(K, V)"), @SqlParameter(name = "n", type = "int"), @SqlParameter(name = "f", type = "function(K, K, int)")})
-    @SqlType("array<K>")
-    public static String mapTopNKeysComparator()
-    {
-        return "RETURN IF(n < 0, fail('n must be greater than or equal to 0'), slice(reverse(array_sort(map_keys(input), f)), 1, n))";
-    }
-
     @SqlInvokedScalarFunction(value = "map_top_n_values", deterministic = true, calledOnNullInput = true)
     @Description("Returns the top N values of the given map sorted using the provided lambda comparator.")
     @TypeParameter("K")


### PR DESCRIPTION
## Description
Add E2E tests for map_top_n_keys

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
As part of https://github.com/facebookincubator/velox/issues/16041

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add native end-to-end coverage for map_top_n_keys and align plugin wiring with the desired implementation surface.

Enhancements:
- Remove the inlined SQL implementation of map_top_n_keys from the native SQL functions helper to rely on the central implementation.

Tests:
- Introduce native E2E tests comparing map_top_n_keys behavior between native and Java runners under various comparators and configurations.
- Adjust sidecar plugin tests to exercise map_top_n_keys only in the intended overridden configuration.