### PR TITLE
refactor(plugin-iceberg): Remove per-query table cache in favour of per-transaction metastore caching

### DIFF
--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestPerTransactionHiveMetastoreCaching.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestPerTransactionHiveMetastoreCaching.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.spi.WarningCollector;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
+import static org.testng.Assert.assertEquals;
+
+public class TestPerTransactionHiveMetastoreCaching
+{
+    @Test
+    public void testRepeatedLookupsWithinTransactionHitMetastoreOnce()
+    {
+        CountingHiveMetastore counting = new CountingHiveMetastore();
+        ExtendedHiveMetastore transactionMetastore = memoizeMetastore(counting, false, 1000, 0);
+        MetastoreContext context = createMetastoreContext();
+
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+
+        assertEquals(counting.getTableCallCount(), 1);
+    }
+
+    @Test
+    public void testSeparateTransactionsDoNotShareCache()
+    {
+        CountingHiveMetastore counting = new CountingHiveMetastore();
+        ExtendedHiveMetastore txn1 = memoizeMetastore(counting, false, 1000, 0);
+        ExtendedHiveMetastore txn2 = memoizeMetastore(counting, false, 1000, 0);
+        MetastoreContext context = createMetastoreContext();
+
+        txn1.getTable(context, "test_schema", "test_table");
+        assertEquals(counting.getTableCallCount(), 1);
+
+        // Second transaction has its own fresh cache; must go to the underlying metastore
+        txn2.getTable(context, "test_schema", "test_table");
+        assertEquals(counting.getTableCallCount(), 2);
+    }
+
+    @Test
+    public void testWriteOperationsInvalidateCache()
+    {
+        CountingHiveMetastore counting = new CountingHiveMetastore();
+        ExtendedHiveMetastore transactionMetastore = memoizeMetastore(counting, false, 1000, 0);
+        MetastoreContext context = createMetastoreContext();
+
+        // First lookup populates the cache
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+        assertEquals(counting.getTableCallCount(), 1);
+
+        // Repeated lookup is served from cache
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+        assertEquals(counting.getTableCallCount(), 1);
+
+        // Write path (dropTable) invalidates the cached entry via AbstractCachingHiveMetastore
+        transactionMetastore.dropTable(context, "test_schema", "test_table", false);
+
+        // Lookup after write must hit the underlying metastore again
+        transactionMetastore.getTable(context, "test_schema", "test_table");
+        assertEquals(counting.getTableCallCount(), 2);
+    }
+
+    private static MetastoreContext createMetastoreContext()
+    {
+        return new MetastoreContext(
+                "test_user",
+                "test_query_id",
+                Optional.empty(),
+                ImmutableSet.of(),
+                Optional.empty(),
+                Optional.empty(),
+                false,
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                WarningCollector.NOOP,
+                new RuntimeStats());
+    }
+
+    private static final class CountingHiveMetastore
+            extends UnimplementedHiveMetastore
+    {
+        private final AtomicInteger getTableCallCount = new AtomicInteger();
+
+        public int getTableCallCount()
+        {
+            return getTableCallCount.get();
+        }
+
+        @Override
+        public Optional<Table> getTable(MetastoreContext metastoreContext, String databaseName, String tableName)
+        {
+            getTableCallCount.incrementAndGet();
+            return Optional.empty();
+        }
+
+        @Override
+        public void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData)
+        {
+            // no-op to allow cache-invalidation path through AbstractCachingHiveMetastore.dropTable
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -67,13 +67,10 @@ import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.MetricsConfig;
@@ -96,7 +93,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.hive.HiveStatisticsUtil.createPartitionStatistics;
@@ -149,7 +145,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
-import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -166,15 +161,12 @@ import static org.apache.iceberg.Transactions.createTableTransaction;
 public class IcebergHiveMetadata
         extends IcebergAbstractMetadata
 {
-    public static final int MAXIMUM_PER_QUERY_TABLE_CACHE_SIZE = 1000;
-
     private final IcebergCatalogName catalogName;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final DateTimeZone timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID())));
     private final IcebergHiveTableOperationsConfig hiveTableOperationsConfig;
     private final ConnectorSystemConfig connectorSystemConfig;
-    private final Cache<SchemaTableName, Optional<Table>> tableCache;
     private final ManifestFileCache manifestFileCache;
 
     public IcebergHiveMetadata(
@@ -204,7 +196,6 @@ public class IcebergHiveMetadata
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hiveTableOperationsConfig = requireNonNull(hiveTableOperationsConfig, "hiveTableOperationsConfig is null");
-        this.tableCache = CacheBuilder.newBuilder().maximumSize(MAXIMUM_PER_QUERY_TABLE_CACHE_SIZE).build();
         this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
         this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
@@ -286,17 +277,7 @@ public class IcebergHiveMetadata
     private Optional<Table> getHiveTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         IcebergTableName name = IcebergTableName.from(schemaTableName.getTableName());
-        try {
-            return tableCache.get(schemaTableName, () ->
-                    metastore.getTable(getMetastoreContext(session), schemaTableName.getSchemaName(), name.getTableName()));
-        }
-        catch (UncheckedExecutionException e) {
-            throwIfInstanceOf(e.getCause(), PrestoException.class);
-            throw e;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException("Unexpected checked exception by cache load from metastore", e);
-        }
+        return metastore.getTable(getMetastoreContext(session), schemaTableName.getSchemaName(), name.getTableName());
     }
 
     @Override
@@ -797,8 +778,6 @@ public class IcebergHiveMetadata
         catch (TableAlreadyExistsException e) {
             throw new PrestoException(ALREADY_EXISTS, "Materialized view already exists: " + viewName);
         }
-
-        tableCache.invalidate(viewName);
     }
 
     @Override
@@ -816,8 +795,6 @@ public class IcebergHiveMetadata
         catch (TableNotFoundException e) {
             throw new PrestoException(NOT_FOUND, "Materialized view not found: " + schemaTableName);
         }
-
-        tableCache.invalidate(schemaTableName);
     }
 
     @Override
@@ -855,8 +832,6 @@ public class IcebergHiveMetadata
                     viewName.getTableName(),
                     updatedTable,
                     privileges);
-
-            tableCache.invalidate(viewName);
         }
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -16,8 +16,10 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionMetadata;
 import com.facebook.presto.spi.ConnectorSystemConfig;
@@ -55,6 +57,9 @@ public class IcebergHiveMetadataFactory
     final ManifestFileCache manifestFileCache;
     final IcebergTableProperties tableProperties;
     final ConnectorSystemConfig connectorSystemConfig;
+    final long perTransactionCacheMaximumSize;
+    final boolean metastoreImpersonationEnabled;
+    final int metastorePartitionCacheMaxColumnCount;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -74,7 +79,8 @@ public class IcebergHiveMetadataFactory
             StatisticsFileCache statisticsFileCache,
             ManifestFileCache manifestFileCache,
             IcebergTableProperties tableProperties,
-            ConnectorSystemConfig connectorSystemConfig)
+            ConnectorSystemConfig connectorSystemConfig,
+            MetastoreClientConfig metastoreClientConfig)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -93,6 +99,10 @@ public class IcebergHiveMetadataFactory
         this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "icebergTableProperties is null");
         this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
+        requireNonNull(metastoreClientConfig, "metastoreClientConfig is null");
+        this.perTransactionCacheMaximumSize = metastoreClientConfig.getPerTransactionMetastoreCacheMaximumSize();
+        this.metastoreImpersonationEnabled = metastoreClientConfig.isMetastoreImpersonationEnabled();
+        this.metastorePartitionCacheMaxColumnCount = metastoreClientConfig.getPartitionCacheColumnCountLimit();
     }
 
     public IcebergTransactionMetadata create()
@@ -102,9 +112,11 @@ public class IcebergHiveMetadataFactory
 
     public IcebergTransactionMetadata create(IsolationLevel isolationLevel, boolean autoCommitContext)
     {
+        ExtendedHiveMetastore perTransactionMetastore = InMemoryCachingHiveMetastore.memoizeMetastore(
+                metastore, metastoreImpersonationEnabled, perTransactionCacheMaximumSize, metastorePartitionCacheMaxColumnCount);
         return new IcebergHiveMetadata(
                 catalogName,
-                metastore,
+                perTransactionMetastore,
                 hdfsEnvironment,
                 typeManager,
                 procedureRegistry,

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -425,7 +425,8 @@ public class TestRenameTableOnFragileFileSystem
                 new StatisticsFileCache(CacheBuilder.newBuilder().build()),
                 new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024),
                 new IcebergTableProperties(new IcebergConfig()),
-                () -> false);
+                () -> false,
+                new MetastoreClientConfig());
         return icebergHiveMetadataFactory.create();
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Align Iceberg Hive catalog with Hudi/Hive per-transaction metastore caching. Refactor per-query table cache from IcebergHiveMetadata in favour of per-transaction metastore caching.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No impact

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor Iceberg Hive metadata to rely on per-transaction Hive metastore caching instead of a per-query table cache.

Enhancements:
- Remove the per-query table cache from IcebergHiveMetadata and use the metastore directly for table lookups.
- Introduce per-transaction memoized Hive metastore instances in IcebergHiveMetadataFactory using MetastoreClientConfig settings.
- Add tests verifying that per-transaction Hive metastore caching behaves correctly across repeated lookups, separate transactions, and cache invalidation on writes.

Tests:
- Extend existing Iceberg Hive tests to construct metadata with MetastoreClientConfig.
- Add a new TestPerTransactionHiveMetastoreCaching suite to validate transactional cache hit behavior and invalidation semantics.