### PR TITLE
refactor(docs): Refine troubleshooting pages

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -167,7 +167,7 @@ The maximum size of the request header from the HTTP server.
 
 Note: The default value can cause errors when large session properties
 or other large session information is involved.
-See :ref:`troubleshoot/query:\`\`Request Header Fields Too Large\`\``.
+See :ref:`troubleshoot/query:Request Header Fields Too Large`.
 
 ``offset-clause-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/sql/prepare.rst
+++ b/presto-docs/src/main/sphinx/sql/prepare.rst
@@ -23,7 +23,7 @@ Note: If a query that includes ``PREPARE`` returns an error similar to the follo
 
     Request Header Fields Too Large
 
-see :ref:`troubleshoot/query:\`\`Request Header Fields Too Large\`\``.
+see :ref:`troubleshoot/query:Request Header Fields Too Large`.
 
 Examples
 --------

--- a/presto-docs/src/main/sphinx/troubleshoot/deploy.rst
+++ b/presto-docs/src/main/sphinx/troubleshoot/deploy.rst
@@ -9,71 +9,76 @@ This page presents common problems encountered when deploying Presto.
     :backlinks: none
     :depth: 1
 
-``Permission denied: ‘/private/var/presto/data/var/run/launcher.pid``
----------------------------------------------------------------------
+Permission denied for ``launcher.pid``
+--------------------------------------
 
-Problem
-^^^^^^^
+.. rubric:: Problem
 
-``bin/launcher run`` or ``bin/launcher start`` returns the following error: 
-
-``Permission denied: ‘/private/var/presto/data/var/run/launcher.pid``
-
-Solution
-^^^^^^^^
-
-Run the command as root or using ``sudo``. 
+Running ``bin/launcher run`` or ``bin/launcher start`` returns the following error:
 
 .. code-block:: none
+   :class: no-copy
 
-    sudo bin/launcher run
-    sudo bin/launcher start
+   Permission denied: '/private/var/presto/data/var/run/launcher.pid'
 
 
-``xcode select failed to locate python``
-----------------------------------------
+.. rubric:: Solution
 
-Problem
-^^^^^^^
+Run the command as root or using ``sudo``:
 
-(OS X only) ``bin/launcher run`` or ``bin/launcher start`` returns the following error: 
+.. code-block:: shell
 
-``xcode select failed to locate python requesting installation of command``
+   sudo bin/launcher run
+   sudo bin/launcher start
 
-Solution
-^^^^^^^^
+
+
+Xcode failed to locate Python
+-----------------------------
+
+.. rubric:: Problem
+
+.. note::
+
+   macOS only
+
+Running ``bin/launcher run`` or ``bin/launcher start`` returns the following error:
+
+.. code-block:: none
+   :class: no-copy
+
+   xcode select failed to locate python requesting installation of command
+
+
+.. rubric:: Solution
 
 Create a symlink where XCode looks for python that links to python3. An example of such a command: 
 
-.. code-block:: none
+.. code-block:: shell
 
     ln -s /Library/Developer/CommandLineTools/usr/bin/python3 /Library/Developer/CommandLineTools/usr/bin/python
 
 
 
+JVM option 'UseG1GC' is experimental
+------------------------------------
 
-``Error: VM option ‘UseG1GC’ is experimental``
-----------------------------------------------
+.. rubric:: Problem
 
-Problem
-^^^^^^^
-``bin/launcher run`` or ``bin/launcher start`` returns the following error: 
+Running ``bin/launcher run`` or ``bin/launcher start`` returns the following error:
 
 .. code-block:: none
+   :class: no-copy
 
-    Error: VM option ‘UseG1GC’ is experimental and must be enabled via -XX:+UnlockExperimentalVM Options.
+    Error: VM option 'UseG1GC' is experimental and must be enabled via -XX:+UnlockExperimentalVM Options.
 
     Error: Could not create the Java Virtual Machine.
 
     Error: A fatal exception has occurred. Program will exit.
 
-Solution
-^^^^^^^^
 
-This error occurs with some versions of Java. 
+.. rubric:: Solution
 
-1. Check the version of Java that is installed on the system. 
+This error occurs with some versions of Java.
 
-2. If the installed version of Java is not the version in 
-   `Requirements <https://github.com/prestodb/presto?tab=readme-ov-file#requirements>`_, 
-   then uninstall Java and install a recommended version.
+Ensure installed Java version meets the `Requirements <https://github.com/prestodb/presto?tab=readme-ov-file#requirements>`_.

--- a/presto-docs/src/main/sphinx/troubleshoot/query.rst
+++ b/presto-docs/src/main/sphinx/troubleshoot/query.rst
@@ -9,15 +9,15 @@ This page presents problems encountered with queries in Presto.
     :backlinks: none
     :depth: 1
 
-``Request Header Fields Too Large``
------------------------------------
+Request Header Fields Too Large
+-------------------------------
 
-Problem
-^^^^^^^
+.. rubric:: Problem
 
 A query may return an error similar to the following example: 
 
 .. code-block:: none
+   :class: no-copy
 
     Error running command: Error starting query at http://localhost:8080/v1/statement 
     returned an invalid response: JsonResponse{statusCode=431, statusMessage=Request 
@@ -31,20 +31,16 @@ Some examples of how this can happen are:
 * putting a lot of information in ``clientInfo``
 * large security keys being sent in the session
 
-If such an error happens, increasing the value of ``http-server.max-request-header-size``  
-can help avoid it.
+.. rubric:: Solution
 
-Solution
-^^^^^^^^
+If such an error happens, increasing the value of ``http-server.max-request-header-size`` can help avoid it.
+Edit ``config.properties`` for the Presto coordinator, and set the value to a larger size. For example:
 
-Edit ``config.properties`` for the Presto coordinator, and set the value of the 
-``http-server.max-request-header-size`` configuration property to a larger size. For example:
-
-.. code-block:: none
+.. code-block:: properties
 
     http-server.max-request-header-size=5MB
 
 See :ref:`admin/properties:\`\`http-server.max-request-header-size\`\``.
 
-Alternatively, avoid using prepared statements for large queries. Prepared statements
-place the SQL template in request headers, which can exceed the header size limit. 
+Alternatively, avoid using prepared statements for large queries.
+Prepared statements place the SQL template in request headers, which can exceed the header size limit.


### PR DESCRIPTION
## Description
The changes resolve 4 warnings and improve readability:

1. Replaced `Problem` and `Solution` subheadings with [rubric](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-rubric) directive resolves the following warnings:
```
./presto-docs/src/main/sphinx/troubleshoot/deploy.rst:37: WARNING: duplicate label troubleshoot/deploy:problem, other instance in ./presto-docs/src/main/sphinx/troubleshoot/deploy.rst [autosectionlabel.troubleshoot/deploy]                                                                                                                                      
./presto-docs/src/main/sphinx/troubleshoot/deploy.rst:44: WARNING: duplicate label troubleshoot/deploy:solution, other instance in ./presto-docs/src/main/sphinx/troubleshoot/deploy.rst [autosectionlabel.troubleshoot/deploy]                                                                                                                                     
./presto-docs/src/main/sphinx/troubleshoot/deploy.rst:59: WARNING: duplicate label troubleshoot/deploy:problem, other instance in ./presto-docs/src/main/sphinx/troubleshoot/deploy.rst [autosectionlabel.troubleshoot/deploy]                                                                                                                                      
./presto-docs/src/main/sphinx/troubleshoot/deploy.rst:71: WARNING: duplicate label troubleshoot/deploy:solution, other instance in ./presto-docs/src/main/sphinx/troubleshoot/deploy.rst [autosectionlabel.troubleshoot/deploy]
```
2. Used `shell` and `properties` lexers for `code-block` directives where applicable.
3. Used `no-copy` class for `code-block` directives where applicable.
4. Simplified several sections by removing redundant text and improving flow.

## Motivation and Context
The PR improves the formatting and readability of the troubleshooting pages.

## Impact
_None_

## Test Plan
Build the documentation and check the pages are correct:
```shell
presto-docs/build

open presto-docs/target/html/troubleshoot/deploy.html
open presto-docs/target/html/troubleshoot/query.html
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refine troubleshooting documentation pages for deployment and query issues to improve readability and eliminate Sphinx build warnings.

Documentation:
- Rework troubleshooting deploy and query pages to use rubric sections instead of repeated Problem/Solution headings.
- Update code examples in troubleshooting and related docs to use appropriate shell and properties code-block lexers and no-copy behavior where applicable.
- Simplify and streamline troubleshooting text to remove redundancy and improve flow in the affected pages.