### PR TITLE
fix(native): Surface HTTPException fields in PrestoExchangeSource failures

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -16,6 +16,7 @@
 #include <fmt/core.h>
 #include <folly/Conv.h>
 #include <folly/SocketAddress.h>
+#include <proxygen/lib/http/HTTPException.h>
 #include <re2/re2.h>
 #include <sstream>
 
@@ -65,6 +66,21 @@ std::string bodyAsString(
     }
   }
   return oss.str();
+}
+
+std::string formatExchangeError(const folly::exception_wrapper& error) {
+  if (auto* httpException = error.get_exception<proxygen::HTTPException>()) {
+    return httpException->describe();
+  }
+  return error.what().toStdString();
+}
+
+std::string formatExchangeError(const std::exception& error) {
+  if (auto* httpException =
+          dynamic_cast<const proxygen::HTTPException*>(&error)) {
+    return httpException->describe();
+  }
+  return error.what();
 }
 } // namespace
 
@@ -226,7 +242,7 @@ void PrestoExchangeSource::handleDataResponse(
         httpRequestPath,
         maxBytes,
         maxWait,
-        responseTry.exception().what().toStdString());
+        formatExchangeError(responseTry.exception()));
   } else {
     try {
       auto& response = responseTry.value();
@@ -255,7 +271,8 @@ void PrestoExchangeSource::handleDataResponse(
         processDataResponse(std::move(response), isGetDataSizeRequest);
       }
     } catch (const std::exception& e) {
-      processDataError(httpRequestPath, maxBytes, maxWait, e.what());
+      processDataError(
+          httpRequestPath, maxBytes, maxWait, formatExchangeError(e));
     }
   }
 }
@@ -533,7 +550,7 @@ void PrestoExchangeSource::handleAbortResponse(
     folly::Try<std::unique_ptr<http::HttpResponse>> responseTry) {
   std::optional<std::string> error;
   if (responseTry.hasException()) {
-    error = responseTry.exception().what();
+    error = formatExchangeError(responseTry.exception());
   } else {
     auto statusCode = responseTry.value()->headers()->getStatusCode();
     if (statusCode != http::kHttpOk && statusCode != http::kHttpNoContent) {


### PR DESCRIPTION
Summary:
## Description

Add a `formatExchangeError` helper in `PrestoExchangeSource.cpp` (two overloads — one for `folly::exception_wrapper`, one for `std::exception&`) that downcasts to `proxygen::HTTPException` and returns its `describe()`, falling through to `what()` otherwise. Plumb it through all three failure paths that funnel into `processDataError` / `onFinalFailure`: `handleDataResponse`'s `thenTry` branch, its inner `catch (std::exception&)` block, and `handleAbortResponse`.

## Motivation and Context

Today every failure path formats the exception via `.what().toStdString()` (or bare `.what()`), which routes through `std::exception::what()` and drops every `proxygen::HTTPException` accessor — `getProxygenError`, `getCodecStatusCode`, `getHttpStatusCode`, `getHttp3ErrorCode`, direction.

Those fields are the only signal that distinguishes codec-level failures on the wire. HPACK desync (`COMPRESSION_ERROR`), frame-structure violation (`PROTOCOL_ERROR`), and frame-size mismatch (`FRAME_SIZE_ERROR`) all collapse to the same `Shutdown transport: MalformedInput` string once stringified through `what()`, so error details are not visible for low-level network errors.

## Impact

Purely additive on the failure path; non-`HTTPException` exceptions pass through unchanged. The `failure_message` Scuba column (and other log sinks) will now contain structured fields like `proxygenError=...`, `codecStatusCode=...`, `httpStatusCode=...`, `http3ErrorCode=...` for `HTTPException` instances. No change to query behavior, performance, or API surface. `describe()` is the proxygen-canonical stringification (already used in proxygen's own logging via `operator<<`), so the format is stable and future-proof against new accessor fields.

## Test Plan

`buck2 test fbcode//github/presto-trunk/presto-native-execution/presto_cpp/main/tests:presto_main_test -- --regex 'PrestoExchangeSource'` — 208/208 pass; `buck2 build fbcode//github/presto-trunk/presto-native-execution/presto_cpp/main:presto_server_lib` OK.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D107917108


