### PR TITLE
fix: Break down plugin loading logic to switch TypeManager when sidecar is enabled

### DIFF
--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
@@ -41,6 +41,8 @@ import com.facebook.presto.type.TypeDeserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -72,6 +74,7 @@ public class FlightShimPluginManager
     private final StaticCatalogStore staticCatalogStore;
     private final TypeDeserializer typeDeserializer;
     private final BlockEncodingManager blockEncodingManager;
+    private final Supplier<List<PluginManagerUtil.PluginClassLoaderHandle>> cachedPluginClassLoaders;
 
     @Inject
     public FlightShimPluginManager(
@@ -96,6 +99,7 @@ public class FlightShimPluginManager
             this.plugins = ImmutableList.copyOf(pluginManagerConfig.getPlugins());
         }
         this.resolver = new ArtifactResolver(pluginManagerConfig.getMavenLocalRepository(), pluginManagerConfig.getMavenRemoteRepository());
+        this.cachedPluginClassLoaders = Suppliers.memoize(this::createPluginClassLoaders);
     }
 
     @PreDestroy
@@ -110,15 +114,9 @@ public class FlightShimPluginManager
         PluginManagerUtil.loadPlugins(
                 pluginsLoading,
                 pluginsLoaded,
-                installedPluginsDir,
-                plugins,
                 null,
-                resolver,
-                SPI_PACKAGES,
-                null,
-                SERVICES_FILE,
                 this,
-                getClass().getClassLoader());
+                cachedPluginClassLoaders.get());
     }
 
     public void loadCatalogs(Map<String, Map<String, String>> additionalCatalogs)
@@ -208,6 +206,23 @@ public class FlightShimPluginManager
         JsonCodec<? extends ConnectorTransactionHandle> getCodecTransactionHandle()
         {
             return codecTransactionHandle;
+        }
+    }
+
+    private List<PluginManagerUtil.PluginClassLoaderHandle> createPluginClassLoaders()
+    {
+        try {
+            return PluginManagerUtil.buildClassLoaders(
+                    installedPluginsDir,
+                    plugins,
+                    resolver,
+                    SPI_PACKAGES,
+                    null,
+                    SERVICES_FILE,
+                    getClass().getClassLoader());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to build plugin classloaders", e);
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -61,6 +61,8 @@ import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.ThreadSafe;
@@ -110,6 +112,7 @@ public class PluginManager
     private final PlanCheckerProviderManager planCheckerProviderManager;
     private final ExpressionOptimizerManager expressionOptimizerManager;
     private final PluginInstaller pluginInstaller;
+    private final Supplier<List<PluginManagerUtil.PluginClassLoaderHandle>> cachedPluginClassLoaders;
 
     @Inject
     public PluginManager(
@@ -172,6 +175,7 @@ public class PluginManager
         this.planCheckerProviderManager = requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null");
         this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionManager is null");
         this.pluginInstaller = new MainPluginInstaller(this);
+        this.cachedPluginClassLoaders = Suppliers.memoize(this::createPluginClassLoaders);
     }
 
     public void loadPlugins()
@@ -182,35 +186,21 @@ public class PluginManager
     }
 
     public void loadCoordinatorPluginsOnly()
-            throws Exception
     {
         PluginManagerUtil.loadCoordinatorPluginsOnly(
                 pluginsLoading,
-                installedPluginsDir,
-                plugins,
-                resolver,
-                SPI_PACKAGES,
-                COORDINATOR_PLUGIN_SERVICES_FILE,
-                PLUGIN_SERVICES_FILE,
                 pluginInstaller,
-                getClass().getClassLoader());
+                cachedPluginClassLoaders.get());
     }
 
     public void loadRemainingPlugins()
-            throws Exception
     {
         PluginManagerUtil.loadRemainingPlugins(
                 pluginsLoading,
                 pluginsLoaded,
-                installedPluginsDir,
-                plugins,
                 metadata,
-                resolver,
-                SPI_PACKAGES,
-                COORDINATOR_PLUGIN_SERVICES_FILE,
-                PLUGIN_SERVICES_FILE,
                 pluginInstaller,
-                getClass().getClassLoader());
+                cachedPluginClassLoaders.get());
     }
 
     public void installPlugin(Plugin plugin)
@@ -384,6 +374,23 @@ public class PluginManager
         public void installCoordinatorPlugin(CoordinatorPlugin plugin)
         {
             pluginManager.installCoordinatorPlugin(plugin);
+        }
+    }
+
+    private List<PluginManagerUtil.PluginClassLoaderHandle> createPluginClassLoaders()
+    {
+        try {
+            return PluginManagerUtil.buildClassLoaders(
+                    installedPluginsDir,
+                    plugins,
+                    resolver,
+                    SPI_PACKAGES,
+                    COORDINATOR_PLUGIN_SERVICES_FILE,
+                    PLUGIN_SERVICES_FILE,
+                    getClass().getClassLoader());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to build plugin classloaders", e);
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -177,7 +177,29 @@ public class PluginManager
     public void loadPlugins()
             throws Exception
     {
-        PluginManagerUtil.loadPlugins(
+        loadCoordinatorPluginsOnly();
+        loadRemainingPlugins();
+    }
+
+    public void loadCoordinatorPluginsOnly()
+            throws Exception
+    {
+        PluginManagerUtil.loadCoordinatorPluginsOnly(
+                pluginsLoading,
+                installedPluginsDir,
+                plugins,
+                resolver,
+                SPI_PACKAGES,
+                COORDINATOR_PLUGIN_SERVICES_FILE,
+                PLUGIN_SERVICES_FILE,
+                pluginInstaller,
+                getClass().getClassLoader());
+    }
+
+    public void loadRemainingPlugins()
+            throws Exception
+    {
+        PluginManagerUtil.loadRemainingPlugins(
                 pluginsLoading,
                 pluginsLoaded,
                 installedPluginsDir,

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -40,10 +40,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.server.PluginDiscovery.discoverPlugins;
 import static com.facebook.presto.server.PluginDiscovery.writePluginServices;
+import static com.google.common.base.Preconditions.checkState;
 
 public class PluginManagerUtil
 {
     private static final Logger log = Logger.get(PluginManagerUtil.class);
+    // Temporary cache to share classloaders between loadCoordinatorPluginsOnly and loadRemainingPlugins
+    // within a single initialization sequence. Cleared after loadRemainingPlugins completes.
+    private static volatile List<PluginClassLoaderHandle> sharedPluginClassLoaders;
 
     /*
      When generating code the AfterBurner module loads classes with *some* classloader.
@@ -87,30 +91,34 @@ public class PluginManagerUtil
             ClassLoader parent)
             throws Exception
     {
-        if (!pluginsLoading.compareAndSet(false, true)) {
-            return;
-        }
-
-        List<String> pluginsToLoad = new ArrayList<>();
-
-        for (File file : listFiles(installedPluginsDir)) {
-            if (file.isDirectory()) {
-                pluginsToLoad.add(file.getAbsolutePath());
-            }
-        }
-
-        pluginsToLoad.addAll(plugins);
-        loadPlugins(pluginsToLoad, resolver, spiPackages, coordinatorPluginServicesFile, pluginServicesFile, pluginInstaller, parent);
-
-        if (metadata != null) {
-            metadata.verifyComparableOrderableContract();
-        }
-
-        pluginsLoaded.set(true);
+        loadCoordinatorPluginsOnly(
+                pluginsLoading,
+                installedPluginsDir,
+                plugins,
+                resolver,
+                spiPackages,
+                coordinatorPluginServicesFile,
+                pluginServicesFile,
+                pluginInstaller,
+                parent);
+        loadRemainingPlugins(
+                pluginsLoading,
+                pluginsLoaded,
+                installedPluginsDir,
+                plugins,
+                metadata,
+                resolver,
+                spiPackages,
+                coordinatorPluginServicesFile,
+                pluginServicesFile,
+                pluginInstaller,
+                parent);
     }
 
-    public static void loadPlugins(
-            List<String> pluginsList,
+    public static synchronized void loadCoordinatorPluginsOnly(
+            AtomicBoolean pluginsLoading,
+            File installedPluginsDir,
+            List<String> plugins,
             ArtifactResolver resolver,
             List<String> spiPackages,
             String coordinatorPluginServicesFile,
@@ -119,9 +127,100 @@ public class PluginManagerUtil
             ClassLoader parent)
             throws Exception
     {
+        if (!pluginsLoading.compareAndSet(false, true)) {
+            return;
+        }
+
+        // Build classloaders and store them for reuse in loadRemainingPlugins
+        sharedPluginClassLoaders = buildClassLoaders(
+                installedPluginsDir,
+                plugins,
+                resolver,
+                spiPackages,
+                coordinatorPluginServicesFile,
+                pluginServicesFile,
+                parent);
+
+        loadPlugins(sharedPluginClassLoaders, CoordinatorPlugin.class, pluginInstaller);
+    }
+
+    public static synchronized void loadRemainingPlugins(
+            AtomicBoolean pluginsLoading,
+            AtomicBoolean pluginsLoaded,
+            File installedPluginsDir,
+            List<String> plugins,
+            Metadata metadata,
+            ArtifactResolver resolver,
+            List<String> spiPackages,
+            String coordinatorPluginServicesFile,
+            String pluginServicesFile,
+            PluginInstaller pluginInstaller,
+            ClassLoader parent)
+            throws Exception
+    {
+        if (pluginsLoaded.get()) {
+            return;
+        }
+
+        // If loadCoordinatorPluginsOnly wasn't called yet, call it first to ensure
+        // coordinator plugins are loaded and classloaders are built
+        if (!pluginsLoading.get()) {
+            loadCoordinatorPluginsOnly(
+                    pluginsLoading,
+                    installedPluginsDir,
+                    plugins,
+                    resolver,
+                    spiPackages,
+                    coordinatorPluginServicesFile,
+                    pluginServicesFile,
+                    pluginInstaller,
+                    parent);
+        }
+
+        // Reuse classloaders from loadCoordinatorPluginsOnly
+        checkState(
+                sharedPluginClassLoaders != null,
+                "sharedPluginClassLoaders is null in loadRemainingPlugins (installedPluginsDir=%s, plugins=%s)",
+                installedPluginsDir,
+                plugins);
+
+        try {
+            loadPlugins(sharedPluginClassLoaders, Plugin.class, pluginInstaller);
+            loadPlugins(sharedPluginClassLoaders, RouterPlugin.class, pluginInstaller);
+
+            if (metadata != null) {
+                metadata.verifyComparableOrderableContract();
+            }
+
+            pluginsLoaded.set(true);
+        }
+        finally {
+            // Clear the shared reference to allow GC of the handle list
+            sharedPluginClassLoaders = null;
+        }
+    }
+
+    private static List<PluginClassLoaderHandle> buildClassLoaders(
+            File installedPluginsDir,
+            List<String> plugins,
+            ArtifactResolver resolver,
+            List<String> spiPackages,
+            String coordinatorPluginServicesFile,
+            String pluginServicesFile,
+            ClassLoader parent)
+            throws Exception
+    {
+        List<String> pluginsToLoad = new ArrayList<>();
+        for (File file : listFiles(installedPluginsDir)) {
+            if (file.isDirectory()) {
+                pluginsToLoad.add(file.getAbsolutePath());
+            }
+        }
+        pluginsToLoad.addAll(plugins);
+
         List<PluginClassLoaderHandle> pluginClassLoaders = new ArrayList<>();
         try {
-            for (String plugin : pluginsList) {
+            for (String plugin : pluginsToLoad) {
                 pluginClassLoaders.add(new PluginClassLoaderHandle(
                         plugin,
                         buildClassLoader(
@@ -138,11 +237,7 @@ public class PluginManagerUtil
             throw e;
         }
 
-        // Ensuring all coordinator plugins are installed before any plugins across all plugin bundles.
-        // router plugins ordering is not relevant here.
-        loadPlugins(pluginClassLoaders, CoordinatorPlugin.class, pluginInstaller);
-        loadPlugins(pluginClassLoaders, Plugin.class, pluginInstaller);
-        loadPlugins(pluginClassLoaders, RouterPlugin.class, pluginInstaller);
+        return pluginClassLoaders;
     }
 
     private static void loadPlugins(

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -45,10 +45,6 @@ import static com.google.common.base.Preconditions.checkState;
 public class PluginManagerUtil
 {
     private static final Logger log = Logger.get(PluginManagerUtil.class);
-    // Temporary cache to share classloaders between loadCoordinatorPluginsOnly and loadRemainingPlugins
-    // within a single initialization sequence. Cleared after loadRemainingPlugins completes.
-    private static volatile List<PluginClassLoaderHandle> sharedPluginClassLoaders;
-
     /*
      When generating code the AfterBurner module loads classes with *some* classloader.
      When the AfterBurner module is configured not to use the value classloader
@@ -80,127 +76,59 @@ public class PluginManagerUtil
     public static void loadPlugins(
             AtomicBoolean pluginsLoading,
             AtomicBoolean pluginsLoaded,
-            File installedPluginsDir,
-            List<String> plugins,
             Metadata metadata,
-            ArtifactResolver resolver,
-            List<String> spiPackages,
-            String coordinatorPluginServicesFile,
-            String pluginServicesFile,
             PluginInstaller pluginInstaller,
-            ClassLoader parent)
+            List<PluginClassLoaderHandle> pluginClassLoaderHandles)
             throws Exception
     {
         loadCoordinatorPluginsOnly(
                 pluginsLoading,
-                installedPluginsDir,
-                plugins,
-                resolver,
-                spiPackages,
-                coordinatorPluginServicesFile,
-                pluginServicesFile,
                 pluginInstaller,
-                parent);
+                pluginClassLoaderHandles);
         loadRemainingPlugins(
                 pluginsLoading,
                 pluginsLoaded,
-                installedPluginsDir,
-                plugins,
                 metadata,
-                resolver,
-                spiPackages,
-                coordinatorPluginServicesFile,
-                pluginServicesFile,
                 pluginInstaller,
-                parent);
+                pluginClassLoaderHandles);
     }
 
-    public static synchronized void loadCoordinatorPluginsOnly(
+    public static void loadCoordinatorPluginsOnly(
             AtomicBoolean pluginsLoading,
-            File installedPluginsDir,
-            List<String> plugins,
-            ArtifactResolver resolver,
-            List<String> spiPackages,
-            String coordinatorPluginServicesFile,
-            String pluginServicesFile,
             PluginInstaller pluginInstaller,
-            ClassLoader parent)
-            throws Exception
+            List<PluginClassLoaderHandle> pluginClassLoaderHandles)
     {
         if (!pluginsLoading.compareAndSet(false, true)) {
             return;
         }
 
-        // Build classloaders and store them for reuse in loadRemainingPlugins
-        sharedPluginClassLoaders = buildClassLoaders(
-                installedPluginsDir,
-                plugins,
-                resolver,
-                spiPackages,
-                coordinatorPluginServicesFile,
-                pluginServicesFile,
-                parent);
-
-        loadPlugins(sharedPluginClassLoaders, CoordinatorPlugin.class, pluginInstaller);
+        loadPlugins(pluginClassLoaderHandles, CoordinatorPlugin.class, pluginInstaller);
     }
 
-    public static synchronized void loadRemainingPlugins(
+    public static void loadRemainingPlugins(
             AtomicBoolean pluginsLoading,
             AtomicBoolean pluginsLoaded,
-            File installedPluginsDir,
-            List<String> plugins,
             Metadata metadata,
-            ArtifactResolver resolver,
-            List<String> spiPackages,
-            String coordinatorPluginServicesFile,
-            String pluginServicesFile,
             PluginInstaller pluginInstaller,
-            ClassLoader parent)
-            throws Exception
+            List<PluginClassLoaderHandle> pluginClassLoaderHandles)
     {
         if (pluginsLoaded.get()) {
             return;
         }
 
-        // If loadCoordinatorPluginsOnly wasn't called yet, call it first to ensure
-        // coordinator plugins are loaded and classloaders are built
-        if (!pluginsLoading.get()) {
-            loadCoordinatorPluginsOnly(
-                    pluginsLoading,
-                    installedPluginsDir,
-                    plugins,
-                    resolver,
-                    spiPackages,
-                    coordinatorPluginServicesFile,
-                    pluginServicesFile,
-                    pluginInstaller,
-                    parent);
+        checkState(pluginsLoading.get(), "loadCoordinatorPluginsOnly should be called before loadRemainingPlugins");
+
+        loadPlugins(pluginClassLoaderHandles, Plugin.class, pluginInstaller);
+        loadPlugins(pluginClassLoaderHandles, RouterPlugin.class, pluginInstaller);
+
+        if (metadata != null) {
+            metadata.verifyComparableOrderableContract();
         }
 
-        // Reuse classloaders from loadCoordinatorPluginsOnly
-        checkState(
-                sharedPluginClassLoaders != null,
-                "sharedPluginClassLoaders is null in loadRemainingPlugins (installedPluginsDir=%s, plugins=%s)",
-                installedPluginsDir,
-                plugins);
-
-        try {
-            loadPlugins(sharedPluginClassLoaders, Plugin.class, pluginInstaller);
-            loadPlugins(sharedPluginClassLoaders, RouterPlugin.class, pluginInstaller);
-
-            if (metadata != null) {
-                metadata.verifyComparableOrderableContract();
-            }
-
-            pluginsLoaded.set(true);
-        }
-        finally {
-            // Clear the shared reference to allow GC of the handle list
-            sharedPluginClassLoaders = null;
-        }
+        pluginsLoaded.set(true);
     }
 
-    private static List<PluginClassLoaderHandle> buildClassLoaders(
+    public static List<PluginClassLoaderHandle> buildClassLoaders(
             File installedPluginsDir,
             List<String> plugins,
             ArtifactResolver resolver,
@@ -414,7 +342,7 @@ public class PluginManagerUtil
         }
     }
 
-    private static class PluginClassLoaderHandle
+    public static class PluginClassLoaderHandle
     {
         private final String plugin;
         private final URLClassLoader classLoader;

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -168,7 +168,19 @@ public class PrestoServer
         try {
             Injector injector = app.initialize();
 
-            injector.getInstance(PluginManager.class).loadPlugins();
+            PluginManager pluginManager = injector.getInstance(PluginManager.class);
+
+            // Load only CoordinatorPlugin service providers first
+            pluginManager.loadCoordinatorPluginsOnly();
+
+            // todo: fix this hack
+            //  Load type managers before loading any other plugin service providers as we could have a new serving type manager.
+            //  Currently, when sidecar plugin is installed, the serving type manager is NativeTypeManager and we need to ensure
+            //  any types loaded from plugins are added to the serving type manager.
+            injector.getInstance(StaticTypeManagerStore.class).loadTypeManagers();
+
+            // Load remaining service providers (Plugin and RouterPlugin)
+            pluginManager.loadRemainingPlugins();
 
             // get all required auth configs to pass down to http clients
             AuthClientConfigs authClientConfigs =
@@ -195,7 +207,6 @@ public class PrestoServer
                     injector.getInstance(DriftServer.class));
 
             injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers(authClientConfigs);
-            injector.getInstance(StaticTypeManagerStore.class).loadTypeManagers();
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             if (injector.getInstance(FeaturesConfig.class).isBuiltInSidecarFunctionsEnabled()) {

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterPluginManager.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterPluginManager.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.RouterPlugin;
 import com.facebook.presto.spi.router.SchedulerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.ThreadSafe;
 import io.airlift.resolver.ArtifactResolver;
@@ -53,6 +55,7 @@ public class RouterPluginManager
     private final AtomicBoolean pluginsLoaded = new AtomicBoolean();
     private final PluginInstaller pluginInstaller;
     private final PrestoAuthenticatorManager prestoAuthenticatorManager;
+    private final Supplier<List<PluginManagerUtil.PluginClassLoaderHandle>> cachedPluginClassLoaders;
 
     List<SchedulerFactory> registeredSchedulerFactoryList = new ArrayList<>();
 
@@ -80,6 +83,7 @@ public class RouterPluginManager
         this.passwordAuthenticatorManager = requireNonNull(passwordAuthenticatorManager, "passwordAuthenticatorManager is null");
         this.pluginInstaller = new RouterPluginInstaller(this);
         this.prestoAuthenticatorManager = requireNonNull(prestoAuthenticatorManager, "prestoAuthenticatorManager is null");
+        this.cachedPluginClassLoaders = Suppliers.memoize(this::createPluginClassLoaders);
     }
 
     public void loadPlugins()
@@ -88,15 +92,9 @@ public class RouterPluginManager
         PluginManagerUtil.loadPlugins(
                 pluginsLoading,
                 pluginsLoaded,
-                installedPluginsDir,
-                plugins,
                 null,
-                resolver,
-                SPI_PACKAGES,
-                null,
-                SERVICES_FILE,
                 pluginInstaller,
-                getClass().getClassLoader());
+                cachedPluginClassLoaders.get());
     }
 
     public void installPlugin(Plugin plugin)
@@ -146,6 +144,23 @@ public class RouterPluginManager
         public void installRouterPlugin(RouterPlugin plugin)
         {
             pluginManager.installRouterPlugin(plugin);
+        }
+    }
+
+    private List<PluginManagerUtil.PluginClassLoaderHandle> createPluginClassLoaders()
+    {
+        try {
+            return PluginManagerUtil.buildClassLoaders(
+                    installedPluginsDir,
+                    plugins,
+                    resolver,
+                    SPI_PACKAGES,
+                    null,
+                    SERVICES_FILE,
+                    getClass().getClassLoader());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to build plugin classloaders", e);
         }
     }
 }


### PR DESCRIPTION
## Description
Refactored plugin loading to initialize `NativeTypeManager` before loading plugins when sidecar is enabled. This ensures plugins register types with the correct `TypeManager`.

Before: Load plugins → Switch to `NativeTypeManager` (types lost)

After: Switch to `NativeTypeManager` → Load plugins (types preserved)

## Motivation and Context
When sidecar mode is enabled in native execution, queries involving plugin loaded types could fail with type resolution errors. The root cause is a timing issue in how plugins are loaded.

Current (Broken) Flow:
- System starts with default `TypeManager`: `BuiltInTypeAndFunctionNamespaceManager`
- Plugins load and register their custom types (e.g., Mongo's ObjectId) with the default `TypeManager`
- After all plugins are loaded, system switches to `NativeTypeManager` for sidecar mode
- `NativeTypeManager` doesn't have the custom types → Mongo queries fail

## Impact
No user impact

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Split plugin loading into coordinator-only and remaining phases and adjust server startup to load type managers between them.

Bug Fixes:
- Ensure plugin loading sequence allows type managers to be initialized before non-coordinator plugins are installed.

Enhancements:
- Introduce shared plugin classloader construction reused across phased plugin loading.
- Expose separate PluginManager APIs for loading coordinator plugins and remaining plugins.
- Refine PrestoServer bootstrap flow to respect the new phased plugin initialization order.

## Summary by Sourcery

Refactor plugin loading into phased coordinator and remaining stages to ensure type managers are initialized before non-coordinator plugins, preventing type registration issues in sidecar mode.

Bug Fixes:
- Ensure plugin-loaded types are registered with the correct TypeManager in sidecar mode by loading type managers between coordinator and non-coordinator plugin installation phases.

Enhancements:
- Introduce reusable plugin classloader construction that is cached and shared across plugin loading phases.
- Expose separate APIs for loading only coordinator plugins and loading remaining plugins in PluginManager and related managers.
- Adjust PrestoServer startup sequence to load type managers between phased plugin initialization steps.