### PR TITLE
chore(ci): Advance velox

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -220,7 +220,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -11,7 +11,7 @@ jobs:
   prestocpp-linux-adapters-build:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-adapters-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-build-test-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -135,7 +135,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -260,7 +260,7 @@ jobs:
         storage-format: [PARQUET, DWRF]
         enable-sidecar: [true, false]
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -389,7 +389,7 @@ jobs:
       group: ${{ github.workflow }}-prestocpp-linux-presto-on-spark-e2e-tests-${{ matrix.storage-format }}-${{ matrix.enable-sidecar }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -502,7 +502,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -614,7 +614,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.297-202602190453-8d6d9543
+      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -92,6 +92,10 @@ jobs:
           install_wangle
           install_mvfst
 
+          # FileUtils.h pulls Buffer.h without declaring the dependency leading
+          # to a missing xsimd header if bundled.
+          install_xsimd
+
           # Velox dependencies that Presto directly depends on.
           install_re2
           install_fbthrift

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.24)
 
 # set the project name
 project(PrestoCpp)
@@ -37,6 +37,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
     string(APPEND DISABLED_WARNINGS " -Wno-error=template-id-cdtor")
   endif()
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+  # Handle Apple toolchain Clang change of name of variable.
+  # Remove when upgrading to the latest FBOS version where this has been addressed.
+  add_compile_options(-D_LIBCPP_HAS_NO_ASAN)
 endif()
 
 # Important warnings that must be explicitly enabled.
@@ -142,7 +146,11 @@ find_package(gflags COMPONENTS shared)
 
 find_library(GLOG glog)
 
-find_library(FMT fmt)
+# Must precede find_package(folly), which transitively imports fmt via
+# folly-config.cmake's find_dependency(fmt). Use GLOBAL so the imported
+# target's directory scope doesn't trip (GPU) rapids-cmake's make_global() when
+# cudf is later configured under add_subdirectory(velox).
+find_package(fmt CONFIG REQUIRED GLOBAL)
 
 find_library(EVENT event)
 # On macOS, explicitly find and add libevent include directory to handle

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -27,6 +27,7 @@
 #include "presto_cpp/main/TaskResource.h"
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Counters.h"
+#include "presto_cpp/main/common/LegacyHiveConfigKeys.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/connectors/Registration.h"
 #include "presto_cpp/main/connectors/SystemConnector.h"
@@ -1428,6 +1429,11 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
           fileName.substr(0, fileName.size() - kPropertiesExtension.size());
 
       auto connectorConf = util::readConfig(entry.path());
+      auto connectorName =
+          util::requiredProperty(connectorConf, kConnectorName);
+
+      util::migrateLegacyHiveParquetKeys(connectorName, connectorConf);
+
       PRESTO_STARTUP_LOG(INFO)
           << "Registered catalog property keys from " << entry.path() << ":\n"
           << logConnectorConfigPropertyKeys(connectorConf);
@@ -1435,8 +1441,6 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
       std::shared_ptr<const velox::config::ConfigBase> properties =
           std::make_shared<const velox::config::ConfigBase>(
               std::move(connectorConf));
-
-      auto connectorName = util::requiredProperty(*properties, kConnectorName);
 
       catalogNames.emplace_back(catalogName);
 

--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -14,6 +14,7 @@
 
 #include "presto_cpp/main/PrestoToVeloxQueryConfig.h"
 #include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/LegacyHiveConfigKeys.h"
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "velox/common/compression/Compression.h"
 #include "velox/core/QueryConfig.h"
@@ -296,6 +297,7 @@ toConnectorConfigs(const protocol::TaskUpdateRequest& taskUpdateRequest) {
           : sessionProperty.first;
       connectorConfig.emplace(veloxConfig, sessionProperty.second);
     }
+    util::migrateLegacyHiveParquetSessionKeys(connectorConfig);
     connectorConfig.insert(
         taskUpdateRequest.extraCredentials.begin(),
         taskUpdateRequest.extraCredentials.end());

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -11,7 +11,14 @@
 # limitations under the License.
 
 add_library(presto_exception Exception.cpp)
-add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
+add_library(
+  presto_common
+  Counters.cpp
+  Utils.cpp
+  ConfigReader.cpp
+  Configs.cpp
+  LegacyHiveConfigKeys.cpp
+)
 
 target_link_libraries(presto_exception velox_exception)
 set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/common/LegacyHiveConfigKeys.cpp
+++ b/presto-native-execution/presto_cpp/main/common/LegacyHiveConfigKeys.cpp
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/common/LegacyHiveConfigKeys.h"
+
+#include <array>
+#include <string_view>
+#include <utility>
+
+#include "presto_cpp/main/common/Utils.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/iceberg/IcebergConnector.h"
+
+namespace facebook::presto::util {
+
+void migrateLegacyHiveParquetKeys(
+    const std::string& connectorName,
+    std::unordered_map<std::string, std::string>& configs) {
+  if (connectorName !=
+          velox::connector::hive::HiveConnectorFactory::kHiveConnectorName &&
+      connectorName !=
+          velox::connector::hive::iceberg::IcebergConnectorFactory::
+              kIcebergConnectorName) {
+    return;
+  }
+
+  static constexpr std::array<std::pair<std::string_view, std::string_view>, 4>
+      kRenames = {{
+          {"parquet.use-column-names", "hive.parquet.use-column-names"},
+          {"parquet.allow-int32-narrowing",
+           "hive.parquet.allow-int32-narrowing"},
+          {"parquet.footer-speculative-io-size",
+           "hive.parquet.footer-speculative-io-size"},
+          {"parquet-footer-memory-tracking-threshold",
+           "hive.parquet.footer-memory-tracking-threshold"},
+      }};
+  for (const auto& [oldKey, newKey] : kRenames) {
+    auto node = configs.extract(std::string{oldKey});
+    if (!node) {
+      continue;
+    }
+    if (configs.find(std::string{newKey}) == configs.end()) {
+      PRESTO_STARTUP_LOG(WARNING)
+          << "Hive connector config '" << oldKey
+          << "' is deprecated; rewriting to '" << newKey << "'.";
+      configs.emplace(std::string{newKey}, std::move(node.mapped()));
+    } else {
+      PRESTO_STARTUP_LOG(WARNING) << "Hive connector config '" << oldKey
+                                  << "' is deprecated and ignored because '"
+                                  << newKey << "' is also set.";
+    }
+  }
+
+  static constexpr std::string_view kLegacyMaxTargetFileSize =
+      "max-target-file-size";
+  static constexpr std::array<std::string_view, 3>
+      kPerFormatMaxTargetFileSizeKeys = {
+          "hive.parquet.writer.max-target-file-size",
+          "hive.orc.writer.max-target-file-size",
+          "hive.nimble.writer.max-target-file-size",
+      };
+  auto legacyNode = configs.extract(std::string{kLegacyMaxTargetFileSize});
+  if (legacyNode) {
+    PRESTO_STARTUP_LOG(WARNING)
+        << "Hive connector config '" << kLegacyMaxTargetFileSize
+        << "' is deprecated and has been split into per-format keys; "
+        << "fanning out value to all of: " << kPerFormatMaxTargetFileSizeKeys[0]
+        << ", " << kPerFormatMaxTargetFileSizeKeys[1] << ", "
+        << kPerFormatMaxTargetFileSizeKeys[2] << ".";
+    const auto& value = legacyNode.mapped();
+    for (const auto newKey : kPerFormatMaxTargetFileSizeKeys) {
+      if (configs.find(std::string{newKey}) == configs.end()) {
+        configs.emplace(std::string{newKey}, value);
+      } else {
+        PRESTO_STARTUP_LOG(WARNING)
+            << "  '" << newKey << "' is already set; not overwriting.";
+      }
+    }
+  }
+}
+
+void migrateLegacyHiveParquetSessionKeys(
+    std::unordered_map<std::string, std::string>& sessionProperties) {
+  static constexpr std::pair<std::string_view, std::string_view> kRename = {
+      "allow_int32_narrowing", "parquet_allow_int32_narrowing"};
+  if (auto node = sessionProperties.extract(std::string{kRename.first})) {
+    LOG_FIRST_N(WARNING, 1)
+        << "Hive connector session property '" << kRename.first
+        << "' is deprecated; rewriting to '" << kRename.second
+        << "'. (Logged once per process.)";
+    if (sessionProperties.find(std::string{kRename.second}) ==
+        sessionProperties.end()) {
+      sessionProperties.emplace(
+          std::string{kRename.second}, std::move(node.mapped()));
+    }
+  }
+
+  static constexpr std::string_view kLegacyMaxTargetFileSize =
+      "max_target_file_size";
+  static constexpr std::array<std::string_view, 3>
+      kPerFormatMaxTargetFileSizeSessionKeys = {
+          "parquet_writer_max_target_file_size",
+          "orc_writer_max_target_file_size",
+          "nimble_writer_max_target_file_size",
+      };
+  if (auto legacyNode =
+          sessionProperties.extract(std::string{kLegacyMaxTargetFileSize})) {
+    LOG_FIRST_N(WARNING, 1)
+        << "Hive connector session property '" << kLegacyMaxTargetFileSize
+        << "' is deprecated; fanning out to format-specific keys. "
+        << "(Logged once per process.)";
+    const auto& value = legacyNode.mapped();
+    for (const auto newKey : kPerFormatMaxTargetFileSizeSessionKeys) {
+      if (sessionProperties.find(std::string{newKey}) ==
+          sessionProperties.end()) {
+        sessionProperties.emplace(std::string{newKey}, value);
+      }
+    }
+  }
+}
+
+} // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/LegacyHiveConfigKeys.h
+++ b/presto-native-execution/presto_cpp/main/common/LegacyHiveConfigKeys.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace facebook::presto::util {
+
+/// Transitional. Rewrites legacy Hive Parquet connector property keys to
+/// their post-rename equivalents from Velox commit
+/// 1f90087b4e0431578777eba68e6dccc2155df3ee. No-op unless `connectorName`
+/// is `hive` or `iceberg`. `max-target-file-size` is fanned out to all
+/// three new format-specific keys to preserve its previous format-agnostic
+/// behavior. On conflict, the existing new key wins.
+void migrateLegacyHiveParquetKeys(
+    const std::string& connectorName,
+    std::unordered_map<std::string, std::string>& configs);
+
+/// Transitional. Same as above for connector session properties. Rewrites
+/// `allow_int32_narrowing` and fans `max_target_file_size` out across the
+/// three format-specific session keys. Logs a deprecation warning once per
+/// process (called per task update).
+void migrateLegacyHiveParquetSessionKeys(
+    std::unordered_map<std::string, std::string>& sessionProperties);
+
+} // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(presto_mutable_configs MutableConfigs.cpp)
 
 target_link_libraries(presto_mutable_configs presto_common velox_file)
 
-add_executable(presto_common_test CommonTest.cpp ConfigTest.cpp)
+add_executable(presto_common_test CommonTest.cpp ConfigTest.cpp LegacyHiveConfigKeysTest.cpp)
 
 add_test(presto_common_test presto_common_test)
 

--- a/presto-native-execution/presto_cpp/main/common/tests/LegacyHiveConfigKeysTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/LegacyHiveConfigKeysTest.cpp
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/common/LegacyHiveConfigKeys.h"
+
+#include <gtest/gtest.h>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::presto::util {
+namespace {
+
+using ConfigMap = std::unordered_map<std::string, std::string>;
+
+TEST(LegacyHiveConfigKeysTest, configRename) {
+  ConfigMap configs{
+      {"parquet.use-column-names", "true"},
+      {"parquet.allow-int32-narrowing", "true"},
+      {"parquet.footer-speculative-io-size", "1048576"},
+      {"parquet-footer-memory-tracking-threshold", "2048"},
+      {"connector.name", "hive"},
+  };
+  migrateLegacyHiveParquetKeys("hive", configs);
+
+  EXPECT_EQ(configs["hive.parquet.use-column-names"], "true");
+  EXPECT_EQ(configs["hive.parquet.allow-int32-narrowing"], "true");
+  EXPECT_EQ(configs["hive.parquet.footer-speculative-io-size"], "1048576");
+  EXPECT_EQ(configs["hive.parquet.footer-memory-tracking-threshold"], "2048");
+  EXPECT_EQ(configs.count("parquet.use-column-names"), 0);
+  EXPECT_EQ(configs.count("parquet.allow-int32-narrowing"), 0);
+  EXPECT_EQ(configs.count("parquet.footer-speculative-io-size"), 0);
+  EXPECT_EQ(configs.count("parquet-footer-memory-tracking-threshold"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, configMaxTargetFileSizeFanOut) {
+  ConfigMap configs{{"max-target-file-size", "1MB"}};
+  migrateLegacyHiveParquetKeys("hive", configs);
+
+  EXPECT_EQ(configs["hive.parquet.writer.max-target-file-size"], "1MB");
+  EXPECT_EQ(configs["hive.orc.writer.max-target-file-size"], "1MB");
+  EXPECT_EQ(configs["hive.nimble.writer.max-target-file-size"], "1MB");
+  EXPECT_EQ(configs.count("max-target-file-size"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, configIcebergGate) {
+  ConfigMap configs{{"max-target-file-size", "2MB"}};
+  migrateLegacyHiveParquetKeys("iceberg", configs);
+
+  EXPECT_EQ(configs["hive.parquet.writer.max-target-file-size"], "2MB");
+  EXPECT_EQ(configs.count("max-target-file-size"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, configNonHiveConnectorNoOp) {
+  ConfigMap configs{
+      {"max-target-file-size", "1MB"},
+      {"parquet.use-column-names", "true"},
+  };
+  migrateLegacyHiveParquetKeys("tpch", configs);
+
+  EXPECT_EQ(configs["max-target-file-size"], "1MB");
+  EXPECT_EQ(configs["parquet.use-column-names"], "true");
+  EXPECT_EQ(configs.count("hive.parquet.writer.max-target-file-size"), 0);
+  EXPECT_EQ(configs.count("hive.parquet.use-column-names"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, configNewKeyWins) {
+  ConfigMap configs{
+      {"parquet.use-column-names", "true"},
+      {"hive.parquet.use-column-names", "false"},
+      {"max-target-file-size", "1MB"},
+      {"hive.orc.writer.max-target-file-size", "8MB"},
+  };
+  migrateLegacyHiveParquetKeys("hive", configs);
+
+  EXPECT_EQ(configs["hive.parquet.use-column-names"], "false");
+  EXPECT_EQ(configs.count("parquet.use-column-names"), 0);
+  EXPECT_EQ(configs["hive.parquet.writer.max-target-file-size"], "1MB");
+  EXPECT_EQ(configs["hive.orc.writer.max-target-file-size"], "8MB");
+  EXPECT_EQ(configs["hive.nimble.writer.max-target-file-size"], "1MB");
+  EXPECT_EQ(configs.count("max-target-file-size"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, sessionRename) {
+  ConfigMap session{{"allow_int32_narrowing", "true"}};
+  migrateLegacyHiveParquetSessionKeys(session);
+
+  EXPECT_EQ(session["parquet_allow_int32_narrowing"], "true");
+  EXPECT_EQ(session.count("allow_int32_narrowing"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, sessionMaxTargetFileSizeFanOut) {
+  ConfigMap session{{"max_target_file_size", "4KB"}};
+  migrateLegacyHiveParquetSessionKeys(session);
+
+  EXPECT_EQ(session["parquet_writer_max_target_file_size"], "4KB");
+  EXPECT_EQ(session["orc_writer_max_target_file_size"], "4KB");
+  EXPECT_EQ(session["nimble_writer_max_target_file_size"], "4KB");
+  EXPECT_EQ(session.count("max_target_file_size"), 0);
+}
+
+TEST(LegacyHiveConfigKeysTest, sessionNoLegacyKeysIsNoOp) {
+  ConfigMap session{
+      {"parquet_use_column_names", "true"},
+      {"parquet_writer_max_target_file_size", "8KB"},
+  };
+  const ConfigMap before = session;
+  migrateLegacyHiveParquetSessionKeys(session);
+  EXPECT_EQ(session, before);
+}
+
+TEST(LegacyHiveConfigKeysTest, sessionNewKeyWins) {
+  ConfigMap session{
+      {"max_target_file_size", "4KB"},
+      {"orc_writer_max_target_file_size", "16KB"},
+      {"allow_int32_narrowing", "true"},
+      {"parquet_allow_int32_narrowing", "false"},
+  };
+  migrateLegacyHiveParquetSessionKeys(session);
+
+  EXPECT_EQ(session["parquet_writer_max_target_file_size"], "4KB");
+  EXPECT_EQ(session["orc_writer_max_target_file_size"], "16KB");
+  EXPECT_EQ(session["nimble_writer_max_target_file_size"], "4KB");
+  EXPECT_EQ(session.count("max_target_file_size"), 0);
+  EXPECT_EQ(session["parquet_allow_int32_narrowing"], "false");
+  EXPECT_EQ(session.count("allow_int32_narrowing"), 0);
+}
+
+} // namespace
+} // namespace facebook::presto::util

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -32,11 +32,15 @@ COPY velox/scripts /velox/scripts
 # Copy extra script called during setup.
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
+COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /velox
+ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
+COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
+ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 COPY CMake/arrow/arrow-flight.patch /scripts
-ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
 RUN bash -c "mkdir build && \
-    (cd build && ../scripts/setup-centos.sh && \
+    (cd build && export VELOX_BUILD_SHARED=ON && \
+                 ../scripts/setup-centos.sh && \
                  ../scripts/setup-adapters.sh && \
                  source ../velox/scripts/setup-centos9.sh && \
                  source ../velox/scripts/setup-centos-adapters.sh && \

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -35,10 +35,16 @@ COPY velox/scripts /velox/scripts
 # Copy extra script called during setup.
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
-ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
+COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /velox
+ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
+COPY CMake/arrow/arrow-flight.patch /scripts
+ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
+COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
+ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 # install rpm needed for minio install.
 RUN mkdir build && \
-    (cd build && ../scripts/setup-ubuntu.sh && \
+    (cd build && export VELOX_BUILD_SHARED=ON && \
+                 ../scripts/setup-ubuntu.sh && \
                          apt install -y rpm && \
                  ../velox/scripts/setup-ubuntu.sh install_adapters && \
                  ../scripts/setup-adapters.sh ) && \


### PR DESCRIPTION
Additional fixes:
- bump minimum cmake to 3.24 - Velox minimum is 3.28
- add backwards compatible mapping for renamed hive config properties
- Build folly to link with shared gflags in the dependency images - fbthrift brings in folly (and by default links gflags statically) and conflicts with the prestissimo build that links gflags shared. Issue fixed is with the thrift_io_test.
- adding the folly patch to build the dependency image - will be removed with FBOS update.
- workaround missing Velox xsimd dependency from the FileUtils by installing it to macOS to not be bundled.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Chores:
- Update the presto-native-execution Velox submodule pointer to the latest desired commit.