### PR TITLE
fix(optimizer): Handle constant-folded ROW literals in OptimizeRowInPredicate

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
@@ -14,6 +14,9 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.metadata.Metadata;
@@ -25,6 +28,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -40,10 +44,12 @@ import java.util.Optional;
 import static com.facebook.presto.SystemSessionProperties.isOptimizeRowInPredicate;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.expressions.LogicalRowExpressions.and;
 import static com.facebook.presto.expressions.LogicalRowExpressions.or;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CONSTRUCTOR;
+import static com.facebook.presto.sql.relational.Expressions.constant;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -219,19 +225,55 @@ public class OptimizeRowInPredicate
             }
 
             int arity = rowFields.size();
-            List<SpecialFormExpression> candidateRows = new ArrayList<>(args.size() - 1);
+            List<List<RowExpression>> candidateRows = new ArrayList<>(args.size() - 1);
             for (int i = 1; i < args.size(); i++) {
-                if (!(args.get(i) instanceof SpecialFormExpression)) {
+                Optional<List<RowExpression>> candidate = normalizeCandidateRow(args.get(i), arity);
+                if (!candidate.isPresent()) {
                     return Optional.empty();
                 }
-                SpecialFormExpression candidate = (SpecialFormExpression) args.get(i);
-                if (candidate.getForm() != ROW_CONSTRUCTOR || candidate.getArguments().size() != arity) {
-                    return Optional.empty();
-                }
-                candidateRows.add(candidate);
+                candidateRows.add(candidate.get());
             }
 
             return Optional.of(new RowFields(fieldVars, candidateRows));
+        }
+
+        /**
+         * Normalizes one candidate row from the IN list into its per-field expressions. A candidate
+         * appears either as an unfolded ROW_CONSTRUCTOR special form, or — when all of its fields are
+         * literals — as a constant-folded ConstantExpression of RowType. The latter is what the
+         * expression optimizer produces for real queries (e.g. {@code (a, b) IN ((1, 2), (3, 4))}),
+         * so handling it is what makes this rule fire in production rather than only in unit tests.
+         * Returns empty if the candidate does not match the expected arity/shape.
+         */
+        private static Optional<List<RowExpression>> normalizeCandidateRow(RowExpression candidate, int arity)
+        {
+            if (candidate instanceof SpecialFormExpression) {
+                SpecialFormExpression row = (SpecialFormExpression) candidate;
+                if (row.getForm() != ROW_CONSTRUCTOR || row.getArguments().size() != arity) {
+                    return Optional.empty();
+                }
+                return Optional.of(row.getArguments());
+            }
+
+            if (candidate instanceof ConstantExpression) {
+                ConstantExpression constant = (ConstantExpression) candidate;
+                if (constant.isNull() || !(constant.getType() instanceof RowType) || !(constant.getValue() instanceof Block)) {
+                    return Optional.empty();
+                }
+                List<Type> fieldTypes = ((RowType) constant.getType()).getTypeParameters();
+                Block rowBlock = (Block) constant.getValue();
+                if (fieldTypes.size() != arity || rowBlock.getPositionCount() != arity) {
+                    return Optional.empty();
+                }
+                ImmutableList.Builder<RowExpression> fields = ImmutableList.builder();
+                for (int fieldIdx = 0; fieldIdx < arity; fieldIdx++) {
+                    Type fieldType = fieldTypes.get(fieldIdx);
+                    fields.add(constant(readNativeValue(fieldType, rowBlock, fieldIdx), fieldType));
+                }
+                return Optional.of(fields.build());
+            }
+
+            return Optional.empty();
         }
 
         /**
@@ -249,11 +291,11 @@ public class OptimizeRowInPredicate
 
             // Build: (col1 = v1_1 AND col2 = v1_2) OR (col1 = v2_1 AND col2 = v2_2) OR ...
             ImmutableList.Builder<RowExpression> disjuncts = ImmutableList.builder();
-            for (SpecialFormExpression candidate : rowFields.candidateRows) {
+            for (List<RowExpression> candidate : rowFields.candidateRows) {
                 ImmutableList.Builder<RowExpression> conjuncts = ImmutableList.builder();
                 for (int fieldIdx = 0; fieldIdx < arity; fieldIdx++) {
                     VariableReferenceExpression leftVar = rowFields.fieldVars.get(fieldIdx);
-                    RowExpression rightVal = candidate.getArguments().get(fieldIdx);
+                    RowExpression rightVal = candidate.get(fieldIdx);
 
                     conjuncts.add(new CallExpression(
                             EQUAL.name(),
@@ -316,8 +358,8 @@ public class OptimizeRowInPredicate
             VariableReferenceExpression fieldVar = rowFields.fieldVars.get(fieldIdx);
 
             ImmutableList.Builder<RowExpression> columnValues = ImmutableList.builder();
-            for (SpecialFormExpression candidate : rowFields.candidateRows) {
-                columnValues.add(candidate.getArguments().get(fieldIdx));
+            for (List<RowExpression> candidate : rowFields.candidateRows) {
+                columnValues.add(candidate.get(fieldIdx));
             }
 
             return new SpecialFormExpression(
@@ -332,9 +374,9 @@ public class OptimizeRowInPredicate
         private static final class RowFields
         {
             final List<VariableReferenceExpression> fieldVars;
-            final List<SpecialFormExpression> candidateRows;
+            final List<List<RowExpression>> candidateRows;
 
-            RowFields(List<VariableReferenceExpression> fieldVars, List<SpecialFormExpression> candidateRows)
+            RowFields(List<VariableReferenceExpression> fieldVars, List<List<RowExpression>> candidateRows)
             {
                 this.fieldVars = fieldVars;
                 this.candidateRows = candidateRows;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeRowInPredicate.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeRowInPredicate.java
@@ -13,9 +13,13 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RowBlockBuilder;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -42,6 +46,7 @@ import java.util.Optional;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_ROW_IN_PREDICATE;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractDisjuncts;
@@ -76,6 +81,63 @@ public class TestOptimizeRowInPredicate
                 new SpecialFormExpression(ROW_CONSTRUCTOR, ROW_VARCHAR_BIGINT, ImmutableList.of(
                         new ConstantExpression(Slices.utf8Slice("b"), VARCHAR),
                         new ConstantExpression(2L, BIGINT)))));
+    }
+
+    /**
+     * Builds a candidate row as a constant-folded ConstantExpression of RowType — exactly what the
+     * expression optimizer produces when every field of a {@code ROW(...)} in the IN list is a
+     * literal. Mirrors RowExpressionInterpreter's ROW_CONSTRUCTOR folding.
+     */
+    private static ConstantExpression foldedRow(Object v1, Type t1, Object v2, Type t2)
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(t1, t2));
+        BlockBuilder blockBuilder = new RowBlockBuilder(ImmutableList.of(t1, t2), null, 1);
+        BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
+        writeNativeValue(t1, singleRowBlockWriter, v1);
+        writeNativeValue(t2, singleRowBlockWriter, v2);
+        blockBuilder.closeEntry();
+        Block rowBlock = rowType.getObject(blockBuilder, 0);
+        return new ConstantExpression(rowBlock, rowType);
+    }
+
+    private static SpecialFormExpression rowInWithFoldedCandidates(VariableReferenceExpression c1, VariableReferenceExpression c2)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.of(
+                new SpecialFormExpression(ROW_CONSTRUCTOR, ROW_VARCHAR_BIGINT, ImmutableList.of(c1, c2)),
+                foldedRow(Slices.utf8Slice("a"), VARCHAR, 1L, BIGINT),
+                foldedRow(Slices.utf8Slice("b"), VARCHAR, 2L, BIGINT)));
+    }
+
+    @Test
+    public void testRowInRewriteFiresOnConstantFoldedCandidates()
+    {
+        // Regression test: in real queries the all-literal candidate rows are constant-folded into
+        // ConstantExpressions of RowType (not ROW_CONSTRUCTOR special forms). The rewrite must still
+        // fire and produce the same per-column IN predicates. Before the fix it bailed and the
+        // optimization never triggered in production.
+        tester().assertThat(new OptimizeRowInPredicate(tester().getMetadata()))
+                .setSystemProperty(OPTIMIZE_ROW_IN_PREDICATE, "true")
+                .on(p -> {
+                    VariableReferenceExpression c1 = p.variable("c1", VARCHAR);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    return p.filter(
+                            rowInWithFoldedCandidates(c1, c2),
+                            p.tableScan(
+                                    tableHandle(),
+                                    ImmutableList.of(c1, c2),
+                                    ImmutableMap.of(
+                                            c1, new TpchColumnHandle("c1", VARCHAR),
+                                            c2, new TpchColumnHandle("c2", BIGINT))));
+                })
+                .validates(plan -> {
+                    FilterNode filter = (FilterNode) plan.getRoot();
+                    List<RowExpression> conjuncts = extractConjuncts(filter.getPredicate());
+                    // Expect: c1 IN (a, b), c2 IN (1, 2), OR-of-ANDs
+                    assertEquals(conjuncts.size(), 3);
+                    assertColumnIn(conjuncts.get(0), "c1", 2);
+                    assertColumnIn(conjuncts.get(1), "c2", 2);
+                    assertEquals(extractDisjuncts(conjuncts.get(2)).size(), 2);
+                });
     }
 
     @Test


### PR DESCRIPTION
## Description

`OptimizeRowInPredicate` rewrites `ROW(a, b) IN ((..), (..), ...)` into per-column
equality disjunctions so the connector can derive per-column predicates and prune
partitions. While collecting the candidate rows from the `IN` list, it only recognized
candidates that appear as unfolded `ROW_CONSTRUCTOR` special-form expressions.

In real queries, the expression optimizer **constant-folds** literal rows such as
`(1, 2)` into a single `ConstantExpression` of `RowType` (whose value is a `Block`).
Because the rule did not recognize that shape, it bailed out (`Optional.empty()`) and the
rewrite **silently never fired in production** — it only worked in unit tests that
hand-built `ROW_CONSTRUCTOR` nodes.

This change adds `normalizeCandidateRow()`, which accepts both shapes:
- an unfolded `ROW_CONSTRUCTOR` (validating form + arity), and
- a constant-folded `RowType` `ConstantExpression`: it validates arity/shape and
  reconstructs per-field constant expressions by reading native values out of the row
  `Block` via `readNativeValue`.

Candidate rows are now normalized to `List<List<RowExpression>>`, and the downstream
disjunction/IN-list builders operate on that uniform representation.

## Motivation and Context

The `optimize_row_in_predicate` optimization was effectively a no-op for the literal
`ROW IN` lists that occur in practice, since those are constant-folded before the rule
runs. This fix makes the rule actually apply, enabling the intended per-column predicate
derivation and partition pruning.

## Impact

No new SQL syntax, configuration, or API. Behavioral fix for the existing
session-gated optimizer rule `optimize_row_in_predicate` (default off): it now fires on
constant-folded `ROW(...) IN (...)` predicates as intended. Plans for such queries gain
per-column predicates; results are unchanged.

## Test Plan

- Added unit coverage in `TestOptimizeRowInPredicate` for the constant-folded `RowType`
  candidate path (in addition to the existing `ROW_CONSTRUCTOR` cases).
- `./mvnw -pl presto-main-base -Dtest=TestOptimizeRowInPredicate test` →
  **Tests run: 9, Failures: 0, Errors: 0, Skipped: 0**.

## Contributor checklist

- [x] Please make sure your submission complies with our development and coding standards.
- [x] PR description addresses the issue accurately and concisely.
- [ ] Documented new properties, SQL syntax, functions, or other functionality (N/A).
- [x] If release notes are required, they follow the release notes guidelines.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix the ``optimize_row_in_predicate`` optimization so it applies to constant-folded ``ROW(...) IN (...)`` predicates, enabling per-column predicate derivation and partition pruning that previously did not occur.
```

## Summary by Sourcery

Handle constant-folded ROW literals in OptimizeRowInPredicate so row IN predicates are consistently rewritten into per-column predicates.

Bug Fixes:
- Ensure OptimizeRowInPredicate recognizes constant-folded RowType ConstantExpressions as candidate rows in ROW IN lists, fixing a case where the optimization previously never fired in real queries.

Tests:
- Add regression tests verifying that ROW IN rewrite fires when candidate rows are constant-folded, and that resulting per-column IN predicates are as expected.