### PR TITLE
test: Add test coverage for Iceberg V3 initial-default with filter pushdown

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -382,8 +382,21 @@ public abstract class IcebergDistributedTestBase
         assertEquals(icebergTable.schema().findField("country").initialDefault(), "IN");
         assertEquals(icebergTable.schema().findField("country").writeDefault(), "IN");
         assertQuery(session, "SELECT id, name, country FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        // Test filter pushdown on column with initial-default (matching value)
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country = 'IN' ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        // Test filter pushdown on column with initial-default (non-matching value)
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country = 'US'", "SELECT 1 WHERE false");
+        // Test filter pushdown with IS NOT NULL
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country IS NOT NULL ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        // Test filter pushdown with IS NULL
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country IS NULL", "SELECT 1 WHERE false");
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES(3, 'Charlie', 'US')", 1);
         assertQuery(session, "SELECT id, name, country FROM " + tableName + " ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN'), (3, 'Charlie', 'US')");
+        // Test filter after new data inserted
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country = 'IN' ORDER BY id", "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN')");
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE country = 'US'", "VALUES (3, 'Charlie', 'US')");
+        // Test combined filter on file column and default column
+        assertQuery(session, "SELECT id, name, country FROM " + tableName + " WHERE id > 1 AND country = 'IN'", "VALUES (2, 'Bob', 'IN')");
         assertUpdate(session, "DROP TABLE " + tableName);
 
         // Test empty string default

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3DefaultColumnValues.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3DefaultColumnValues.java
@@ -141,6 +141,115 @@ public class TestIcebergV3DefaultColumnValues
         }
     }
 
+    @Test
+    public void testSelectWithInitialDefaultAndFilters()
+    {
+        String tableName = "select_initial_default_filters";
+        try {
+            createTableWithRows(tableName, "(id INTEGER, name VARCHAR)", "VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')", 3);
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN country VARCHAR DEFAULT 'IN'", tableName));
+            // This tests filter pushdown - without the fix, this would return 0 rows
+            assertQuery(String.format("SELECT id, name, country FROM %s WHERE country = 'IN' ORDER BY id", tableName),
+                    "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN'), (3, 'Charlie', 'IN')");
+            // Test filter on column with initial-default (non-matching value)
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, country FROM %s WHERE country = 'US'", tableName));
+            // Test IS NOT NULL filter
+            assertQuery(String.format("SELECT id, name, country FROM %s WHERE country IS NOT NULL ORDER BY id", tableName),
+                    "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN'), (3, 'Charlie', 'IN')");
+            // Test IS NULL filter
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, country FROM %s WHERE country IS NULL", tableName));
+            // Insert new data with explicit country value
+            assertUpdate(String.format("INSERT INTO %s VALUES (4, 'David', 'US')", tableName), 1);
+            // Test filter after new data inserted
+            assertQuery(String.format("SELECT id, name, country FROM %s WHERE country = 'IN' ORDER BY id", tableName),
+                    "VALUES (1, 'Alice', 'IN'), (2, 'Bob', 'IN'), (3, 'Charlie', 'IN')");
+            assertQuery(String.format("SELECT id, name, country FROM %s WHERE country = 'US'", tableName), "VALUES (4, 'David', 'US')");
+            // Test combined filter on file column and default column
+            assertQuery(String.format("SELECT id, name, country FROM %s WHERE id > 1 AND country = 'IN' ORDER BY id", tableName), "VALUES (2, 'Bob', 'IN'), (3, 'Charlie', 'IN')");
+            // Test combined filter with OR
+            assertQuery(String.format("SELECT id FROM %s WHERE country = 'US' OR id = 1 ORDER BY id", tableName), "VALUES (1), (4)");
+        }
+        finally {
+            dropTableIfExists(tableName);
+        }
+    }
+
+    @Test
+    public void testSelectWithNumericInitialDefaultAndFilters()
+    {
+        String tableName = "select_numeric_initial_default_filters";
+        try {
+            createTableWithRows(tableName, "(id INTEGER, name VARCHAR)", "VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')", 3);
+            // Add INTEGER column with initial-default value
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN age INTEGER DEFAULT 25", tableName));
+            // Test 1: Filter pushdown on INTEGER initial-default - matching value
+            assertQuery(
+                    String.format("SELECT id, name, age FROM %s WHERE age = 25 ORDER BY id", tableName),
+                    "VALUES (1, 'Alice', 25), (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 2: Filter on INTEGER initial-default (non-matching value)
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, age FROM %s WHERE age = 30", tableName));
+            // Test 3: Range filter on INTEGER initial-default (greater than)
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE age > 20 ORDER BY id", tableName), "VALUES (1, 'Alice', 25), (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 4: Range filter on INTEGER initial-default (less than)
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, age FROM %s WHERE age < 20", tableName));
+            // Test 5: Range filter on INTEGER initial-default (between)
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE age >= 25 AND age <= 30 ORDER BY id", tableName), "VALUES (1, 'Alice', 25), (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 6: IS NOT NULL filter on INTEGER initial-default
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE age IS NOT NULL ORDER BY id", tableName), "VALUES (1, 'Alice', 25), (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 7: IS NULL filter on INTEGER initial-default
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, age FROM %s WHERE age IS NULL", tableName));
+            // Test 8: Insert new data with explicit age value
+            assertUpdate(String.format("INSERT INTO %s VALUES (4, 'David', 30)", tableName), 1);
+            // Test 9: Filter after new data inserted - matching default
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE age = 25 ORDER BY id", tableName), "VALUES (1, 'Alice', 25), (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 10: Filter after new data inserted - matching new value
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE age = 30", tableName), "VALUES (4, 'David', 30)");
+            // Test 11: Combined filter on file column and INTEGER default column
+            assertQuery(String.format("SELECT id, name, age FROM %s WHERE id > 1 AND age = 25 ORDER BY id", tableName), "VALUES (2, 'Bob', 25), (3, 'Charlie', 25)");
+            // Test 12: Combined filter with OR on INTEGER default
+            assertQuery(String.format("SELECT id FROM %s WHERE age = 30 OR id = 1 ORDER BY id", tableName), "VALUES (1), (4)");
+            // Add REAL column with initial-default value
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN score REAL DEFAULT 3.14", tableName));
+            // Test 13: Filter on REAL initial-default (matching)
+            assertQuery(String.format("SELECT id, name, score FROM %s WHERE score = 3.14 ORDER BY id", tableName), "VALUES (1, 'Alice', CAST(3.14 AS REAL)), (2, 'Bob', CAST(3.14 AS REAL)), (3, 'Charlie', CAST(3.14 AS REAL)), (4, 'David', CAST(3.14 AS REAL))");
+            // Test 14: Filter on REAL initial-default (non-matching)
+            assertQueryReturnsEmptyResult(String.format("SELECT id, name, score FROM %s WHERE score = 2.5", tableName));
+            // Test 15: Range filter on REAL initial-default
+            assertQuery(String.format("SELECT id, name, score FROM %s WHERE score > 3.0 AND score < 4.0 ORDER BY id", tableName), "VALUES (1, 'Alice', CAST(3.14 AS REAL)), (2, 'Bob', CAST(3.14 AS REAL)), (3, 'Charlie', CAST(3.14 AS REAL)), (4, 'David', CAST(3.14 AS REAL))");
+            // Test 16: Insert new data with explicit REAL value
+            assertUpdate(String.format("INSERT INTO %s VALUES (5, 'Eve', 35, 4.5)", tableName), 1);
+            // Test 17: Combined filter on multiple numeric initial-defaults
+            assertQuery(String.format("SELECT id, name, age, score FROM %s WHERE age = 25 AND score = 3.14 ORDER BY id", tableName), "VALUES (1, 'Alice', 25, CAST(3.14 AS REAL)), (2, 'Bob', 25, CAST(3.14 AS REAL)), (3, 'Charlie', 25, CAST(3.14 AS REAL))");
+            // Test 18: Complex OR condition with numeric initial-defaults
+            assertQuery(String.format("SELECT id FROM %s WHERE (age = 30 AND score = 3.14) OR (age = 35 AND score = 4.5) ORDER BY id", tableName), "VALUES (4), (5)");
+            // Add BIGINT column with initial-default
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN salary BIGINT DEFAULT 50000", tableName));
+            // Test 19: Filter on BIGINT initial-default
+            assertQuery(String.format("SELECT id, name, salary FROM %s WHERE salary = 50000 ORDER BY id", tableName), "VALUES (1, 'Alice', 50000), (2, 'Bob', 50000), (3, 'Charlie', 50000), (4, 'David', 50000), (5, 'Eve', 50000)");
+            // Test 20: Range filter on BIGINT initial-default
+            assertQuery(String.format("SELECT id FROM %s WHERE salary >= 40000 AND salary <= 60000 ORDER BY id", tableName), "VALUES (1), (2), (3), (4), (5)");
+            // Add SMALLINT column with initial-default
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN department_id SMALLINT DEFAULT CAST(10 AS SMALLINT)", tableName));
+            // Test 21: Filter on SMALLINT initial-default
+            assertQuery(String.format("SELECT id, name, department_id FROM %s WHERE department_id = 10 ORDER BY id", tableName), "VALUES (1, 'Alice', 10), (2, 'Bob', 10), (3, 'Charlie', 10), (4, 'David', 10), (5, 'Eve', 10)");
+            // Add TINYINT column with initial-default
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN status TINYINT DEFAULT CAST(1 AS TINYINT)", tableName));
+            // Test 22: Filter on TINYINT initial-default
+            assertQuery(String.format("SELECT id, name, status FROM %s WHERE status = 1 ORDER BY id", tableName), "VALUES (1, 'Alice', 1), (2, 'Bob', 1), (3, 'Charlie', 1), (4, 'David', 1), (5, 'Eve', 1)");
+            // Test 23: Combined filter on all numeric types
+            assertQuery(String.format("SELECT id FROM %s WHERE age = 25 AND score = 3.14 AND salary = 50000 AND department_id = 10 AND status = 1 ORDER BY id", tableName), "VALUES (1), (2), (3)");
+            // Add DOUBLE column with initial-default
+            assertUpdate(String.format("ALTER TABLE %s ADD COLUMN rating DOUBLE DEFAULT 4.567", tableName));
+            // Test 24: Filter on DOUBLE initial-default
+            assertQuery(String.format("SELECT id, name, rating FROM %s WHERE rating = 4.567 ORDER BY id", tableName), "VALUES (1, 'Alice', 4.567), (2, 'Bob', 4.567), (3, 'Charlie', 4.567), (4, 'David', 4.567), (5, 'Eve', 4.567)");
+            // Test 25: Range filter combining REAL and DOUBLE
+            assertQuery(String.format("SELECT id FROM %s WHERE score > 3.0 AND rating > 4.0 ORDER BY id", tableName), "VALUES (1), (2), (3), (4), (5)");
+        }
+        finally {
+            dropTableIfExists(tableName);
+        }
+    }
+
     private void createTableWithRows(String tableName, String tableDefinition, String values, long rowCount)
     {
         assertUpdate(String.format("CREATE TABLE %s %s WITH (\"format-version\" = '3', format = 'PARQUET')", tableName, tableDefinition));


### PR DESCRIPTION
## Description
Add test coverage for Iceberg V3 initial-default with filter pushdown.
For Java and Presto C++
There is a bug in the Presto C++ side that needs a fix in Velox for this scenario - https://github.com/facebookincubator/velox/pull/17778

## Motivation and Context
Add test coverage for Iceberg V3 initial-default with filter pushdown.
For Java and Presto C++
There is a bug in the Presto C++ side that needs a fix in Velox for this scenario.

## Impact
Cover a wider test scenario and catch a bug

## Test Plan
Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Expand Iceberg V3 initial-default column coverage with filter pushdown scenarios in both Java and Presto native tests.

Tests:
- Add native Iceberg V3 test verifying filter pushdown behavior on columns with initial default values, including equality, null checks, and combined predicates.
- Extend distributed Iceberg tests to cover filter pushdown on initial-default columns before and after inserting additional rows.

## Summary by Sourcery

Expand Iceberg V3 initial-default column test coverage to validate filter pushdown behavior in both native and distributed test suites.

Tests:
- Add native Iceberg V3 tests covering filter pushdown on initial-default columns across string and multiple numeric types, including equality, range, nullability, and compound predicates before and after inserting explicit values.
- Extend distributed Iceberg tests to assert correct filter pushdown and combined predicates on initial-default columns after schema evolution and data insertion.