### PR TITLE
docs: Add user documentation and contributing guide for LanceDB connector

### DIFF
--- a/presto-lance/CONTRIBUTING.md
+++ b/presto-lance/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Presto LanceDB Connector
+
+Thank you for your interest in contributing to the Presto LanceDB connector! This document outlines development guidelines, compilation procedures, testing, and formatting requirements.
+
+## Prerequisites
+
+- **Java Development Kit (JDK):** Java 17 (matching the Presto project configuration).
+- **Apache Maven:** Maven 3.6.0+ is required.
+
+---
+
+## Build Commands
+
+Compile the `presto-lance` module along with its required dependency projects using the following Maven command:
+
+```bash
+mvn clean package -pl presto-lance -am -DskipTests
+```
+
+---
+
+## Running Unit Tests
+
+To run the unit tests of the `presto-lance` module:
+
+```bash
+mvn test -pl presto-lance
+```
+
+*Note: The test suite includes unit tests that instantiate embedded Arrow dataset allocations and local filesystem databases under `target/test-data`. Ensure your environment has sufficient temporary file creation permissions.*
+
+---
+
+## Code Quality & Formatting
+
+Presto maintains strict styling and code-quality rules. Make sure to run these checks before submitting a pull request:
+
+### 1. Checkstyle
+Ensure code style complies with Presto standards:
+```bash
+mvn checkstyle:check -pl presto-lance
+```
+
+### 2. License Headers
+Verify all source code files have proper license headers:
+```bash
+mvn license:check -pl presto-lance
+```
+To automatically apply/format the license headers:
+```bash
+mvn license:format -pl presto-lance
+```
+
+### 3. Code Style Guidelines
+- **Imports order:** Imports should be sorted alphabetically, with static imports grouped separately.
+- **Null Checks:** Always use `java.util.Objects.requireNonNull` for mandatory fields in constructor injections.
+- **Error Codes:** Define new error conditions in `LanceErrorCode.java` mapping to appropriate Presto error categorizations.

--- a/presto-lance/src/docs/.pages
+++ b/presto-lance/src/docs/.pages
@@ -1,0 +1,6 @@
+nav:
+  - Welcome: index.md
+  - Install: install.md
+  - Config: config.md
+  - Performance: performance.md
+  - Operations: operations

--- a/presto-lance/src/docs/config.md
+++ b/presto-lance/src/docs/config.md
@@ -1,0 +1,35 @@
+# Configuration
+
+To configure the Presto LanceDB connector, create a catalog properties file `etc/catalog/lance.properties` inside your Presto server's configuration directory.
+
+Here is a minimal configuration example:
+
+```ini
+connector.name=lance
+lance.root-url=/Users/saurabhmahawar/Desktop/presto-server-0.297/lance-data
+```
+
+## Configuration Properties
+
+The following configuration properties are available:
+
+| Property Name | Description | Default Value | Required |
+|---|---|---|---|
+| `lance.root-url` | The root filesystem path where LanceDB tables are stored. Use absolute paths (e.g. `/path/to/data` or `file:///path/to/data`). | None | Yes |
+| `lance.impl` | The namespace manager implementation to use (`dir` for local directories). | `dir` | No |
+| `lance.single-level-ns` | If `true`, the connector registers a virtual schema named `default` to query flat folders directly inside the root URL. | `true` | No |
+| `lance.read-batch-size` | The number of rows to retrieve in a single batch during reads. | `8192` | No |
+| `lance.write-batch-size` | The number of rows to batch in memory before flushing to the Lance file. | `10000` | No |
+| `lance.max-rows-per-file` | The maximum number of rows to write per output Lance file. | `1000000` | No |
+| `lance.max-rows-per-group` | The maximum number of rows per row group inside the output Lance file. | `100000` | No |
+| `lance.index-cache-size` | Size of the Lance index cache per Presto worker. | `128MB` | No |
+| `lance.metadata-cache-size` | Size of the Lance metadata cache per Presto worker. | `128MB` | No |
+| `lance.dataset-cache-max-entries` | The maximum number of cached Lance dataset handles per worker. | `100` | No |
+| `lance.dataset-cache-ttl` | The duration for which cached Lance dataset handles remain valid. | `60m` | No |
+
+## Schema Namespaces
+
+Presto enforces a 3-part naming hierarchy (`catalog.schema.table`), while LanceDB handles datasets flatly in the root filesystem. 
+* By default, `lance.single-level-ns` is set to `true`.
+* Under this mode, the connector maps all Lance directories (ending with `.lance`) in the `lance.root-url` directory to a single virtual schema called `default`.
+* Custom schemas cannot be created dynamically. Therefore, you must use the `default` schema when writing and querying tables (e.g., `lance.default.my_table`).

--- a/presto-lance/src/docs/index.md
+++ b/presto-lance/src/docs/index.md
@@ -1,0 +1,13 @@
+# Presto LanceDB Connector
+
+The Presto LanceDB connector allows querying and writing LanceDB datasets from Presto. 
+
+[LanceDB](https://github.com/lancedb/lancedb) is an open-source database for vector search built on top of the [Lance](https://github.com/lancedb/lance) columnar data format. Lance is designed for high-performance ML workloads, supporting fast random access, vector search, and versioned datasets.
+
+## Key Features
+
+- **High-Performance Columnar Reads:** Direct integration with Lance's C++ library via Arrow Dataset API.
+- **SQL Operations:** Support for `CREATE TABLE`, `DROP TABLE`, `DESCRIBE`, `SELECT` queries, and `INSERT INTO` operations.
+- **Predicate Pushdown:** Translates Presto query filters into Lance scan filters to minimize disk I/O and CPU overhead.
+- **Snapshot Isolation:** Queries are executed against a consistent version of the dataset at the start of the transaction.
+- **Worker-Level Caching:** Integrated caching for indexes, metadata, and dataset objects to minimize remote storage latency.

--- a/presto-lance/src/docs/install.md
+++ b/presto-lance/src/docs/install.md
@@ -1,0 +1,63 @@
+# Installation
+
+To run the Presto LanceDB connector, you must compile the plugin and deploy it to your Presto server's plugin directory.
+
+## Prerequisites
+
+- Java 17 (matching the Presto target runtime)
+- Apache Maven (version 3.6 or higher)
+- A running Presto Server (e.g., version 0.297 or higher)
+
+## Build from Source
+
+1. Clone the Presto repository containing the LanceDB connector:
+   ```bash
+   git clone https://github.com/prestodb/presto.git
+   cd presto
+   ```
+
+2. Compile the `presto-lance` module:
+   ```bash
+   mvn clean package -pl presto-lance -am -DskipTests
+   ```
+
+3. Locate the compiled plugin directory in the target folder:
+   ```bash
+   ls presto-lance/target/presto-lance-*-SNAPSHOT/
+   ```
+
+## Deploying to Presto Server
+
+1. Create a directory named `lance` inside the Presto server's plugin folder:
+   ```bash
+   mkdir -p <presto-server-root>/plugin/lance
+   ```
+
+2. Copy all JAR files from the target directory to the newly created folder:
+   ```bash
+   cp -r presto-lance/target/presto-lance-*-SNAPSHOT/* <presto-server-root>/plugin/lance/
+   ```
+
+3. Configure a catalog property file inside the `etc/catalog` directory to mount the connector. See [Configuration](config.md) for details.
+
+## JVM Configuration for Java 17
+
+Because the connector relies on Apache Arrow and vector calculations, you must configure Presto's JVM options to allow unsafe memory access and native library loading under Java 17.
+
+Add the following options to `<presto-server-root>/etc/jvm.config`:
+
+```ini
+--add-opens=java.base/java.nio=ALL-UNNAMED
+--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+```
+
+## JNI Troubleshooting
+
+The Lance connector relies on a C++ native library (`liblance_core`) loaded via JNI:
+- **Architecture Support:** The native library is compiled for common 64-bit systems (macOS x86_64, macOS aarch64/Apple Silicon, Linux x86_64, Linux aarch64, Windows x86_64).
+- **Temp Directory Permissions:** The JVM extracts native libraries to the temporary directory (usually `/tmp`). If your system blocks execution in `/tmp` (e.g., mounted with the `noexec` option), the connector will fail to start and throw `java.lang.UnsatisfiedLinkError`.
+  - **Resolution:** Set the JVM temporary directory to a path with executable permissions by adding this option to `etc/jvm.config`:
+    ```ini
+    -Djava.io.tmpdir=/path/to/executable/temp
+    ```
+

--- a/presto-lance/src/docs/operations/.pages
+++ b/presto-lance/src/docs/operations/.pages
@@ -1,0 +1,5 @@
+nav:
+  - Data Types: data-types.md
+  - DDL: ddl
+  - DML: dml
+  - DQL: dql

--- a/presto-lance/src/docs/operations/data-types.md
+++ b/presto-lance/src/docs/operations/data-types.md
@@ -1,0 +1,22 @@
+# Supported Data Types
+
+The Presto LanceDB connector supports standard primitive and complex types by mapping Presto data types to Apache Arrow types.
+
+| Presto Type | Arrow / Lance Type | Description |
+|---|---|---|
+| `BOOLEAN` | `Bool` | Boolean true/false |
+| `TINYINT` | `Int (8-bit, signed)` | 8-bit signed integer |
+| `SMALLINT` | `Int (16-bit, signed)` | 16-bit signed integer |
+| `INTEGER` | `Int (32-bit, signed)` | 32-bit signed integer |
+| `BIGINT` | `Int (64-bit, signed)` | 64-bit signed integer |
+| `REAL` | `FloatingPoint (32-bit, single precision)` | 32-bit single precision float |
+| `DOUBLE` | `FloatingPoint (64-bit, double precision)` | 64-bit double precision float |
+| `VARCHAR` | `Utf8` / `LargeUtf8` | UTF-8 encoded string |
+| `VARBINARY` | `Binary` / `LargeBinary` | Unstructured binary data |
+| `DATE` | `Date (unit DAY)` | Calendar date |
+| `TIMESTAMP` | `Timestamp (unit MICROSECOND)` | Timestamp without time zone |
+| `ARRAY` | `List` / `FixedSizeList` | Ordered list of elements |
+| `ROW` | `Struct` | Structured nested fields |
+
+> [!NOTE]
+> Fixed-size arrays (such as `FixedSizeList`) are read as Presto `ARRAY` types, which is useful for processing embeddings and high-dimensional vector representations.

--- a/presto-lance/src/docs/operations/ddl/.pages
+++ b/presto-lance/src/docs/operations/ddl/.pages
@@ -1,0 +1,7 @@
+nav:
+  - Create Table: create-table.md
+  - Drop Table: drop-table.md
+  - Describe Table: describe-table.md
+  - Show Columns: show-columns.md
+  - Show Schemas: show-schemas.md
+  - Show Tables: show-tables.md

--- a/presto-lance/src/docs/operations/ddl/create-table.md
+++ b/presto-lance/src/docs/operations/ddl/create-table.md
@@ -1,0 +1,28 @@
+# CREATE TABLE
+
+Creates a new empty Lance table with the specified schema.
+
+## Syntax
+
+```sql
+CREATE TABLE [ IF NOT EXISTS ] table_name (
+    column_name data_type,
+    ...
+)
+```
+
+## Example
+
+```sql
+CREATE TABLE lance.default.vector_embeddings (
+    id bigint,
+    embedding array(real),
+    description varchar
+);
+```
+
+## Remarks
+
+* Since Lance operates on a flat namespace structure, tables are always created under the virtual `default` schema.
+* Creating tables with partition schemes (e.g. `WITH (partitioned_by = ...)`) is not supported by the Lance connector.
+* Table properties are not supported.

--- a/presto-lance/src/docs/operations/ddl/describe-table.md
+++ b/presto-lance/src/docs/operations/ddl/describe-table.md
@@ -1,0 +1,25 @@
+# DESCRIBE TABLE
+
+Shows the column names, data types, and nullability properties of the specified Lance table.
+
+## Syntax
+
+```sql
+DESCRIBE table_name
+-- or
+DESC table_name
+```
+
+## Example
+
+```sql
+DESCRIBE lance.default.vector_embeddings;
+```
+
+**Output:**
+
+| Column | Type | Extra | Comment |
+|---|---|---|---|
+| `id` | `bigint` | | |
+| `embedding` | `array(real)` | | |
+| `description` | `varchar` | | |

--- a/presto-lance/src/docs/operations/ddl/drop-table.md
+++ b/presto-lance/src/docs/operations/ddl/drop-table.md
@@ -1,0 +1,20 @@
+# DROP TABLE
+
+Deletes a Lance table from the filesystem.
+
+## Syntax
+
+```sql
+DROP TABLE [ IF EXISTS ] table_name
+```
+
+## Example
+
+```sql
+DROP TABLE lance.default.vector_embeddings;
+```
+
+## Remarks
+
+* Dropping a table will completely remove the table subdirectory (e.g. `vector_embeddings.lance`) and all its underlying fragments and metadata files from the configured `lance.root-url`.
+* This operation is irreversible.

--- a/presto-lance/src/docs/operations/ddl/show-columns.md
+++ b/presto-lance/src/docs/operations/ddl/show-columns.md
@@ -1,0 +1,23 @@
+# SHOW COLUMNS
+
+Lists the columns in a Lance table along with their data types and properties.
+
+## Syntax
+
+```sql
+SHOW COLUMNS FROM table_name
+```
+
+## Example
+
+```sql
+SHOW COLUMNS FROM lance.default.vector_embeddings;
+```
+
+**Output:**
+
+| Column | Type | Null | Key | Default | Extra |
+|---|---|---|---|---|---|
+| `id` | `bigint` | `true` | | | |
+| `embedding` | `array(real)` | `true` | | | |
+| `description` | `varchar` | `true` | | | |

--- a/presto-lance/src/docs/operations/ddl/show-schemas.md
+++ b/presto-lance/src/docs/operations/ddl/show-schemas.md
@@ -1,0 +1,22 @@
+# SHOW SCHEMAS
+
+Lists the schemas inside the Lance catalog.
+
+## Syntax
+
+```sql
+SHOW SCHEMAS [ FROM catalog_name ]
+```
+
+## Example
+
+```sql
+SHOW SCHEMAS FROM lance;
+```
+
+**Output:**
+
+| Schema |
+|---|
+| `default` |
+| `information_schema` |

--- a/presto-lance/src/docs/operations/ddl/show-tables.md
+++ b/presto-lance/src/docs/operations/ddl/show-tables.md
@@ -1,0 +1,21 @@
+# SHOW TABLES
+
+Lists the tables in the Lance catalog schema.
+
+## Syntax
+
+```sql
+SHOW TABLES [ FROM schema_name ]
+```
+
+## Example
+
+```sql
+SHOW TABLES FROM lance.default;
+```
+
+**Output:**
+
+| Table |
+|---|
+| `vector_embeddings` |

--- a/presto-lance/src/docs/operations/dml/.pages
+++ b/presto-lance/src/docs/operations/dml/.pages
@@ -1,0 +1,2 @@
+nav:
+  - Insert: insert.md

--- a/presto-lance/src/docs/operations/dml/insert.md
+++ b/presto-lance/src/docs/operations/dml/insert.md
@@ -1,0 +1,34 @@
+# INSERT INTO
+
+Appends new rows to an existing Lance table.
+
+## Syntax
+
+```sql
+INSERT INTO table_name [ ( column_name, ... ) ]
+VALUES ( value, ... ), ...
+-- or
+INSERT INTO table_name
+SELECT ...
+```
+
+## Examples
+
+### Insert values directly
+```sql
+INSERT INTO lance.default.vector_embeddings (id, embedding, description)
+VALUES 
+(1, ARRAY[0.1, 0.2, 0.3], 'embedding one'),
+(2, ARRAY[0.4, 0.5, 0.6], 'embedding two');
+```
+
+### Insert from select query (CTAS equivalent append)
+```sql
+INSERT INTO lance.default.vector_embeddings
+SELECT id, embedding, description FROM other_catalog.other_schema.source_table;
+```
+
+## Limitations
+
+* **No Update/Delete/Merge:** `UPDATE`, `DELETE`, and `MERGE` SQL statements are not supported by the connector.
+* **Schema Validation:** The schemas of the values/rows being inserted must exactly match the schema defined in the table.

--- a/presto-lance/src/docs/operations/dql/.pages
+++ b/presto-lance/src/docs/operations/dql/.pages
@@ -1,0 +1,2 @@
+nav:
+  - Select: select.md

--- a/presto-lance/src/docs/operations/dql/select.md
+++ b/presto-lance/src/docs/operations/dql/select.md
@@ -1,0 +1,45 @@
+# SELECT
+
+Queries data from a Lance table.
+
+## Syntax
+
+```sql
+SELECT column_name, ...
+FROM table_name
+[ WHERE condition ]
+[ LIMIT count ]
+```
+
+## Example
+
+```sql
+SELECT id, description 
+FROM lance.default.vector_embeddings
+WHERE id > 100 AND description LIKE 'embed%'
+LIMIT 10;
+```
+
+---
+
+## Filter Pushdown Optimization
+
+The Presto LanceDB connector supports **Predicate Filter Pushdown**. This optimization translates Presto query engine filters directly into Lance's scanner filters. This allows Lance to filter out irrelevant rows at the storage level, avoiding reading them into memory or transferring them over the network.
+
+### Supported Filters
+The following conditions are translated and pushed down to the Lance storage layer:
+* **Null Check:** `IS NULL` and `IS NOT NULL`
+* **Comparisons:** `=`, `>`, `>=`, `<`, `<=`
+* **Set Membership:** `IN (val1, val2, ...)` 
+* **Supported Pushdown Data Types:** `BOOLEAN`, all integer types (`TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`), floating-point types (`REAL`, `DOUBLE`), `VARCHAR`, `DATE`, and `TIMESTAMP`.
+
+### Session Property
+By default, filter pushdown is enabled. You can toggle this behavior at session level:
+
+```sql
+-- Disable filter pushdown
+SET SESSION lance.filter_pushdown_enabled = false;
+
+-- Re-enable filter pushdown
+SET SESSION lance.filter_pushdown_enabled = true;
+```

--- a/presto-lance/src/docs/performance.md
+++ b/presto-lance/src/docs/performance.md
@@ -1,0 +1,36 @@
+# Performance Tuning
+
+The Presto LanceDB connector utilizes caching at multiple layers to deliver high-performance analytical queries. Tuning these caches and batch sizes is key to optimizing memory usage and request throughput.
+
+## Caching Architecture
+
+The connector maintains three cache categories per worker:
+
+### 1. Dataset Cache
+* **Property:** `lance.dataset-cache-max-entries` and `lance.dataset-cache-ttl`
+* **Purpose:** Caches the opened Lance dataset objects to prevent constant filesystem metadata re-evaluation during concurrent reads.
+* **Tuning:** If you query a large number of distinct tables within a short timeframe, increase the maximum entry limit (default `100`) to avoid thrashing.
+
+### 2. Metadata Cache
+* **Property:** `lance.metadata-cache-size`
+* **Purpose:** Allocates a chunk of off-heap memory to cache Arrow/Lance metadata.
+* **Tuning:** Increase this value (default `128MB`) if your tables have extremely wide schemas, thousands of columns, or nested structures.
+
+### 3. Index Cache
+* **Property:** `lance.index-cache-size`
+* **Purpose:** Caches vector search indexes (such as IVF_PQ) during execution.
+* **Tuning:** For heavily indexed vector tables, increase this size (default `128MB`) to keep indexes hot in RAM.
+
+---
+
+## Batch Sizing
+
+### Read Batch Size (`lance.read-batch-size`)
+* Default: `8192` rows.
+* Determines how many records are returned in a single Arrow record batch. 
+* **Tuning:** For wide tables, you can lower this value to reduce heap fragmentation. For narrow tables, increasing this value can improve throughput.
+
+### Write Batch Size (`lance.write-batch-size`)
+* Default: `10000` rows.
+* The number of rows accumulated in Presto page memory before flushing them to Lance files.
+* **Tuning:** Larger sizes lead to better compression and layout efficiency in the final files, but increase JVM heap usage during `INSERT` operations.


### PR DESCRIPTION
## Description
This PR adds user documentation and developer contribution guidelines for the Presto LanceDB connector.
The documentation is organized under `presto-lance/src/docs/` and structured to mirror the layout of the Trino Lance connector. This format is designed to integrate with the automatic rendering CI pipeline of the `lance.org` website using MkDocs and `.pages` navigation index files.
Additionally, a `CONTRIBUTING.md` is added at the root of the `presto-lance/` module to guide contributors.

## Motivation and Context
The LanceDB documentation team requested maintaining these documents directly in the repository to serve as the single source of truth.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add user-facing documentation and contributor guidelines for the Presto LanceDB connector.

Documentation:
- Document installation, configuration, supported data types, and performance tuning for the Presto LanceDB connector.
- Add SQL operation guides for DDL, DML, and DQL usage with Lance tables, including examples and limitations.
- Introduce navigation index files to integrate LanceDB connector docs with the existing documentation site structure.

Chores:
- Add a module-level CONTRIBUTING guide for building, testing, and enforcing code style for the presto-lance connector.