### PR TITLE
feat: Add read/write support for DWRF type attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1141,7 +1141,7 @@
             <dependency>
                 <groupId>com.facebook.presto.orc</groupId>
                 <artifactId>orc-protobuf</artifactId>
-                <version>13</version>
+                <version>15</version>
             </dependency>
 
             <dependency>

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -566,9 +566,25 @@ public class DwrfMetadataReader
         return new MapStatistics(mapStatisticsEntries.build());
     }
 
-    private static OrcType toType(DwrfProto.Type type)
+    static OrcType toType(DwrfProto.Type type)
     {
-        return new OrcType(toTypeKind(type.getKind()), type.getSubtypesList(), type.getFieldNamesList(), Optional.empty(), Optional.empty(), Optional.empty());
+        return new OrcType(toTypeKind(type.getKind()), type.getSubtypesList(), type.getFieldNamesList(), Optional.empty(), Optional.empty(), Optional.empty(), toMap(type.getAttributesList()));
+    }
+
+    // Mirrors OrcMetadataReader.toMap. DWRF files written by older writers (or by writers
+    // that don't set attributes) yield an empty list here, producing an empty map -- no
+    // change in observable behavior for the attribute-less case.
+    static Map<String, String> toMap(List<DwrfProto.StringPair> attributes)
+    {
+        ImmutableMap.Builder<String, String> results = new ImmutableMap.Builder<>();
+        if (attributes != null) {
+            for (DwrfProto.StringPair attribute : attributes) {
+                if (attribute.hasKey() && attribute.hasValue()) {
+                    results.put(attribute.getKey(), attribute.getValue());
+                }
+            }
+        }
+        return results.build();
     }
 
     private static List<OrcType> toType(List<DwrfProto.Type> types)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -164,14 +164,28 @@ public class DwrfMetadataWriter
         return builder.build();
     }
 
-    private static Type toType(OrcType type)
+    static Type toType(OrcType type)
     {
         Builder builder = Type.newBuilder()
                 .setKind(toTypeKind(type.getOrcTypeKind()))
                 .addAllSubtypes(type.getFieldTypeIndexes())
-                .addAllFieldNames(type.getFieldNames());
+                .addAllFieldNames(type.getFieldNames())
+                .addAllAttributes(toStringPairList(type.getAttributes()));
 
         return builder.build();
+    }
+
+    // Mirrors OrcMetadataWriter.toStringPairList. Empty input map produces an empty
+    // attribute list -- the resulting DWRF file is byte-compatible with the pre-patch
+    // writer when the type carries no attributes.
+    static List<DwrfProto.StringPair> toStringPairList(Map<String, String> attributes)
+    {
+        return attributes.entrySet().stream()
+                .map(entry -> DwrfProto.StringPair.newBuilder()
+                        .setKey(entry.getKey())
+                        .setValue(entry.getValue())
+                        .build())
+                .collect(toImmutableList());
     }
 
     private static Type.Kind toTypeKind(OrcTypeKind orcTypeKind)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
@@ -29,6 +29,7 @@ import com.facebook.presto.orc.metadata.statistics.StringStatistics;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.protobuf.ByteString;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.DataProvider;
@@ -39,12 +40,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
+import static com.facebook.presto.orc.metadata.DwrfMetadataReader.toMap;
+import static com.facebook.presto.orc.metadata.DwrfMetadataReader.toType;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.maxStringTruncateToValidRange;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.minStringTruncateToValidRange;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LONG;
 import static com.facebook.presto.orc.metadata.TestOrcMetadataReader.ALL_UTF8_SEQUENCES;
 import static com.facebook.presto.orc.metadata.TestOrcMetadataReader.TEST_CODE_POINTS;
 import static com.facebook.presto.orc.metadata.TestOrcMetadataReader.concatSlice;
@@ -402,5 +407,81 @@ public class TestDwrfMetadataReader
         DwrfProto.ColumnStatistics dwrfColumnStatistics = DwrfMetadataWriter.toColumnStatistics(input);
         ColumnStatistics actual = dwrfMetadataReader.toColumnStatistics(HiveWriterVersion.ORC_HIVE_8732, dwrfColumnStatistics, false, null);
         assertEquals(actual, output);
+    }
+
+    @Test
+    public void testToMapEmpty()
+    {
+        // Empty attribute list (the common case for files written by attribute-
+        // unaware writers) produces empty map -- no behavior change.
+        assertEquals(toMap(ImmutableList.of()), ImmutableMap.of());
+    }
+
+    @Test
+    public void testToMapNull()
+    {
+        // Defensive: handle null input gracefully.
+        assertEquals(toMap(null), ImmutableMap.of());
+    }
+
+    @Test
+    public void testToMapBuildsKeyValueMap()
+    {
+        List<DwrfProto.StringPair> attributes = ImmutableList.of(
+                DwrfProto.StringPair.newBuilder().setKey("iceberg.id").setValue("11").build(),
+                DwrfProto.StringPair.newBuilder().setKey("iceberg.long-type-name").setValue("string").build());
+
+        Map<String, String> result = toMap(attributes);
+        assertEquals(result, ImmutableMap.of(
+                "iceberg.id", "11",
+                "iceberg.long-type-name", "string"));
+    }
+
+    @Test
+    public void testToMapSkipsPairsMissingKeyOrValue()
+    {
+        // Defensive: malformed proto records (missing key OR value) shouldn't
+        // produce null entries in the map -- they get silently dropped, mirroring
+        // OrcMetadataReader's behavior.
+        List<DwrfProto.StringPair> attributes = ImmutableList.of(
+                DwrfProto.StringPair.newBuilder().setKey("iceberg.id").setValue("42").build(),
+                DwrfProto.StringPair.newBuilder().setKey("missing.value").build(),
+                DwrfProto.StringPair.newBuilder().setValue("missing.key").build());
+
+        Map<String, String> result = toMap(attributes);
+        assertEquals(result, ImmutableMap.of("iceberg.id", "42"));
+    }
+
+    @Test
+    public void testToTypeRoundtripsAttributes()
+    {
+        // Construct a DwrfProto.Type carrying an iceberg field-id-style attribute,
+        // run it through the reader's type conversion, and assert the resulting
+        // OrcType exposes the attribute via getAttributes().
+        DwrfProto.Type proto = DwrfProto.Type.newBuilder()
+                .setKind(DwrfProto.Type.Kind.LONG)
+                .addAttributes(DwrfProto.StringPair.newBuilder()
+                        .setKey("iceberg.id")
+                        .setValue("99")
+                        .build())
+                .build();
+
+        OrcType orcType = toType(proto);
+        assertEquals(orcType.getOrcTypeKind(), LONG);
+        assertEquals(orcType.getAttributes(), ImmutableMap.of("iceberg.id", "99"));
+    }
+
+    @Test
+    public void testToTypeAttributeAbsenceProducesEmptyMap()
+    {
+        // Backward-compat probe: DWRF files written by attribute-unaware writers
+        // have no attribute proto entries -- the resulting OrcType should still
+        // be constructable and report an empty attributes map.
+        DwrfProto.Type proto = DwrfProto.Type.newBuilder()
+                .setKind(DwrfProto.Type.Kind.LONG)
+                .build();
+
+        OrcType orcType = toType(proto);
+        assertEquals(orcType.getAttributes(), ImmutableMap.of());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataWriter.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.orc.metadata;
 
 import com.facebook.presto.orc.proto.DwrfProto;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
@@ -29,6 +31,9 @@ import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toColumnEncodi
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toColumnEncodings;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStream;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStreamKind;
+import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStringPairList;
+import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toType;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LONG;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_COUNT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
@@ -195,5 +200,69 @@ public class TestDwrfMetadataWriter
         assertEquals(actual.getLength(), expectedLength);
         assertTrue(actual.getUseVInts());
         assertEquals(actual.getOffset(), expectedOffset);
+    }
+
+    @Test
+    public void testToStringPairListEmpty()
+    {
+        // Empty attributes map produces empty pair list -- the resulting DWRF
+        // type is byte-compatible with pre-patch writers for the common case.
+        assertEquals(toStringPairList(ImmutableMap.of()), ImmutableList.of());
+    }
+
+    @Test
+    public void testToStringPairListPreservesKeyValuePairs()
+    {
+        Map<String, String> attributes = ImmutableMap.of(
+                "iceberg.id", "42",
+                "iceberg.long-type-name", "decimal(38, 9)");
+
+        List<DwrfProto.StringPair> pairs = toStringPairList(attributes);
+        assertEquals(pairs.size(), 2);
+        // Order isn't guaranteed by Map iteration, so build a map back to assert.
+        Map<String, String> roundTripped = pairs.stream()
+                .collect(ImmutableMap.toImmutableMap(
+                        DwrfProto.StringPair::getKey,
+                        DwrfProto.StringPair::getValue));
+        assertEquals(roundTripped, attributes);
+    }
+
+    @Test
+    public void testToTypeEmitsAttributes()
+    {
+        // Construct an OrcType that carries an iceberg field-id-style attribute,
+        // run it through the writer's type conversion, and assert the proto
+        // builder picks up the attribute slot.
+        OrcType orcType = new OrcType(
+                LONG,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("iceberg.id", "7"));
+
+        DwrfProto.Type proto = toType(orcType);
+        assertEquals(proto.getAttributesCount(), 1);
+        assertEquals(proto.getAttributes(0).getKey(), "iceberg.id");
+        assertEquals(proto.getAttributes(0).getValue(), "7");
+    }
+
+    @Test
+    public void testToTypeEmitsNoAttributesWhenMapEmpty()
+    {
+        // Backward-compat probe: types with no attributes should produce
+        // attribute-less DWRF proto, matching pre-patch wire output for the
+        // common case.
+        OrcType orcType = new OrcType(
+                LONG,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        DwrfProto.Type proto = toType(orcType);
+        assertEquals(proto.getAttributesCount(), 0);
     }
 }


### PR DESCRIPTION
## Description
DWRF's `Type` proto gained an `attributes` field (`repeated StringPair`, mirroring Apache ORC's `Type.attributes`) in orc-protobuf 15. Wire it through the DWRF metadata path so per-column attributes are preserved in DWRF footers, matching the ORC path (`OrcMetadataReader.toMap` / `OrcMetadataWriter.toStringPairList`).

## Motivation and Context
`OrcType` already carries `Map<String, String> attributes` and the ORC metadata path reads/writes it, but the DWRF path dropped it (the reader passed an empty map, the writer never emitted it). A concrete use case is preserving the Iceberg field-id (`iceberg.id`) per column for Iceberg-on-DWRF schema evolution.

## Impact
- Bumps `orc-protobuf` 13 -> 15 (brings `DwrfProto.Type.attributes`).
- `DwrfMetadataReader.toType` reads attributes into `OrcType`.
- `DwrfMetadataWriter.toType` emits `OrcType` attributes into the proto.
- Backward compatible: types without attributes produce an empty map / attribute-less proto, so existing DWRF files and writers are byte-compatible.

## Test Plan
- New unit tests in `TestDwrfMetadataReader` / `TestDwrfMetadataWriter` (round-trip, empty, null, malformed-pair).
- `mvn -pl presto-orc test -Dtest=TestDwrfMetadataReader,TestDwrfMetadataWriter` -> 37 tests pass.

## Contributor checklist
- [x] Complies with contributing guide and commit standards
- [x] PR description is accurate and concise
- [ ] Documented new properties/SQL/functions (N/A)
- [x] Release notes follow the guidelines
- [x] Adequate tests added
- [x] CI passed
- [x] No new dependencies (orc-protobuf already a dependency)

## Release Notes
```
== RELEASE NOTES ==

Hive Connector Changes
* Add support for reading and writing per-column type attributes in DWRF files.
```

## Summary by Sourcery

Add support for reading and writing DWRF type attributes so per-column metadata is preserved in DWRF files, aligning behavior with the existing ORC path.

New Features:
- Preserve per-column type attributes on DWRF types when reading DWRF metadata into OrcType.
- Emit OrcType attributes into DWRF Type protos when writing DWRF metadata.

Enhancements:
- Expose DwrfMetadataReader.toType and DwrfMetadataWriter.toType for reuse in tests and attribute handling.
- Introduce helpers to convert between DWRF StringPair attribute lists and OrcType attribute maps while remaining backward compatible with attribute-less files.

Build:
- Bump orc-protobuf dependency from version 13 to 15 to pick up DwrfProto.Type.attributes support.

Tests:
- Add unit tests covering DWRF attribute map parsing, malformed pairs handling, and attribute round-tripping through DwrfMetadataReader.
- Add unit tests verifying DWRF writer emits attributes correctly and remains byte-compatible when attributes are absent.