### PR TITLE
refactor: Avoid List and Array to track row index column in Parquet

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -50,10 +50,10 @@ public class ParquetPageSource
     private final List<Optional<Field>> fields;
 
     /**
-     * Specifies the index of the row number column. If presents,
+     * Specifies the index of the row position column. If presents,
      * the column at the specified index should be populated with the indices of its rows
      */
-    private final OptionalInt rowNumberColumnIndex;
+    private final OptionalInt rowPositionColumnIndex;
 
     private int batchId;
     private long completedPositions;
@@ -75,23 +75,26 @@ public class ParquetPageSource
             ParquetReader parquetReader,
             List<Type> types,
             List<Optional<Field>> fields,
-            OptionalInt rowNumberColumnIndex,
+            OptionalInt rowPositionColumnIndex,
             List<String> columnNames,
             RuntimeStats runtimeStats)
     {
         this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
-        this.rowNumberColumnIndex = requireNonNull(rowNumberColumnIndex, "rowNumberColumnIndex is null");
+        this.rowPositionColumnIndex = requireNonNull(rowPositionColumnIndex, "rowPositionColumnIndex is null");
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
 
         checkArgument(types.size() == fields.size(),
                 "types and fields must correspond one-to-one");
-        checkArgument(rowNumberColumnIndex.isEmpty() ||
-                (rowNumberColumnIndex.getAsInt() >= 0 && rowNumberColumnIndex.getAsInt() < types.size()), "row number column index is incorrect");
-        checkArgument(rowNumberColumnIndex.isEmpty() || fields.get(rowNumberColumnIndex.getAsInt()).isEmpty(),
-                "Field info for row index column must be empty Optional");
+
+        checkArgument(rowPositionColumnIndex.isEmpty() ||
+                (rowPositionColumnIndex.getAsInt() >= 0 && rowPositionColumnIndex.getAsInt() < types.size()),
+                "Invalid row position column index: %s (valid range: [0, %s))",
+                rowPositionColumnIndex.orElse(-1), types.size());
+        checkArgument(rowPositionColumnIndex.isEmpty() || fields.get(rowPositionColumnIndex.getAsInt()).isEmpty(),
+                "Field info for row position column must be empty Optional");
     }
 
     @Override
@@ -238,7 +241,7 @@ public class ParquetPageSource
 
     private boolean isIndexColumn(int column)
     {
-        return rowNumberColumnIndex.isPresent() && rowNumberColumnIndex.getAsInt() == column;
+        return rowPositionColumnIndex.isPresent() && rowPositionColumnIndex.getAsInt() == column;
     }
 
     private static Block getRowIndexColumn(long baseIndex, int size)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -27,18 +27,17 @@ import com.facebook.presto.parquet.reader.ParquetReader;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Streams;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetPageSource
@@ -51,10 +50,10 @@ public class ParquetPageSource
     private final List<Optional<Field>> fields;
 
     /**
-     * Indicates whether the column at each index should be populated with the
-     * indices of its rows
+     * Specifies the index of the row number column. If presents,
+     * the column at the specified index should be populated with the indices of its rows
      */
-    private final List<Boolean> rowIndexLocations;
+    private final OptionalInt rowNumberColumnIndex;
 
     private int batchId;
     private long completedPositions;
@@ -69,33 +68,30 @@ public class ParquetPageSource
             List<String> columnNames,
             RuntimeStats runtimeStats)
     {
-        this(parquetReader, types, fields, nCopies(types.size(), false), columnNames, runtimeStats);
+        this(parquetReader, types, fields, OptionalInt.empty(), columnNames, runtimeStats);
     }
 
     public ParquetPageSource(
             ParquetReader parquetReader,
             List<Type> types,
             List<Optional<Field>> fields,
-            List<Boolean> rowIndexLocations,
+            OptionalInt rowNumberColumnIndex,
             List<String> columnNames,
             RuntimeStats runtimeStats)
     {
         this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
-        this.rowIndexLocations = requireNonNull(rowIndexLocations, "rowIndexLocations is null");
+        this.rowNumberColumnIndex = requireNonNull(rowNumberColumnIndex, "rowNumberColumnIndex is null");
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
 
-        checkArgument(
-                types.size() == rowIndexLocations.size() && types.size() == fields.size(),
-                "types, rowIndexLocations, and fields must correspond one-to-one-to-one");
-        Streams.forEachPair(
-                rowIndexLocations.stream(),
-                fields.stream(),
-                (isIndexColumn, field) -> checkArgument(
-                        !(isIndexColumn && field.isPresent()),
-                        "Field info for row index column must be empty Optional"));
+        checkArgument(types.size() == fields.size(),
+                "types and fields must correspond one-to-one");
+        checkArgument(rowNumberColumnIndex.isEmpty() ||
+                (rowNumberColumnIndex.getAsInt() >= 0 && rowNumberColumnIndex.getAsInt() < types.size()), "row number column index is incorrect");
+        checkArgument(rowNumberColumnIndex.isEmpty() || fields.get(rowNumberColumnIndex.getAsInt()).isEmpty(),
+                "Field info for row index column must be empty Optional");
     }
 
     @Override
@@ -242,7 +238,7 @@ public class ParquetPageSource
 
     private boolean isIndexColumn(int column)
     {
-        return rowIndexLocations.get(column);
+        return rowNumberColumnIndex.isPresent() && rowNumberColumnIndex.getAsInt() == column;
     }
 
     private static Block getRowIndexColumn(long baseIndex, int size)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -72,6 +72,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -271,8 +272,9 @@ public class ParquetPageSourceFactory
             ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
-            ImmutableList.Builder<Boolean> rowIndexColumns = ImmutableList.builder();
-            for (HiveColumnHandle column : columns) {
+            OptionalInt rowPositionColumnIndex = OptionalInt.empty();
+            for (int idx = 0; idx < columns.size(); idx++) {
+                HiveColumnHandle column = columns.get(idx);
                 checkArgument(column == PARQUET_ROW_INDEX_COLUMN || column.getColumnType() == REGULAR || column.getColumnType() == SYNTHESIZED, "column type must be REGULAR: %s", column);
 
                 String name = column.getName();
@@ -281,7 +283,10 @@ public class ParquetPageSourceFactory
                 namesBuilder.add(name);
                 typesBuilder.add(type);
 
-                rowIndexColumns.add(column == PARQUET_ROW_INDEX_COLUMN);
+                if (column == PARQUET_ROW_INDEX_COLUMN) {
+                    checkArgument(rowPositionColumnIndex.isEmpty(), "Requesting more than 1 row number columns is not allowed.");
+                    rowPositionColumnIndex = OptionalInt.of(idx);
+                }
 
                 if (column.getColumnType() == SYNTHESIZED) {
                     if (column == PARQUET_ROW_INDEX_COLUMN) {
@@ -307,7 +312,7 @@ public class ParquetPageSourceFactory
                     fieldsBuilder.add(Optional.empty());
                 }
             }
-            return new ParquetPageSource(parquetReader, typesBuilder.build(), fieldsBuilder.build(), rowIndexColumns.build(), namesBuilder.build(), hiveFileContext.getStats());
+            return new ParquetPageSource(parquetReader, typesBuilder.build(), fieldsBuilder.build(), rowPositionColumnIndex, namesBuilder.build(), hiveFileContext.getStats());
         }
         catch (Exception e) {
             try {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -355,7 +355,7 @@ public class IcebergPageSourceProvider
             ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> prestoTypes = ImmutableList.builder();
             ImmutableList.Builder<Optional<Field>> internalFields = ImmutableList.builder();
-            List<Boolean> isRowPositionList = new ArrayList<>();
+            OptionalInt rowPositionColumnIndex = OptionalInt.empty();
             for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
                 IcebergColumnHandle column = regularColumns.get(columnIndex);
                 namesBuilder.add(column.getName());
@@ -383,11 +383,14 @@ public class IcebergPageSourceProvider
                         internalFields.add(constructField(column.getType(), messageColumnIO.getChild(parquetField.get().getName())));
                     }
                 }
-                isRowPositionList.add(column.isRowPositionColumn());
+                if (column.isRowPositionColumn()) {
+                    checkArgument(rowPositionColumnIndex.isEmpty(), "Requesting more than 1 row number columns is not allowed.");
+                    rowPositionColumnIndex = OptionalInt.of(columnIndex);
+                }
             }
 
             return new ConnectorPageSourceWithRowPositions(
-                    new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), isRowPositionList, namesBuilder.build(), new RuntimeStats()),
+                    new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), rowPositionColumnIndex, namesBuilder.build(), new RuntimeStats()),
                     startRowPosition,
                     endRowPosition);
         }


### PR DESCRIPTION
## Description

Previously, the `ParquetPageSource` accept a `List<Boolean>` parameter to indicate which columns are row position columns, and converted it into a `boolean[]` for later use. This seems unnecessary; we can just use an `OptionalInt` for the row position column index, and use `OptionalInt.empty()` if there isn't one.

## Motivation and Context

Avoid the unnecessary logic of creating a list and converting it to an array

## Impact

N/A

## Test Plan

- Make sure this refactoring do not affect any existing test cases

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor Parquet page source row-position tracking to use a single optional row-number column index instead of per-column boolean flags.

Enhancements:
- Replace per-column Boolean list for row index tracking in ParquetPageSource with an OptionalInt row-number column index and adjust constructors and validation accordingly.
- Update Hive ParquetPageSourceFactory and IcebergPageSourceProvider to compute and pass a single optional row-position column index, enforcing that at most one row-position column is requested.