### PR TITLE
docs: Fix use of Latin abbreviations in Presto doc (part 2)

### DIFF
--- a/presto-docs/src/main/sphinx/admin/dist-sort.rst
+++ b/presto-docs/src/main/sphinx/admin/dist-sort.rst
@@ -3,7 +3,7 @@ Distributed sort
 ================
 
 Distributed sort allows to sort data which exceeds ``query.max-memory-per-node``.
-Distributed sort is enabled via ``distributed_sort`` session property or
+Distributed sort is enabled with the ``distributed_sort`` session property or
 ``distributed-sort`` configuration property set in
 ``etc/config.properties`` of the coordinator. Distributed sort is enabled by
 default.

--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -11,7 +11,7 @@ Function namespace managers support storing and retrieving SQL
 functions, allowing the Presto engine to perform actions such as
 creating, altering, deleting functions.
 
-A function namespace is in the format of ``catalog.schema`` (e.g.
+A function namespace is in the format of ``catalog.schema`` (for example, 
 ``example.test``). It can be thought of as a schema for storing
 functions. However, it is not a full fledged schema as it does not
 support storing tables and views, but only functions.
@@ -20,7 +20,7 @@ Each Presto function, whether built-in or user-defined, resides in
 a function namespace. All built-in functions reside in the
 ``presto.default`` function namespace. The qualified function name of
 a function is the function namespace in which it reside followed by
-its function name (e.g. ``example.test.func``). Built-in functions can
+its function name (for example, ``example.test.func``). Built-in functions can
 be referenced in queries with their function namespaces omitted, while
 user-defined functions needs to be referenced by its qualified function
 name. A function is uniquely identified by its qualified function name

--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -19,7 +19,7 @@ support storing tables and views, but only functions.
 Each Presto function, whether built-in or user-defined, resides in
 a function namespace. All built-in functions reside in the
 ``presto.default`` function namespace. The qualified function name of
-a function is the function namespace in which it reside followed by
+a function is the function namespace in which it resides followed by
 its function name (for example, ``example.test.func``). Built-in functions can
 be referenced in queries with their function namespaces omitted, while
 user-defined functions needs to be referenced by its qualified function

--- a/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
+++ b/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
@@ -2,7 +2,7 @@
 JMX Metrics Reference
 =====================
 
-Presto exposes comprehensive metrics via Java Management Extensions (JMX) for monitoring
+Presto exposes comprehensive metrics through Java Management Extensions (JMX) for monitoring
 cluster health, query performance, and system behavior. This page documents some
 important JMX metrics available for production monitoring.
 
@@ -15,7 +15,7 @@ JMX metrics can be accessed through:
 * **SQL queries**: Using the :doc:`/connector/jmx` connector
 * **Monitoring systems**: Prometheus, Grafana, or other JMX exporters
 
-Querying Metrics via SQL
+Querying Metrics with SQL
 -------------------------
 
 Once configured, you can query metrics using SQL:

--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -112,7 +112,7 @@ when the view's data may be stale:
   - The materialized view itself is not updated
 
 **FAIL**
-  Fails the query if the materialized view is stale.wit
+  Fails the query if the materialized view is stale.
 
   - Requires the materialized view to be refreshed before querying
   - Useful when you want to ensure queries only use pre-computed results

--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -106,13 +106,13 @@ when the view's data may be stale:
 
 **USE_STITCHING** (default)
   Reads fresh data from storage, recomputes stale data from base tables,
-  and combines results via UNION.
+  and combines results with UNION.
 
   - Provides up-to-date results without refreshing the storage
   - The materialized view itself is not updated
 
 **FAIL**
-  Fails the query if the materialized view is stale.
+  Fails the query if the materialized view is stale.wit
 
   - Requires the materialized view to be refreshed before querying
   - Useful when you want to ensure queries only use pre-computed results
@@ -184,7 +184,7 @@ to use UNION::
         JOIN customers c ON o.customer_id = c.customer_id
                         AND o.order_date = c.reg_date
         WHERE o.order_date IN ('2024-01-15', '2024-01-16')  -- Stale partition filter
-          AND c.reg_date IN ('2024-01-15', '2024-01-16')    -- Propagated via equivalence
+          AND c.reg_date IN ('2024-01-15', '2024-01-16')    -- Propagated through equivalence
           AND o.order_date >= '2024-01-01'  -- Original filter preserved
     )
 
@@ -213,7 +213,7 @@ See connector-specific documentation for details on staleness tracking requireme
 Predicate stitching does not work with:
 
 * **Outer joins**: LEFT, RIGHT, and FULL OUTER joins
-* **Non-deterministic functions**: ``RANDOM()``, ``NOW()``, ``UUID()``, etc.
+* **Non-deterministic functions**: ``RANDOM()``, ``NOW()``, ``UUID()``
 
 **Security Constraints**
 
@@ -235,8 +235,8 @@ are not directly in the materialized view's output.
 **Column Equivalence**
 
 When tables are joined with equality predicates, those columns become equivalent for
-predicate propagation purposes. This applies to any type of staleness predicate
-(partition-based, snapshot-based, etc.). For example with partition predicates::
+predicate propagation purposes. This applies to any type of staleness predicate such as 
+partition-based or snapshot-based. For example, with partition predicates::
 
     CREATE TABLE orders (order_id BIGINT, customer_id BIGINT, order_date VARCHAR)
       WITH (partitioning = ARRAY['order_date']);
@@ -317,8 +317,8 @@ However, this is typically much cheaper than:
 1. **Predicate granularity**: For partition-based connectors, choose partition columns that align
    with data modification patterns
 
-   * Too coarse (e.g., partitioning by year): Recomputes too much data
-   * Too fine (e.g., partitioning by second): Too many partitions to manage
+   * Too coarse (for example, partitioning by year): Recomputes too much data
+   * Too fine (for example, partitioning by second): Too many partitions to manage
 
 2. **Refresh frequency**: Balance freshness needs with refresh costs
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1090,7 +1090,7 @@ null padded rows that may be produced by the outer join, the optimizer introduce
 join with corresponding aggregations over a single null value and then coalesces the aggregations
 from the join output with these null aggregated values.
 
-For certain aggregate functions (those that ignore nulls, ``COUNT``, or others) the cross join may be
+For certain aggregate functions (those that ignore nulls, ``COUNT``, and similar functions) the cross join may be
 avoided and the default/known aggregate value over ``NULL`` may be coalesced  directly with the aggregate
 outputs of the join. This optimization eliminates the cross join, may convert the outer join into an inner
 join and thereby produces more optimal plans.

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -237,10 +237,10 @@ Memory Management Properties
 * **Type:** ``data size``
 * **Default value:** ``JVM max memory * 0.1``
 
-This is the max amount of user memory a query can use on a worker.
+This is the maximum amount of user memory a query can use on a worker.
 User memory is allocated during execution for things that are directly
 attributable to or controllable by a user query. For example, memory used
-by the hash tables built during execution, memory used during sorting, etc.
+by the hash tables built during execution, or memory used during sorting.
 When the user memory allocation of a query on any worker hits this limit
 it will be killed.
 
@@ -253,7 +253,7 @@ it will be killed.
 This is the max amount of user and system memory a query can use on a worker.
 System memory is allocated during execution for things that are not directly
 attributable to or controllable by a user query. For example, memory allocated
-by the readers, writers, network buffers, etc. When the sum of the user and
+by the readers, writers, and network buffers. When the sum of the user and
 system memory allocated by a query on any worker hits this limit it will be killed.
 The value of ``query.max-total-memory-per-node`` must be greater than
 ``query.max-memory-per-node``.
@@ -267,7 +267,7 @@ The value of ``query.max-total-memory-per-node`` must be greater than
 This is the max amount of user memory a query can use across the entire cluster.
 User memory is allocated during execution for things that are directly
 attributable to or controllable by a user query. For example, memory used
-by the hash tables built during execution, memory used during sorting, etc.
+by the hash tables built during execution, or memory used during sorting.
 When the user memory allocation of a query across all workers hits this limit
 it will be killed.
 
@@ -280,7 +280,7 @@ it will be killed.
 This is the max amount of user and system memory a query can use across the entire cluster.
 System memory is allocated during execution for things that are not directly
 attributable to or controllable by a user query. For example, memory allocated
-by the readers, writers, network buffers, etc. When the sum of the user and
+by the readers, writers, and network buffers. When the sum of the user and
 system memory allocated by a query across all workers hits this limit it will be
 killed. The value of ``query.max-total-memory`` must be greater than
 ``query.max-memory``.
@@ -701,7 +701,7 @@ or thousands of workers.
 
 Number of threads used to handle timeouts when generating HTTP responses. This value
 should be increased if all the threads are frequently in use. This can be monitored
-via the ``com.facebook.presto.server:name=AsyncHttpExecutionMBean:TimeoutExecutor``
+with the ``com.facebook.presto.server:name=AsyncHttpExecutionMBean:TimeoutExecutor``
 JMX object. If ``ActiveCount`` is always the same as ``PoolSize``, increase the
 number of threads.
 
@@ -736,7 +736,7 @@ Sets the number of threads used by workers to process splits. Increasing this nu
 can improve throughput if worker CPU utilization is low and all the threads are in use,
 but will cause increased heap space usage. Setting the value too high may cause a drop
 in performance due to a context switching. The number of active threads is available
-via the ``RunningSplits`` property of the
+through the ``RunningSplits`` property of the
 ``com.facebook.presto.execution.executor:name=TaskExecutor.RunningSplits`` JMX object.
 
 The number of threads can be configured using either an absolute value (for example, ``10``)
@@ -796,7 +796,7 @@ The target value for the number of splits that can be running for
 each worker node, assuming all splits have the standard split weight.
 
 Using a higher value is recommended if queries are submitted in large batches
-(e.g., running a large group of reports periodically) or for connectors that
+(such as running a large group of reports periodically) or for connectors that
 produce many splits that complete quickly but do not support assigning split
 weight values to express that to the split scheduler. Increasing this value
 may improve query latency by ensuring that the workers have enough splits to
@@ -1090,7 +1090,7 @@ null padded rows that may be produced by the outer join, the optimizer introduce
 join with corresponding aggregations over a single null value and then coalesces the aggregations
 from the join output with these null aggregated values.
 
-For certain aggregate functions (those that ignore nulls, ``COUNT``, etc) the cross join may be
+For certain aggregate functions (those that ignore nulls, ``COUNT``, or others) the cross join may be
 avoided and the default/known aggregate value over ``NULL`` may be coalesced  directly with the aggregate
 outputs of the join. This optimization eliminates the cross join, may convert the outer join into an inner
 join and thereby produces more optimal plans.
@@ -1536,7 +1536,7 @@ comprehensive coordinator load management. When both are configured:
 Without query-pacing, the cluster can admit multiple queries at once, which
 can lead to significantly more concurrent tasks than expected over this limit.
 
-Set to a lower value (e.g., ``50000``) to limit coordinator task management
+Set to a lower value such as ``50000`` to limit coordinator task management
 overhead. The default value effectively disables this feature.
 
 .. note::
@@ -1586,7 +1586,7 @@ for cross-cluster retry operations.
 Comma-separated list of error codes that allow cross-cluster retry. When a query
 fails with one of these error codes, it can be automatically retried on a backup
 cluster if a retry URL is provided. Available error codes include standard Presto
-error codes such as ``REMOTE_TASK_ERROR``, ``CLUSTER_OUT_OF_MEMORY``, etc.
+error codes such as ``REMOTE_TASK_ERROR``, ``CLUSTER_OUT_OF_MEMORY``.
 
 View and Materialized View Properties
 -------------------------------------

--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -208,7 +208,7 @@ Here are the key properties that can be set for a Resource Group:
   scheduling policy. A higher weight means that the group gets a larger share of the parent group's
   resources.
 
-* ``jmxExport`` (optional):  If set to ``true``, the statistics of the resource group will be exported via JMX.
+* ``jmxExport`` (optional):  If set to ``true``, the statistics of the resource group will be exported with JMX.
   Defaults to ``false``.
 
 * ``perQueryLimits`` (optional): specifies max resources that each query in a

--- a/presto-docs/src/main/sphinx/admin/spill.rst
+++ b/presto-docs/src/main/sphinx/admin/spill.rst
@@ -65,7 +65,7 @@ excessive spilling for queries that consume large amounts of memory per node.
 These queries would finish much quicker if spill were disabled because they
 would execute in the reserved pool. However, doing so could also significantly
 reduce cluster concurrency. In such a situation we recommend disabling the 
-reserved memory pool via the ``experimental.reserved-pool-enabled`` config 
+reserved memory pool by using the ``experimental.reserved-pool-enabled`` configuration 
 property.
 
 Spill Disk Space

--- a/presto-docs/src/main/sphinx/admin/web-interface.rst
+++ b/presto-docs/src/main/sphinx/admin/web-interface.rst
@@ -3,7 +3,7 @@ Web Interface
 =============
 
 Presto provides a web interface for monitoring and managing queries.
-The web interface is accessible on the Presto coordinator via HTTP,
+The web interface is accessible on the Presto coordinator through HTTP,
 using the HTTP port number specified in the coordinator :ref:`config_properties`.
 
 The main page has a list of queries along with information like unique query ID, query text,
@@ -17,8 +17,8 @@ The possible query states are as follows:
 * ``PLANNING`` -- Query is being planned.
 * ``STARTING`` -- Query execution is being started.
 * ``RUNNING`` -- Query has at least one running task.
-* ``BLOCKED`` -- Query is blocked and is waiting for resources (buffer space, memory, splits, etc.).
-* ``FINISHING`` -- Query is finishing (e.g. commit for autocommit queries).
+* ``BLOCKED`` -- Query is blocked and is waiting for resources (buffer space, memory, or splits).
+* ``FINISHING`` -- Query is finishing (for example, commit for autocommit queries).
 * ``FINISHED`` -- Query has finished executing and all output has been consumed.
 * ``FAILED`` -- Query execution failed.
 

--- a/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
@@ -74,9 +74,9 @@ Capping replicated table size
 
 Join distribution type will be chosen automatically when join reordering strategy
 is set to ``COST_BASED`` or when join distribution type is set to ``AUTOMATIC``.
-In such case it is possible to cap the maximum size of replicated table via
-``join-max-broadcast-table-size`` config property (e.g. ``join-max-broadcast-table-size=100MB``)
-or via ``join_max_broadcast_table_size`` session property (e.g. ``set session join_max_broadcast_table_size='100MB';``)
+In such case it is possible to cap the maximum size of replicated table by using the 
+``join-max-broadcast-table-size`` configuration property (for example, ``join-max-broadcast-table-size=100MB``)
+or by using the ``join_max_broadcast_table_size`` session property (``set session join_max_broadcast_table_size='100MB';``)
 This allows improving cluster concurrency and prevents bad plans when CBO misestimates size of joined tables.
 
 By default replicated table size is capped to 100MB.
@@ -84,5 +84,5 @@ By default replicated table size is capped to 100MB.
 Connector Implementations
 -------------------------
 
-In order for the Presto optimizer to use the cost based strategies,
+In order for the Presto optimizer to use the cost based strategies, 
 the connector implementation must provide :doc:`statistics`.

--- a/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
+++ b/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
@@ -65,7 +65,7 @@ Session property Name                                       Description         
                                                             ``optimizer.history-based-optimizer-timeout`` in the current session.
 ``enforce_history_based_optimizer_register_timeout``        Overrides the behavior of the configuration property                                                 ``optimizer.enforce-timeout-for-hbo-query-registration``
                                                             ``optimizer.enforce-timeout-for-hbo-query-registration`` in the current session.
-``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries - queries with join and aggregation.      ``True``
+``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries - queries with joins and aggregations.    ``True``
 ``history_input_table_statistics_matching_threshold``       Overrides the behavior of the configuration property                                                 ``hbo.history-matching-threshold``
                                                             ``hbo.history-matching-threshold`` in the current session.
 ``treat_low_confidence_zero_estimation_unknown_enabled``    Overrides the behavior of the configuration property

--- a/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
+++ b/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
@@ -65,7 +65,7 @@ Session property Name                                       Description         
                                                             ``optimizer.history-based-optimizer-timeout`` in the current session.
 ``enforce_history_based_optimizer_register_timeout``        Overrides the behavior of the configuration property                                                 ``optimizer.enforce-timeout-for-hbo-query-registration``
                                                             ``optimizer.enforce-timeout-for-hbo-query-registration`` in the current session.
-``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries, i.e. queries with join and aggregation.  ``True``
+``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries - queries with join and aggregation.  ``True``
 ``history_input_table_statistics_matching_threshold``       Overrides the behavior of the configuration property                                                 ``hbo.history-matching-threshold``
                                                             ``hbo.history-matching-threshold`` in the current session.
 ``treat_low_confidence_zero_estimation_unknown_enabled``    Overrides the behavior of the configuration property

--- a/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
+++ b/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
@@ -65,7 +65,7 @@ Session property Name                                       Description         
                                                             ``optimizer.history-based-optimizer-timeout`` in the current session.
 ``enforce_history_based_optimizer_register_timeout``        Overrides the behavior of the configuration property                                                 ``optimizer.enforce-timeout-for-hbo-query-registration``
                                                             ``optimizer.enforce-timeout-for-hbo-query-registration`` in the current session.
-``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries - queries with join and aggregation.  ``True``
+``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries - queries with join and aggregation.      ``True``
 ``history_input_table_statistics_matching_threshold``       Overrides the behavior of the configuration property                                                 ``hbo.history-matching-threshold``
                                                             ``hbo.history-matching-threshold`` in the current session.
 ``treat_low_confidence_zero_estimation_unknown_enabled``    Overrides the behavior of the configuration property

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -92,7 +92,7 @@ Additional Kerberos Debugging Information
 
 You can enable additional Kerberos debugging information for the Presto CLI
 process by passing ``-Dsun.security.krb5.debug=true`` as a JVM argument when
-starting the CLI process. Doing so requires invoking the CLI JAR via ``java``
+starting the CLI process. Doing so requires invoking the CLI JAR by using ``java``
 instead of running the self-executable JAR directly. The self-executable jar
 file cannot pass the option to the JVM.
 

--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -43,7 +43,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
    - It is also possible to specify each node's fully-qualified hostname manually.
      This will be different for every host. Hosts should be in the same domain to
      make it easy to create the correct SSL/TLS certificates.
-     e.g.: ``coordinator.example.com``, ``worker1.example.com``, ``worker2.example.com``.
+     For example: ``coordinator.example.com``, ``worker1.example.com``, ``worker2.example.com``.
 
      .. code-block:: none
 
@@ -123,7 +123,7 @@ It is
   between nodes of the cluster
 * Optional when configuring only :doc:`external authentication </security>` method
   between clients and the coordinator
-* Mandatory when configuring both the above i.e internal TLS along with external authentication.
+* Mandatory when configuring both internal TLS and external authentication.
 
 There are multiple ways to enable internal authentication:
 
@@ -187,7 +187,7 @@ Enabling encryption impacts performance. The performance degradation can vary
 based on the environment, queries, and concurrency.
 
 For queries that do not require transferring too much data between the Presto
-nodes (e.g. ``SELECT count(*) FROM table``), the performance impact is negligible.
+nodes (such as ``SELECT count(*) FROM table``), the performance impact is negligible.
 
 However, for CPU intensive queries which require a considerable amount of data
 to be transferred between the nodes (for example, distributed joins, aggregations and
@@ -203,8 +203,8 @@ significantly.
 
 By default, TLS encryption uses the ``/dev/urandom`` system device as a source of entropy.
 This device has limited throughput, so on environments with high network bandwidth
-(e.g. InfiniBand), it may become a bottleneck. In such situations, it is recommended to try
-to switch the random number generator algorithm to ``SHA1PRNG``, by setting it via
+(for example, InfiniBand), it may become a bottleneck. In such situations, it is recommended to try
+to switch the random number generator algorithm to ``SHA1PRNG``, by setting it with the 
 ``http-server.https.secure-random-algorithm`` property in ``config.properties`` on the coordinator
 and all of the workers:
 


### PR DESCRIPTION
## Description
Revised the Presto documentation in
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/security
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/admin
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/optimizer

to remove use of `e.g.`, `via`, `etc.`, and `i.e.` from the Presto documentation in these directories.

Also checked `/plugin`, `/language`, `/migration`, `/rest`, `/ecosystem`, `/router`, `/troubleshoot`, and `/ext`, and found none. 
(Note: There is a `via` in `/troubleshoot`, but it's in an error message and should stay as it is in the documentation.) 

Building on the work in #27969.

Followup PRs will address `/connector`, `/develop`, `/functions`, `/sql`, and `/presto-cpp`. I'm intentionally keeping these PRs smaller than they could be to make the reviewers' job easier. 

## Motivation and Context
Latin abbreviations should be avoided in documentation. See:

* the [GitLab documentation style guide recommended word list entry for e.g.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#eg)
* the [GitLab documentation style guide recommended word list entry for via](https://docs.gitlab.com/development/documentation/styleguide/word_list/#via)
* the [GitLab documentation style guide recommended word list entry for etc](https://docs.gitlab.com/development/documentation/styleguide/word_list/#etc)
* the [GitLab documentation style guide recommended word list entry for I.e.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#ie)

I've been applying these rules for a long while when editing new Presto documentation, and @dnskr's work on https://github.com/prestodb/presto/pull/27961 prompted me to make a start at the existing doc set for consistency. Thanks @dnskr!

## Impact
Improved readability of the Presto documentation.

## Test Plan
Local doc builds. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Replace Latin abbreviations such as e.g., i.e., via, and etc. with clearer phrasing in admin, security, and optimizer Sphinx docs.