### PR TITLE
feat(plugin-hive-metastore)!: Add comprehensive cache metrics for all metastore caches

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -396,6 +396,81 @@ Property Name                                                         Descriptio
   * ``ROLES``: Caches the list of available Hive roles.
   * ``ROLE_GRANTS``: Caches role grant mappings for principals.
 
+Metastore Cache Metrics
+-----------------------
+
+Overview
+^^^^^^^^
+
+The Hive connector uses in-memory caching to reduce load on the Hive metastore and improve query performance. 
+The connector maintains 14 distinct caches, each optimized for specific types of metadata. All caches expose 
+JMX metrics that provide visibility into cache performance, helping you monitor efficiency, tune cache 
+configurations, and troubleshoot performance issues.
+
+Metric Types
+^^^^^^^^^^^^
+
+Each cache exposes four types of metrics:
+
+* **hit** - Number of successful cache lookups (metadata found in cache)
+* **miss** - Number of cache misses requiring metastore access
+* **eviction** - Number of entries evicted from cache due to size limits or TTL expiration
+* **size** - Current number of entries stored in the cache
+
+JMX Metric Naming Convention
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All cache metrics can be queried from the following JMX table:
+
+.. code-block:: sql
+
+    SELECT <metricname> FROM jmx.current."com.facebook.presto.hive.metastore:name=<catalogname>,type=metastorecachestatscache"
+
+Where:
+
+* ``<catalogname>`` is the catalog name
+* ``<metricname>`` is the cache metric name
+
+
+Each of the 14 caches exposes 4 metrics (``hit``, ``miss``, ``eviction``, ``size``) following the pattern ``<cachename><metrictype>``:
+
+Available Metrics
+^^^^^^^^^^^^^^^^^
+
+The following table lists the available cache metrics.
+
+================================ ========================================
+Cache Name                       Example Metric
+================================ ========================================
+``databasecache``                ``databasecachehit``
+``databasenamescache``           ``databasenamescachehit``
+``tablecache``                   ``tablecachehit``
+``tablenamescache``              ``tablenamescachehit``
+``tablestatisticscache``         ``tablestatisticscachehit``
+``tableconstraintscache``        ``tableconstraintscachehit``
+``partitioncache``               ``partitioncachehit``
+``partitionfiltercache``         ``partitionfiltercachehit``
+``partitionnamescache``          ``partitionnamescachehit``
+``partitionstatisticscache``     ``partitionstatisticscachehit``
+``viewnamescache``               ``viewnamescachehit``
+``tableprivilegescache``         ``tableprivilegescachehit``
+``rolescache``                   ``rolescachehit``
+``rolegrantscache``              ``rolegrantscachehit``
+================================ ========================================
+
+**Example:**
+
+.. code-block:: sql
+
+    SELECT databasecachehit, tablecachehit, partitionfiltercachehit FROM jmx.current."com.facebook.presto.hive.metastore:name=<catalogname>,type=metastorecachestatscache"
+
+For cache invalidation procedures, see `Invalidate Metastore Cache`_.
+
+.. note::
+
+    All 14 caches are enabled by default when metastore caching is configured. Metrics are automatically 
+    exposed via JMX without additional configuration.
+
 AWS Glue Catalog Configuration Properties
 -----------------------------------------
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
@@ -22,9 +22,32 @@ public class HiveMetastoreCacheStats
         implements MetastoreCacheStats
 {
     private final CounterStat partitionsWithColumnCountGreaterThanThreshold = new CounterStat();
+    private LoadingCache<?, ?> databaseCache;
+    private LoadingCache<?, ?> databaseNamesCache;
     private LoadingCache<?, ?> tableCache;
-    private LoadingCache<?, ?> partitionNamesCache;
+    private LoadingCache<?, ?> tableNamesCache;
+    private LoadingCache<?, ?> tableStatisticsCache;
+    private LoadingCache<?, ?> tableConstraintsCache;
+    private LoadingCache<?, ?> partitionStatisticsCache;
+    private LoadingCache<?, ?> viewNamesCache;
     private LoadingCache<?, ?> partitionCache;
+    private LoadingCache<?, ?> partitionFilterCache;
+    private LoadingCache<?, ?> partitionNamesCache;
+    private LoadingCache<?, ?> tablePrivilegesCache;
+    private LoadingCache<?, ?> rolesCache;
+    private LoadingCache<?, ?> roleGrantsCache;
+
+    @Override
+    public void setDatabaseCache(LoadingCache<?, ?> databaseCache)
+    {
+        this.databaseCache = databaseCache;
+    }
+
+    @Override
+    public void setDatabaseNamesCache(LoadingCache<?, ?> databaseNamesCache)
+    {
+        this.databaseNamesCache = databaseNamesCache;
+    }
 
     @Override
     public void setTableCache(LoadingCache<?, ?> tableCache)
@@ -33,9 +56,33 @@ public class HiveMetastoreCacheStats
     }
 
     @Override
-    public void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache)
+    public void setTableNamesCache(LoadingCache<?, ?> tableNamesCache)
     {
-        this.partitionNamesCache = partitionNamesCache;
+        this.tableNamesCache = tableNamesCache;
+    }
+
+    @Override
+    public void setTableStatisticsCache(LoadingCache<?, ?> tableStatisticsCache)
+    {
+        this.tableStatisticsCache = tableStatisticsCache;
+    }
+
+    @Override
+    public void setTableConstraintsCache(LoadingCache<?, ?> tableConstraintsCache)
+    {
+        this.tableConstraintsCache = tableConstraintsCache;
+    }
+
+    @Override
+    public void setPartitionStatisticsCache(LoadingCache<?, ?> partitionStatisticsCache)
+    {
+        this.partitionStatisticsCache = partitionStatisticsCache;
+    }
+
+    @Override
+    public void setViewNamesCache(LoadingCache<?, ?> viewNamesCache)
+    {
+        this.viewNamesCache = viewNamesCache;
     }
 
     @Override
@@ -45,9 +92,95 @@ public class HiveMetastoreCacheStats
     }
 
     @Override
+    public void setPartitionFilterCache(LoadingCache<?, ?> partitionFilterCache)
+    {
+        this.partitionFilterCache = partitionFilterCache;
+    }
+
+    @Override
+    public void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache)
+    {
+        this.partitionNamesCache = partitionNamesCache;
+    }
+
+    @Override
+    public void setTablePrivilegesCache(LoadingCache<?, ?> tablePrivilegesCache)
+    {
+        this.tablePrivilegesCache = tablePrivilegesCache;
+    }
+
+    @Override
+    public void setRolesCache(LoadingCache<?, ?> rolesCache)
+    {
+        this.rolesCache = rolesCache;
+    }
+
+    @Override
+    public void setRoleGrantsCache(LoadingCache<?, ?> roleGrantsCache)
+    {
+        this.roleGrantsCache = roleGrantsCache;
+    }
+
+    @Override
     public void incrementPartitionsWithColumnCountGreaterThanThreshold()
     {
         partitionsWithColumnCountGreaterThanThreshold.update(1);
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseCacheHit()
+    {
+        return databaseCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseCacheMiss()
+    {
+        return databaseCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseCacheEviction()
+    {
+        return databaseCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseCacheSize()
+    {
+        return databaseCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseNamesCacheHit()
+    {
+        return databaseNamesCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseNamesCacheMiss()
+    {
+        return databaseNamesCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseNamesCacheEviction()
+    {
+        return databaseNamesCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getDatabaseNamesCacheSize()
+    {
+        return databaseNamesCache.size();
     }
 
     @Managed
@@ -80,30 +213,142 @@ public class HiveMetastoreCacheStats
 
     @Managed
     @Override
-    public long getPartitionNamesCacheHit()
+    public long getTableNamesCacheHit()
     {
-        return partitionNamesCache.stats().hitCount();
+        return tableNamesCache.stats().hitCount();
     }
 
     @Managed
     @Override
-    public long getPartitionNamesCacheMiss()
+    public long getTableNamesCacheMiss()
     {
-        return partitionNamesCache.stats().missCount();
+        return tableNamesCache.stats().missCount();
     }
 
     @Managed
     @Override
-    public long getPartitionNamesCacheEviction()
+    public long getTableNamesCacheEviction()
     {
-        return partitionNamesCache.stats().evictionCount();
+        return tableNamesCache.stats().evictionCount();
     }
 
     @Managed
     @Override
-    public long getPartitionNamesCacheSize()
+    public long getTableNamesCacheSize()
     {
-        return partitionNamesCache.size();
+        return tableNamesCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getTableStatisticsCacheHit()
+    {
+        return tableStatisticsCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableStatisticsCacheMiss()
+    {
+        return tableStatisticsCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableStatisticsCacheEviction()
+    {
+        return tableStatisticsCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableStatisticsCacheSize()
+    {
+        return tableStatisticsCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getTableConstraintsCacheHit()
+    {
+        return tableConstraintsCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableConstraintsCacheMiss()
+    {
+        return tableConstraintsCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableConstraintsCacheEviction()
+    {
+        return tableConstraintsCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getTableConstraintsCacheSize()
+    {
+        return tableConstraintsCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionStatisticsCacheHit()
+    {
+        return partitionStatisticsCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionStatisticsCacheMiss()
+    {
+        return partitionStatisticsCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionStatisticsCacheEviction()
+    {
+        return partitionStatisticsCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionStatisticsCacheSize()
+    {
+        return partitionStatisticsCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getViewNamesCacheHit()
+    {
+        return viewNamesCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getViewNamesCacheMiss()
+    {
+        return viewNamesCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getViewNamesCacheEviction()
+    {
+        return viewNamesCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getViewNamesCacheSize()
+    {
+        return viewNamesCache.size();
     }
 
     @Managed
@@ -132,6 +377,146 @@ public class HiveMetastoreCacheStats
     public long getPartitionCacheSize()
     {
         return partitionCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionFilterCacheHit()
+    {
+        return partitionFilterCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionFilterCacheMiss()
+    {
+        return partitionFilterCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionFilterCacheEviction()
+    {
+        return partitionFilterCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionFilterCacheSize()
+    {
+        return partitionFilterCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionNamesCacheHit()
+    {
+        return partitionNamesCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionNamesCacheMiss()
+    {
+        return partitionNamesCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionNamesCacheEviction()
+    {
+        return partitionNamesCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionNamesCacheSize()
+    {
+        return partitionNamesCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getTablePrivilegesCacheHit()
+    {
+        return tablePrivilegesCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getTablePrivilegesCacheMiss()
+    {
+        return tablePrivilegesCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getTablePrivilegesCacheEviction()
+    {
+        return tablePrivilegesCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getTablePrivilegesCacheSize()
+    {
+        return tablePrivilegesCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getRolesCacheHit()
+    {
+        return rolesCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getRolesCacheMiss()
+    {
+        return rolesCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getRolesCacheEviction()
+    {
+        return rolesCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getRolesCacheSize()
+    {
+        return rolesCache.size();
+    }
+
+    @Managed
+    @Override
+    public long getRoleGrantsCacheHit()
+    {
+        return roleGrantsCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getRoleGrantsCacheMiss()
+    {
+        return roleGrantsCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getRoleGrantsCacheEviction()
+    {
+        return roleGrantsCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getRoleGrantsCacheSize()
+    {
+        return roleGrantsCache.size();
     }
 
     @Managed

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
@@ -200,6 +200,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadAllDatabases),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setDatabaseNamesCache(databaseNamesCache);
 
         databaseCache = buildCache(
                 executor,
@@ -207,6 +208,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadDatabase),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setDatabaseCache(databaseCache);
 
         tableNamesCache = buildCache(
                 executor,
@@ -214,6 +216,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadAllTables),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setTableNamesCache(tableNamesCache);
 
         tableStatisticsCache = buildCache(
                 executor,
@@ -221,6 +224,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadTableColumnStatistics),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setTableStatisticsCache(tableStatisticsCache);
 
         partitionStatisticsCache = buildCache(
                 executor,
@@ -241,6 +245,7 @@ public class InMemoryCachingHiveMetastore
                 },
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setPartitionStatisticsCache(partitionStatisticsCache);
 
         tableCache = buildCache(
                 executor,
@@ -256,6 +261,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadTableConstraints),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setTableConstraintsCache(tableConstraintsCache);
 
         viewNamesCache = buildCache(
                 executor,
@@ -263,6 +269,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadAllViews),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setViewNamesCache(viewNamesCache);
 
         partitionNamesCache = buildCache(
                 executor,
@@ -270,6 +277,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadPartitionNames),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setPartitionNamesCache(partitionNamesCache);
 
         partitionFilterCache = buildCache(
                 executor,
@@ -277,7 +285,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadPartitionNamesByFilter),
                 perTransactionCache,
                 maximumSize);
-        metastoreCacheStats.setPartitionNamesCache(partitionFilterCache);
+        metastoreCacheStats.setPartitionFilterCache(partitionFilterCache);
 
         partitionCache = buildCache(
                 executor,
@@ -306,6 +314,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadTablePrivileges),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setTablePrivilegesCache(tablePrivilegesCache);
 
         rolesCache = buildCache(
                 executor,
@@ -313,6 +322,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadAllRoles),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setRolesCache(rolesCache);
 
         roleGrantsCache = buildCache(
                 executor,
@@ -320,6 +330,7 @@ public class InMemoryCachingHiveMetastore
                 CacheLoader.from(this::loadRoleGrants),
                 perTransactionCache,
                 maximumSize);
+        metastoreCacheStats.setRoleGrantsCache(roleGrantsCache);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
@@ -18,13 +18,51 @@ import com.google.common.cache.LoadingCache;
 
 public interface MetastoreCacheStats
 {
+    void setDatabaseCache(LoadingCache<?, ?> databaseCache);
+
+    void setDatabaseNamesCache(LoadingCache<?, ?> databaseNamesCache);
+
     void setTableCache(LoadingCache<?, ?> tableCache);
 
-    void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache);
+    void setTableNamesCache(LoadingCache<?, ?> tableNamesCache);
+
+    void setTableStatisticsCache(LoadingCache<?, ?> tableStatisticsCache);
+
+    void setTableConstraintsCache(LoadingCache<?, ?> tableConstraintsCache);
+
+    void setPartitionStatisticsCache(LoadingCache<?, ?> partitionStatisticsCache);
+
+    void setViewNamesCache(LoadingCache<?, ?> viewNamesCache);
 
     void setPartitionCache(LoadingCache<?, ?> partitionCache);
 
+    void setPartitionFilterCache(LoadingCache<?, ?> partitionFilterCache);
+
+    void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache);
+
+    void setTablePrivilegesCache(LoadingCache<?, ?> tablePrivilegesCache);
+
+    void setRolesCache(LoadingCache<?, ?> rolesCache);
+
+    void setRoleGrantsCache(LoadingCache<?, ?> roleGrantsCache);
+
     void incrementPartitionsWithColumnCountGreaterThanThreshold();
+
+    long getDatabaseCacheHit();
+
+    long getDatabaseCacheMiss();
+
+    long getDatabaseCacheEviction();
+
+    long getDatabaseCacheSize();
+
+    long getDatabaseNamesCacheHit();
+
+    long getDatabaseNamesCacheMiss();
+
+    long getDatabaseNamesCacheEviction();
+
+    long getDatabaseNamesCacheSize();
 
     long getTableCacheHit();
 
@@ -34,13 +72,45 @@ public interface MetastoreCacheStats
 
     long getTableCacheSize();
 
-    long getPartitionNamesCacheHit();
+    long getTableNamesCacheHit();
 
-    long getPartitionNamesCacheMiss();
+    long getTableNamesCacheMiss();
 
-    long getPartitionNamesCacheEviction();
+    long getTableNamesCacheEviction();
 
-    long getPartitionNamesCacheSize();
+    long getTableNamesCacheSize();
+
+    long getTableStatisticsCacheHit();
+
+    long getTableStatisticsCacheMiss();
+
+    long getTableStatisticsCacheEviction();
+
+    long getTableStatisticsCacheSize();
+
+    long getTableConstraintsCacheHit();
+
+    long getTableConstraintsCacheMiss();
+
+    long getTableConstraintsCacheEviction();
+
+    long getTableConstraintsCacheSize();
+
+    long getPartitionStatisticsCacheHit();
+
+    long getPartitionStatisticsCacheMiss();
+
+    long getPartitionStatisticsCacheEviction();
+
+    long getPartitionStatisticsCacheSize();
+
+    long getViewNamesCacheHit();
+
+    long getViewNamesCacheMiss();
+
+    long getViewNamesCacheEviction();
+
+    long getViewNamesCacheSize();
 
     long getPartitionCacheHit();
 
@@ -49,6 +119,46 @@ public interface MetastoreCacheStats
     long getPartitionCacheEviction();
 
     long getPartitionCacheSize();
+
+    long getPartitionFilterCacheHit();
+
+    long getPartitionFilterCacheMiss();
+
+    long getPartitionFilterCacheEviction();
+
+    long getPartitionFilterCacheSize();
+
+    long getPartitionNamesCacheHit();
+
+    long getPartitionNamesCacheMiss();
+
+    long getPartitionNamesCacheEviction();
+
+    long getPartitionNamesCacheSize();
+
+    long getTablePrivilegesCacheHit();
+
+    long getTablePrivilegesCacheMiss();
+
+    long getTablePrivilegesCacheEviction();
+
+    long getTablePrivilegesCacheSize();
+
+    long getRolesCacheHit();
+
+    long getRolesCacheMiss();
+
+    long getRolesCacheEviction();
+
+    long getRolesCacheSize();
+
+    long getRoleGrantsCacheHit();
+
+    long getRoleGrantsCacheMiss();
+
+    long getRoleGrantsCacheEviction();
+
+    long getRoleGrantsCacheSize();
 
     CounterStat getPartitionsWithColumnCountGreaterThanThreshold();
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
@@ -22,12 +22,42 @@ public class NoopMetastoreCacheStats
     public static final NoopMetastoreCacheStats NOOP_METASTORE_CACHE_STATS = new NoopMetastoreCacheStats();
 
     @Override
+    public void setDatabaseCache(LoadingCache<?, ?> databaseCache)
+    {
+    }
+
+    @Override
+    public void setDatabaseNamesCache(LoadingCache<?, ?> databaseNamesCache)
+    {
+    }
+
+    @Override
     public void setTableCache(LoadingCache<?, ?> tableCache)
     {
     }
 
     @Override
-    public void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache)
+    public void setTableNamesCache(LoadingCache<?, ?> tableNamesCache)
+    {
+    }
+
+    @Override
+    public void setTableStatisticsCache(LoadingCache<?, ?> tableStatisticsCache)
+    {
+    }
+
+    @Override
+    public void setTableConstraintsCache(LoadingCache<?, ?> tableConstraintsCache)
+    {
+    }
+
+    @Override
+    public void setPartitionStatisticsCache(LoadingCache<?, ?> partitionStatisticsCache)
+    {
+    }
+
+    @Override
+    public void setViewNamesCache(LoadingCache<?, ?> viewNamesCache)
     {
     }
 
@@ -37,66 +67,367 @@ public class NoopMetastoreCacheStats
     }
 
     @Override
+    public void setPartitionFilterCache(LoadingCache<?, ?> partitionFilterCache)
+    {
+    }
+
+    @Override
+    public void setPartitionNamesCache(LoadingCache<?, ?> partitionNamesCache)
+    {
+    }
+
+    @Override
+    public void setTablePrivilegesCache(LoadingCache<?, ?> tablePrivilegesCache)
+    {
+    }
+
+    @Override
+    public void setRolesCache(LoadingCache<?, ?> rolesCache)
+    {
+    }
+
+    @Override
+    public void setRoleGrantsCache(LoadingCache<?, ?> roleGrantsCache)
+    {
+    }
+
+    @Override
     public void incrementPartitionsWithColumnCountGreaterThanThreshold()
     {
     }
 
+    @Override
+    public long getDatabaseCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseNamesCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseNamesCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseNamesCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getDatabaseNamesCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
     public long getTableCacheHit()
     {
         return 0;
     }
 
+    @Override
     public long getTableCacheMiss()
     {
         return 0;
     }
 
+    @Override
     public long getTableCacheEviction()
     {
         return 0;
     }
 
+    @Override
     public long getTableCacheSize()
     {
         return 0;
     }
 
-    public long getPartitionNamesCacheHit()
+    @Override
+    public long getTableNamesCacheHit()
     {
         return 0;
     }
 
-    public long getPartitionNamesCacheMiss()
+    @Override
+    public long getTableNamesCacheMiss()
     {
         return 0;
     }
 
-    public long getPartitionNamesCacheEviction()
+    @Override
+    public long getTableNamesCacheEviction()
     {
         return 0;
     }
 
-    public long getPartitionNamesCacheSize()
+    @Override
+    public long getTableNamesCacheSize()
     {
         return 0;
     }
 
+    @Override
+    public long getTableStatisticsCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableStatisticsCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableStatisticsCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableStatisticsCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableConstraintsCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableConstraintsCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableConstraintsCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTableConstraintsCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionStatisticsCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionStatisticsCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionStatisticsCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionStatisticsCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getViewNamesCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getViewNamesCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getViewNamesCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getViewNamesCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
     public long getPartitionCacheHit()
     {
         return 0;
     }
 
+    @Override
     public long getPartitionCacheMiss()
     {
         return 0;
     }
 
+    @Override
     public long getPartitionCacheEviction()
     {
         return 0;
     }
 
+    @Override
     public long getPartitionCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionFilterCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionFilterCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionFilterCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionFilterCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionNamesCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionNamesCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionNamesCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getPartitionNamesCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTablePrivilegesCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTablePrivilegesCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTablePrivilegesCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTablePrivilegesCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRolesCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRolesCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRolesCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRolesCacheSize()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRoleGrantsCacheHit()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRoleGrantsCacheMiss()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRoleGrantsCacheEviction()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getRoleGrantsCacheSize()
     {
         return 0;
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInvalidateMetastoreCacheProcedure.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInvalidateMetastoreCacheProcedure.java
@@ -141,7 +141,7 @@ public class TestInvalidateMetastoreCacheProcedure
                 .hasRowsCount(5);
         assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
                 .hasRowsCount(5);
-        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionfiltercachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
                 .contains(row(1, 5, 1));
 
         // Add new partition outside Presto
@@ -152,19 +152,19 @@ public class TestInvalidateMetastoreCacheProcedure
                 .hasRowsCount(5);
         assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
                 .hasRowsCount(5);
-        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionfiltercachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
                 .contains(row(1, 5, 1));
 
         // After invalidating the cache, we should be able to see the new partition once we invalidate any partition in the table
         onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema1', 'nation_partitioned', ARRAY['regionkey'], ARRAY['0'])");
-        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionfiltercachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
                 .contains(row(1, 4, 0));
         assertThat(onPresto().executeQuery("SELECT * FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.\"nation_partitioned$partitions\""))
                 .hasRowsCount(6);
         assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
                 .hasRowsCount(6)
                 .contains(row(5));
-        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionfiltercachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
                 .contains(row(1, 6, 1));
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Expand metrics coverage from 3 caches to all 14 caches in `InMemoryCachingHiveMetastore` to provide comprehensive observability of the Hive metastore caching layer.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
The implementation provides complete observability of all Hive metastore caches, enabling better performance monitoring, capacity planning, and troubleshooting for Presto users.

BREAKING CHANGE: Partition filter cache metrics renamed from `partitionnamescache*` to `partitionfiltercache*`

Previously, partition filter cache metrics were incorrectly registered under the partition names cache identifier. This change corrects the association to properly reflect which cache the metrics represent.

Affected metrics:
- `partitionnamescachehit` → `partitionfiltercachehit`
- `partitionnamescachemiss` → `partitionfiltercachemiss`
- `partitionnamescacheeviction` → `partitionfiltercacheeviction`
- `partitionnamescachesize` → `partitionfiltercachesize`

## Test Plan
<!---Please fill in how you tested your change-->
Sample JMX Query for a few of the new metrics:

```
presto> select databasecachehit, databasecachemiss, databasecachesize, databasenamescachehit, databasenamescachemiss, databasenamescachesize, tablenamescachemiss, tablenamescachehit, tablenamescachesize from jmx.current."com.facebook.presto.hive.metastore:name=hive,type=metastorecachestats";
 databasecachehit | databasecachemiss | databasecachesize | databasenamescachehit | databasenamescachemiss | databasenamescachesize | tablenamescachemiss | tablenamescachehit | tablenamescachesize 
------------------+-------------------+-------------------+-----------------------+------------------------+------------------------+---------------------+--------------------+---------------------
                5 |                 1 |                 1 |                     2 |                      1 |                      1 |                   1 |                  2 |                   1 
(1 row)

```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add comprehensive cache metrics for all metastore caches.
* Fix partition filter cache metrics association. **BREAKING**: Metric names changed from `partitionnamescache*` to `partitionfiltercache*`. Users monitoring these JMX metrics must update their dashboards, alerts, and scripts to use the new metric names. The old metrics tracked the partition filter cache (filtered partition queries), not the partition names cache, as the name suggested.
```

## Summary by Sourcery

Expand Hive metastore cache statistics to cover all caches and expose their metrics via JMX.

New Features:
- Expose hit, miss, eviction, and size metrics for all Hive metastore caches, including databases, tables, partitions, statistics, views, privileges, roles, and grants.

Bug Fixes:
- Correctly associate partition filter cache statistics with the partition filter cache instead of the partition names cache.

Enhancements:
- Extend the MetastoreCacheStats interface and its Hive and no-op implementations to support the full set of cache metrics used by InMemoryCachingHiveMetastore.

## Summary by Sourcery

Expand Hive metastore cache statistics to cover all metastore caches and expose their metrics via JMX for improved observability.

New Features:
- Expose hit, miss, eviction, and size metrics for all Hive metastore caches, including databases, tables, partitions, statistics, views, privileges, roles, and grants.

Bug Fixes:
- Correctly attribute partition filter cache statistics to the partition filter cache instead of the partition names cache, updating the corresponding JMX metric names and tests.

Enhancements:
- Extend the MetastoreCacheStats interface and its concrete implementations to support the full set of cache metrics used by InMemoryCachingHiveMetastore.

Tests:
- Update Hive metastore cache invalidation product tests to assert the new partition filter cache size metric instead of the partition names cache size metric.