### PR TITLE
fix: Prune index-join index source partitions via node constraint

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -17,6 +17,9 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayoutResult;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
@@ -74,6 +77,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
@@ -253,12 +257,38 @@ public class SplitSourceFactory
                     : ImmutableMap.of();
 
             // Use LazySplitSource to defer the potentially expensive MetaStore
-            // call (split enumeration) until splits are actually needed,
-            // consistent with visitTableScan(). The table layout is guaranteed
-            // to be resolved by the connector's plan optimizer
-            // (ApplyConnectorOptimization).
+            // call (split enumeration and layout resolution) until splits are
+            // actually needed, consistent with visitTableScan().
             SplitSource splitSource = new LazySplitSource(
-                    () -> splitSourceProvider.getSplits(session, table, strategy, warningCollector, partitionColumnMapping));
+                    () -> {
+                        // The index source's table handle frequently arrives
+                        // without a resolved layout (IndexJoinOptimizer passes
+                        // the bare TableScan handle, and the connector plan
+                        // optimizer does not always fold the static partition
+                        // predicate into it). When that happens,
+                        // SplitManager.getSplits falls back to
+                        // Constraint.alwaysTrue() and enumerates ALL
+                        // partitions, ignoring static partition predicates.
+                        // Resolve a pruned layout from the node's
+                        // currentConstraint so partition predicates prune the
+                        // index side.
+                        TableHandle resolvedTable = table;
+                        if (!resolvedTable.getLayout().isPresent()
+                                && !node.getCurrentConstraint().isAll()) {
+                            TableLayoutResult layoutResult = metadata.getLayout(
+                                    session,
+                                    resolvedTable,
+                                    new Constraint<ColumnHandle>(node.getCurrentConstraint()),
+                                    Optional.empty());
+                            resolvedTable = layoutResult.getLayout().getNewTableHandle();
+                        }
+                        return splitSourceProvider.getSplits(
+                                session,
+                                resolvedTable,
+                                strategy,
+                                warningCollector,
+                                partitionColumnMapping);
+                    });
             splitSources.add(splitSource);
 
             return ImmutableMap.of(node.getId(), splitSource);


### PR DESCRIPTION
Summary:
The index source table handle in `SplitSourceFactory.visitIndexSource` frequently arrives without a resolved layout — `IndexJoinOptimizer` passes the bare `TableScan` handle and the connector plan optimizer does not always fold static partition predicates into it. Without a layout, `SplitManager.getSplits` falls back to `Constraint.alwaysTrue()` and enumerates all partitions ignoring predicates. For tables with many partitions and buckets this produces millions of splits and hits `HIVE_EXCEEDED_SPLIT_BUFFERING_LIMIT`.

Resolve a pruned layout from the node's `currentConstraint` inside the `LazySplitSource` supplier when the layout is absent, so partition predicates prune the index side before splits are enumerated.

## Release Notes

```
== NO RELEASE NOTE ==
```