### PR TITLE
Fix: Fix cleanupQuery not called on CTAS target connector

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
@@ -92,6 +92,10 @@ public class BuiltInQueryAnalysis
             connectors.add(target.getConnectorId());
         }
 
+        if (analysis.getCreateTableDestination().isPresent()) {
+            connectors.add(new ConnectorId(analysis.getCreateTableDestination().get().getCatalogName()));
+        }
+
         return connectors.build();
     }
 }

--- a/presto-analyzer/src/test/java/com/facebook/presto/sql/analyzer/TestBuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/test/java/com/facebook/presto/sql/analyzer/TestBuiltInQueryAnalysis.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.sql.tree.Explain;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.Table;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestBuiltInQueryAnalysis
+{
+    private static final ConnectorId CONNECTOR_A = new ConnectorId("catalog_a");
+    private static final ConnectorId CONNECTOR_B = new ConnectorId("catalog_b");
+    private static final ConnectorId CONNECTOR_C = new ConnectorId("catalog_c");
+
+    private static final ConnectorTableHandle TABLE_HANDLE = new ConnectorTableHandle() {};
+    private static final ConnectorTransactionHandle TRANSACTION_HANDLE = new ConnectorTransactionHandle() {};
+
+    @Test
+    public void testExtractConnectorsFromTables()
+    {
+        Analysis analysis = createAnalysis(null);
+        Table table = new Table(QualifiedName.of("t1"));
+        analysis.registerTable(table, createTableHandle(CONNECTOR_A));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 1);
+        assertTrue(connectors.contains(CONNECTOR_A));
+    }
+
+    @Test
+    public void testExtractConnectorsFromMultipleTables()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("t1")), createTableHandle(CONNECTOR_A));
+        analysis.registerTable(new Table(QualifiedName.of("t2")), createTableHandle(CONNECTOR_B));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 2);
+        assertTrue(connectors.contains(CONNECTOR_A));
+        assertTrue(connectors.contains(CONNECTOR_B));
+    }
+
+    @Test
+    public void testExtractConnectorsFromInsert()
+    {
+        Analysis analysis = createAnalysis(null);
+        TableHandle insertTarget = createTableHandle(CONNECTOR_B);
+        ColumnHandle column = new ColumnHandle() {};
+        analysis.setInsert(new Analysis.Insert(insertTarget, ImmutableList.of(column)));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertTrue(connectors.contains(CONNECTOR_B));
+    }
+
+    @Test
+    public void testExtractConnectorsFromInsertWithSourceTable()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("source")), createTableHandle(CONNECTOR_A));
+
+        TableHandle insertTarget = createTableHandle(CONNECTOR_B);
+        ColumnHandle column = new ColumnHandle() {};
+        analysis.setInsert(new Analysis.Insert(insertTarget, ImmutableList.of(column)));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 2);
+        assertTrue(connectors.contains(CONNECTOR_A));
+        assertTrue(connectors.contains(CONNECTOR_B));
+    }
+
+    @Test
+    public void testExtractConnectorsFromCreateTableDestination()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("source")), createTableHandle(CONNECTOR_A));
+        analysis.setCreateTableDestination(new QualifiedObjectName("catalog_c", "schema", "new_table"));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 2);
+        assertTrue(connectors.contains(CONNECTOR_A));
+        assertTrue(connectors.contains(CONNECTOR_C));
+    }
+
+    @Test
+    public void testExtractConnectorsCreateTableDestinationSameConnector()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("source")), createTableHandle(CONNECTOR_A));
+        analysis.setCreateTableDestination(new QualifiedObjectName("catalog_a", "schema", "new_table"));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 1);
+        assertTrue(connectors.contains(CONNECTOR_A));
+    }
+
+    @Test
+    public void testExtractConnectorsCreateTableWithoutSource()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.setCreateTableDestination(new QualifiedObjectName("catalog_b", "schema", "new_table"));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 1);
+        assertTrue(connectors.contains(CONNECTOR_B));
+    }
+
+    @Test
+    public void testExtractConnectorsEmpty()
+    {
+        Analysis analysis = createAnalysis(null);
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertTrue(connectors.isEmpty());
+    }
+
+    @Test
+    public void testExtractConnectorsAllSources()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("t1")), createTableHandle(CONNECTOR_A));
+
+        TableHandle insertTarget = createTableHandle(CONNECTOR_B);
+        ColumnHandle column = new ColumnHandle() {};
+        analysis.setInsert(new Analysis.Insert(insertTarget, ImmutableList.of(column)));
+
+        analysis.setCreateTableDestination(new QualifiedObjectName("catalog_c", "schema", "new_table"));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 3);
+        assertTrue(connectors.contains(CONNECTOR_A));
+        assertTrue(connectors.contains(CONNECTOR_B));
+        assertTrue(connectors.contains(CONNECTOR_C));
+    }
+
+    @Test
+    public void testExtractConnectorsDeduplicated()
+    {
+        Analysis analysis = createAnalysis(null);
+        analysis.registerTable(new Table(QualifiedName.of("t1")), createTableHandle(CONNECTOR_A));
+        analysis.registerTable(new Table(QualifiedName.of("t2")), createTableHandle(CONNECTOR_A));
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+        Set<ConnectorId> connectors = queryAnalysis.extractConnectors();
+
+        assertEquals(connectors.size(), 1);
+        assertTrue(connectors.contains(CONNECTOR_A));
+    }
+
+    @Test
+    public void testIsExplainAnalyzeQueryTrue()
+    {
+        Query innerQuery = simpleQuery();
+        Explain explainAnalyze = new Explain(innerQuery, true, false, ImmutableList.of());
+        Analysis analysis = createAnalysis(explainAnalyze);
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+
+        assertTrue(queryAnalysis.isExplainAnalyzeQuery());
+    }
+
+    @Test
+    public void testIsExplainAnalyzeQueryFalseWhenNotAnalyze()
+    {
+        Query innerQuery = simpleQuery();
+        Explain explain = new Explain(innerQuery, false, false, ImmutableList.of());
+        Analysis analysis = createAnalysis(explain);
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+
+        assertFalse(queryAnalysis.isExplainAnalyzeQuery());
+    }
+
+    @Test
+    public void testIsExplainAnalyzeQueryFalseWhenNotExplain()
+    {
+        Query query = simpleQuery();
+        Analysis analysis = createAnalysis(query);
+
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+
+        assertFalse(queryAnalysis.isExplainAnalyzeQuery());
+    }
+
+    @Test
+    public void testGetAnalysis()
+    {
+        Analysis analysis = createAnalysis(null);
+        BuiltInQueryAnalysis queryAnalysis = new BuiltInQueryAnalysis(analysis);
+
+        assertEquals(queryAnalysis.getAnalysis(), analysis);
+    }
+
+    private static Analysis createAnalysis(com.facebook.presto.sql.tree.Statement statement)
+    {
+        return new Analysis(statement, ImmutableMap.of(), false, new ViewDefinitionReferences());
+    }
+
+    private static TableHandle createTableHandle(ConnectorId connectorId)
+    {
+        return new TableHandle(connectorId, TABLE_HANDLE, TRANSACTION_HANDLE, Optional.empty());
+    }
+
+    private static Query simpleQuery()
+    {
+        return (Query) new com.facebook.presto.sql.parser.SqlParser().createStatement("SELECT 1");
+    }
+}


### PR DESCRIPTION
`BuiltInQueryAnalysis.extractConnectors()` collects the set of connectors registered with `beginQuery()`, which determines which connectors receive `cleanupQuery()` when a query terminates. For CTAS queries, `extractConnectors()` checked `analysis.getTables()` (source tables) and `analysis.getInsert()` (INSERT targets), but did not check `analysis.getCreateTableDestination()` (CTAS targets). This meant that for cross-catalog CTAS (e.g., `CREATE TABLE impulse.x AS SELECT FROM prism.y`), only the source connector was registered — the target connector never received `cleanupQuery()`.

This caused write locks acquired in `beginCreateTable()` to leak when a CTAS query was cancelled or timed out, blocking subsequent DROP TABLE operations on the target table.

The fix adds `getCreateTableDestination()` to `extractConnectors()`, mirroring the existing `getInsert()` pattern. Existing tests in `TestBeginQuery` are updated to reflect that cross-catalog CTAS now correctly triggers `beginQuery`/`cleanupQuery` on the target connector.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure CTAS destination connectors are included in query connector tracking so they receive lifecycle callbacks.

Bug Fixes:
- Register the connector for CREATE TABLE AS SELECT destinations in BuiltInQueryAnalysis so target connectors receive cleanupQuery on query termination.

Tests:
- Add unit tests for BuiltInQueryAnalysis.extractConnectors and isExplainAnalyzeQuery to cover tables, inserts, CTAS destinations, deduplication, and explain-analyze detection.