### PR TITLE
docs: Add config property doc for optimizer.optimize-top-n-rank

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -75,6 +75,23 @@ alphabetical order.
   Velox does not support optimized hash generation, instead using a HashTable
   with adaptive runtime optimizations that does not use extra hash fields.
 
+``optimizer.optimize-top-n-rank``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+  If this is ``true``, then filter and limit queries for ``n`` rows of
+  ``rank()`` and ``dense_rank()`` window function values are executed
+  with a special ``TopNRowNumber`` operator instead of the
+  ``WindowFunction`` operator.
+
+  The ``TopNRowNumber`` operator is more efficient than window as
+  it has a streaming behavior and does not need to buffer all input rows.
+
+  This optimization is only applicable for Presto C++ as the runtime code
+  is only available for it.
+
 ``regex-library``
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description

Add documentation for the configuration property `optimizer.optimize-top-n-rank` in `presto-docs/src/main/sphinx/presto_cpp/properties.rst`.

The session property documentation already exists in `properties-session.rst`, but the config property counterpart was missing.

## Related Issue

Closes #27915

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```