### PR TITLE
fix(ci): Move OWASP NVD download off the PR critical path

### DIFF
--- a/.github/actions/maven-owasp-scan/action.yml
+++ b/.github/actions/maven-owasp-scan/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: OWASP data directory path
     required: false
     default: /tmp/.owasp/dependency-check-data
+  auto-update:
+    description: Allow updating the NVD database from the NVD API; PR scans pass false.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -21,6 +25,7 @@ runs:
       env:
         OWASP_VERSION: ${{ inputs.owasp-version }}
         OWASP_DATA_DIRECTORY: ${{ inputs.data-directory }}
+        OWASP_AUTO_UPDATE: ${{ inputs.auto-update }}
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
@@ -29,8 +34,8 @@ runs:
           -Dformat=JSON \
           -DprettyPrint=true \
           -DfailOnError=false \
+          -DautoUpdate=$OWASP_AUTO_UPDATE \
           -DossindexAnalyzerEnabled=true \
-          -DnvdApiAnalyzerEnabled=false \
           -DnodeAnalyzerEnabled=false \
           -DassemblyAnalyzerEnabled=false \
           -DcentralAnalyzerEnabled=false \

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,6 +1,4 @@
 name: Maven OWASP Dependency Check
-permissions:
-  contents: read
 on:
   pull_request: {}
   workflow_dispatch:
@@ -33,6 +31,8 @@ jobs:
   dependency-check:
     needs: changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -59,7 +59,7 @@ jobs:
         run: |
           merge_base=$(gh api -q '.merge_base_commit.sha' \
             "/repos/$REPO/compare/$BASE_REF...$HEAD_SHA")
-          echo "sha=$merge_base" >> $GITHUB_OUTPUT
+          echo "sha=$merge_base" >> "$GITHUB_OUTPUT"
           echo "Using merge base: $merge_base"
 
       - name: Checkout base branch
@@ -78,47 +78,44 @@ jobs:
           java-version: 17
           cache: maven
 
-      - name: Get date for cache key
-        if: needs.changes.outputs.codechange == 'true'
-        id: get-date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Restore OWASP database cache
+      # Refreshed by owasp-nvd-cache.yml; forks can read default-branch caches.
+      - name: Restore cached NVD database
         if: needs.changes.outputs.codechange == 'true'
         uses: actions/cache/restore@v4
         id: cache-owasp-restore
         with:
           path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
-            owasp-cache-${{ runner.os }}-
+            owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-restore-only
+
+      # A missing DB is an infra gap, not a CVE regression: warn instead of failing.
+      - name: Skip if NVD database unavailable
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key == ''
+        run: |
+          echo "::warning::OWASP NVD database cache not found; skipping the dependency check for this run."
+          echo "::warning::Trigger the 'OWASP NVD Database Cache' workflow to repopulate the cache."
 
       - name: Run OWASP check on base branch
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: base
           owasp-version: ${{ env.OWASP_VERSION }}
           data-directory: /tmp/.owasp/dependency-check-data
-
-      - name: Save OWASP cache after base scan
-        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}-partial
+          auto-update: 'false'
 
       - name: Run OWASP check on PR branch
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: .
           owasp-version: ${{ env.OWASP_VERSION }}
           data-directory: /tmp/.owasp/dependency-check-data
+          auto-update: 'false'
 
       - name: Compare and fail on new CVEs above threshold
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         run: |
           # Extract CVEs above threshold from both branches (CVSS >= $CVSS_THRESHOLD)
           threshold=$CVSS_THRESHOLD
@@ -180,13 +177,6 @@ jobs:
           else
             echo "✅ No new vulnerabilities introduced"
           fi
-
-      - name: Save OWASP database cache
-        if: needs.changes.outputs.codechange == 'true' && always()
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
 
       - name: Upload reports
         if: needs.changes.outputs.codechange == 'true' && always()

--- a/.github/workflows/owasp-nvd-cache.yml
+++ b/.github/workflows/owasp-nvd-cache.yml
@@ -1,0 +1,66 @@
+name: OWASP NVD Database Cache
+# Publishes the NVD database to the Actions cache for PR runs to restore (forks included).
+on:
+  schedule:
+    # Stay within the 7-day cache retention window.
+    - cron: 0 */12 * * *
+  workflow_dispatch: {}
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      OWASP_VERSION: 12.1.3
+      OWASP_DATA_DIRECTORY: /tmp/.owasp/dependency-check-data
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      # Restore prior DB so the update is incremental.
+      - name: Restore previous NVD database
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          restore-keys: |
+            owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-restore-only
+
+      # NVD updates flake (503/524); keep retrying.
+      - name: Update NVD database
+        id: nvd_update
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          # Optional; raises the NVD rate limit.
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        with:
+          max_attempts: 30
+          timeout_minutes: 40
+          retry_wait_seconds: 120
+          retry_on: error
+          warning_on_retry: true
+          shell: bash
+          command: |
+            mvn -B org.owasp:dependency-check-maven:$OWASP_VERSION:update-only \
+              -DnvdValidForHours=0 \
+              ${NVD_API_KEY:+-DnvdApiKey=$NVD_API_KEY} \
+              -DdataDirectory=$OWASP_DATA_DIRECTORY
+
+      # Rotating key (caches are immutable). Guard on outcome: hashFiles can't see /tmp.
+      - name: Save NVD database cache
+        if: steps.nvd_update.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ github.run_id }}


### PR DESCRIPTION
## Description
PRs intermittently failed with 'Missing base report' when a cache miss forced a from-scratch NVD API pull that timed out (503/524).

A scheduled job now refreshes the NVD database in the Actions cache; PR runs (forks included) restore it and scan with -DautoUpdate=false, never contacting the NVD API. If the cache is missing, the PR job warns instead of failing.

## Motivation and Context
Resolve OWASP failures

## Impact
More reliable CI

## Test Plan
Verified on my fork:
- `actionlint` clean; local `update-only` → `-DautoUpdate=false` scan produces a report; compare logic flags an injected CVE and passes when clean.
- [Scheduled cache build](https://github.com/tdcmeehan/presto/actions/runs/26911653380) (~4 min) → [PR check](https://github.com/tdcmeehan/presto/actions/runs/26912181743) restored it, scanned both branches with `autoUpdate=false`, **zero NVD API contact**, compare passed in ~11 min (vs ~1h17m). Test PR: [#15](https://github.com/tdcmeehan/presto/pull/15).

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a scheduled workflow to pre-hydrate the OWASP NVD database into the GitHub Actions cache and update PR OWASP scans to consume this cache without contacting the NVD API directly.

CI:
- Add an OWASP NVD hydration workflow that periodically updates the NVD database and stores it in the Actions cache.
- Update the OWASP dependency-check workflow to restore a hydrated NVD database cache, disable auto-updates during PR scans, and skip scans with a warning when the cache is unavailable.