### PR TITLE
build: Add optional S3-backed sccache support to Prestissimo build

### DIFF
--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile
 
+  # ==========================================
+  # CentOS services
+  # ==========================================
   centos-native-dependency:
     # Usage:
     #   docker compose build centos-native-dependency

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -50,6 +50,13 @@ RUN bash -c "mkdir build && \
                  install_ucx) && \
     rm -rf build"
 
+# Install sccache for optional S3-backed compile caching
+# See: https://github.com/mozilla/sccache
+ARG SCCACHE_VERSION="0.13.0"
+RUN wget -q -O- "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" \
+    | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x '*/sccache' && \
+    chmod +x /usr/bin/sccache
+
 # put CUDA binaries on the PATH
 ENV PATH=/usr/local/cuda/bin:${PATH}
 

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -15,16 +15,20 @@ FROM quay.io/centos/centos:stream9
 # Set this when build arm with common flags
 # from https://github.com/facebookincubator/velox/pull/14366
 ARG ARM_BUILD_TARGET
-
-# This defaults to 12.9 but can be overridden with a build arg
 ARG CUDA_VERSION
+
+# This defaults to 13.0 but can be overridden with a build arg
+ARG CUDA_VERSION
+
+# This defaults to 1.20.1 but can be overridden with a build arg
+ARG UCX_VERSION
 
 ENV PROMPT_ALWAYS_RESPOND=y
 ENV CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-12/root/bin/g++
 ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
-ENV CUDA_VERSION=${CUDA_VERSION:-12.9}
-ENV UCX_VERSION="1.19.0"
+ENV CUDA_VERSION=${CUDA_VERSION:-13.0}
+ENV UCX_VERSION=${UCX_VERSION:-1.20.1}
 
 RUN mkdir -p /scripts /velox/scripts
 COPY scripts /scripts

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -12,6 +12,10 @@
 
 ARG DEPENDENCY_IMAGE=presto/prestissimo-dependency:centos9
 ARG BASE_IMAGE=quay.io/centos/centos:stream9
+
+# ==========================================
+# Stage 1: Build prestissimo from source
+# ==========================================
 FROM ${DEPENDENCY_IMAGE} as prestissimo-image
 
 ARG OSNAME=centos
@@ -21,6 +25,12 @@ ARG NUM_THREADS=8
 ARG CUDA_ARCHITECTURES="80-real;86-real;90a-real;100f-real;120a-real;120"
 ENV CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 
+# Optional: sccache with S3 backend for shared compile caching across builds
+# Set SCCACHE_BUCKET to enable (e.g., --build-arg SCCACHE_BUCKET=my-bucket)
+ARG SCCACHE_BUCKET=""
+ARG SCCACHE_REGION=""
+ARG SCCACHE_S3_KEY_PREFIX=""
+
 ENV PROMPT_ALWAYS_RESPOND=n
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
@@ -28,21 +38,32 @@ ENV BUILD_DIR=""
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
-    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
-    EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
+    /bin/bash -c '\
+    if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
+    COMPILER_LAUNCHER_FLAGS="" && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then \
+        export SCCACHE_BUCKET="${SCCACHE_BUCKET}" SCCACHE_CACHE_SIZE=2G SCCACHE_IDLE_TIMEOUT=0 SCCACHE_ERROR_LOG=/tmp/sccache-server.log SCCACHE_LOG=warn; \
+        [ -n "${SCCACHE_REGION}" ] && export SCCACHE_REGION="${SCCACHE_REGION}"; \
+        [ -n "${SCCACHE_S3_KEY_PREFIX}" ] && export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX}"; \
+        sccache --start-server && \
+        COMPILER_LAUNCHER_FLAGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache"; \
+        echo "Using sccache with S3 backend: s3://${SCCACHE_BUCKET}/${SCCACHE_S3_KEY_PREFIX:-}"; \
+    else \
+        echo "Using ccache (local)"; \
+    fi && \
+    EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} ${COMPILER_LAUNCHER_FLAGS}" \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
-    ccache -sz -v'
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then (sccache --stop-server && sccache --show-stats) || true ; echo "===== sccache server log (/tmp/sccache-server.log) ====="; cat /tmp/sccache-server.log 2>/dev/null || true ; else ccache -sz -v; fi'
 RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -v libcuda) && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 
 RUN cp -rf /usr/local/lib/ucx /runtime-libraries/ucx
 RUN echo "${CUDA_VERSION}" > /cuda_version
 
-#/////////////////////////////////////////////
-#          prestissimo-runtime
-#//////////////////////////////////////////////
-
-FROM ${BASE_IMAGE}
+# ==========================================
+# Stage 2: Runtime image (minimal, production-ready)
+# ==========================================
+FROM ${BASE_IMAGE} as prestissimo-runtime
 
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -18,7 +18,8 @@ ARG OSNAME=centos
 ARG BUILD_TYPE=Release
 ARG EXTRA_CMAKE_FLAGS=''
 ARG NUM_THREADS=8
-ARG CUDA_ARCHITECTURES=70
+ARG CUDA_ARCHITECTURES="80-real;86-real;90a-real;100f-real;120a-real;120"
+ENV CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 
 ENV PROMPT_ALWAYS_RESPOND=n
 ENV BUILD_BASE_DIR=_build
@@ -31,8 +32,11 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -v libcuda) && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
+
+RUN cp -rf /usr/local/lib/ucx /runtime-libraries/ucx
+RUN echo "${CUDA_VERSION}" > /cuda_version
 
 #/////////////////////////////////////////////
 #          prestissimo-runtime
@@ -43,10 +47,26 @@ FROM ${BASE_IMAGE}
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
 
+# Copy scripts and CUDA version from build stage
+COPY --from=prestissimo-image /prestissimo/velox/scripts/ /tmp/scripts/
+COPY --from=prestissimo-image /cuda_version /tmp/
+
+# Install CUDA runtime packages and RDMA libraries
+RUN CUDA_VERSION=$(cat /tmp/cuda_version) && \
+    source /tmp/scripts/setup-centos-adapters.sh && \
+    install_cuda_runtime "${CUDA_VERSION}" && \
+    dnf install -y librdmacm libibverbs && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /tmp/scripts /tmp/cuda_version
+
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/
+COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/ucx /usr/lib64/prestissimo-libs/ucx
 COPY --chmod=0755 ./etc /opt/presto-server/etc
 COPY --chmod=0775 ./entrypoint.sh /opt/entrypoint.sh
-RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && ldconfig
+RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/lib64/prestissimo-libs/ucx" >> /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
 
 ENTRYPOINT ["/opt/entrypoint.sh"]


### PR DESCRIPTION
## Description
Adds optional distributed compile caching for the Prestissimo native build using sccache (https://github.com/mozilla/sccache) with an S3 backend:
- Install a pinned sccache binary in the CentOS dependency image.
- Wire sccache in as the CMake C/C++/CUDA compiler launcher when an SCCACHE_BUCKET build arg is set; otherwise the build falls back to local ccache exactly as before.
- Expose SCCACHE_BUCKET, SCCACHE_REGION, and SCCACHE_S3_KEY_PREFIX build args and print cache statistics after the build.
- Split the prestissimo runtime Dockerfile into explicitly named build and runtime stages, and add a CentOS section header to docker-compose.yml.

Depends on https://github.com/prestodb/presto/pull/27972

## Motivation and Context
Native (cuDF/CUDA) builds are expensive, as they have to consider a sufficiently wide range of Nvidia GPU architectures, but they are required to get the best performance with GPU-enabled presto. ccache is local to a single machine, so CI and developer rebuilds repeatedly recompile identical objects. A shared S3-backed sccache lets builds reuse compilation results across machines and CI runs, cutting build times significantly. The feature is opt-in and does not change the default local-ccache behavior.

## Impact
Docker build only; no runtime or API changes. sccache activates only when SCCACHE_BUCKET is provided, so existing builds are unaffected. Adds sccache as a build-time dependency in the dependency image.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add optional S3-backed sccache support and modern GPU architecture defaults to the Prestissimo native Docker build while splitting the Dockerfile into explicit build and runtime stages.

Build:
- Install a pinned sccache binary in the CentOS dependency image for optional distributed compile caching.
- Expose SCCACHE_* build arguments and conditionally wire sccache as the C/C++/CUDA compiler launcher in the Prestissimo build when an S3 bucket is configured.
- Update CUDA and UCX default versions in the dependency image and propagate CUDA version into the runtime image setup.
- Refactor the Prestissimo runtime Dockerfile into distinct build and runtime stages with explicit CUDA runtime and RDMA library installation and UCX library handling.
- Clarify docker-compose configuration with a CentOS services section header.