### PR TITLE
docs: Fix use of Latin abbreviations in Presto doc (partial)

### DIFF
--- a/presto-docs/src/main/sphinx/clients/tableau.rst
+++ b/presto-docs/src/main/sphinx/clients/tableau.rst
@@ -35,6 +35,6 @@ for further analysis with Tableau.
      ``bool``, ``date``, ``datetime``, ``float``, ``int`` and ``string``.
      Presto ``boolean`` and ``date`` types will be converted to the Tableau
      data types ``bool`` and ``date``, respectively, on the Tableau client side.
-     Any other Presto types such as ``array``, ``map``, ``row``, ``double``,
-     ``bigint``, etc., will be converted to a Tableau ``string`` as they do
+     Any other Presto types such as ``array``, ``map``, ``row``, ``double``, or
+     ``bigint`` will be converted to a Tableau ``string`` as they do
      not map to any Tableau type.

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -375,7 +375,7 @@ If it is the first time to launch the Hive Metastore, prepare the corresponding 
     bin/schematool -dbType derby -initSchema
 
 If you want to access AWS S3, append the following lines in ``conf/hive-env.sh``.
-Hive needs the corresponding jars to access files with ``s3a://`` addresses, and AWS credentials as well to access an S3 bucket (even it is public).
+Hive needs the corresponding jars to access files with ``s3a://`` addresses and AWS credentials to access an S3 bucket (even if it is public).
 These jars can be found in Hadoop distribution (for example, under ``${HADOOP_HOME}/share/hadoop/tools/lib/``),
 or downloaded from `maven central repository <https://repo1.maven.org/>`_.
 

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -263,7 +263,7 @@ You may also wish to set the following properties:
 
 * ``jmx.rmiserver.port``:
   Specifies the port for the JMX RMI server. Presto exports many metrics
-  that are useful for monitoring via JMX.
+  that are useful for monitoring with JMX.
 
 See also :doc:`/admin/resource-groups`.
 
@@ -291,7 +291,7 @@ There are four levels: ``DEBUG``, ``INFO``, ``WARN`` and ``ERROR``.
 Catalog Properties
 ^^^^^^^^^^^^^^^^^^
 
-Presto accesses data via *connectors*, which are mounted in catalogs.
+Presto accesses data through *connectors*, which are mounted in catalogs.
 The connector provides all of the schemas and tables inside of the catalog.
 For example, the Hive connector maps each Hive database to a schema,
 so if the Hive connector is mounted as the ``hive`` catalog, and Hive
@@ -376,7 +376,7 @@ If it is the first time to launch the Hive Metastore, prepare the corresponding 
 
 If you want to access AWS S3, append the following lines in ``conf/hive-env.sh``.
 Hive needs the corresponding jars to access files with ``s3a://`` addresses, and AWS credentials as well to access an S3 bucket (even it is public).
-These jars can be found in Hadoop distribution (e.g., under ``${HADOOP_HOME}/share/hadoop/tools/lib/``),
+These jars can be found in Hadoop distribution (for example, under ``${HADOOP_HOME}/share/hadoop/tools/lib/``),
 or downloaded from `maven central repository <https://repo1.maven.org/>`_.
 
 .. code-block:: bash

--- a/presto-docs/src/main/sphinx/overview/concepts.rst
+++ b/presto-docs/src/main/sphinx/overview/concepts.rst
@@ -113,9 +113,9 @@ from both Hive clusters (even within the same SQL query).
 Catalog
 ^^^^^^^
 
-A Presto catalog contains schemas and references a data source via a
+A Presto catalog contains schemas and references a data source through a
 connector.  For example, you can configure a JMX catalog to provide
-access to JMX information via the JMX connector. When you run a SQL
+access to JMX information through the JMX connector. When you run a SQL
 statement in Presto, you are running it against one or more catalogs.
 Other examples of catalogs include the Hive catalog to connect to a
 Hive data source.
@@ -247,7 +247,7 @@ Split
 
 Tasks operate on splits which are sections of a larger data
 set. Stages at the lowest level of a distributed query plan retrieve
-data via splits from connectors, and intermediate stages at a higher
+data by using splits from connectors, and intermediate stages at a higher
 level of a distributed query plan retrieve data from other stages.
 
 When Presto is scheduling a query, the coordinator will query a


### PR DESCRIPTION
## Description
Revised the Presto documentation in 
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/overview
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/installation
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/clients

to remove use of `e.g.`, `via`, `etc.`, and `i.e` from the Presto documentation in these directories. 

## Motivation and Context
Latin abbreviations should be avoided in documentation. See: 
* the [GitLab documentation style guide recommended word list entry for e.g.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#eg)
* the [GitLab documentation style guide recommended word list entry for via](https://docs.gitlab.com/development/documentation/styleguide/word_list/#via)
* the [GitLab documentation style guide recommended word list entry for etc](https://docs.gitlab.com/development/documentation/styleguide/word_list/#etc)
* the [GitLab documentation style guide recommended word list entry for I.e.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#ie) 

I've been applying these rules for a long while when editing new Presto documentation, and @dnskr's work on #27961 prompted me to make a start at the existing doc set for consistency. Thanks @dnskr!

## Impact
Improved readability of the Presto documentation. 

## Test Plan
Local doc builds. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Update overview, installation, and client documentation to replace Latin abbreviations like e.g., i.e., via, and etc. with clearer phrasing.