### PR TITLE
fix(docs): Resolve minor duplicate label warnings

### DIFF
--- a/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
+++ b/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
@@ -29,7 +29,7 @@ Once configured, you can query metrics using SQL:
     SELECT * FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";
 
 Metadata Operation Metrics
----------------------------
+--------------------------
 
 **JMX Table Name:** ``com.facebook.presto.metadata:name=metadatamanagerstats``
 
@@ -145,14 +145,11 @@ Track data insertion performance:
     -- 1.0               | 11.47       | 11.47       | 11.47
 
 System Access Control Metrics
-------------------------------
+-----------------------------
 
 **JMX Table Name:** ``com.facebook.presto.security:name=accesscontrolmanager``
 
 Tracks performance of access control checks.
-
-Key Metrics
-^^^^^^^^^^^
 
 Similar structure to metadata metrics, tracking operations like:
 
@@ -180,7 +177,7 @@ Query Execution Metrics
 * ``com.facebook.presto.execution:name=querymanager``: Query execution statistics
 
 Connector-Specific Metrics
----------------------------
+--------------------------
 
 Hive Connector
 ^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -262,8 +262,8 @@ Avro Configuration Properties
 
 When querying or creating Avro-formatted tables with the Hive connector, you may need to supply or override the Avro schema. In addition, Hive Metastore, especially Hive 3.x, must be configured to read storage schemas for Avro tables.
 
-Table Properties
-^^^^^^^^^^^^^^^^
+Avro Table Properties
+^^^^^^^^^^^^^^^^^^^^^
 
 These properties can be used when creating or querying Avro tables in Presto:
 
@@ -303,8 +303,8 @@ You must restart the metastore service for this configuration to take effect. Th
 Textfile Configuration Properties
 ---------------------------------
 
-Table Properties
-^^^^^^^^^^^^^^^^
+Textfile Table Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These properties can be used when creating TEXTFILE tables in Presto:
 

--- a/presto-docs/src/main/sphinx/develop/procedures.rst
+++ b/presto-docs/src/main/sphinx/develop/procedures.rst
@@ -375,8 +375,8 @@ enabling connectors to dynamically provide these callable distributed procedures
 as a ``Provider<DistributedProcedure>``, which ensures an instance is created on-demand when a procedure needs to be executed. The following steps will
 guide you through implementing and supplying a distributed procedure in your connector.
 
-1. Procedure Provider Class
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. DistributedProcedure Provider Class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An implementation class must implement the ``Provider<DistributedProcedure>`` interface. In its constructor, it can use @Inject to receive any Guice-managed
 dependencies. The class is required to implement the ``get()`` method from the Provider interface, which is responsible for constructing and returning a

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -220,8 +220,8 @@ Presto CLI
 
 See :doc:`/clients/presto-cli` for instructions to set up Presto CLI.
 
-Environment Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Presto CLI Environment Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 TLS Configuration
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
The PR resolves minor `duplicate label` warnings for the following pages:

1. `Administration`/`JMX Metrics Reference`
```
./presto/presto-docs/src/main/sphinx/admin/jmx-metrics.rst:155: WARNING: duplicate label admin/jmx-metrics:key metrics, other instance in ./presto/presto-docs/src/main/sphinx/admin/jmx-metrics.rst [autosectionlabel.admin/jmx-metrics]
```
Header `Key Metrics` deleted from `System Access Control Metrics` as redundant. 
<img width="1328" height="630" alt="image" src="https://github.com/user-attachments/assets/1683d0ab-2b3d-473f-b946-73d2ec4f3a61" />


2. `Developer Guide`/`Procedures`
```
./presto/presto-docs/src/main/sphinx/develop/procedures.rst:379: WARNING: duplicate label develop/procedures:1. procedure provider class, other instance in ./presto/presto-docs/src/main/sphinx/develop/procedures.rst [autosectionlabel.develop/procedures]
```
Used DistributedProcedure class name for the header uniqueness. 
<img width="1322" height="752" alt="image" src="https://github.com/user-attachments/assets/95600a18-c267-44aa-9b7d-341516a193aa" />


3. `Security`/`LDAP Authentication`
```
./presto/presto-docs/src/main/sphinx/security/ldap.rst:224: WARNING: duplicate label security/ldap:environment configuration, other instance in ./presto/presto-docs/src/main/sphinx/security/ldap.rst [autosectionlabel.security/ldap]  
```
Added `Presto CLI` for the header uniqueness similar to the next header `Presto CLI Execution`.
<img width="1365" height="784" alt="image" src="https://github.com/user-attachments/assets/6d1705bd-9947-4798-b0a2-6c5576c6f032" />


4. `Connectors`/`Hive Connector`
```
./presto/presto-docs/src/main/sphinx/connector/hive.rst:307: WARNING: duplicate label connector/hive:table properties, other instance in ./presto/presto-docs/src/main/sphinx/connector/hive.rst [autosectionlabel.connector/hive]
```
Added `Avro` and `Textfile` to `Table Properties` headers for uniqueness.
<img width="1362" height="674" alt="image" src="https://github.com/user-attachments/assets/89ca2844-c59b-488a-bc19-8ea2dd2b8e33" />


## Motivation and Context
Reduce the number of warnings during the documentation build process.
The end goal to have zero warnings and enable zero warnings policy for documentation to prevent introducing new issues.

## Impact
_None_

## Test Plan
Build the documentation and check the pages are correct:
```
presto-docs/build

open presto-docs/target/html/admin/jmx-metrics.html
open presto-docs/target/html/develop/procedures.html
open presto-docs/target/html/security/ldap.html
open presto-docs/target/html/connector/hive.html
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Adjust headings in JMX metrics, procedures, LDAP authentication, and Hive connector docs to ensure unique section labels and remove redundant titles.