### PR TITLE
fix(native-pos): Fix MaterializedOutput crash on zero-column (row-count-only) output

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -242,14 +242,22 @@ void MaterializedOutput::serializeVariableWidthRows(
 void MaterializedOutput::ensureFlatBufferCapacity(int64_t additionalBytes) {
   const auto requiredSize = flatBufferSize_ + additionalBytes;
   const auto currentCapacity = flatBuffer_ ? flatBuffer_->capacity() : 0;
-  if (requiredSize > static_cast<int64_t>(currentCapacity)) {
-    const auto newSize =
-        std::max(requiredSize, static_cast<int64_t>(currentCapacity) * 2);
-    if (!flatBuffer_) {
-      flatBuffer_ = velox::AlignedBuffer::allocate<char>(newSize, pool());
-    } else {
-      velox::AlignedBuffer::reallocate<char>(&flatBuffer_, newSize);
-    }
+  // Nothing to do once a buffer exists and is large enough.
+  if (flatBuffer_ != nullptr &&
+      requiredSize <= static_cast<int64_t>(currentCapacity)) {
+    return;
+  }
+  // Always allocate a non-null buffer on first use, even for a zero-byte batch
+  // (e.g. a zero-column / row-count-only output type where
+  // CompactRow::fixedRowSize() == 0). serializeRows() and buildRowGroup() index
+  // into flatBuffer_ unconditionally, so a null buffer would be dereferenced
+  // and crash. Allocate at least one byte.
+  const auto newSize = std::max<int64_t>(
+      {requiredSize, static_cast<int64_t>(currentCapacity) * 2, 1});
+  if (!flatBuffer_) {
+    flatBuffer_ = velox::AlignedBuffer::allocate<char>(newSize, pool());
+  } else {
+    velox::AlignedBuffer::reallocate<char>(&flatBuffer_, newSize);
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -418,6 +418,70 @@ TEST_F(MaterializedExchangeTest, emptyInput) {
   cleanupDirectory(tempDir_->getPath());
 }
 
+// Row-count-only output: the MaterializedOutputNode projects to a ZERO-column
+// output type (e.g. a count-only shuffle after a dedupe). CompactRow::
+// fixedRowSize(ROW({})) == 0, so each serialized row is zero bytes and the
+// flat buffer would never be allocated. serializeFixedWidthRows() and
+// buildRowGroup() index into the flat buffer unconditionally, so it must be
+// non-null. The partition routing still runs on the (non-empty) source
+// columns, so all input rows must round-trip as zero-column rows.
+TEST_F(MaterializedExchangeTest, zeroColumnOutput) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+  });
+  auto sourceType = asRowType(data->type());
+  auto emptyOutputType = ROW({}, {});
+
+  const int numPartitions = 4;
+  const int numDrivers = 1;
+
+  auto writeInfoStr = localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfoStr,
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      "zerocol.0.0.0.0",
+      rootPool_.get());
+
+  // Partition on the (non-empty) source column even though the projected
+  // output has no columns.
+  std::vector<core::TypedExprPtr> keys{
+      std::make_shared<core::FieldAccessTypedExpr>(
+          sourceType->childAt(0), sourceType->nameOf(0))};
+  auto partitionFunctionSpec =
+      std::make_shared<exec::HashPartitionFunctionSpec>(
+          sourceType, std::vector<column_index_t>{0});
+
+  auto valuesNode = exec::test::PlanBuilder().values({data}, true).planNode();
+  auto exchangeWriteNode = std::make_shared<MaterializedOutputNode>(
+      "exchangeWrite",
+      keys,
+      numPartitions,
+      emptyOutputType,
+      partitionFunctionSpec,
+      /*replicateNullsAndAny=*/false,
+      ShuffleWriterMetadata{},
+      valuesNode);
+
+  auto taskId = makeTaskId("write", 0);
+  MaterializedOutputBuffer::registerBuffer(taskId, buffer);
+  auto task = makeTask(taskId, exchangeWriteNode, 0);
+  task->start(numDrivers);
+
+  EXPECT_TRUE(exec::test::waitForTaskCompletion(task.get(), 10'000'000));
+  MaterializedOutputBuffer::removeBuffer(taskId);
+
+  // Every input row must come back as a zero-column row across all partitions.
+  auto actual = runExchangeRead(numPartitions, emptyOutputType);
+  int64_t totalRows = 0;
+  for (const auto& vec : actual) {
+    EXPECT_EQ(vec->type()->size(), 0);
+    totalRows += vec->size();
+  }
+  EXPECT_EQ(totalRows, data->size());
+  cleanupDirectory(tempDir_->getPath());
+}
+
 // Verify that buffered RowGroups are tracked through the pool. With a
 // constrained pool, enqueuing too much data without draining should fail.
 TEST_F(MaterializedExchangeTest, bufferMemoryTracking) {


### PR DESCRIPTION
Summary:
`MaterializedOutput::serializeFixedWidthRows` crashed with SIGSEGV (null dereference) when the operator's output row type has zero columns — a row-count-only shuffle output, e.g. after a dedupe projection. `CompactRow::fixedRowSize(ROW({}))` returns 0 (zero fields means zero null-header bytes, so total size 0), hence `fixedSize == 0` and `batchBytes = numRows * 0 == 0`. `ensureFlatBufferCapacity(0)` then never allocated (`requiredSize 0 > capacity 0` is false), leaving `flatBuffer_` null, and the subsequent `std::memset(flatBuffer_->asMutable<char>() + ...)` and `compactRow.serialize(..., flatBuffer_->asMutable<char>())` dereferenced a null `velox::BufferPtr`. `buildRowGroup` had the same latent null dereference for zero-length rows.

Fix: `ensureFlatBufferCapacity` now always allocates a non-null `flatBuffer_` on first use (at least one byte), even for a zero-byte batch. `serializeRows` and `buildRowGroup` index into `flatBuffer_` unconditionally, so guaranteeing a non-null buffer makes the zero-length `memset` / `serialize` / `memcpy` safe no-ops while the row-size, offset, partition and row-count bookkeeping is preserved.

Observed in production as ~709 SIGSEGV per 6 hours on certified Sapphire-Velox, 98.6% from a single pipeline that projects to a count-only output.

Differential Revision: D108225006

## Summary by Sourcery

Handle zero-column (row-count-only) outputs safely in MaterializedOutput by ensuring a non-null flat buffer and validating behavior via tests.

Bug Fixes:
- Prevent SIGSEGV in MaterializedOutput serialization when processing zero-column (row-count-only) output rows by always allocating a non-null flat buffer, even for zero-byte batches.

Tests:
- Add a MaterializedExchange test that exercises zero-column (row-count-only) shuffle output and verifies all input rows round-trip as zero-column rows across partitions.

```
== NO RELEASE NOTE ==
```