### PR TITLE
fix: Properly delete Iceberg data files on DROP TABLE for S3 storage

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1199,17 +1199,21 @@ already exists but is not known by the catalog.
 The following arguments are available:
 
 
-===================== ========== =============== =======================================================================
-Argument Name         Required   Type            Description
-===================== ========== =============== =======================================================================
-``schema``            Yes        string          Schema of the table to register
+======================= ========== =============== ====================================================================================
+Argument Name           Required   Type            Description
+======================= ========== =============== ====================================================================================
+``schema``              Yes        string          Schema of the table to register
 
-``table_name``        Yes        string          Name of the table to register
+``table_name``          Yes        string          Name of the table to register
 
-``metadata_location`` Yes        string          The location of the table metadata which is to be registered
+``metadata_location``   Yes        string          The location of the table metadata which is to be registered
 
-``metadata_file``                string          An optionally specified metadata file which is to be registered
-===================== ========== =============== =======================================================================
+``metadata_file``                  string          An optionally specified metadata file which is to be registered
+
+``delete_data_on_drop``            boolean         When ``true``, dropping the registered table will also delete the underlying Iceberg
+                                                   data and metadata files. Defaults to ``false``, which removes only the catalog
+                                                   entry and preserves all data files.
+======================= ========== =============== ====================================================================================
 
 Examples:
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -108,6 +108,7 @@ public class HiveTableOperations
 
     public static final String METADATA_LOCATION = "metadata_location";
     public static final String PREVIOUS_METADATA_LOCATION = "previous_metadata_location";
+    public static final String PRESTO_DELETE_DATA_ON_DROP = "presto_delete_data_on_drop";
     private static final String METADATA_FOLDER_NAME = "metadata";
 
     public static final StorageFormat STORAGE_FORMAT = StorageFormat.create(
@@ -256,6 +257,7 @@ public class HiveTableOperations
                     String tableComment = metadata.properties().get(TABLE_COMMENT);
                     Map<String, String> parameters = new HashMap<>();
                     parameters.put("EXTERNAL", "TRUE");
+                    parameters.put(PRESTO_DELETE_DATA_ON_DROP, "true");
                     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE);
                     parameters.put(METADATA_LOCATION, newMetadataLocation);
                     if (tableComment != null) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -405,7 +405,7 @@ public abstract class IcebergAbstractMetadata
 
     protected abstract boolean tableExists(ConnectorSession session, SchemaTableName schemaTableName);
 
-    public abstract void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation);
+    public abstract void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation, boolean deleteDataOnDrop);
 
     public abstract void unregisterTable(ConnectorSession clientSession, SchemaTableName schemaTableName);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -73,6 +74,8 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes.None;
 import org.apache.iceberg.PartitionSpec;
@@ -161,6 +164,7 @@ import static org.apache.iceberg.Transactions.createTableTransaction;
 public class IcebergHiveMetadata
         extends IcebergAbstractMetadata
 {
+    private static final Logger LOG = Logger.get(IcebergHiveMetadata.class);
     private final IcebergCatalogName catalogName;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
@@ -443,7 +447,45 @@ public class IcebergHiveMetadata
                 throw new PrestoException(NOT_SUPPORTED, "Table " + handle.getSchemaTableName() + " contains Iceberg path override properties and cannot be dropped from Presto");
             }
         }
-        metastore.dropTable(getMetastoreContext(session), handle.getSchemaName(), handle.getIcebergTableName().getTableName(), true);
+
+        Optional<Table> hiveTable = getHiveTable(session, handle.getSchemaTableName());
+        boolean shouldDeleteData = hiveTable
+                .map(t -> t.getParameters()
+                        .getOrDefault(HiveTableOperations.PRESTO_DELETE_DATA_ON_DROP, "false"))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+
+        // When shouldDeleteData is true, first use Iceberg's CatalogUtil to delete all
+        // data and metadata files across every snapshot (the S3-safe approach), then
+        // let the metastore drop the HMS entry and remove the table directory.
+        // When shouldDeleteData is false, only remove the HMS entry.
+        if (shouldDeleteData) {
+            // Capture Iceberg metadata before dropping the HMS entry, because
+            // table.operations().current() re-queries HMS and will fail with
+            // TableNotFoundException after the entry is removed.
+            Optional<org.apache.iceberg.TableMetadata> icebergMetadata = Optional.empty();
+            try {
+                icebergMetadata = Optional.of(((BaseTable) table).operations().current());
+            }
+            catch (RuntimeException e) {
+                LOG.warn(e, "Could not read metadata for %s before drop; data files will not be deleted", handle.getSchemaTableName());
+                shouldDeleteData = false;
+            }
+            icebergMetadata.ifPresent(metadata -> {
+                try {
+                    CatalogUtil.dropTableData(table.io(), metadata);
+                }
+                catch (RuntimeException e) {
+                    LOG.warn(e, "Failed to delete table data for %s", handle.getSchemaTableName());
+                }
+            });
+        }
+
+        metastore.dropTable(
+                getMetastoreContext(session),
+                handle.getSchemaName(),
+                handle.getIcebergTableName().getTableName(),
+                shouldDeleteData);
     }
 
     @Override
@@ -693,7 +735,7 @@ public class IcebergHiveMetadata
     }
 
     @Override
-    public void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation)
+    public void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation, boolean deleteDataOnDrop)
     {
         String tableLocation = metadataLocation.getName();
         HdfsContext hdfsContext = new HdfsContext(
@@ -722,7 +764,8 @@ public class IcebergHiveMetadata
                 .withStorage(storage -> storage.setStorageFormat(STORAGE_FORMAT))
                 .setParameter("EXTERNAL", "TRUE")
                 .setParameter(BaseMetastoreTableOperations.TABLE_TYPE_PROP, BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
-                .setParameter(BaseMetastoreTableOperations.METADATA_LOCATION_PROP, tableMetadata.metadataFileLocation());
+                .setParameter(BaseMetastoreTableOperations.METADATA_LOCATION_PROP, tableMetadata.metadataFileLocation())
+                .setParameter(HiveTableOperations.PRESTO_DELETE_DATA_ON_DROP, String.valueOf(deleteDataOnDrop));
         Table table = builder.build();
 
         PrestoPrincipal owner = new PrestoPrincipal(USER, table.getOwner());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -463,7 +463,7 @@ public class IcebergHiveMetadata
             // Capture Iceberg metadata before dropping the HMS entry, because
             // table.operations().current() re-queries HMS and will fail with
             // TableNotFoundException after the entry is removed.
-            Optional<org.apache.iceberg.TableMetadata> icebergMetadata = Optional.empty();
+            Optional<TableMetadata> icebergMetadata = Optional.empty();
             try {
                 icebergMetadata = Optional.of(((BaseTable) table).operations().current());
             }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -509,8 +509,9 @@ public class IcebergNativeMetadata
     }
 
     @Override
-    public void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation)
+    public void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation, boolean deleteDataOnDrop)
     {
+        // deleteDataOnDrop is not used in the native catalog implementation
         catalogFactory.getCatalog(clientSession).registerTable(toIcebergTableIdentifier(schemaTableName, catalogFactory.isNestedNamespaceEnabled()), metadataLocation.toString());
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RegisterTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RegisterTableProcedure.java
@@ -40,6 +40,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
@@ -59,7 +60,8 @@ public class RegisterTableProcedure
             String.class,
             String.class,
             String.class,
-            String.class);
+            String.class,
+            Boolean.class);
     private final IcebergMetadataFactory metadataFactory;
     private final HdfsEnvironment hdfsEnvironment;
 
@@ -87,18 +89,19 @@ public class RegisterTableProcedure
                         new Argument("schema", VARCHAR),
                         new Argument("table_name", VARCHAR),
                         new Argument("metadata_location", VARCHAR),
-                        new Argument("metadata_file", VARCHAR, false, null)),
+                        new Argument("metadata_file", VARCHAR, false, null),
+                        new Argument("delete_data_on_drop", BOOLEAN, false, false)),
                 REGISTER_TABLE.bindTo(this));
     }
 
-    public void registerTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, String metadataFile)
+    public void registerTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, String metadataFile, Boolean deleteDataOnDrop)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doRegisterTable(clientSession, schema, table, metadataLocation, Optional.ofNullable(metadataFile));
+            doRegisterTable(clientSession, schema, table, metadataLocation, Optional.ofNullable(metadataFile), requireNonNull(deleteDataOnDrop, "deleteDataOnDrop is null"));
         }
     }
 
-    private void doRegisterTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, Optional<String> metadataFile)
+    private void doRegisterTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, Optional<String> metadataFile, boolean deleteDataOnDrop)
     {
         IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) metadataFactory.create();
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
@@ -116,7 +119,7 @@ public class RegisterTableProcedure
                         getFileSystem(clientSession, hdfsEnvironment, schemaTableName, metadataDirectory),
                         metadataDirectory));
 
-        metadata.registerTable(clientSession, schemaTableName, metadataPath);
+        metadata.registerTable(clientSession, schemaTableName, metadataPath, deleteDataOnDrop);
     }
 
     public static FileSystem getFileSystem(ConnectorSession clientSession, HdfsEnvironment hdfsEnvironment, SchemaTableName schemaTableName, Path location)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
@@ -296,8 +296,43 @@ public class TestIcebergRegisterAndUnregisterProcedure
         errorMessage = "path must not be null or empty";
         assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '')", errorMessage);
 
-        errorMessage = "line 1:1: Too many arguments for procedure";
+        errorMessage = ".*Cannot cast type varchar\\(0\\) to boolean";
         assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '/dummy/location', 'dummyfile.json', '')", errorMessage);
+
+        errorMessage = "line 1:1: Too many arguments for procedure";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '/dummy/location', 'dummyfile.json', true, 'extra')", errorMessage);
+    }
+
+    @Test
+    public void testRegisterWithDeleteDataOnDrop()
+    {
+        String tableName = "table_for_delete_data_on_drop";
+        String registerTableName = "register_for_delete_data_on_drop";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+
+            String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+
+            // Register with default (delete_data_on_drop = false): dropping the registered table should preserve the original
+            assertUpdate(format("CALL system.register_table(metadata_location => '%s', table_name => '%s', schema => '%s')",
+                    metadataLocation, registerTableName, TEST_SCHEMA));
+            assertQuery("SELECT * FROM " + registerTableName, "VALUES (1, 1)");
+
+            assertUpdate("DROP TABLE " + registerTableName);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+
+            // Register with delete_data_on_drop = true: dropping the registered table should delete the underlying data
+            assertUpdate(format("CALL system.register_table(metadata_location => '%s', table_name => '%s', schema => '%s', delete_data_on_drop => %s)",
+                    metadataLocation, registerTableName, TEST_SCHEMA, true));
+            assertQuery("SELECT * FROM " + registerTableName, "VALUES (1, 1)");
+
+            assertUpdate("DROP TABLE " + registerTableName);
+            assertQueryFails("SELECT * FROM " + tableName, "Failed to open input stream for file: .*");
+        }
+        finally {
+            dropTable(tableName);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR fixes an issue where dropping Iceberg tables in Presto/Prestissimo with S3 storage only removes metadata from the Hive metastore but leaves all data files in S3.

## Motivation and Context
Problem: When users drop Iceberg tables stored on S3, only the metadata is removed from the Hive metastore, but all data files (Parquet files, manifest files, metadata files) remain in S3. Over time, this causes significant storage bloat and cost.

Root Cause: The original implementation called `metastore.dropTable(..., true)` which attempts naive directory deletion, but this doesn't work properly with Iceberg's multi-snapshot architecture and S3 storage.

Solution: Use Iceberg's `CatalogUtil.dropTableData()` which properly handles:
- All data files across all snapshots (not just current)
- Manifest files and manifest lists
- Metadata files and statistics files
- Complete directory cleanup for S3

## Impact

- Tables created with CREATE TABLE will now have their data deleted on DROP TABLE
- Tables registered with REGISTER TABLE will preserve their data on DROP TABLE (safe for external data)
- Legacy tables (created before this fix) will default to preserving data (backward compatible)

## Test Plan
1. CREATE TABLE → DROP TABLE (underlying data deleted)
```
CREATE TABLE iceberg.test_s3.final_test (
    id INT,
    name VARCHAR
)
WITH (
    location = 's3a://s3-drop-test-sh/test_s3/final_test/'
);

INSERT INTO iceberg.test_s3.final_test
VALUES (1, 'test');

DROP TABLE iceberg.test_s3.final_test;
```
Verified:

- Metastore entry removed
- Underlying Iceberg metadata files deleted
- Underlying data files deleted from S3

2. REGISTER TABLE → DROP TABLE (underlying data preserved)
```
CREATE TABLE iceberg.test_s3.source_table (
    id INT,
    name VARCHAR
)
WITH (
    location = 's3a://s3-drop-test-sh/register-test/'
);

INSERT INTO iceberg.test_s3.source_table
VALUES
    (1, 'A'),
    (2, 'B');

CALL iceberg.system.register_table(
    'test_s3',
    'registered_table',
    's3a://s3-drop-test-sh/register-test/'
);

DROP TABLE iceberg.test_s3.registered_table;

SELECT * FROM iceberg.test_s3.source_table;
```
Verified:

- Registered table removed from metastore
- Original table remained queryable
- Underlying Iceberg metadata and data files remained present in S3

## Release Notes

Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
 == RELEASE NOTES ==
 
 Iceberg Connector Changes
 * Fix DROP TABLE for Hive-backed Iceberg tables to properly delete all data and metadata files on S3 using Iceberg's CatalogUtil instead of relying on Hive metastore directory deletion.
 * Add optional ``delete_data_on_drop`` parameter to the ``register_table`` procedure to control whether underlying Iceberg data is deleted when the registered table is dropped.
 
 ```

CC: @imjalpreet

## Summary by Sourcery

Ensure Iceberg tables on S3 delete data files correctly on DROP TABLE while preserving data for registered/external tables.

New Features:
- Respect a table-level presto.delete_data_on_drop flag to control whether underlying Iceberg data is deleted when dropping a table.

Bug Fixes:
- Fix DROP TABLE for Iceberg tables on S3 to delete Iceberg data and metadata files via Iceberg utilities instead of relying on Hive metastore directory deletion.

Enhancements:
- Add logging around failures when deleting Iceberg table data and table directories during drop operations.
- Mark registered Iceberg tables as external by default and prevent their data from being deleted on DROP TABLE via a metastore parameter.

## Summary by Sourcery

Ensure Iceberg tables dropped from Hive-backed catalogs correctly clean up underlying data when configured, while preserving data for registered/external tables.

New Features:
- Add a presto.delete_data_on_drop table parameter, configurable via REGISTER TABLE, to control whether Iceberg data files are deleted on DROP TABLE.

Bug Fixes:
- Fix DROP TABLE for Iceberg tables using the Hive metastore so that Iceberg data and metadata files are deleted using Iceberg utilities instead of relying on metastore directory deletion.

Enhancements:
- Default newly created Hive-backed Iceberg tables to delete data on drop, while marking registered tables as external with configurable data-deletion behavior.
- Add logging for failures when reading Iceberg metadata and deleting table data during DROP TABLE.
- Extend the Iceberg REGISTER TABLE procedure signature to accept an optional delete_data_on_drop boolean argument.

Tests:
- Adjust the REGISTER TABLE procedure tests to cover the new delete_data_on_drop argument and related validation errors.