### PR TITLE
feat(native-pos): Make MaterializedOutputBuffer reclaim configurable and fix reclaimableBytes logic (#27941)

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -807,6 +807,18 @@ double SystemConfig::exchangeMaterializationReclaimDrainThresholdRatio() const {
       .value_or(0.67);
 }
 
+bool SystemConfig::exchangeMaterializationReclaimWaitForWriterDrainEnabled()
+    const {
+  return optionalProperty<bool>(
+             kExchangeMaterializationReclaimWaitForWriterDrainEnabled)
+      .value_or(false);
+}
+
+bool SystemConfig::exchangeMaterializationReclaimHighPriority() const {
+  return optionalProperty<bool>(kExchangeMaterializationReclaimHighPriority)
+      .value_or(false);
+}
+
 bool SystemConfig::enableSerializedPageChecksum() const {
   return optionalProperty<bool>(kEnableSerializedPageChecksum).value();
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -704,6 +704,17 @@ class SystemConfig : public ConfigBase {
       kExchangeMaterializationReclaimDrainThresholdRatio{
           "exchange.materialization.reclaim-drain-threshold-ratio"};
 
+  /// Wait for the writer to drain after flushing partition buffers during
+  /// reclaim. Default: false.
+  static constexpr std::string_view
+      kExchangeMaterializationReclaimWaitForWriterDrainEnabled{
+          "exchange.materialization.reclaim-wait-for-writer-drain-enabled"};
+
+  /// Use high reclaim priority (-1) for the output buffer pool.
+  /// Default: false (uses default priority 0).
+  static constexpr std::string_view kExchangeMaterializationReclaimHighPriority{
+      "exchange.materialization.reclaim-high-priority"};
+
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
@@ -1172,6 +1183,10 @@ class SystemConfig : public ConfigBase {
   int64_t exchangeMaterializationOutputBufferPerPartitionMaxBytes() const;
 
   double exchangeMaterializationReclaimDrainThresholdRatio() const;
+
+  bool exchangeMaterializationReclaimWaitForWriterDrainEnabled() const;
+
+  bool exchangeMaterializationReclaimHighPriority() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -290,6 +290,17 @@ int64_t MaterializedOutputBuffer::drainPartition(
   return drainedBytes;
 }
 
+uint64_t MaterializedOutputBuffer::reclaimableBufferedBytes() const {
+  uint64_t reclaimableBytes = 0;
+  for (int32_t i = 0; i < numPartitions_; ++i) {
+    auto partBytes = partitionBuffers_[i]->bufferedBytes_.load();
+    if (partBytes > reclaimDrainThresholdBytes_) {
+      reclaimableBytes += partBytes - reclaimDrainThresholdBytes_;
+    }
+  }
+  return reclaimableBytes;
+}
+
 uint64_t MaterializedOutputBuffer::tryDrainPartitions() {
   std::vector<int32_t> orderedPartitions(numPartitions_);
   std::iota(orderedPartitions.begin(), orderedPartitions.end(), 0);
@@ -411,14 +422,18 @@ MaterializedOutputBuffer::stats() const {
 
 MaterializedOutputBuffer::Reclaimer::Reclaimer(
     MaterializedOutputBuffer* partitionBuffer)
-    : MemoryReclaimer(kHighReclaimPriority), partitionBuffer_(partitionBuffer) {
+    : MemoryReclaimer(
+          SystemConfig::instance()->exchangeMaterializationReclaimHighPriority()
+              ? kHighReclaimPriority
+              : 0),
+      partitionBuffer_(partitionBuffer) {
   VELOX_CHECK_NOT_NULL(partitionBuffer_, "Reclaimer requires a buffer");
 }
 
 bool MaterializedOutputBuffer::Reclaimer::reclaimableBytes(
-    const velox::memory::MemoryPool& pool,
+    const velox::memory::MemoryPool& /*pool*/,
     uint64_t& reclaimableBytes) const {
-  reclaimableBytes = pool.usedBytes();
+  reclaimableBytes = partitionBuffer_->reclaimableBufferedBytes();
   return reclaimableBytes > 0;
 }
 
@@ -507,8 +522,11 @@ uint64_t MaterializedOutputBuffer::Reclaimer::reclaim(
     }
   }
 
-  // Wait for writer to drain to release memory after flush to network.
-  waitForWriterDrain(pool, targetUsedBytes, deadline);
+  // Optionally wait for the writer to drain packages to the network.
+  if (SystemConfig::instance()
+          ->exchangeMaterializationReclaimWaitForWriterDrainEnabled()) {
+    waitForWriterDrain(pool, targetUsedBytes, deadline);
+  }
 
   auto totalFreedBytes =
       prevUsedBytes > pool->usedBytes() ? prevUsedBytes - pool->usedBytes() : 0;

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -173,6 +173,9 @@ class MaterializedOutputBuffer {
     return reclaimDrainThresholdBytes_;
   }
 
+  /// Returns the bytes that tryDrainPartitions() will actually flush.
+  uint64_t reclaimableBufferedBytes() const;
+
   /// Signal that no more data will be enqueued. Drains remaining data
   /// and calls writer->noMoreData(true).
   void noMoreData();

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
@@ -26,6 +26,7 @@ namespace facebook::presto::operators::test {
 
 using Reclaimer = MaterializedOutputBuffer::Reclaimer;
 
+constexpr int64_t kKB = 1L << 10;
 constexpr int64_t kMB = 1L << 20;
 
 namespace {
@@ -85,7 +86,7 @@ TEST_F(ReclaimerTest, emptyPoolReturnsImmediately) {
   EXPECT_EQ(reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats), 0);
 }
 
-TEST_F(ReclaimerTest, reclaimableReportsPoolUsage) {
+TEST_F(ReclaimerTest, reclaimableReportsBufferedBytes) {
   NoOpShuffleFactory factory;
   MaterializedOutputBuffer buffer(
       /*numPartitions=*/1,
@@ -95,16 +96,19 @@ TEST_F(ReclaimerTest, reclaimableReportsPoolUsage) {
       rootPool_.get());
   Reclaimer reclaimer(&buffer);
 
-  void* allocation = buffer.pool()->allocate(10 * kMB);
+  // Enqueue data above reclaimDrainThreshold (87KB) but below drainThreshold
+  // (130KB) so it stays buffered and is reported as reclaimable.
+  auto iobuf = buffer.allocateTrackedIOBuf(100 * kKB);
+  iobuf->append(100 * kKB);
+  buffer.enqueue(0, std::move(iobuf));
 
+  EXPECT_GT(buffer.bufferedBytes(), 0);
   uint64_t reclaimableBytes = 0;
   EXPECT_TRUE(reclaimer.reclaimableBytes(*buffer.pool(), reclaimableBytes));
-  EXPECT_EQ(reclaimableBytes, 10 * kMB);
-
-  buffer.pool()->free(allocation, 10 * kMB);
+  EXPECT_GT(reclaimableBytes, 0);
 }
 
-TEST_F(ReclaimerTest, fullDrainFromBackgroundThread) {
+TEST_F(ReclaimerTest, reclaimFlushesBufferedData) {
   NoOpShuffleFactory factory;
   MaterializedOutputBuffer buffer(
       /*numPartitions=*/1,
@@ -114,22 +118,20 @@ TEST_F(ReclaimerTest, fullDrainFromBackgroundThread) {
       rootPool_.get());
   Reclaimer reclaimer(&buffer);
 
-  void* allocation = buffer.pool()->allocate(10 * kMB);
+  // Enqueue data above reclaimDrainThreshold so reclaim flushes it.
+  auto iobuf = buffer.allocateTrackedIOBuf(100 * kKB);
+  iobuf->append(100 * kKB);
+  buffer.enqueue(0, std::move(iobuf));
 
-  std::thread drainer([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    buffer.pool()->free(allocation, 10 * kMB);
-  });
+  auto prevUsed = buffer.pool()->usedBytes();
+  EXPECT_GT(prevUsed, 0);
 
   memory::MemoryReclaimer::Stats stats;
-  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats);
-  drainer.join();
-
-  EXPECT_EQ(freedBytes, 10 * kMB);
-  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 100 * kKB, 5000, stats);
+  EXPECT_GT(freedBytes, 0);
 }
 
-TEST_F(ReclaimerTest, partialDrainBeforeTimeout) {
+TEST_F(ReclaimerTest, reclaimReturnsImmediatelyWhenNothingBuffered) {
   NoOpShuffleFactory factory;
   MaterializedOutputBuffer buffer(
       /*numPartitions=*/1,
@@ -139,153 +141,15 @@ TEST_F(ReclaimerTest, partialDrainBeforeTimeout) {
       rootPool_.get());
   Reclaimer reclaimer(&buffer);
 
-  void* allocation1 = buffer.pool()->allocate(5 * kMB);
-  void* allocation2 = buffer.pool()->allocate(5 * kMB);
-
-  std::thread drainer([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    buffer.pool()->free(allocation1, 5 * kMB);
-  });
-
-  memory::MemoryReclaimer::Stats stats;
-  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 200, stats);
-  drainer.join();
-
-  EXPECT_EQ(freedBytes, 5 * kMB);
-  EXPECT_EQ(buffer.pool()->usedBytes(), 5 * kMB);
-
-  buffer.pool()->free(allocation2, 5 * kMB);
-}
-
-TEST_F(ReclaimerTest, timeoutReturnsZeroWhenNothingDrains) {
-  NoOpShuffleFactory factory;
-  MaterializedOutputBuffer buffer(
-      /*numPartitions=*/1,
-      /*shuffleWriterInfo=*/"",
-      &factory,
-      "test.0.0.0.0",
-      rootPool_.get());
-  Reclaimer reclaimer(&buffer);
-
+  // Allocate directly from the pool (not via enqueue). The reclaimer cannot
+  // free this because it only knows about partition buffers.
   void* allocation = buffer.pool()->allocate(10 * kMB);
 
   memory::MemoryReclaimer::Stats stats;
   auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 100, stats);
-
-  EXPECT_EQ(freedBytes, 0);
-  EXPECT_EQ(buffer.pool()->usedBytes(), 10 * kMB);
-
-  buffer.pool()->free(allocation, 10 * kMB);
-}
-
-TEST_F(ReclaimerTest, zeroWaitReturnsImmediately) {
-  NoOpShuffleFactory factory;
-  MaterializedOutputBuffer buffer(
-      /*numPartitions=*/1,
-      /*shuffleWriterInfo=*/"",
-      &factory,
-      "test.0.0.0.0",
-      rootPool_.get());
-  Reclaimer reclaimer(&buffer);
-
-  void* allocation = buffer.pool()->allocate(10 * kMB);
-
-  memory::MemoryReclaimer::Stats stats;
-  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 0, stats);
-
   EXPECT_EQ(freedBytes, 0);
 
   buffer.pool()->free(allocation, 10 * kMB);
-}
-
-TEST_F(ReclaimerTest, targetLargerThanUsage) {
-  NoOpShuffleFactory factory;
-  MaterializedOutputBuffer buffer(
-      /*numPartitions=*/1,
-      /*shuffleWriterInfo=*/"",
-      &factory,
-      "test.0.0.0.0",
-      rootPool_.get());
-  Reclaimer reclaimer(&buffer);
-
-  void* allocation = buffer.pool()->allocate(5 * kMB);
-
-  std::thread drainer([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    buffer.pool()->free(allocation, 5 * kMB);
-  });
-
-  memory::MemoryReclaimer::Stats stats;
-  auto freedBytes = reclaimer.reclaim(buffer.pool(), 100 * kMB, 5000, stats);
-  drainer.join();
-
-  EXPECT_EQ(freedBytes, 5 * kMB);
-  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
-}
-
-TEST_F(ReclaimerTest, incrementalDrain) {
-  NoOpShuffleFactory factory;
-  MaterializedOutputBuffer buffer(
-      /*numPartitions=*/1,
-      /*shuffleWriterInfo=*/"",
-      &factory,
-      "test.0.0.0.0",
-      rootPool_.get());
-  Reclaimer reclaimer(&buffer);
-
-  void* allocation1 = buffer.pool()->allocate(3 * kMB);
-  void* allocation2 = buffer.pool()->allocate(3 * kMB);
-  void* allocation3 = buffer.pool()->allocate(4 * kMB);
-
-  std::thread drainer([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    buffer.pool()->free(allocation1, 3 * kMB);
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    buffer.pool()->free(allocation2, 3 * kMB);
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    buffer.pool()->free(allocation3, 4 * kMB);
-  });
-
-  memory::MemoryReclaimer::Stats stats;
-  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats);
-  drainer.join();
-
-  EXPECT_EQ(freedBytes, 10 * kMB);
-  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
-}
-
-TEST_F(ReclaimerTest, consecutiveReclaims) {
-  NoOpShuffleFactory factory;
-  MaterializedOutputBuffer buffer(
-      /*numPartitions=*/1,
-      /*shuffleWriterInfo=*/"",
-      &factory,
-      "test.0.0.0.0",
-      rootPool_.get());
-  Reclaimer reclaimer(&buffer);
-
-  void* allocation1 = buffer.pool()->allocate(5 * kMB);
-
-  std::thread drainer1([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    buffer.pool()->free(allocation1, 5 * kMB);
-  });
-
-  memory::MemoryReclaimer::Stats stats;
-  auto freedBytes1 = reclaimer.reclaim(buffer.pool(), 5 * kMB, 5000, stats);
-  drainer1.join();
-  EXPECT_EQ(freedBytes1, 5 * kMB);
-
-  void* allocation2 = buffer.pool()->allocate(8 * kMB);
-
-  std::thread drainer2([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    buffer.pool()->free(allocation2, 8 * kMB);
-  });
-
-  auto freedBytes2 = reclaimer.reclaim(buffer.pool(), 8 * kMB, 5000, stats);
-  drainer2.join();
-  EXPECT_EQ(freedBytes2, 8 * kMB);
 }
 
 TEST_F(ReclaimerTest, reclaimSkippedAfterClose) {
@@ -327,6 +191,25 @@ TEST_F(ReclaimerTest, reclaimBlockedWhenAborted) {
 
   memory::MemoryReclaimer::Stats stats;
   auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 100, stats);
+  EXPECT_EQ(freedBytes, 0);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+TEST_F(ReclaimerTest, zeroWaitReturnsImmediately) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 0, stats);
   EXPECT_EQ(freedBytes, 0);
 
   buffer.pool()->free(allocation, 10 * kMB);


### PR DESCRIPTION
Summary:

The MaterializedOutputBuffer reclaimer had two issues causing
memory arbitration timeouts and unnecessary spilling:

1. waitForWriterDrain blocked the reclaim cascade for up to 5 minutes
   when writer threads were stalled, preventing other reclaimers
   (e.g., aggregation spill) from running.

2. reclaimableBytes() reported pool.usedBytes() which includes
   writer packages that the reclaimer cannot free. This misled the
   arbitrator into picking this pool over operators that can spill.

Changes:
- Add config exchange.materialization.reclaim-wait-for-writer-drain-enabled
  (default false) to gate the waitForWriterDrain call.
- Add config exchange.materialization.reclaim-high-priority
  (default false) to control whether the output buffer uses high
  priority (-1) or default priority (0).
- Fix reclaimableBytes() to report only partition buffer bytes above
  reclaimDrainThreshold.

Reviewed By: xiaoxmeng

Differential Revision: D107693168

```
== NO RELEASE NOTE ==
```

