### PR TITLE
feat(analyzer): Exclude stale materialized view partitions during stitching (#27944)

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -60,7 +60,6 @@ import static com.facebook.presto.hive.TestHiveLogicalPlanner.replicateHiveMetas
 import static com.facebook.presto.hive.TestHiveLogicalPlanner.utf8Slices;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
-import static com.facebook.presto.spi.plan.JoinType.LEFT;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -362,7 +361,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
                             ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_17 < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey")))));
+                    filter("((orderkey_17) < (BIGINT'10000')) AND (NOT(COALESCE((ds_19) = (VARCHAR'2019-01-02'), false)))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_19", "ds", "orderkey_17", "orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS test_orders_view");
@@ -406,7 +405,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                             filter("orderkey < BIGINT'100'", constrainedTableScan(table,
                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
                                     ImmutableMap.of("orderkey", "orderkey")))),
-                    filter("orderkey_62 < BIGINT'100'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_62", "orderkey")))));
+                    filter("((orderkey_62) < (BIGINT'100')) AND (NOT(COALESCE((ds_64) = (VARCHAR'2019-01-02'), false)))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_64", "ds", "orderkey_62", "orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -542,9 +541,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
                             ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2019-03-02", "2019-04-02", "2019-05-02", "2019-06-02", "2019-07-02"))),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_17 < BIGINT'10000'", constrainedTableScan(view,
-                            ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2020-01-01", "2019-01-02", "2019-02-02"))),
-                            ImmutableMap.of("orderkey_17", "orderkey")))));
+                    filter(constrainedTableScan(view, ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2020-01-01", "2019-01-02", "2019-02-02"))), ImmutableMap.of("ds_19", "ds", "orderkey_17", "orderkey")))));
 
             // if there are too many missing partitions, the optimization rewrite should not happen
             session = Session.builder(getQueryRunner().getDefaultSession())
@@ -594,7 +591,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
                             ImmutableMap.of("ds", create(ValueSet.of(createVarcharType(10), utf8Slice("2019-01-02")), true)),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_17 < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey")))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_19", "ds", "orderkey_17", "orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -635,7 +632,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02")),
                                     "orderpriority", multipleValues(createVarcharType(15), utf8Slices("1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW"))),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_17 < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey")))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_19", "ds", "orderkey_17", "orderkey", "orderpriority_18", "orderpriority")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -683,7 +680,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     filter("custkey_21 <= BIGINT'900'", constrainedTableScan(table2,
                                             ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                             ImmutableMap.of("custkey_21", "custkey"))))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("nationkey_68", "nationkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -729,7 +726,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     filter("custkey_21 >= BIGINT'1000'", constrainedTableScan(table2,
                             ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                             ImmutableMap.of("custkey_21", "custkey"))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("nationkey_68", "nationkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -772,7 +769,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                             ImmutableMap.of("ds_27", expression("'2019-01-02'")),
                             constrainedTableScan(table2,
                                     ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2019-01-02"))))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter("NOT(COALESCE((ds_32) = (VARCHAR'2019-01-02'), false))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_32", "ds")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -821,7 +818,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     filter("custkey_21 > BIGINT'900'", constrainedTableScan(table2,
                                             ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                             ImmutableMap.of("custkey_21", "custkey"))))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("nationkey_56", "nationkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -903,7 +900,7 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertPlan(getSession(), viewQuery, anyTree(
                     anyTree(constrainedTableScan(table,
                             ImmutableMap.of("shipmode", multipleValues(createVarcharType(10), utf8Slices("AIR", "FOB", "MAIL", "REG AIR", "SHIP", "TRUCK"))))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("shipmode_22", "shipmode")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -944,7 +941,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02")),
                                     "orderpriority", multipleValues(createVarcharType(15), utf8Slices("1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW"))),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_23 < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_23", "orderkey")))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_25", "ds", "orderkey_23", "orderkey", "orderpriority_24", "orderpriority")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -1000,7 +997,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                             ImmutableMap.of("nationkey", multipleValues(BIGINT,
                                                     ImmutableList.of(0L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 18L, 19L, 20L, 21L, 22L, 23L))),
                                             ImmutableMap.of("r_nationkey", "nationkey")))),
-                            constrainedTableScan(view, ImmutableMap.of())));
+                            filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("nationkey_106", "nationkey", "regionkey_107", "regionkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -1201,13 +1198,13 @@ public class TestHiveMaterializedViewLogicalPlanner
                     anyTree(constrainedTableScan(table, ImmutableMap.of(
                             "shipmode", multipleValues(createVarcharType(10), utf8Slices("AIR", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK")),
                             "ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))))),
-                    constrainedTableScan(view, ImmutableMap.of())));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("mvds", "mvds", "shipmode_27", "shipmode")))));
 
             assertPlan(queryOptimizationWithMaterializedView, baseQuery, anyTree(
                     anyTree(constrainedTableScan(table, ImmutableMap.of(
                             "shipmode", multipleValues(createVarcharType(10), utf8Slices("AIR", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK")),
                             "ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))))),
-                    anyTree(constrainedTableScan(view, ImmutableMap.of()))));
+                    anyTree(filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("mvds", "mvds", "shipmode_27", "shipmode"))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -1796,7 +1793,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     anyTree(filter("orderkey < BIGINT'10000'", constrainedTableScan(table1,
                                             ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
                                             ImmutableMap.of("orderkey", "orderkey")))))),
-                    filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+                    filter("((view_orderkey) < (BIGINT'10000')) AND (NOT(COALESCE((ds_35) = (VARCHAR'2019-01-02'), false)))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_35", "ds", "view_orderkey", "view_orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -1843,7 +1840,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     constrainedTableScan(table,
                             ImmutableMap.of("ds", multipleValues(createVarcharType(10), utf8Slices("2021-07-11"))),
                             ImmutableMap.of()),
-                    constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_43", "orderkey")));
+                    filter("NOT(COALESCE((ds_44) = (VARCHAR'2021-07-11'), false))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_44", "ds"))));
 
             String baseQuery = format("SELECT orderkey FROM %s ORDER BY orderkey", table);
 
@@ -2276,7 +2273,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                                                             constrainedTableScan(table1,
                                                                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
                                                                                     ImmutableMap.of("orderkey", "orderkey")))))))),
-                            filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+                            filter("((view_orderkey) < (BIGINT'10000')) AND (NOT(COALESCE((ds_59) = (VARCHAR'2019-01-02'), false)))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_59", "ds", "view_orderkey", "view_orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2313,7 +2310,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                     filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
                             ImmutableMap.of("totalprice", multipleValues(DOUBLE, ImmutableList.of(105367.67, 172799.49, 205654.3, 271885.66))),
                             ImmutableMap.of("orderkey", "orderkey"))),
-                    filter("orderkey_17 < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey")))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey", "totalprice_19", "totalprice")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2438,10 +2435,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                             table,
                             ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))),
                             ImmutableMap.of())),
-                    constrainedTableScan(
-                            view,
-                            ImmutableMap.of(),
-                            ImmutableMap.of()))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_21", "ds"))))));
 
             Session queryOptimizationWithMaterializedView = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
@@ -2458,10 +2452,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     table,
                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))),
                                     ImmutableMap.of())),
-                            anyTree(constrainedTableScan(
-                                    view,
-                                    ImmutableMap.of(),
-                                    ImmutableMap.of())))));
+                            anyTree(filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_21", "ds")))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2513,10 +2504,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                             table,
                             ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))),
                             ImmutableMap.of())),
-                    constrainedTableScan(
-                            view,
-                            ImmutableMap.of(),
-                            ImmutableMap.of()))));
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_mv", "ds_mv"))))));
 
             Session queryOptimizationWithMaterializedView = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
@@ -2533,10 +2521,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                     table,
                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))),
                                     ImmutableMap.of())),
-                            anyTree(constrainedTableScan(
-                                    view,
-                                    ImmutableMap.of(),
-                                    ImmutableMap.of())))));
+                            anyTree(filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_mv", "ds_mv")))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2863,15 +2848,14 @@ public class TestHiveMaterializedViewLogicalPlanner
             MaterializedResult baseTable = computeActual(baseQuery);
             assertEquals(viewTable, baseTable);
 
+            // Partition columns come from different base tables, so recompute uses an outer filter over the
+            // view definition; the exclusion predicate's term order is non-deterministic, so assert structure: a join
+            // over both bases plus a filter over the view scan (the exact predicate is covered by unit tests).
             assertPlan(getSession(), viewQuery, anyTree(
-                    join(INNER, ImmutableList.of(),
-                            filter("orderkey < BIGINT'10000'", constrainedTableScan(table1,
-                                    ImmutableMap.of(
-                                            "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02")),
-                                            "orderpriority", multipleValues(createVarcharType(15), utf8Slices("1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW"))),
-                                    ImmutableMap.of("orderkey", "orderkey"))),
-                            anyTree(constrainedTableScan(table2, ImmutableMap.of()))),
-                    filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+                    anyTree(node(JoinNode.class,
+                            anyTree(constrainedTableScan(table1, ImmutableMap.of(), ImmutableMap.of())),
+                            anyTree(constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of())))),
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2961,22 +2945,14 @@ public class TestHiveMaterializedViewLogicalPlanner
             MaterializedResult baseTable = computeActual(baseQuery);
             assertEquals(viewTable, baseTable);
 
+            // Partition columns come from different base tables, so recompute uses an outer filter over the
+            // view definition; the exclusion predicate's term order is non-deterministic, so assert structure: a join
+            // over both bases plus a filter over the view scan (the exact predicate is covered by unit tests).
             assertPlan(getSession(), viewQuery, anyTree(
-                    project(
-                            join(LEFT, ImmutableList.of(equiJoinClause("expr_6", "expr_23"), equiJoinClause("orderkey", "orderkey_7")),
-                                    anyTree(
-                                            project(
-                                                    ImmutableMap.of("expr_6", expression("'2019-01-02'")),
-                                                    filter("orderkey < BIGINT'10000'",
-                                                            constrainedTableScan(table1,
-                                                                    ImmutableMap.of(
-                                                                            "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
-                                                                    ImmutableMap.of("orderkey", "orderkey"))))),
-                                    anyTree(
-                                            project(ImmutableMap.of("expr_23", expression("'2019-01-02'")),
-                                                    anyTree(
-                                                            constrainedTableScan(table2, ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))), ImmutableMap.of("totalprice", "totalprice", "orderkey_7", "orderkey"))))))),
-                    filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+                    anyTree(node(JoinNode.class,
+                            anyTree(constrainedTableScan(table1, ImmutableMap.of(), ImmutableMap.of())),
+                            anyTree(constrainedTableScan(table2, ImmutableMap.of(), ImmutableMap.of())))),
+                    filter(constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -3154,7 +3130,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                             unnest(filter("orderkey < BIGINT'10000'", constrainedTableScan(table,
                                     ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
                                     ImmutableMap.of("orderkey", "orderkey"))))),
-                    filter("view_orderkey < BIGINT'10000'", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+                    filter("((view_orderkey) < (BIGINT'10000')) AND (NOT(COALESCE((ds_18) = (VARCHAR'2019-01-02'), false)))", constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("ds_18", "ds", "view_orderkey", "view_orderkey")))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Expression;
@@ -42,7 +43,7 @@ import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
-import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.Rollup;
@@ -59,7 +60,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,13 +71,12 @@ import static com.facebook.presto.common.predicate.TupleDomain.extractFixedValue
 import static com.facebook.presto.common.type.StandardTypes.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjuncts;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.tree.ArithmeticBinaryExpression.Operator.DIVIDE;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
-import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.AND;
-import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.OR;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -148,46 +148,100 @@ public final class MaterializedViewUtils
     public static Map<SchemaTableName, Expression> generateBaseTablePredicates(Map<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> predicatesFromBaseTables, Metadata metadata)
     {
         Map<SchemaTableName, Expression> baseTablePredicates = new HashMap<>();
-
-        for (SchemaTableName baseTable : predicatesFromBaseTables.keySet()) {
-            MaterializedViewStatus.MaterializedDataPredicates predicatesInfo = predicatesFromBaseTables.get(baseTable);
-            List<String> partitionKeys = predicatesInfo.getColumnNames();
-            ImmutableList<Expression> keyExpressions = partitionKeys.stream().map(Identifier::new).collect(toImmutableList());
-            List<TupleDomain<String>> predicateDisjuncts = predicatesInfo.getPredicateDisjuncts();
-            Expression disjunct = null;
-
-            for (TupleDomain<String> predicateDisjunct : predicateDisjuncts) {
-                Expression conjunct = null;
-                Iterator<Expression> keyExpressionsIterator = keyExpressions.stream().iterator();
-                Map<String, NullableValue> predicateKeyValue = extractFixedValues(predicateDisjunct)
-                        .orElseThrow(() -> new IllegalStateException("predicateKeyValue is not present!"));
-
-                for (String key : partitionKeys) {
-                    NullableValue nullableValue = predicateKeyValue.get(key);
-                    Expression expression;
-
-                    if (nullableValue.isNull()) {
-                        expression = new IsNullPredicate(keyExpressionsIterator.next());
-                    }
-                    else {
-                        LiteralEncoder literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
-                        Expression valueExpression = literalEncoder.toExpression(nullableValue.getValue(), nullableValue.getType(), false);
-                        expression = new ComparisonExpression(EQUAL, keyExpressionsIterator.next(), valueExpression);
-                    }
-
-                    conjunct = conjunct == null ? expression : new LogicalBinaryExpression(AND, conjunct, expression);
-                }
-
-                disjunct = conjunct == null ? disjunct : disjunct == null ? conjunct : new LogicalBinaryExpression(OR, disjunct, conjunct);
-            }
-            // If no (fresh) partitions are found for table, that means we should not select from it
-            if (disjunct == null) {
-                disjunct = FALSE_LITERAL;
-            }
-            baseTablePredicates.put(baseTable, disjunct);
+        for (Map.Entry<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> entry : predicatesFromBaseTables.entrySet()) {
+            baseTablePredicates.put(entry.getKey(), buildPartitionPredicate(entry.getValue(), metadata));
         }
-
         return baseTablePredicates;
+    }
+
+    // True when a recompute column doesn't map to every base table (UNION/outer-join) and so can't be folded per base.
+    public static boolean requiresOuterFilter(
+            Optional<MaterializedViewStatus.MaterializedDataPredicates> partitionsToRecompute,
+            Map<String, Map<SchemaTableName, String>> viewToBaseColumnMappings,
+            List<SchemaTableName> baseTables)
+    {
+        if (!partitionsToRecompute.isPresent() || partitionsToRecompute.get().isEmpty()) {
+            return false;
+        }
+        for (String viewColumn : partitionsToRecompute.get().getColumnNames()) {
+            if (!viewToBaseColumnMappings.getOrDefault(viewColumn, ImmutableMap.of()).keySet().containsAll(baseTables)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Renders partitions as (k = v AND ...) OR ... (FALSE when empty). Literals carry no CAST so the query round-trips.
+    private static Expression buildPartitionPredicate(MaterializedViewStatus.MaterializedDataPredicates predicatesInfo, Metadata metadata)
+    {
+        LiteralEncoder literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
+        List<Expression> disjuncts = new ArrayList<>();
+        for (TupleDomain<String> predicateDisjunct : predicatesInfo.getPredicateDisjuncts()) {
+            Map<String, NullableValue> predicateKeyValue = extractFixedValues(predicateDisjunct)
+                    .orElseThrow(() -> new IllegalStateException("predicateKeyValue is not present!"));
+            List<Expression> conjuncts = new ArrayList<>();
+            for (String key : predicatesInfo.getColumnNames()) {
+                NullableValue nullableValue = predicateKeyValue.get(key);
+                if (nullableValue == null) {
+                    continue;
+                }
+                Identifier column = new Identifier(key);
+                conjuncts.add(nullableValue.isNull()
+                        ? new IsNullPredicate(column)
+                        : new ComparisonExpression(EQUAL, column, literalEncoder.toExpression(nullableValue.getValue(), nullableValue.getType(), false)));
+            }
+            if (!conjuncts.isEmpty()) {
+                disjuncts.add(combineConjuncts(conjuncts));
+            }
+        }
+        return disjuncts.isEmpty() ? FALSE_LITERAL : combineDisjuncts(disjuncts);
+    }
+
+    // NULL-safe negation of buildPartitionsToRecomputeFilter (COALESCE keeps fresh NULL-partition rows) so each partition is served once.
+    public static Optional<Expression> buildMaterializedViewScanFilter(Optional<MaterializedViewStatus.MaterializedDataPredicates> partitionsToExclude, Metadata metadata)
+    {
+        return buildPartitionsToRecomputeFilter(partitionsToExclude, metadata)
+                .map(recomputeFilter -> new NotExpression(new CoalesceExpression(recomputeFilter, FALSE_LITERAL)));
+    }
+
+    // Positive predicate selecting exactly the partitions to recompute; negated, it is the view-scan exclusion.
+    public static Optional<Expression> buildPartitionsToRecomputeFilter(Optional<MaterializedViewStatus.MaterializedDataPredicates> partitionsToRecompute, Metadata metadata)
+    {
+        if (!partitionsToRecompute.isPresent() || partitionsToRecompute.get().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(buildPartitionPredicate(partitionsToRecompute.get(), metadata));
+    }
+
+    // Projects the per-base recompute partitions back into view-column space (inverse of viewToBaseColumnMappings).
+    // Unmapped columns are dropped (partial tuples are expected for joins).
+    public static MaterializedViewStatus.MaterializedDataPredicates projectBaseTablePartitionsToView(
+            Map<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> partitionsFromBaseTables,
+            Map<String, Map<SchemaTableName, String>> viewToBaseColumnMappings)
+    {
+        List<TupleDomain<String>> viewDisjuncts = new ArrayList<>();
+        Set<String> viewColumns = new LinkedHashSet<>();
+        for (Map.Entry<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> entry : partitionsFromBaseTables.entrySet()) {
+            SchemaTableName baseTable = entry.getKey();
+            Map<String, String> baseToViewColumn = new HashMap<>();
+            for (Map.Entry<String, Map<SchemaTableName, String>> mapping : viewToBaseColumnMappings.entrySet()) {
+                String baseColumn = mapping.getValue().get(baseTable);
+                if (baseColumn != null) {
+                    baseToViewColumn.put(baseColumn, mapping.getKey());
+                }
+            }
+            MaterializedViewStatus.MaterializedDataPredicates basePredicates = entry.getValue();
+            for (String baseColumn : basePredicates.getColumnNames()) {
+                String viewColumn = baseToViewColumn.get(baseColumn);
+                if (viewColumn != null) {
+                    viewColumns.add(viewColumn);
+                }
+            }
+            for (TupleDomain<String> disjunct : basePredicates.getPredicateDisjuncts()) {
+                viewDisjuncts.add(disjunct.transform(baseToViewColumn::get));
+            }
+        }
+        return new MaterializedViewStatus.MaterializedDataPredicates(viewDisjuncts, ImmutableList.copyOf(viewColumns));
     }
 
     public static Map<SchemaTableName, Expression> generateFalsePredicates(List<SchemaTableName> baseTables)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -293,10 +293,14 @@ import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProce
 import static com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure.extractZOrderColumns;
 import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
+import static com.facebook.presto.sql.MaterializedViewUtils.buildMaterializedViewScanFilter;
 import static com.facebook.presto.sql.MaterializedViewUtils.buildOwnerSession;
+import static com.facebook.presto.sql.MaterializedViewUtils.buildPartitionsToRecomputeFilter;
 import static com.facebook.presto.sql.MaterializedViewUtils.generateBaseTablePredicates;
 import static com.facebook.presto.sql.MaterializedViewUtils.generateFalsePredicates;
 import static com.facebook.presto.sql.MaterializedViewUtils.getOwnerIdentity;
+import static com.facebook.presto.sql.MaterializedViewUtils.projectBaseTablePartitionsToView;
+import static com.facebook.presto.sql.MaterializedViewUtils.requiresOuterFilter;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.QueryUtil.selectList;
@@ -2793,13 +2797,33 @@ class StatementAnalyzer
             Statement createSqlStatement = sqlParser.createStatement(materializedViewCreateSql, createParsingOptions(session, warningCollector));
 
             Map<SchemaTableName, Expression> baseTablePredicates = emptyMap();
+            Optional<Expression> materializedViewScanFilter = Optional.empty();
+            Optional<Expression> outerBaseTablesFilter = Optional.empty();
             if (materializedViewStatus.isFullyMaterialized()) {
                 // We need to include base table queries by Union in order to add required access control for the base tables and utilized columns during visit.
                 // Here we stitch with the predicate WHERE FALSE, and the optimizer will then prune the FALSE branch with no extra overhead introduced.
                 baseTablePredicates = generateFalsePredicates(materializedViewDefinition.getBaseTables());
             }
             else if (materializedViewStatus.isPartiallyMaterialized()) {
-                baseTablePredicates = generateBaseTablePredicates(materializedViewStatus.getPartitionsFromBaseTables(), metadata);
+                Map<String, Map<SchemaTableName, String>> columnMappings = materializedViewDefinition.getDirectColumnMappingsAsMap();
+                List<SchemaTableName> baseTables = materializedViewDefinition.getBaseTables();
+                Map<SchemaTableName, MaterializedViewStatus.MaterializedDataPredicates> partitionsFromBaseTables = materializedViewStatus.getPartitionsFromBaseTables();
+
+                // Connector reports the predicates to recompute in base space; project to view space for the scan exclusion.
+                Optional<MaterializedViewStatus.MaterializedDataPredicates> mvPredicatesToRecompute =
+                        Optional.of(projectBaseTablePartitionsToView(partitionsFromBaseTables, columnMappings));
+                materializedViewScanFilter = buildMaterializedViewScanFilter(mvPredicatesToRecompute, metadata);
+                if (requiresOuterFilter(mvPredicatesToRecompute, columnMappings, baseTables)) {
+                    // A recompute column doesn't map onto every base (cross-base join, UNION constant, OUTER JOIN): recompute
+                    // via one outer filter over the view definition. The per-base branch would emit WHERE FALSE on the
+                    // non-recomputing join side and drop the new partitions, so prune it.
+                    outerBaseTablesFilter = buildPartitionsToRecomputeFilter(mvPredicatesToRecompute, metadata);
+                    baseTablePredicates = generateFalsePredicates(baseTables);
+                }
+                else {
+                    // Single base, or partition keys shared across all bases: recompute per base table.
+                    baseTablePredicates = generateBaseTablePredicates(partitionsFromBaseTables, metadata);
+                }
             }
 
             Query predicateStitchedQuery = (Query) new PredicateStitcher(session, baseTablePredicates, metadata).process(createSqlStatement, new PredicateStitcherContext());
@@ -2808,7 +2832,7 @@ class StatementAnalyzer
             QuerySpecification materializedViewQuerySpecification = new QuerySpecification(
                     selectList(new AllColumns()),
                     Optional.of(materializedView),
-                    Optional.empty(),
+                    materializedViewScanFilter,
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
@@ -2817,11 +2841,17 @@ class StatementAnalyzer
 
             // When union, keep predicateStitchedQuery before materializedViewQuerySpecification. Given Scope of Union contains RelationType of the first Relation,
             // this would allow utilizedTableColumnReferences to trace back to base table columns, which is required for correct materialized view access control.
-            Union union = new Union(ImmutableList.of(predicateStitchedQuery.getQueryBody(), materializedViewQuerySpecification), Optional.of(Boolean.FALSE));
+            ImmutableList.Builder<Relation> unionRelations = ImmutableList.builder();
+            unionRelations.add(predicateStitchedQuery.getQueryBody());
+            if (outerBaseTablesFilter.isPresent()) {
+                // Recompute fresh data from the base tables via the outer filter over the view definition.
+                Query freshDataFromBaseTables = (Query) sqlParser.createStatement(materializedViewCreateSql, createParsingOptions(session, warningCollector));
+                unionRelations.add(buildSubqueryWithPredicate(freshDataFromBaseTables, outerBaseTablesFilter.get()).getQueryBody());
+            }
+            unionRelations.add(materializedViewQuerySpecification);
+            Union union = new Union(unionRelations.build(), Optional.of(Boolean.FALSE));
             Query unionQuery = new Query(predicateStitchedQuery.getWith(), union, predicateStitchedQuery.getOrderBy(), predicateStitchedQuery.getOffset(), predicateStitchedQuery.getLimit());
-            // can we return the above query object, instead of building a query string?
-            // in case of returning the query object, make sure to clone the original query object.
-            return getFormattedSql(unionQuery, sqlParser, Optional.empty());
+            return formatSql(unionQuery, Optional.empty());
         }
 
         /**

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestMaterializedViewUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestMaterializedViewUtils.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.NullableValue;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.CoalesceExpression;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QueryBody;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.Union;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.sql.MaterializedViewUtils.buildMaterializedViewScanFilter;
+import static com.facebook.presto.sql.MaterializedViewUtils.buildPartitionsToRecomputeFilter;
+import static com.facebook.presto.sql.MaterializedViewUtils.generateBaseTablePredicates;
+import static com.facebook.presto.sql.MaterializedViewUtils.generateFalsePredicates;
+import static com.facebook.presto.sql.MaterializedViewUtils.requiresOuterFilter;
+import static com.facebook.presto.sql.SqlFormatter.formatSql;
+import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
+import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
+import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.AND;
+import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.OR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.stream.Collectors.joining;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestMaterializedViewUtils
+{
+    private final Metadata metadata = createTestMetadataManager();
+    private static final SchemaTableName BASE_A = new SchemaTableName("s", "base_a");
+    private static final SchemaTableName BASE_B = new SchemaTableName("s", "base_b");
+
+    @Test
+    public void testEmptyReturnsNoFilter()
+    {
+        assertFalse(buildMaterializedViewScanFilter(Optional.empty(), metadata).isPresent());
+        assertFalse(buildMaterializedViewScanFilter(Optional.of(predicates(ImmutableList.of(), "ds")), metadata).isPresent());
+    }
+
+    @Test
+    public void testSinglePartitionNegated()
+    {
+        Optional<Expression> filter = buildMaterializedViewScanFilter(
+                Optional.of(predicates(ImmutableList.of(partition("ds", "2026-05-25")), "ds")), metadata);
+
+        assertTrue(innerOf(filter) instanceof ComparisonExpression);
+    }
+
+    @Test
+    public void testMultiplePartitionsNegatedDisjunction()
+    {
+        Optional<Expression> filter = buildMaterializedViewScanFilter(
+                Optional.of(predicates(ImmutableList.of(partition("ds", "2026-05-25"), partition("ds", "2026-05-26")), "ds")), metadata);
+
+        Expression inner = innerOf(filter);
+        assertTrue(inner instanceof LogicalBinaryExpression);
+        assertEquals(((LogicalBinaryExpression) inner).getOperator(), LogicalBinaryExpression.Operator.OR);
+    }
+
+    @Test
+    public void testMultiColumnPartitionNegatedConjunction()
+    {
+        Optional<Expression> filter = buildMaterializedViewScanFilter(
+                Optional.of(predicates(ImmutableList.of(partition2("ds", "2026-05-25", "region", "us")), "ds", "region")), metadata);
+
+        Expression inner = innerOf(filter);
+        assertTrue(inner instanceof LogicalBinaryExpression);
+        assertEquals(((LogicalBinaryExpression) inner).getOperator(), LogicalBinaryExpression.Operator.AND);
+    }
+
+    @Test
+    public void testPartialColumnMappingBaseTablePredicate()
+    {
+        // Collapsed disjuncts must render without a ts predicate (buildPartitionPredicate skips absent columns).
+        SchemaTableName baseTable = new SchemaTableName("schema", "base");
+        MaterializedDataPredicates predicatesInfo = predicates(
+                ImmutableList.of(
+                        partition3("ds", "d", "ts", "t1", "c", "c2"),
+                        partition3("ds", "d", "ts", "t1", "c", "c3"),
+                        partition3("ds", "d", "ts", "t2", "c", "c2"),
+                        partition2("ds", "d", "c", "c1")),
+                "ds", "ts", "c");
+
+        Expression predicate = generateBaseTablePredicates(ImmutableMap.of(baseTable, predicatesInfo), metadata).get(baseTable);
+
+        Set<String> renderedDisjuncts = flatten(predicate, OR).stream()
+                .map(TestMaterializedViewUtils::renderConjunction)
+                .collect(toImmutableSet());
+
+        assertEquals(renderedDisjuncts, ImmutableSet.of(
+                "c=c2 AND ds=d AND ts=t1",
+                "c=c3 AND ds=d AND ts=t1",
+                "c=c2 AND ds=d AND ts=t2",
+                "c=c1 AND ds=d"));
+    }
+
+    private static String renderConjunction(Expression conjunction)
+    {
+        return flatten(conjunction, AND).stream()
+                .map(conjunct -> {
+                    ComparisonExpression comparison = (ComparisonExpression) conjunct;
+                    return ((Identifier) comparison.getLeft()).getValue() + "=" + valueOf(comparison.getRight());
+                })
+                .sorted()
+                .collect(joining(" AND "));
+    }
+
+    private static String valueOf(Expression expression)
+    {
+        if (expression instanceof Cast) {
+            expression = ((Cast) expression).getExpression();
+        }
+        return ((StringLiteral) expression).getValue();
+    }
+
+    private static List<Expression> flatten(Expression expression, LogicalBinaryExpression.Operator operator)
+    {
+        if (expression instanceof LogicalBinaryExpression && ((LogicalBinaryExpression) expression).getOperator() == operator) {
+            LogicalBinaryExpression binary = (LogicalBinaryExpression) expression;
+            return ImmutableList.<Expression>builder()
+                    .addAll(flatten(binary.getLeft(), operator))
+                    .addAll(flatten(binary.getRight(), operator))
+                    .build();
+        }
+        return ImmutableList.of(expression);
+    }
+
+    @Test
+    public void testGenerateBaseTablePredicatesRendersMissing()
+    {
+        SchemaTableName base1 = new SchemaTableName("s", "base1");
+        Map<SchemaTableName, MaterializedDataPredicates> missing = ImmutableMap.of(
+                base1, predicates(ImmutableList.of(partition("ds", "2026-08-02")), "ds"));
+        assertEquals(renderConjunction(generateBaseTablePredicates(missing, metadata).get(base1)), "ds=2026-08-02");
+    }
+
+    @Test
+    public void testBuildPartitionsToRecomputeFilterIsPositiveFullTuple()
+    {
+        // Positive full tuple; the view-scan exclusion is exactly NOT(COALESCE(<this>, false)).
+        MaterializedDataPredicates toRecompute = predicates(ImmutableList.of(partition2("ds", "2026-06-10", "country", "us")), "ds", "country");
+        assertEquals(renderConjunction(buildPartitionsToRecomputeFilter(Optional.of(toRecompute), metadata).get()), "country=us AND ds=2026-06-10");
+        assertEquals(renderConjunction(innerOf(buildMaterializedViewScanFilter(Optional.of(toRecompute), metadata))), "country=us AND ds=2026-06-10");
+        assertFalse(buildPartitionsToRecomputeFilter(Optional.empty(), metadata).isPresent());
+    }
+
+    @Test
+    public void testScanFilterIsNullSafeForFreshNullPartition()
+    {
+        // COALESCE(<predicate>, false) keeps fresh NULL-partition rows: bare NOT(ds='...') is UNKNOWN for NULL ds and drops them.
+        Optional<Expression> filter = buildMaterializedViewScanFilter(
+                Optional.of(predicates(ImmutableList.of(partition("ds", "2026-05-25")), "ds")), metadata);
+        assertTrue(filter.isPresent());
+        assertTrue(filter.get() instanceof NotExpression);
+        Expression coalesce = ((NotExpression) filter.get()).getValue();
+        assertTrue(coalesce instanceof CoalesceExpression, "expected NULL-safe COALESCE(<predicate>, false) wrapper");
+        List<Expression> operands = ((CoalesceExpression) coalesce).getOperands();
+        assertEquals(operands.size(), 2);
+        assertEquals(operands.get(1), FALSE_LITERAL);
+        assertTrue(operands.get(0) instanceof ComparisonExpression);
+    }
+
+    @Test
+    public void testScanFilterWithNullAndNonNullPartitions()
+    {
+        // A genuinely NULL partition plus a non-null one renders (ds IS NULL) OR (ds = '2026-05-25').
+        MaterializedDataPredicates toRecompute = predicates(ImmutableList.of(nullPartition("ds"), partition("ds", "2026-05-25")), "ds");
+        Set<String> kinds = flatten(innerOf(buildMaterializedViewScanFilter(Optional.of(toRecompute), metadata)), OR).stream()
+                .map(disjunct -> disjunct.getClass().getSimpleName())
+                .collect(toImmutableSet());
+        assertEquals(kinds, ImmutableSet.of("IsNullPredicate", "ComparisonExpression"));
+    }
+
+    @Test
+    public void testGenerateBaseTablePredicatesNoMissingForBaseRendersFalse()
+    {
+        // No missing partitions -> FALSE so PredicateStitcher prunes the base scan (an absent base is left unfiltered).
+        Map<SchemaTableName, MaterializedDataPredicates> noMissing = ImmutableMap.of(BASE_A, predicates(ImmutableList.of(), "ds"));
+        assertEquals(generateBaseTablePredicates(noMissing, metadata).get(BASE_A), FALSE_LITERAL);
+    }
+
+    @Test
+    public void testGenerateFalsePredicatesForFullyMaterialized()
+    {
+        // Fully materialized: every base stitched FALSE so the query is served entirely from the view scan.
+        Map<SchemaTableName, Expression> predicates = generateFalsePredicates(ImmutableList.of(BASE_A, BASE_B));
+        assertEquals(predicates.get(BASE_A), FALSE_LITERAL);
+        assertEquals(predicates.get(BASE_B), FALSE_LITERAL);
+    }
+
+    @Test
+    public void testRequiresOuterFilter()
+    {
+        Optional<MaterializedDataPredicates> toRecompute = Optional.of(predicates(ImmutableList.of(partition("ds", "2026-06-10")), "ds"));
+        Map<String, Map<SchemaTableName, String>> dsToA = ImmutableMap.of("ds", ImmutableMap.of(BASE_A, "ds"));
+
+        // Single base, column maps -> no outer filter (foldable fast path).
+        assertFalse(requiresOuterFilter(toRecompute, dsToA, ImmutableList.of(BASE_A)));
+        // Inner join, shared key maps to every base -> no outer filter (foldable fast path).
+        Map<String, Map<SchemaTableName, String>> dsToBoth = ImmutableMap.of("ds", ImmutableMap.of(BASE_A, "ds", BASE_B, "ds"));
+        assertFalse(requiresOuterFilter(toRecompute, dsToBoth, ImmutableList.of(BASE_A, BASE_B)));
+        // ds maps to BASE_A but not BASE_B -> outer filter.
+        assertTrue(requiresOuterFilter(toRecompute, dsToA, ImmutableList.of(BASE_A, BASE_B)));
+        // Join with partition columns from different base tables (an->A, bn->B) -> outer filter.
+        Optional<MaterializedDataPredicates> joinKeys = Optional.of(
+                predicates(ImmutableList.of(partition2("an", "US", "bn", "FR")), "an", "bn"));
+        Map<String, Map<SchemaTableName, String>> anToAbnToB = ImmutableMap.of(
+                "an", ImmutableMap.of(BASE_A, "an"),
+                "bn", ImmutableMap.of(BASE_B, "bn"));
+        assertTrue(requiresOuterFilter(joinKeys, anToAbnToB, ImmutableList.of(BASE_A, BASE_B)));
+        // UNION constant: a "source" column unmapped to any base -> outer filter.
+        Optional<MaterializedDataPredicates> recomputeWithConstant = Optional.of(
+                predicates(ImmutableList.of(partition2("ds", "2026-06-10", "source", "app")), "ds", "source"));
+        assertTrue(requiresOuterFilter(recomputeWithConstant, dsToA, ImmutableList.of(BASE_A)));
+        // Empty -> no outer filter.
+        assertFalse(requiresOuterFilter(Optional.empty(), ImmutableMap.of(), ImmutableList.of(BASE_A)));
+    }
+
+    @Test
+    public void testUnionArityTwoVsThreeBranches()
+    {
+        // 2 branches (per-base recompute + view scan), plus a 3rd outer-filter branch iff requiresOuterFilter.
+        Optional<MaterializedDataPredicates> toRecompute = Optional.of(predicates(ImmutableList.of(partition("ds", "2026-06-10")), "ds"));
+        Map<String, Map<SchemaTableName, String>> dsToA = ImmutableMap.of("ds", ImmutableMap.of(BASE_A, "ds"));
+
+        // Maps to the only base -> 2-way union.
+        assertEquals(unionBranches(toRecompute, dsToA, ImmutableList.of(BASE_A)), 2);
+        // ds maps to BASE_A but not BASE_B -> outer filter -> 3-way union.
+        assertEquals(unionBranches(toRecompute, dsToA, ImmutableList.of(BASE_A, BASE_B)), 3);
+        // Empty -> 2-way union (legacy shape).
+        assertEquals(unionBranches(Optional.empty(), ImmutableMap.of(), ImmutableList.of(BASE_A)), 2);
+    }
+
+    private int unionBranches(Optional<MaterializedDataPredicates> toRecompute,
+            Map<String, Map<SchemaTableName, String>> mappings, List<SchemaTableName> baseTables)
+    {
+        return 2 + (requiresOuterFilter(toRecompute, mappings, baseTables) ? 1 : 0);
+    }
+
+    @Test
+    public void testFlatThreeWayUnionRequiresFormatSql()
+    {
+        // The 3-way stitched union is built flat (new Union of three branches). getFormattedSql rejects it because the
+        // parser re-associates `a UNION ALL b UNION ALL c` into left-nested binary unions and the structural round-trip
+        // check fails; formatSql produces correct SQL (the caller re-parses it). This is why the outer-filter path uses
+        // formatSql instead of getFormattedSql.
+        SqlParser sqlParser = new SqlParser();
+        ParsingOptions options = new ParsingOptions();
+        Union flat = new Union(ImmutableList.of(
+                queryBody(sqlParser, options, "SELECT 1 AS x"),
+                queryBody(sqlParser, options, "SELECT 2 AS x"),
+                queryBody(sqlParser, options, "SELECT 3 AS x")), Optional.of(false));
+        Query unionQuery = query(flat);
+
+        expectThrows(PrestoException.class, () -> getFormattedSql(unionQuery, sqlParser, Optional.empty()));
+        formatSql(unionQuery, Optional.empty());
+    }
+
+    private static QueryBody queryBody(SqlParser sqlParser, ParsingOptions options, String sql)
+    {
+        return ((Query) sqlParser.createStatement(sql, options)).getQueryBody();
+    }
+
+    private static Query query(QueryBody queryBody)
+    {
+        return new Query(Optional.empty(), queryBody, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static Set<String> disjunctsOf(Expression predicate)
+    {
+        return flatten(predicate, OR).stream().map(TestMaterializedViewUtils::renderConjunction).collect(toImmutableSet());
+    }
+
+    private static TupleDomain<String> nullPartition(String column)
+    {
+        return TupleDomain.fromFixedValues(ImmutableMap.of(column, NullableValue.asNull(VARCHAR)));
+    }
+
+    private static Expression innerOf(Optional<Expression> filter)
+    {
+        assertTrue(filter.isPresent());
+        assertTrue(filter.get() instanceof NotExpression);
+        Expression coalesce = ((NotExpression) filter.get()).getValue();
+        assertTrue(coalesce instanceof CoalesceExpression, "expected NULL-safe COALESCE(<predicate>, false) wrapper");
+        List<Expression> operands = ((CoalesceExpression) coalesce).getOperands();
+        assertEquals(operands.size(), 2);
+        assertEquals(operands.get(1), FALSE_LITERAL);
+        return operands.get(0);
+    }
+
+    private static TupleDomain<String> partition(String column, String value)
+    {
+        return TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.singleValue(VARCHAR, utf8Slice(value))));
+    }
+
+    private static TupleDomain<String> partition2(String column1, String value1, String column2, String value2)
+    {
+        return TupleDomain.withColumnDomains(ImmutableMap.of(
+                column1, Domain.singleValue(VARCHAR, utf8Slice(value1)),
+                column2, Domain.singleValue(VARCHAR, utf8Slice(value2))));
+    }
+
+    private static TupleDomain<String> partition3(String column1, String value1, String column2, String value2, String column3, String value3)
+    {
+        return TupleDomain.withColumnDomains(ImmutableMap.of(
+                column1, Domain.singleValue(VARCHAR, utf8Slice(value1)),
+                column2, Domain.singleValue(VARCHAR, utf8Slice(value2)),
+                column3, Domain.singleValue(VARCHAR, utf8Slice(value3))));
+    }
+
+    private static MaterializedDataPredicates predicates(List<TupleDomain<String>> disjuncts, String... columns)
+    {
+        return new MaterializedDataPredicates(disjuncts, ImmutableList.copyOf(columns));
+    }
+}


### PR DESCRIPTION
Summary:

When a query reads a partially materialized view, stitching recomputes the partitions that are not current from the base tables and serves the rest from the view. The connector reports two kinds of such partitions: missing (never materialized) and stale (materialized but the base changed afterwards). Previously these were modeled separately and stale partitions could be read from both the base recompute and the view scan and counted twice (duplicate rows or inflated aggregates).

This unifies the two. The connector reports a single set of partitions to recompute, expressed in base-table partition space, via `MaterializedViewStatus.getPartitionsFromBaseTables`; the separate `staleMaterializedViewPartitions` SPI field is removed. The engine projects that set back to view-column space (`projectBaseTablePartitionsToView`) and uses it for two symmetric purposes: it excludes those partitions from the view scan with the NULL-safe `NOT(COALESCE(<predicate>, false))`, and it recomputes them from the base tables. Since both come from the same set, every partition is served exactly once.

Recompute takes one of two paths. When every recompute column maps directly to a partition column on every base table, `generateBaseTablePredicates` stitches per base (single-base views and inner joins on shared partition keys). Otherwise (`requiresOuterFilter`: partition columns spanning different base tables, UNION constant columns, or outer joins) `buildPartitionsToRecomputeFilter` recomputes with one outer filter over the whole view definition, `SELECT * FROM (<view definition>) WHERE <recompute tuples>`, and the per-base branch is pruned to FALSE so it does not emit `WHERE FALSE` on the non-recomputing join side and drop the new partitions. With nothing to recompute the output is identical to the previous flow.

== RELEASE NOTES ==

General Changes
* Fix incorrect results when reading from a partially materialized view, where partitions recomputed from the base tables could also be read from the view and counted twice.

Differential Revision: D107589008


