### PR TITLE
fix: Response handling and dependency versions elasticsearch

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.elasticsearch.version>9.0.1</dep.elasticsearch.version>
+        <dep.elasticsearch.version>9.1.0</dep.elasticsearch.version>
         <dep.log4j.version>2.25.4</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.lucene.version>9.12.0</dep.lucene.version>

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -85,11 +85,13 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -111,6 +113,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
@@ -730,12 +733,32 @@ public class ElasticsearchClient
 
         String body;
         try {
-            body = EntityUtils.toString(response.getEntity());
+            HttpEntity entity = response.getEntity();
+            // ES 9.x may return responses with Content-Encoding: gzip header
+            // but without actual GZIP compression. Read the raw bytes and
+            // decompress manually only if the content is actually GZIP encoded.
+            byte[] rawBytes = EntityUtils.toByteArray(entity);
+            if (isGzipped(rawBytes)) {
+                try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(rawBytes))) {
+                    body = new String(gis.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            }
+            else {
+                body = new String(rawBytes, StandardCharsets.UTF_8);
+            }
         }
-        catch (IOException | ParseException e) {
+        catch (IOException e) {
             throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
         }
         return handler.process(body);
+    }
+
+    private static boolean isGzipped(byte[] bytes)
+    {
+        // GZIP magic number is 0x1f 0x8b
+        return bytes.length >= 2
+                && (bytes[0] & 0xFF) == 0x1F
+                && (bytes[1] & 0xFF) == 0x8B;
     }
 
     private static PrestoException propagate(ResponseException exception)

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchMixedCaseTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchMixedCaseTest.java
@@ -41,7 +41,7 @@ import static org.testng.Assert.assertTrue;
 public class TestElasticsearchMixedCaseTest
         extends AbstractTestQueryFramework
 {
-    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:7.17.27";
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:9.1.0";
     private ElasticsearchServer elasticsearch;
     private ElasticsearchClient client;
     @Override


### PR DESCRIPTION
## Description
doRequest was causing tests to flake due to responses marked as `Content-Encoding: gzip` that had bodies which were not actually GZIP compressed. This happens with certain docker environments/configs for the elasticsearch container. Fixed with logic added to doRequest method. 

Also upgraded the server version in mixed case test to match other tests in the module.

Example of potential test failures:
```
06:20:50  [ERROR] com.facebook.presto.elasticsearch.TestElasticsearchIntegrationSmokeTest.testShowTables  Time elapsed: 0.026 s  <<< FAILURE!
06:20:50  java.lang.RuntimeException: Not in GZIP format
06:20:50  	at com.facebook.presto.tests.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:127)
06:20:50  	at com.facebook.presto.tests.DistributedQueryRunner.execute(DistributedQueryRunner.java:970)
06:20:50  	at com.facebook.presto.tests.DistributedQueryRunner.execute(DistributedQueryRunner.java:892)
06:20:50  	at com.facebook.presto.tests.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:143)
06:20:50  	at com.facebook.presto.tests.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:138)
06:20:50  	at com.facebook.presto.tests.AbstractTestIntegrationSmokeTest.testShowTables(AbstractTestIntegrationSmokeTest.java:132)
06:20:50  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
06:20:50  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
06:20:50  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
06:20:50  	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
06:20:50  	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
06:20:50  	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
06:20:50  	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
06:20:50  	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
06:20:50  	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
06:20:50  	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
06:20:50  	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
06:20:50  	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
06:20:50  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
06:20:50  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
06:20:50  	at java.base/java.lang.Thread.run(Thread.java:840)
06:20:50  Caused by: com.facebook.presto.spi.PrestoException: Not in GZIP format
06:20:50  	at com.facebook.presto.elasticsearch.client.ElasticsearchClient.doRequest(ElasticsearchClient.java:736)
06:20:50  	at com.facebook.presto.elasticsearch.client.ElasticsearchClient.getIndexes(ElasticsearchClient.java:466)
06:20:50  	at com.facebook.presto.elasticsearch.ElasticsearchMetadata.listTables(ElasticsearchMetadata.java:357)
06:20:50  	at com.facebook.presto.metadata.MetadataManager.listTables(MetadataManager.java:653)
06:20:50  	at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.lambda$calculatePrefixesWithTableName$7(InformationSchemaMetadata.java:321)
06:20:50  	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
06:20:50  	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
06:20:50  	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
06:20:50  	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
06:20:50  	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
06:20:50  	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
06:20:50  	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
06:20:50  	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
06:20:50  	at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.calculatePrefixesWithTableName(InformationSchemaMetadata.java:329)
06:20:50  	at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.getTableLayoutForConstraint(InformationSchemaMetadata.java:257)
06:20:50  	at com.facebook.presto.metadata.MetadataManager.getLayout(MetadataManager.java:479)
06:20:50  	at com.facebook.presto.metadata.StatsRecordingMetadataManager.getLayout(StatsRecordingMetadataManager.java:1346)
06:20:50  	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout.pushPredicateIntoTableScan(PickTableLayout.java:320)
06:20:50  	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout.pushPredicateIntoTableScan(PickTableLayout.java:255)
06:20:50  	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutForPredicate.apply(PickTableLayout.java:139)
06:20:50  	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutForPredicate.apply(PickTableLayout.java:104)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:238)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:190)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:152)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:282)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:154)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:282)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:154)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:282)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:154)
06:20:50  	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:139)
06:20:50  	at com.facebook.presto.sql.Optimizer.validateAndOptimizePlan(Optimizer.java:114)
06:20:50  	at com.facebook.presto.execution.SqlQueryExecution.lambda$doCreateLogicalPlanAndOptimize$6(SqlQueryExecution.java:603)
06:20:50  	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
06:20:50  	at com.facebook.presto.execution.SqlQueryExecution.doCreateLogicalPlanAndOptimize(SqlQueryExecution.java:601)
06:20:50  	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
06:20:50  	at com.facebook.presto.execution.SqlQueryExecution.createLogicalPlanAndOptimize(SqlQueryExecution.java:572)
06:20:50  	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:500)
06:20:50  	at com.facebook.presto.$gen.Presto_0_299_SNAPSHOT_4f04dea__testversion____20260604_062032_10.run(Unknown Source)
06:20:50  	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:326)
06:20:50  	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:217)
06:20:50  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
06:20:50  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
06:20:50  	at java.base/java.lang.Thread.run(Thread.java:840)
06:20:50  Caused by: java.util.zip.ZipException: Not in GZIP format
06:20:50  	at java.base/java.util.zip.GZIPInputStream.readHeader(GZIPInputStream.java:165)
06:20:50  	at java.base/java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:79)
06:20:50  	at java.base/java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:91)
06:20:50  	at org.apache.hc.client5.http.entity.GZIPInputStreamFactory.create(GZIPInputStreamFactory.java:72)
06:20:50  	at org.apache.hc.client5.http.entity.LazyDecompressingInputStream.initWrapper(LazyDecompressingInputStream.java:56)
06:20:50  	at org.apache.hc.client5.http.entity.LazyDecompressingInputStream.read(LazyDecompressingInputStream.java:73)
06:20:50  	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:281)
06:20:50  	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:324)
06:20:50  	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:189)
06:20:50  	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:177)
06:20:50  	at java.base/java.io.Reader.read(Reader.java:250)
06:20:50  	at org.apache.hc.core5.http.io.entity.EntityUtils.toCharArrayBuffer(EntityUtils.java:188)
06:20:50  	at org.apache.hc.core5.http.io.entity.EntityUtils.toString(EntityUtils.java:231)
06:20:50  	at org.apache.hc.core5.http.io.entity.EntityUtils.toString(EntityUtils.java:371)
06:20:50  	at org.apache.hc.core5.http.io.entity.EntityUtils.toString(EntityUtils.java:351)
06:20:50  	at com.facebook.presto.elasticsearch.client.ElasticsearchClient.doRequest(ElasticsearchClient.java:733)
06:20:50  	... 43 more
06:20:50  
```

Also aligned container versions and upgraded the dependency version

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Refresh the Elasticsearch test dependency from version 7.17.27 to 9.1.0 for the mixed-case test suite.

## Summary by Sourcery

Handle Elasticsearch HTTP responses that may be incorrectly flagged as GZIP-encoded and update the mixed-case Elasticsearch test server version.

Bug Fixes:
- Prevent flaky Elasticsearch tests by safely handling responses whose Content-Encoding is marked as gzip but whose bodies are not actually GZIP compressed.

Enhancements:
- Improve Elasticsearch client response handling by manually detecting and decoding GZIP content based on the response bytes rather than relying solely on headers.

Tests:
- Update the Elasticsearch Docker image version used in the mixed-case test suite to align with the newer 9.x server behavior.