### PR TITLE
Start and stop the UCX exchange communicator in PrestoServer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -85,6 +85,7 @@
 #ifdef PRESTO_ENABLE_CUDF
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/ucx-exchange/Communicator.h"
 #endif
 
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
@@ -176,7 +177,8 @@ bool isSharedLibrary(const fs::path& path) {
   return pathExt == kLinuxSharedLibExt || pathExt == kMacOSSharedLibExt;
 }
 
-void registerVeloxCudf() {
+std::shared_ptr<std::thread> registerVeloxCudf() {
+  std::shared_ptr<std::thread> serverThread = nullptr;
 #ifdef PRESTO_ENABLE_CUDF
   // Disable by default.
   velox::cudf_velox::CudfConfig::getInstance().enabled = false;
@@ -189,13 +191,26 @@ void registerVeloxCudf() {
         systemConfig->values());
     if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
       velox::cudf_velox::registerCudf();
+      if (velox::cudf_velox::CudfConfig::getInstance().exchange) {
+        auto server = facebook::velox::ucx_exchange::Communicator::initAndGet(
+            SystemConfig::instance()->cudfServerPort(),
+            SystemConfig::instance()->discoveryUri().value());
+        if (server) {
+          PRESTO_STARTUP_LOG(INFO) << "cuDF exchange server started";
+          serverThread = std::make_shared<std::thread>(
+              &velox::ucx_exchange::Communicator::run, server.get());
+        } else {
+          PRESTO_STARTUP_LOG(ERROR) << "cuDF exchange server could not start";
+        }
+      }
       PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
     }
   }
 #endif
+  return serverThread;
 }
 
-void unregisterVeloxCudf() {
+void unregisterVeloxCudf(std::shared_ptr<std::thread> serverThread) {
 #ifdef PRESTO_ENABLE_CUDF
   auto systemConfig = SystemConfig::instance();
   if (systemConfig->values().contains(
@@ -203,6 +218,14 @@ void unregisterVeloxCudf() {
       velox::cudf_velox::CudfConfig::getInstance().enabled) {
     velox::cudf_velox::unregisterCudf();
     PRESTO_SHUTDOWN_LOG(INFO) << "cuDF is unregistered.";
+    if (serverThread) {
+      auto server = facebook::velox::ucx_exchange::Communicator::getInstance();
+      server->stop();
+      server.reset();
+      PRESTO_SHUTDOWN_LOG(INFO)
+          << "Joining UCX Communicator thread for shutdown.";
+      serverThread->join();
+    }
   }
 #endif
 }
@@ -297,7 +320,7 @@ void PrestoServer::run() {
 
   // We need to register cuDF before the connectors so that the cuDF connector
   // factories can be used.
-  registerVeloxCudf();
+  auto communicatorThread = registerVeloxCudf();
 
   // Register Presto connector factories and connectors
   registerConnectors();
@@ -368,7 +391,7 @@ void PrestoServer::run() {
   // down.
   startServer(catalogNames);
 
-  shutdownServer();
+  shutdownServer(communicatorThread);
 }
 
 void PrestoServer::initializeConfigs() {
@@ -886,7 +909,8 @@ void PrestoServer::joinExecutors() {
   }
 }
 
-void PrestoServer::shutdownServer() {
+void PrestoServer::shutdownServer(
+    std::shared_ptr<std::thread> communicatorThread) {
   stopAnnouncer();
 
   PRESTO_SHUTDOWN_LOG(INFO) << "Stopping all periodic tasks";
@@ -909,7 +933,7 @@ void PrestoServer::shutdownServer() {
   unregisterFileReadersAndWriters();
   unregisterFileSystems();
   unregisterConnectors();
-  unregisterVeloxCudf();
+  unregisterVeloxCudf(communicatorThread);
 
   joinExecutors();
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -232,7 +232,7 @@ class PrestoServer {
 
   /// Shuts down all server components in the correct order after the HTTP
   /// server stops.
-  void shutdownServer();
+  void shutdownServer(std::shared_ptr<std::thread> communicatorThread);
 
   /// Logs thread pool sizes for all executors.
   void logExecutorInfo();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -169,6 +169,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NONE_PROP(kHttpsClientCaFile),
+          NONE_PROP(kCudfServerPort),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
@@ -318,6 +319,10 @@ SystemConfig* SystemConfig::instance() {
 
 int SystemConfig::httpServerHttpPort() const {
   return requiredProperty<int>(kHttpServerHttpPort);
+}
+
+int SystemConfig::cudfServerPort() const {
+  return requiredProperty<int>(kCudfServerPort);
 }
 
 bool SystemConfig::httpServerReusePort() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -777,6 +777,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpClientConnectionReuseCounterEnabled{
       "http-client.connection-reuse-counter-enabled"};
 
+  static constexpr std::string_view kCudfServerPort{
+      "cudf.exchange.server.port"};
+
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
@@ -972,6 +975,8 @@ class SystemConfig : public ConfigBase {
   static SystemConfig* instance();
 
   int httpServerHttpPort() const;
+
+  int cudfServerPort() const;
 
   bool httpServerReusePort() const;
 

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -26,7 +26,7 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
 endif()
 
 if(PRESTO_ENABLE_CUDF)
-  target_link_libraries(presto_connectors velox_cudf_hive_connector cudf::cudf)
+  target_link_libraries(presto_connectors velox_cudf_hive_connector ucxx::ucxx cudf::cudf)
 endif()
 
 target_link_libraries(


### PR DESCRIPTION
## Description

Wire the UCX-based exchange communicator into the native worker lifecycle so
that, when the cuDF/GPU exchange is enabled, a UCX communicator server is
started during worker startup and cleanly shut down during worker shutdown.

- When cuDF is registered and its exchange is enabled, `registerVeloxCudf()`
  initializes the UCX `Communicator` (using the configured server port and the
  discovery URI) and runs it on a dedicated thread. `registerVeloxCudf()` now
  returns the server thread so its lifetime can be tracked.
- `shutdownServer()` / `unregisterVeloxCudf()` take the communicator thread,
  stop the `Communicator`, and join the thread for an orderly shutdown.
- New system config `cudf.exchange.server.port` (`kCudfServerPort`) with a
  `cudfServerPort()` accessor controls the communicator's listen port.
- The cuDF connector now links against `ucxx::ucxx` when `PRESTO_ENABLE_CUDF`
  is set.

All worker-side changes are guarded by `#ifdef PRESTO_ENABLE_CUDF`, so builds
without cuDF are unaffected.

## Motivation and Context

GPU-accelerated workers can exchange data over UCX, which is faster than the
default HTTP exchange. This change manages the lifecycle of the UCX
communicator server within the native worker process.

## Impact

Native worker only, and only when built with cuDF and the cuDF exchange is
enabled. Default builds and HTTP-exchange deployments are unaffected.

## Test Plan

- Verified the worker starts the UCX communicator on startup and joins the
  communicator thread on shutdown when the cuDF exchange is enabled.

## Summary by Sourcery

Integrate the UCX-based cuDF exchange communicator into the native Presto worker lifecycle and make its port configurable.

New Features:
- Start a UCX exchange communicator server when cuDF exchange is enabled and cuDF is registered in the native worker.
- Expose a configurable cudf.exchange.server.port system property to control the UCX communicator listen port.

Enhancements:
- Track and manage the UCX communicator server thread across server startup and shutdown to ensure orderly termination.
- Extend the native worker shutdown sequence to stop the UCX communicator and join its thread after unregistering cuDF.
- Link the cuDF connector against the ucxx::ucxx library when PRESTO_ENABLE_CUDF is enabled.