### PR TITLE
feat: Add NIMBLE to FileFormat enum [presto-iceberg][java]

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -27,7 +27,9 @@ public enum FileFormat
     PARQUET("parquet", true),
     AVRO("avro", true),
     METADATA("metadata.json", false),
-    PUFFIN("puffin", false);
+    PUFFIN("puffin", false),
+    DWRF("dwrf", true),
+    NIMBLE("nimble", true);
 
     private final String ext;
     private final boolean splittable;
@@ -90,6 +92,12 @@ public enum FileFormat
                 break;
             case PUFFIN:
                 fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
+                break;
+            case DWRF:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
+                break;
+            case NIMBLE:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);


### PR DESCRIPTION
Summary:
Mirror the existing DWRF entry: add NIMBLE as a valid table-property
value for the iceberg 'format' property. Maps to org.apache.iceberg.
FileFormat.ORC on the manifest side (Iceberg's manifest vocabulary has
no NIMBLE; cross-engine readers identify the on-disk format via the
file extension and magic bytes). The Velox C++ side already has
NimbleWriterOptionsAdapter and isSupportedFileFormat(NIMBLE) == true.

Without this, every CREATE TABLE ... WITH (format = 'NIMBLE') fails at
table-property parse time with:
  'Unable to set table property format to NIMBLE:
   No enum constant com.facebook.presto.iceberg.FileFormat.NIMBLE'
…even though the C++ worker side is ready.

Applied to both presto-trunk and presto-facebook-trunk copies (the
FB-fork shadows the OSS class within presto-facebook-iceberg).

=== NO RELEASE NOTES ===

Differential Revision: D106888188

## Summary by Sourcery

Add support for NIMBLE and DWRF file formats in the Presto Iceberg FileFormat enum and map them to the corresponding Iceberg file format.

New Features:
- Allow specifying NIMBLE as a valid Iceberg table format that maps to Iceberg's ORC file format.
- Recognize DWRF in the Iceberg FileFormat enum and map it to Iceberg's ORC file format.