### PR TITLE
feat(spi): Carry materialized view refresh scope to the connector (#27949)

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.function.table.Argument;
 import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
 import com.facebook.presto.spi.procedure.DistributedProcedure;
 import com.facebook.presto.spi.procedure.ProcedureAnalysisContext;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
@@ -1429,13 +1430,17 @@ public class Analysis
         private final List<ColumnHandle> columns;
         private final Query query;
         private final SchemaTableName materializedViewName;
+        // The refresh WHERE predicate (legacy WHERE-based refresh only; empty when there is no WHERE),
+        // carried to the connector at execution time so it can scope refresh work.
+        private final Optional<RowExpression> refreshScopePredicate;
 
-        public RefreshMaterializedViewAnalysis(TableHandle target, List<ColumnHandle> columns, Query query, SchemaTableName materializedViewName)
+        public RefreshMaterializedViewAnalysis(TableHandle target, List<ColumnHandle> columns, Query query, SchemaTableName materializedViewName, Optional<RowExpression> refreshScopePredicate)
         {
             this.target = requireNonNull(target, "target is null");
             this.columns = requireNonNull(columns, "columns is null");
             this.query = requireNonNull(query, "query is null");
             this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+            this.refreshScopePredicate = requireNonNull(refreshScopePredicate, "refreshScopePredicate is null");
             checkArgument(columns.size() > 0, "No columns given to insert");
         }
 
@@ -1457,6 +1462,11 @@ public class Analysis
         public SchemaTableName getMaterializedViewName()
         {
             return materializedViewName;
+        }
+
+        public Optional<RowExpression> getRefreshScopePredicate()
+        {
+            return refreshScopePredicate;
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
@@ -108,7 +108,7 @@ public class TableWriteInfo
             }
             if (target instanceof TableWriterNode.RefreshMaterializedViewReference) {
                 TableWriterNode.RefreshMaterializedViewReference refresh = (TableWriterNode.RefreshMaterializedViewReference) target;
-                return Optional.of(new ExecutionWriterTarget.RefreshMaterializedViewHandle(metadata.beginRefreshMaterializedView(session, refresh.getHandle()), refresh.getSchemaTableName()));
+                return Optional.of(new ExecutionWriterTarget.RefreshMaterializedViewHandle(metadata.beginRefreshMaterializedView(session, refresh.getHandle(), refresh.getRefreshScopePredicate()), refresh.getSchemaTableName()));
             }
             if (target instanceof TableWriterNode.UpdateTarget) {
                 TableWriterNode.UpdateTarget update = (TableWriterNode.UpdateTarget) target;

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
 import com.facebook.presto.spi.procedure.ProcedureRegistry;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -562,9 +563,9 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
     {
-        return delegate.beginRefreshMaterializedView(session, tableHandle);
+        return delegate.beginRefreshMaterializedView(session, tableHandle, refreshScopePredicate);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -494,9 +494,10 @@ public interface Metadata
             QualifiedTablePrefix prefix);
 
     /**
-     * Begin refresh materialized view
+     * Begin refresh materialized view, carrying the refresh scope (the analysis-time WHERE predicate;
+     * {@code Optional.empty()} when there is no WHERE) so the connector can scope refresh work.
      */
-    InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle);
+    InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, Optional<RowExpression> refreshScopePredicate);
 
     /**
      * Finish refresh materialized view

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1408,13 +1408,13 @@ public class MetadataManager
     }
 
     @Override
-    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, connectorId);
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
         ConnectorTransactionHandle transactionHandle = catalogMetadata.getTransactionHandleFor(connectorId);
-        ConnectorInsertTableHandle handle = metadata.beginRefreshMaterializedView(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle());
+        ConnectorInsertTableHandle handle = metadata.beginRefreshMaterializedView(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), refreshScopePredicate);
         return new InsertTableHandle(tableHandle.getConnectorId(), transactionHandle, handle);
     }
 
@@ -1422,7 +1422,10 @@ public class MetadataManager
     public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
-        ConnectorMetadata metadata = getMetadata(session, connectorId);
+        // Use the write-mode metadata so finish runs on the same ConnectorMetadata instance as
+        // beginRefreshMaterializedView (some connectors, e.g. Prism, return distinct read/write
+        // instances); this lets a connector read state set during begin (e.g. the refresh scope).
+        ConnectorMetadata metadata = getMetadataForWrite(session, connectorId);
         return metadata.finishRefreshMaterializedView(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments, computedStatistics);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -653,11 +653,11 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
-    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
     {
         long startTime = System.nanoTime();
         try {
-            return delegate.beginRefreshMaterializedView(session, tableHandle);
+            return delegate.beginRefreshMaterializedView(session, tableHandle, refreshScopePredicate);
         }
         finally {
             stats.recordBeginRefreshMaterializedViewCall(System.nanoTime() - startTime);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -961,11 +961,38 @@ class StatementAnalyzer
                     .filter(column -> !column.isHidden())
                     .map(column -> columnHandles.get(column.getName()))
                     .collect(toImmutableList());
+            // Capture the refresh scope (the WHERE predicate) here, where the full unfactored predicate
+            // with its MV/base column mapping is still available. It is carried on the analysis ->
+            // RefreshMaterializedViewReference -> beginRefreshMaterializedView so the connector receives
+            // it at execution time, rather than calling the connector SPI during analysis.
+            Optional<RowExpression> refreshScopePredicate = Optional.empty();
+            if (isLegacyMaterializedViews(session) && node.getWhere().isPresent()) {
+                Expression refreshWhere = node.getWhere().get();
+                // Analyze with AllowAllAccessControl (as for the view scope above): refresh must not require
+                // SELECT on the materialized view, only INSERT. This only populates expression types for translation.
+                ExpressionAnalyzer.analyzeExpression(
+                        session,
+                        metadata,
+                        new AllowAllAccessControl(),
+                        sqlParser,
+                        viewScope,
+                        analysis,
+                        refreshWhere,
+                        warningCollector);
+                refreshScopePredicate = Optional.of(SqlToRowExpressionTranslator.translate(
+                        refreshWhere,
+                        analysis.getTypes(),
+                        ImmutableMap.of(),
+                        metadata.getFunctionAndTypeManager(),
+                        session));
+            }
+
             analysis.setRefreshMaterializedViewAnalysis(new Analysis.RefreshMaterializedViewAnalysis(
                     tableHandle,
                     targetColumnHandles,
                     refreshQuery,
-                    toSchemaTableName(viewName)));
+                    toSchemaTableName(viewName),
+                    refreshScopePredicate));
 
             return createAndAssignScope(node, scope, Field.newUnqualified(node.getLocation(), "rows", BIGINT));
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -679,7 +679,7 @@ public class LogicalPlanner
         TableHandle storageTableHandle = viewAnalysis.getTarget();
         List<ColumnHandle> columnHandles = viewAnalysis.getColumns();
         SchemaTableName materializedViewName = viewAnalysis.getMaterializedViewName();
-        TableWriterNode.WriterTarget target = new RefreshMaterializedViewReference(storageTableHandle, materializedViewName);
+        TableWriterNode.WriterTarget target = new RefreshMaterializedViewReference(storageTableHandle, materializedViewName, viewAnalysis.getRefreshScopePredicate());
 
         boolean legacyMode = isLegacyMaterializedViews(session);
         if (legacyMode) {

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -327,7 +327,11 @@ public class TestingMetadata
     public void createMaterializedView(ConnectorSession session, ConnectorTableMetadata viewMetadata, MaterializedViewDefinition viewDefinition, boolean ignoreExisting)
     {
         SchemaTableName viewName = new SchemaTableName(viewDefinition.getSchema(), viewDefinition.getTable());
-        tables.put(viewName, new ConnectorTableMetadata(viewName, ImmutableList.of()));
+        // viewMetadata may be null in tests that only exercise the view definition; fall back to no columns then.
+        ConnectorTableMetadata tableMetadata = viewMetadata == null
+                ? new ConnectorTableMetadata(viewName, ImmutableList.of())
+                : new ConnectorTableMetadata(viewName, viewMetadata.getColumns(), viewMetadata.getProperties(), viewMetadata.getComment());
+        tables.put(viewName, tableMetadata);
         materializedViews.put(viewName, viewDefinition);
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
 import com.facebook.presto.spi.procedure.ProcedureRegistry;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -598,7 +599,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -650,6 +650,19 @@ public class AbstractAnalyzerTest
                 });
     }
 
+    protected Analysis analyzeAndGetAnalysis(Session clientSession, @Language("SQL") String query)
+    {
+        return transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .readOnly()
+                .execute(clientSession, session -> {
+                    Analyzer analyzer = createAnalyzer(session, metadata, WarningCollector.NOOP, Optional.empty(), query);
+                    Statement statement = SQL_PARSER.createStatement(query);
+                    return analyzer.analyzeSemantic(statement, false);
+                });
+    }
+
     protected void assertFails(SemanticErrorCode error, @Language("SQL") String query)
     {
         assertFails(CLIENT_SESSION, error, query);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.parser.ParsingException;
@@ -2506,5 +2507,91 @@ public class TestAnalyzer
         finally {
             executor.shutdownNow();
         }
+    }
+
+    // The refresh scope (the REFRESH MATERIALIZED VIEW WHERE predicate) is captured during analysis and
+    // carried to the connector. These tests pin down the exact RowExpression StatementAnalyzer produces.
+    @Test
+    public void testRefreshMaterializedViewCapturesWhereScopePredicate()
+    {
+        // the integer literal coerces to the BIGINT column type, so no explicit cast is needed
+        assertEquals(refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a = 5"), Optional.of("EQUAL(a, 5)"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewCapturesCompoundScopePredicate()
+    {
+        assertEquals(
+                refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a >= 1 AND a <= 10"),
+                Optional.of("AND(GREATER_THAN_OR_EQUAL(a, 1), LESS_THAN_OR_EQUAL(a, 10))"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewCapturesGreaterThanScopePredicate()
+    {
+        assertEquals(refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a > 5"), Optional.of("GREATER_THAN(a, 5)"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewCapturesNotEqualScopePredicate()
+    {
+        assertEquals(refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a <> 5"), Optional.of("NOT_EQUAL(a, 5)"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewCapturesOrScopePredicate()
+    {
+        assertEquals(
+                refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a = 1 OR a = 2"),
+                Optional.of("OR(EQUAL(a, 1), EQUAL(a, 2))"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewCapturesInScopePredicate()
+    {
+        assertEquals(
+                refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1 WHERE a IN (1, 2, 3)"),
+                Optional.of("IN(a, 1, 2, 3)"));
+    }
+
+    @Test
+    public void testRefreshMaterializedViewWithoutWhereHasEmptyScope()
+    {
+        assertEquals(refreshScopePredicate("REFRESH MATERIALIZED VIEW mv1"), Optional.empty());
+    }
+
+    // Negative cases: unsupported WHERE shapes are rejected during analysis (no scope predicate is produced),
+    // so the connector never receives a scope it cannot reason about.
+    @Test
+    public void testRefreshMaterializedViewRejectsNonColumnLeftSide()
+    {
+        assertFails(NOT_SUPPORTED, "REFRESH MATERIALIZED VIEW mv1 WHERE a + 1 = 5");
+    }
+
+    @Test
+    public void testRefreshMaterializedViewRejectsNonLiteralRightSide()
+    {
+        assertFails(NOT_SUPPORTED, "REFRESH MATERIALIZED VIEW mv1 WHERE a = a");
+    }
+
+    @Test
+    public void testRefreshMaterializedViewRejectsNegation()
+    {
+        assertFails(NOT_SUPPORTED, "REFRESH MATERIALIZED VIEW mv1 WHERE NOT (a = 5)");
+    }
+
+    @Test
+    public void testRefreshMaterializedViewRejectsNonLiteralInList()
+    {
+        assertFails(NOT_SUPPORTED, "REFRESH MATERIALIZED VIEW mv1 WHERE a IN (a)");
+    }
+
+    private Optional<String> refreshScopePredicate(String query)
+    {
+        Optional<RowExpression> predicate = analyzeAndGetAnalysis(CLIENT_SESSION, query)
+                .getRefreshMaterializedViewAnalysis()
+                .orElseThrow(() -> new AssertionError("no refresh materialized view analysis"))
+                .getRefreshScopePredicate();
+        return predicate.map(RowExpression::toString);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -845,6 +845,16 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Begin refresh materialized view, carrying the refresh scope (the {@code REFRESH MATERIALIZED VIEW WHERE}
+     * predicate, {@code Optional.empty()} when there is no WHERE). Connectors that scope refresh work should
+     * override this; the default ignores the scope and delegates to the no-predicate overload.
+     */
+    default ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
+    {
+        return beginRefreshMaterializedView(session, tableHandle);
+    }
+
+    /**
      * Finish refresh materialized view
      */
     default Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -645,6 +645,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<RowExpression> refreshScopePredicate)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginRefreshMaterializedView(session, tableHandle, refreshScopePredicate);
+        }
+    }
+
+    @Override
     public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.RowChangeParadigm;
 import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -436,16 +437,26 @@ public final class TableWriterNode
     {
         private final TableHandle handle;
         private final SchemaTableName schemaTableName;
+        // The refresh WHERE predicate (empty when there is no WHERE), carried from analysis so it can
+        // be passed to the connector's beginRefreshMaterializedView at execution time. Planning-only;
+        // this WriterTarget is converted to an ExecutionWriterTarget before fragments are serialized.
+        private final Optional<RowExpression> refreshScopePredicate;
 
-        public RefreshMaterializedViewReference(TableHandle handle, SchemaTableName schemaTableName)
+        public RefreshMaterializedViewReference(TableHandle handle, SchemaTableName schemaTableName, Optional<RowExpression> refreshScopePredicate)
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+            this.refreshScopePredicate = requireNonNull(refreshScopePredicate, "refreshScopePredicate is null");
         }
 
         public TableHandle getHandle()
         {
             return handle;
+        }
+
+        public Optional<RowExpression> getRefreshScopePredicate()
+        {
+            return refreshScopePredicate;
         }
 
         @Override


### PR DESCRIPTION
Summary:

Propagate the `REFRESH MATERIALIZED VIEW` `WHERE` predicate (the refresh scope) to the connector so it can scope refresh work — for example, creating empty partitions only within the refreshed range.

The predicate is captured at analysis time, where the full unfactored `WHERE` and its MV/base column mapping are still available (before the optimizer factors it into a `FilterNode` above the scan), translated to a `RowExpression`, and stored on `RefreshMaterializedViewAnalysis`. It is then carried on the `RefreshMaterializedViewReference` writer target (planning-only; never serialized) and delivered to the connector at execution time via a new `beginRefreshMaterializedView(ConnectorSession, ConnectorTableHandle, Optional<RowExpression>)` overload. The default delegates to the existing no-predicate overload, so existing connectors are unaffected. Delegating overrides are added in `MetadataManager`, `DelegatingMetadataManager`, `StatsRecordingMetadataManager`, and `ClassLoaderSafeConnectorMetadata` so the call reaches the connector through every wrapper.

`finishRefreshMaterializedView` now resolves the connector via write-mode metadata (`getCatalogMetadataForWrite`) to match `beginRefreshMaterializedView`, so a connector can read state it set during begin. Some connectors (e.g. Prism) return distinct read- and write-mode metadata instances, and finish is itself a commit, so write-mode is the correct accessor here.

The refresh `WHERE` is analyzed with `AllowAllAccessControl` against the materialized view scope — consistent with how the view scope itself is analyzed earlier in `visitRefreshMaterializedView`. `REFRESH MATERIALIZED VIEW` requires only `INSERT` on the view, not `SELECT`, so this predicate analysis (which only populates expression types for translation) must not impose a `SELECT` check on the materialized view.

This supersedes the earlier approach of a standalone `setMaterializedViewRefreshScope` SPI method called during analysis: carrying the scope through the plan keeps the analyzer free of connector side effects and delivers the predicate at execution, while remaining coordinator-local (it is read by `finish` on the same connector instance, not serialized to write workers).

== RELEASE NOTES ==

SPI Changes
* Add a ``ConnectorMetadata.beginRefreshMaterializedView`` overload that carries the materialized view refresh predicate (refresh scope) to connectors.

Differential Revision: D106871725


