### PR TITLE
chore: Update release note checker version

### DIFF
--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened]
 
 env:
-  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.14' }}
+  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.16' }}
 
 jobs:
   check_release_note:
@@ -30,24 +30,17 @@ jobs:
         run: |
           curl -L -o /tmp/presto_release "https://github.com/${{ github.repository_owner }}/presto-release-tools/releases/download/${RELEASE_TOOLS_VERSION}/presto-release-tools-${RELEASE_TOOLS_VERSION}-executable.jar"
           chmod 755 /tmp/presto_release
-      - name: Get PR body from GraphQL API
+      - name: Get PR body from event
         id: graphql_query
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY_RAW: ${{ github.event.pull_request.body }}
         run: |
           echo "pr_bodytext<<EOF" >> $GITHUB_OUTPUT
-          gh api graphql -f query='
-              query($owner: String!, $name: String!, $number: Int!) {
-                repository(owner: $owner, name: $name) {
-                  pullRequest(number: $number) {
-                    bodyText
-                  }
-                }
-              }
-            ' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq '.data.repository.pullRequest.bodyText' >> $GITHUB_OUTPUT
+          echo "$PR_BODY_RAW" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Echo PR Text
         env:


### PR DESCRIPTION
## Description
Explicitly specify the 0.16 version for the release note checker. In some cases, the GH worker fails to pick up the env vars from the repo's settings and uses the default value specified in the workflow yaml. Update the default version to the latest version at this moment. Also, I found that we forgot to switch from bodyText to boy to get the raw markdown, which includes the triple backticks. Changed the way to get the PR's content.

## Motivation and Context
Some GH workers failed to load the env vars from the repo, used the old version, and failed to retrieve the release note from the PR's description. 

## Impact
Update the default version to the latest version.

## Test Plan
Check future PRs.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```
