### PR TITLE
build: Add CUDA runtime and UCX support to Prestissimo runtime image

### DIFF
--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -55,6 +55,6 @@ services:
         # A few files in Velox require significant memory to compile and link.
         # Build requires 18GB of memory for 2 threads.
         - NUM_THREADS=2 # default value for NUM_THREADS
-        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_CUDF=${GPU:-OFF}
+        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_CUDF=${GPU:-OFF} -DVELOX_ENABLE_UCX_EXCHANGE=${GPU:-OFF}
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -17,10 +17,6 @@ FROM quay.io/centos/centos:stream9
 ARG ARM_BUILD_TARGET
 ARG CUDA_VERSION
 
-# This defaults to 13.0 but can be overridden with a build arg
-ARG CUDA_VERSION
-
-# This defaults to 1.20.1 but can be overridden with a build arg
 ARG UCX_VERSION
 
 ENV PROMPT_ALWAYS_RESPOND=y

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -15,16 +15,20 @@ FROM quay.io/centos/centos:stream9
 # Set this when build arm with common flags
 # from https://github.com/facebookincubator/velox/pull/14366
 ARG ARM_BUILD_TARGET
-
-# This defaults to 12.9 but can be overridden with a build arg
 ARG CUDA_VERSION
+
+# This defaults to 13.0 but can be overridden with a build arg
+ARG CUDA_VERSION
+
+# This defaults to 1.20.1 but can be overridden with a build arg
+ARG UCX_VERSION
 
 ENV PROMPT_ALWAYS_RESPOND=y
 ENV CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-12/root/bin/g++
 ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
-ENV CUDA_VERSION=${CUDA_VERSION:-12.9}
-ENV UCX_VERSION="1.19.0"
+ENV CUDA_VERSION=${CUDA_VERSION:-13.0}
+ENV UCX_VERSION=${UCX_VERSION:-1.20.1}
 
 RUN mkdir -p /scripts /velox/scripts
 COPY scripts /scripts

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -18,7 +18,8 @@ ARG OSNAME=centos
 ARG BUILD_TYPE=Release
 ARG EXTRA_CMAKE_FLAGS=''
 ARG NUM_THREADS=8
-ARG CUDA_ARCHITECTURES=70
+ARG CUDA_ARCHITECTURES="80-real;86-real;90a-real;100f-real;120a-real;120"
+ENV CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 
 ENV PROMPT_ALWAYS_RESPOND=n
 ENV BUILD_BASE_DIR=_build
@@ -31,8 +32,11 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -v libcuda) && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
+
+RUN cp -rf /usr/local/lib/ucx /runtime-libraries/ucx
+RUN echo "${CUDA_VERSION}" > /cuda_version
 
 #/////////////////////////////////////////////
 #          prestissimo-runtime
@@ -43,10 +47,26 @@ FROM ${BASE_IMAGE}
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
 
+# Copy scripts and CUDA version from build stage
+COPY --from=prestissimo-image /prestissimo/velox/scripts/ /tmp/scripts/
+COPY --from=prestissimo-image /cuda_version /tmp/
+
+# Install CUDA runtime packages and RDMA libraries
+RUN CUDA_VERSION=$(cat /tmp/cuda_version) && \
+    source /tmp/scripts/setup-centos-adapters.sh && \
+    install_cuda_runtime "${CUDA_VERSION}" && \
+    dnf install -y librdmacm libibverbs && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /tmp/scripts /tmp/cuda_version
+
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/
+COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/ucx /usr/lib64/prestissimo-libs/ucx
 COPY --chmod=0755 ./etc /opt/presto-server/etc
 COPY --chmod=0775 ./entrypoint.sh /opt/entrypoint.sh
-RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && ldconfig
+RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/lib64/prestissimo-libs/ucx" >> /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
 
 ENTRYPOINT ["/opt/entrypoint.sh"]


### PR DESCRIPTION
## Description
Updates the Prestissimo CentOS dependency and runtime Docker images so the produced runtime image can execute a CUDA/cuDF-enabled presto_server:
- Install the CUDA runtime packages (matching the CUDA version detected at build time) and RDMA libraries (librdmacm, libibverbs) in the runtime stage.
- Bundle the UCX libraries built in the dependency image into the runtime image and register the UCX and CUDA library paths with ldconfig.
-  Broaden the default CUDA_ARCHITECTURES from a single 70 to a multi-architecture list and expose it as an environment variable.
- Allow libcuda to be missing during the ldd validation step, since the CUDA driver library is supplied by the host at run time, not bundled.
- Bump default CUDA to 13.0 and UCX to 1.20.1, and make the UCX version configurable via a build arg.
- Build the UCX Exchange when cuDF-enabled Presto is built.

## Motivation and Context
The existing runtime image targets CPU-only Prestissimo and does not ship the CUDA runtime, UCX, or RDMA libraries needed to run a GPU/cuDF-enabled worker. The ldd "not found" check also failed because libcuda is intentionally absent from the image and delegated to the Nvidia docker runtime. 

## Impact
Docker build and packaging only; no changes to Presto code, SQL, or public APIs. The runtime image grows due to the bundled CUDA runtime, UCX, and RDMA libraries. Default CUDA/UCX versions change for native-execution Docker builds and remain overridable via build args. UCX-Exchange is built when Presto-cuDF is built.

```
== RELEASE NOTES ==
Prestissimo (Native Execution) Changes
* Add CUDA runtime, UCX, and RDMA libraries to the Prestissimo runtime Docker image to support GPU/cuDF-enabled native workers. :pr:`27972`
```

## Summary by Sourcery

Update Prestissimo CentOS dependency and runtime Docker images to support CUDA/UCX-enabled GPU runtimes and modernize default CUDA/UCX versions.

New Features:
- Enable CUDA runtime installation and RDMA library support in the Prestissimo runtime image for GPU/cuDF workers.
- Expose CUDA_ARCHITECTURES as a configurable environment variable with a multi-architecture default set.

Enhancements:
- Bundle UCX libraries from the dependency image into the runtime image and register UCX and CUDA library paths with ldconfig.
- Relax runtime ldd validation to allow missing libcuda, which is expected to be supplied by the host driver.
- Bump default CUDA to 13.0 and UCX to 1.20.1 and make the UCX version configurable through a build argument.