### PR TITLE
docs: Fix use of Latin abbreviations in Presto doc (part 3)

### DIFF
--- a/presto-docs/src/main/sphinx/develop/client-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/client-protocol.rst
@@ -62,11 +62,11 @@ Attribute                              Description
 ``nextUri``                            If present, the URL that should be used in subsequent ``GET`` or ``DELETE`` requests.  If not present, the query is
                                        complete or ended in error.
 ``columns``                            A list of the names and types of the columns returned by the query.
-``data``                               The ``data`` attribute contains a list of the rows returned by the query request.  Each row is itself a
+``data``                               The ``data`` attribute contains a list of the rows returned by the query request. Each row is itself a
                                        list that holds values of the columns in the row, in the order specified by the ``columns`` attribute.
-``updateType``                         A human-readable string representing the operation.  For a ``CREATE TABLE`` request, the ``updateType`` will be,
-                                       "CREATE TABLE"; for ``SET SESSION`` it will be "SET SESSION"; etc.
-``error``                              If query failed, the ``error`` attribute will contain JSON for a ``QueryError`` object.  That object contains
+``updateType``                         A human-readable string representing the operation. For example, for a ``CREATE TABLE`` request the ``updateType`` 
+                                       will be "CREATE TABLE"; or for ``SET SESSION`` it will be "SET SESSION".
+``error``                              If query failed, the ``error`` attribute will contain JSON for a ``QueryError`` object. That object contains
                                        a ``message``, an ``errorCode`` and other information about the error.  See the ``QueryError`` class for more details.
 ====================================== ===========================================================================================================================
 
@@ -91,7 +91,7 @@ Request Header Name                    Description
                                        the Presto engine.
 ``X-Presto-Language``                  The language to be used when running the query and formatting results.  The language
                                        of the session can be set on a per-query basis using the ``X-Presto-Language``
-                                       HTTP header, or via the ``PrestoConnection.setLocale(Locale)`` method in the
+                                       HTTP header, or with the ``PrestoConnection.setLocale(Locale)`` method in the
                                        JDBC driver.
 ``X-Presto-Trace-Token``               Supplies a trace token to the Presto engine to help identify log lines that originate
                                        with this query request.
@@ -114,11 +114,11 @@ Request Header Name                    Description
 ``X-Presto-Resource-Estimate``         A comma-separated list of ``resource=value`` type assignments.  The possible choices
                                        of ``resource`` are "EXECUTION_TIME", "CPU_TIME",  "PEAK_MEMORY" and "PEAK_TASK_MEMORY".
                                        "EXECUTION_TIME" and "CPU_TIME" have values specified as airlift ``Duration`` strings,
-                                       whose format is a double precision number followed by a ``TimeUnit`` string, e.g.,
-                                       of ``s`` for seconds, ``m`` for minutes, ``h`` for hours, etc.  "PEAK_MEMORY" and
+                                       whose format is a double precision number followed by a ``TimeUnit`` string
+                                       of ``s`` for seconds, ``m`` for minutes, ``h`` for hours.  "PEAK_MEMORY" and
                                        "PEAK_TASK_MEMORY" are specified as as airlift ``DataSize`` strings, whose format
                                        is an integer followed by ``B`` for bytes; ``kB`` for kilobytes; ``mB`` for megabytes,
-                                       ``gB`` for gigabytes, etc.
+                                       ``gB`` for gigabytes.
 ``X-Presto-Extra-Credential``          Provides extra credentials to the connector.  The header is a name=value string that
                                        is saved in the session ``Identity`` object.  The name and value are only
                                        meaningful to the connector.
@@ -247,7 +247,7 @@ Cross-cluster retry has the following limitations:
   works well for:
   
   - ``CREATE TABLE AS SELECT`` statements
-  - DDL operations (``CREATE``, ``ALTER``, ``DROP``, etc.)
+  - DDL operations (such as ``CREATE``, ``ALTER``, ``DROP``)
   - ``INSERT`` statements
   - ``SELECT`` queries that fail before any results are produced
   

--- a/presto-docs/src/main/sphinx/develop/example-http.rst
+++ b/presto-docs/src/main/sphinx/develop/example-http.rst
@@ -106,6 +106,6 @@ Record Set Provider: ExampleRecordSetProvider
 
 The record set provider creates a record set which in turn creates a
 record cursor that returns the actual data to Presto.
-``ExampleRecordCursor`` reads data from a URI via HTTP. Each line
+``ExampleRecordCursor`` reads data from a URI by using HTTP. Each line
 corresponds to a single row. Lines are split on comma into individual
 field values which are then returned to Presto.

--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -263,7 +263,7 @@ a bit more complex.
   you want, and the framework will generate all the implementations and
   serializers for you. If you need a more complex state object, you will need
   to implement ``AccumulatorStateFactory`` and ``AccumulatorStateSerializer``
-  and provide these via the ``AccumulatorStateMetadata`` annotation.
+  and provide these through the ``AccumulatorStateMetadata`` annotation.
 
 The following code implements the aggregation function ``avg_double`` which computes the
 average of a ``DOUBLE`` column:
@@ -334,8 +334,8 @@ function follows:
   you must annotate the arguments with ``@SqlType``.  Note that, unlike in the above
   scalar example where ``Slice`` is used to hold ``VARCHAR``, the primitive
   ``double`` type is used for the argument to input. In this example, the input
-  function simply keeps track of the running count of rows (via ``setLong()``)
-  and the running sum (via ``setDouble()``).
+  function simply keeps track of the running count of rows (through ``setLong()``)
+  and the running sum (through ``setDouble()``).
 
 * ``@CombineFunction``:
 

--- a/presto-docs/src/main/sphinx/develop/password-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/password-authenticator.rst
@@ -2,7 +2,7 @@
 Password Authenticator
 ======================
 
-Presto supports authentication with a username and password via a custom
+Presto supports authentication with a username and password through a custom
 password authenticator that validates the credentials and creates a principal.
 
 Implementation

--- a/presto-docs/src/main/sphinx/develop/spi-overview.rst
+++ b/presto-docs/src/main/sphinx/develop/spi-overview.rst
@@ -20,7 +20,7 @@ Plugin Metadata
 ---------------
 
 Each plugin identifies an entry point: an implementation of the
-``Plugin`` interface. This class name is provided to Presto via
+``Plugin`` interface. This class name is provided to Presto through 
 the standard Java ``ServiceLoader`` interface: the classpath contains
 a resource file named ``com.facebook.presto.spi.Plugin`` in the
 ``META-INF/services`` directory. The content of this file is a
@@ -49,8 +49,8 @@ is ready to create an instance of a connector to back a catalog. There are simil
 methods for ``Type``, ``ParametricType``, ``Function``, ``SystemAccessControl``, and
 ``EventListenerFactory`` objects.
 
-Building Plugins via Maven
---------------------------
+Building Plugins with Maven
+---------------------------
 
 Plugins depend on the SPI from Presto:
 
@@ -99,7 +99,7 @@ functionality for the Presto coordinator. Presto SPI defines different service
 provider factories and service providers that allow customization of session
 property providers, function namespace managers, type managers, expression
 optimizers, and plan checkers. The following service providers can be accessed
-via their respective provider factories.
+through their respective provider factories.
 
 +----------------------+----------------------------------------+---------------------------------+
 |       Service        |             Provider Factory           |        Service Provider         |
@@ -126,7 +126,7 @@ Native Sidecar Plugin
 ---------------------
 
 The ``NativeSidecarPlugin`` class implements ``CoordinatorPlugin`` interface
-and returns the following service providers via their respective provider
+and returns the following service providers through their respective provider
 factories.
 
 +----------------------+----------------------------------------------+---------------------------------------+

--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -19,7 +19,7 @@ query fragment and track execution status.
 * A ``POST`` to ``/v1/task/{taskId}`` starts execution of the query fragment
   specified in the ``POST`` body. The request optionally includes a set of
   initial splits to process. The request also specifies how to partition results,
-  e.g. hash partition using specified output columns into specified number of
+  either hash partition using specified output columns into specified number of
   output buffers or combine all results into a single output buffer or broadcast
   combined results into multiple output buffers.
 * A subsequent ``POST`` to ``/v1/task/{taskId}`` may provide additional splits
@@ -45,7 +45,7 @@ time even if the task state stays the same.
 The design ensures that coordinator receives task state changes in a timely
 manner without polling the worker in a tight loop.
 
-The same design applies to requests for extended task information via a ``GET``
+The same design applies to requests for extended task information with a ``GET``
 on ``/v1/task/{taskId}``.
 
 Data Plane
@@ -134,7 +134,7 @@ upstream workers using buffer number 2.
 Failure Handling
 ~~~~~~~~~~~~~~~~
 
-Task failures are reported to the coordinator via ``TaskStatus`` and ``TaskInfo``
+Task failures are reported to the coordinator through ``TaskStatus`` and ``TaskInfo``
 updates.
 
 When a task failure is discovered, the coordinator aborts all remaining tasks and

--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -19,8 +19,8 @@ query fragment and track execution status.
 * A ``POST`` to ``/v1/task/{taskId}`` starts execution of the query fragment
   specified in the ``POST`` body. The request optionally includes a set of
   initial splits to process. The request also specifies how to partition results,
-  either hash partition using specified output columns into specified number of
-  output buffers or combine all results into a single output buffer or broadcast
+  either hash partitioning using specified output columns into a specified number of output buffers 
+  or combine all results into a single output buffer or broadcast
   combined results into multiple output buffers.
 * A subsequent ``POST`` to ``/v1/task/{taskId}`` may provide additional splits
   for processing and eventually specify that no more splits will be coming.

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -39,7 +39,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 
 .. function:: array_cum_sum(array(T)) -> array(T)
 
-    Returns the array whose elements are the cumulative sum of the input array, i.e. result[i] = input[1]+input[2]+...+input[i].
+    Returns the array whose elements are the cumulative sum of the input array: result[i] = input[1]+input[2]+...+input[i].
     If there there is null elements in the array, the cumulative sum at and after the element is null. ::
 
         SELECT array_cum_sum(ARRAY [1, 2, null, 3]) -- array[1, 3, null, null]

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -40,7 +40,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 .. function:: array_cum_sum(array(T)) -> array(T)
 
     Returns the array whose elements are the cumulative sum of the input array: result[i] = input[1]+input[2]+...+input[i].
-    If there there is null elements in the array, the cumulative sum at and after the element is null. ::
+    If there are null elements in the array, the cumulative sum at and after the element is null. ::
 
         SELECT array_cum_sum(ARRAY [1, 2, null, 3]) -- array[1, 3, null, null]
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -51,7 +51,7 @@ Date and Time Functions
 .. function:: current_timezone() -> varchar
 
     Returns the current time zone in the format defined by IANA
-    (for example., ``America/Los_Angeles``) or as fixed offset from UTC (``+08:35``)
+    (for example, ``America/Los_Angeles``) or as fixed offset from UTC (``+08:35``)
 
 .. function:: date(x) -> date
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -51,7 +51,7 @@ Date and Time Functions
 .. function:: current_timezone() -> varchar
 
     Returns the current time zone in the format defined by IANA
-    (e.g., ``America/Los_Angeles``) or as fixed offset from UTC (e.g., ``+08:35``)
+    (for example., ``America/Los_Angeles``) or as fixed offset from UTC (``+08:35``)
 
 .. function:: date(x) -> date
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -88,7 +88,7 @@ Constructors
     than two non-empty points in the input array, an empty LineString will be
     returned.  Throws an exception if any element in the array is ``null`` or
     empty or same as the previous one.  The returned geometry may not be
-    simple, e.g. may self-intersect or may contain duplicate vertexes depending
+    simple: for instance it may self-intersect or may contain duplicate vertexes depending
     on the input.
 
 .. function:: ST_MultiPoint(array(Point)) -> MultiPoint
@@ -264,10 +264,13 @@ Accessors
 
     It supports Points and MultiPoints as input and returns the three-dimensional centroid
     projected onto the surface of the (spherical) Earth
-    e.g. MULTIPOINT (0 -45, 0 45, 30 0, -30 0) returns Point(0, 0)
+    
+    ``MULTIPOINT (0 -45, 0 45, 30 0, -30 0)`` returns ``Point(0, 0)``
+
     Note: In the case that the three-dimensional centroid is at (0, 0, 0), the spherical centroid
     is undefined and an arbitrary point will be returned
-    e.g. MULTIPOINT (0 0, -180 0) returns Point(-90, 45)
+    
+    ``MULTIPOINT (0 0, -180 0)`` returns ``Point(-90, 45)``
 
 .. function:: ST_ConvexHull(Geometry) -> Geometry
 
@@ -303,12 +306,12 @@ Accessors
 .. function:: ST_GeometryN(Geometry, index) -> Geometry
 
     Returns the geometry element at a given index (indices start at 1).
-    If the geometry is a collection of geometries (e.g., GEOMETRYCOLLECTION or MULTI*),
+    If the geometry is a collection of geometries such as GEOMETRYCOLLECTION or MULTI*,
     returns the geometry at a given index.
     If the given index is less than 1 or greater than the total number of elements in the collection,
     returns ``NULL``.
     Use :func:``ST_NumGeometries`` to find out the total number of elements.
-    Singular geometries (e.g., POINT, LINESTRING, POLYGON), are treated as collections of one element.
+    Singular geometries such as POINT, LINESTRING, or POLYGON are treated as collections of one element.
     Empty geometries are treated as empty collections.
 
 .. function:: ST_InteriorRingN(Geometry, index) -> Geometry
@@ -409,7 +412,7 @@ Accessors
 .. function:: ST_NumGeometries(Geometry) -> bigint
 
     Returns the number of geometries in the collection.
-    If the geometry is a collection of geometries (e.g., GEOMETRYCOLLECTION or
+    If the geometry is a collection of geometries (GEOMETRYCOLLECTION or
     MULTI*), returns the number of geometries, for single geometries returns 1,
     for empty geometries returns 0.  Note that empty geometries inside of a
     GEOMETRYCOLLECTION will count as a geometry; eg

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -263,7 +263,7 @@ Accessors
     Returns the point value that is the mathematical centroid of a spherical geometry.
 
     It supports Points and MultiPoints as input and returns the three-dimensional centroid
-    projected onto the surface of the (spherical) Earth
+    projected onto the surface of the (spherical) Earth.
     
     ``MULTIPOINT (0 -45, 0 45, 30 0, -30 0)`` returns ``Point(0, 0)``
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -88,7 +88,7 @@ Constructors
     than two non-empty points in the input array, an empty LineString will be
     returned.  Throws an exception if any element in the array is ``null`` or
     empty or same as the previous one.  The returned geometry may not be
-    simple: for instance it may self-intersect or may contain duplicate vertexes depending
+    simple: for instance, it may self-intersect or may contain duplicate vertices depending
     on the input.
 
 .. function:: ST_MultiPoint(array(Point)) -> MultiPoint

--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -115,7 +115,7 @@ JSON Functions
 --------------
 .. function:: is_json_scalar(json) -> boolean
 
-    Determine if ``json`` is a scalar (i.e. a JSON number, a JSON string, ``true``, ``false`` or ``null``)::
+    Determine if ``json`` is a scalar (a JSON number, a JSON string, ``true``, ``false`` or ``null``)::
 
         SELECT is_json_scalar('1'); -- true
         SELECT is_json_scalar('[1, 2, 3]'); -- false

--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -32,7 +32,7 @@ Functions
 .. function:: cardinality(khll) -> bigint
     :noindex:
 
-    This calculates the cardinality of the MinHash sketch, i.e. ``x``'s cardinality.
+    This calculates the cardinality of the MinHash sketch, that is, ``x``'s cardinality.
 
 .. function:: intersection_cardinality(khll1, khll2) ->  bigint
 

--- a/presto-docs/src/main/sphinx/functions/noisy.rst
+++ b/presto-docs/src/main/sphinx/functions/noisy.rst
@@ -103,7 +103,7 @@ Approximate Distinct Counting/Sketching
 ---------------------------------------
 
 Noisy approximate distinct counting and sketching (analogous to the deterministic :doc:`hyperloglog`)
-is supported via the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
+is supported through the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
 
 .. function:: noisy_approx_set_sfm(col, epsilon[, buckets[, precision]]) -> SfmSketch
 
@@ -205,7 +205,7 @@ privacy-preserving purposes, including:
   This means a ``NULL`` return value noiselessly indicates the absence of data.
 - ``GROUP BY`` clauses used in combination with noisy aggregation functions
   reveal non-noisy information: the presence or absence of a group noiselessly
-  indicates the presence or absence of data. See, e.g., [Wilkins2024]_.
+  indicates the presence or absence of data. See [Wilkins2024]_.
 - Functions relying on floating-point noise may be susceptible to inference
   attacks such as those identified in [Mironov2012]_ and [Casacuberta2022]_.
 

--- a/presto-docs/src/main/sphinx/functions/regexp.rst
+++ b/presto-docs/src/main/sphinx/functions/regexp.rst
@@ -5,10 +5,10 @@ Regular Expression Functions
 All of the regular expression functions use the `Java pattern`_ syntax,
 with a few notable exceptions:
 
-* When using multi-line mode (enabled via the ``(?m)`` flag),
+* When using multi-line mode (enabled with the ``(?m)`` flag),
   only ``\n`` is recognized as a line terminator. Additionally,
   the ``(?d)`` flag is not supported and must not be used.
-* Case-insensitive matching (enabled via the ``(?i)`` flag) is always
+* Case-insensitive matching (enabled with the ``(?i)`` flag) is always
   performed in a Unicode-aware manner. However, context-sensitive and
   local-sensitive matching is not supported. Additionally, the
   ``(?u)`` flag is not supported and must not be used.

--- a/presto-docs/src/main/sphinx/functions/setdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/setdigest.rst
@@ -51,7 +51,7 @@ Presto offers the ability to merge multiple Set Digest data sketches.
 Serialization
 -------------
 
-Data sketches such as those created via the use of MinHash or HyperLogLog can be serialized into a varbinary data type.
+Data sketches such as those created with the use of MinHash or HyperLogLog can be serialized into a varbinary data type.
 Serializing these data structures allows them to be efficiently stored and, if needed, transferred between different
 systems or sessions.
 Once stored, they can then be deserialized back into to their original state when they need to be used again.

--- a/presto-docs/src/main/sphinx/functions/setdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/setdigest.rst
@@ -54,7 +54,7 @@ Serialization
 Data sketches such as those created with the use of MinHash or HyperLogLog can be serialized into a varbinary data type.
 Serializing these data structures allows them to be efficiently stored and, if needed, transferred between different
 systems or sessions.
-Once stored, they can then be deserialized back into to their original state when they need to be used again.
+Once stored, they can then be deserialized back into their original state when they need to be used again.
 In the context of Presto, you might normally do this using functions that convert these data sketches to and from binary.
 An example might include using ``to_utf8()`` or ``from_utf8()``.
 

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -55,7 +55,7 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
 .. function:: hamming_distance(string1, string2) -> bigint
 
     Returns the Hamming distance of ``string1`` and ``string2``,
-    i.e. the number of positions at which the corresponding characters are different.
+    that is, the number of positions at which the corresponding characters are different.
     Note that the two strings must have the same length.
 
 .. function:: jarowinkler_similarity(string1, string2) -> double
@@ -69,7 +69,7 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
 .. function:: levenshtein_distance(string1, string2) -> bigint
 
     Returns the Levenshtein edit distance of ``string1`` and ``string2``,
-    i.e. the minimum number of single-character edits (insertions,
+    that is, the minimum number of single-character edits (insertions,
     deletions or substitutions) needed to change ``string1`` into ``string2``.
 
 .. function:: longest_common_prefix(string1, string2) -> varchar
@@ -156,14 +156,14 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
     Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
     ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
     each pair into key and value. Note that ``entryDelimiter`` and ``keyValueDelimiter`` are
-    interpreted literally, i.e., as full string matches.
+    interpreted literally, as full string matches.
 
 .. function:: split_to_map(string, entryDelimiter, keyValueDelimiter, function(K,V1,V2,R)) -> map<varchar, varchar>
 
     Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
     ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
     each pair into key and value. Note that ``entryDelimiter`` and ``keyValueDelimiter`` are
-    interpreted literally, i.e., as full string matches. ``function(K,V1,V2,R)``
+    interpreted literally, as full string matches. ``function(K,V1,V2,R)``
     is invoked in cases of duplicate keys to resolve the value that should be in the map. ::
 
         SELECT(split_to_map('a:1;b:2;a:3', ';', ':', (k, v1, v2) -> v1)); -- {"a": "1", "b": "2"}
@@ -176,7 +176,7 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
     into key-value pairs. ``keyValueDelimiter`` splits each pair into key and value. The
     values for each key will be in the same order as they appeared in ``string``.
     Note that ``entryDelimiter`` and ``keyValueDelimiter`` are interpreted literally,
-    i.e., as full string matches.
+    as full string matches.
 
 .. function:: strpos(string, substring) -> bigint
 

--- a/presto-docs/src/main/sphinx/sql/call.rst
+++ b/presto-docs/src/main/sphinx/sql/call.rst
@@ -37,7 +37,7 @@ Intermediate parameters cannot be omitted::
 Some connectors, such as the :doc:`/connector/postgresql`, are for systems
 that have their own stored procedures. These stored procedures are separate
 from the connector-defined procedures discussed here and thus are not
-directly callable via ``CALL``.
+directly callable with ``CALL``.
 
 See connector documentation for details on available procedures.
 

--- a/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
@@ -108,7 +108,7 @@ Create a materialized view with timestamp-based staleness detection::
 
 .. note::
 
-    The ``use_timestamp_based_staleness`` property enables timestamp-based staleness detection for connectors where snapshot comparison is not feasible (e.g., non-Iceberg tables). This approach tracks only the time since last refresh, not individual base table modifications. This is a connector-specific property - consult your connector documentation for availability.
+    The ``use_timestamp_based_staleness`` property enables timestamp-based staleness detection for connectors where snapshot comparison is not feasible such as in non-Iceberg tables. This approach tracks only the time since last refresh, not individual base table modifications. This is a connector-specific property - consult your connector documentation for availability.
 
 Create a materialized view with connector properties::
 

--- a/presto-docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/explain-analyze.rst
@@ -30,7 +30,7 @@ Examples
 In the example below, you can see the CPU time spent in each stage, as well as the relative
 cost of each plan node in the stage. Note that the relative cost of the plan nodes is based on
 wall time, which may or may not be correlated to CPU time. For each plan node you can see
-some additional statistics (e.g: average input per node instance, average number of hash collisions for
+some additional statistics (for example, average input per node instance, average number of hash collisions for
 relevant plan nodes). Such statistics are useful when one wants to detect data anomalies for a query
 (skewness, abnormal hash collisions).
 

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -18,7 +18,7 @@ Revokes the specified privileges from the specified grantee.
 
 Specifying ``ALL PRIVILEGES`` revokes :doc:`delete`, :doc:`insert` and :doc:`select` privileges.
 
-Specifying ``ROLE PUBLIC`` revokes privileges from the ``PUBLIC`` role. Users will retain privileges assigned to them directly or via other roles.
+Specifying ``ROLE PUBLIC`` revokes privileges from the ``PUBLIC`` role. Users will retain privileges assigned to them directly or through other roles.
 
 The optional ``GRANT OPTION FOR`` clause also revokes the privileges to grant the specified privileges.
 

--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -212,7 +212,7 @@ source is not deterministic.
 
 **CUBE**
 
-The ``CUBE`` operator generates all possible grouping sets (i.e. a power set)
+The ``CUBE`` operator generates all possible grouping sets (that is, a power set)
 for a given set of columns. For example, the query::
 
     SELECT origin_state, destination_state, sum(package_weight)
@@ -476,7 +476,7 @@ argument is not supported for ``INTERSECT`` or ``EXCEPT``.
 
 
 Multiple set operations are processed left to right, unless the order is explicitly
-specified via parentheses. Additionally, ``INTERSECT`` binds more tightly
+specified with parentheses. Additionally, ``INTERSECT`` binds more tightly
 than ``EXCEPT`` and ``UNION``. That means ``A UNION B INTERSECT C EXCEPT D``
 is the same as ``A UNION (B INTERSECT C) EXCEPT D``.
 

--- a/presto-docs/src/main/sphinx/sql/values.rst
+++ b/presto-docs/src/main/sphinx/sql/values.rst
@@ -22,7 +22,7 @@ Description
 
 Defines a literal inline table.
 
-``VALUES`` can be used anywhere a query can be used (e.g., the ``FROM`` clause
+``VALUES`` can be used anywhere a query can be used (for example, the ``FROM`` clause
 of a :doc:`select`, an :doc:`insert`, or even at the top level). ``VALUES`` creates
 an anonymous table without column names, but the table and columns can be named
 using an ``AS`` clause with column aliases.


### PR DESCRIPTION
## Description
Revised the Presto documentation in
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/sql
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/functions
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/develop

to remove use of `e.g.`, `via`, `etc.`, and `i.e.` from the Presto documentation in these directories.

Also checked `/plugin`, and found none there. 

Building on the work in #27969 and #27974.

Followup PRs will address `/connector` and `/presto-cpp`. I'm intentionally keeping these PRs small to make reviewing easier. 

## Motivation and Context
Latin abbreviations should be avoided in documentation. See:

* the [GitLab documentation style guide recommended word list entry for e.g.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#eg)
* the [GitLab documentation style guide recommended word list entry for via](https://docs.gitlab.com/development/documentation/styleguide/word_list/#via)
* the [GitLab documentation style guide recommended word list entry for etc](https://docs.gitlab.com/development/documentation/styleguide/word_list/#etc)
* the [GitLab documentation style guide recommended word list entry for I.e.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#ie)

I've been applying these rules for a long while when editing new Presto documentation, and @dnskr's work on https://github.com/prestodb/presto/pull/27961 prompted me to make a start at the existing doc set for consistency. Thanks @dnskr!

## Impact
Improved readability of the Presto documentation.

## Test Plan
Local doc builds. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Replace Latin abbreviations such as e.g., i.e., via, and etc. with clearer phrasing across SQL, functions, and developer documentation sections.