### PR TITLE
fix(native-pos): Enable native exchange materialization by default (#27980)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -2221,7 +2221,7 @@ public final class SystemSessionProperties
                         !featuresConfig.isNativeExecutionEnabled()),
                 booleanProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED,
                         "Native Execution only. Enable materialized exchange operators in Velox (MaterializedOutput/MaterializedExchange). When false, uses PartitionAndSerialize + ShuffleWrite.",
-                        false,
+                        true,
                         false),
                 stringProperty(
                         EXPRESSION_OPTIMIZER_NAME,

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.facebook.airlift.log.Level.WARN;
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXCHANGE_MATERIALIZATION_ENABLED;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerHiveProperties;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerSystemProperties;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.getNativeQueryRunnerParameters;
@@ -70,9 +71,28 @@ public class PrestoSparkNativeQueryRunnerUtils
     private static final String SPARK_SHUFFLE_MANAGER = "spark.shuffle.manager";
     private static final String FALLBACK_SPARK_SHUFFLE_MANAGER = "spark.fallback.shuffle.manager";
     private static final String DEFAULT_STORAGE_FORMAT = "DWRF";
+    private static final Map<String, String> NATIVE_EXECUTION_SESSION_PROPERTIES = ImmutableMap.of(
+            NATIVE_EXCHANGE_MATERIALIZATION_ENABLED,
+            "false");
+    private static final Map<String, String> NATIVE_EXECUTION_SYSTEM_CONFIGS = ImmutableMap.of(
+            "exchange.materialization.enabled",
+            "false");
     private static Optional<Path> dataDirectory = Optional.empty();
 
     private PrestoSparkNativeQueryRunnerUtils() {}
+
+    public static Map<String, String> getNativeExecutionSystemConfigs()
+    {
+        return NATIVE_EXECUTION_SYSTEM_CONFIGS;
+    }
+
+    public static Map<String, String> getNativeExecutionSystemConfigs(Map<String, String> overrides)
+    {
+        return ImmutableMap.<String, String>builder()
+                .putAll(NATIVE_EXECUTION_SYSTEM_CONFIGS)
+                .putAll(overrides)
+                .build();
+    }
 
     public static Map<String, String> getNativeExecutionSparkConfigs()
     {
@@ -103,7 +123,7 @@ public class PrestoSparkNativeQueryRunnerUtils
     {
         PrestoSparkQueryRunner queryRunner = createRunner("hive", new NativeExecutionModule(),
                 new NativeExecutionConfigModule(
-                        ImmutableMap.of(),
+                        NATIVE_EXECUTION_SYSTEM_CONFIGS,
                         ImmutableMap.of(
                                 "hive",
                                 ImmutableMap.of("connector.name", "hive"))));
@@ -130,7 +150,7 @@ public class PrestoSparkNativeQueryRunnerUtils
                 "hive",
                 new NativeExecutionModule(),
                 new NativeExecutionConfigModule(
-                        additionalSystemConfigs,
+                        getNativeExecutionSystemConfigs(additionalSystemConfigs),
                         catalogBuilder.build()));
 
         // Add connectors on the Java side to make them visible during planning.
@@ -172,7 +192,7 @@ public class PrestoSparkNativeQueryRunnerUtils
                 "tpchstandard",
                 new NativeExecutionModule(),
                 new NativeExecutionConfigModule(
-                        ImmutableMap.of(),
+                        NATIVE_EXECUTION_SYSTEM_CONFIGS,
                         ImmutableMap.of(
                                 "tpchstandard",
                                 ImmutableMap.of("connector.name", "tpch"))));
@@ -190,7 +210,8 @@ public class PrestoSparkNativeQueryRunnerUtils
                 additionalSparkProperties,
                 dataDir,
                 nativeModules,
-                AVAILABLE_CPU_COUNT);
+                AVAILABLE_CPU_COUNT,
+                NATIVE_EXECUTION_SESSION_PROPERTIES);
 
         ExtendedHiveMetastore metastore = queryRunner.getMetastore();
         if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -122,7 +122,7 @@ public class NativeExecutionSystemConfig
     private final String orderBySpillEnabledDefault = "true";
     private final String maxSpillBytesDefault = String.valueOf(600L << 30);
     private final String planConsistencyCheckEnabled = "true";
-    private final String exchangeMaterializationEnabledDefault = "false";
+    private final String exchangeMaterializationEnabledDefault = "true";
 
     private final Map<String, String> systemConfigs;
     private final Map<String, String> defaultSystemConfigs;

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -305,6 +305,27 @@ public class PrestoSparkQueryRunner
             ImmutableList<Module> additionalModules,
             int availableCpuCount)
     {
+        this(
+                defaultCatalog,
+                additionalConfigProperties,
+                hiveProperties,
+                additionalSparkProperties,
+                dataDirectory,
+                additionalModules,
+                availableCpuCount,
+                ImmutableMap.of());
+    }
+
+    public PrestoSparkQueryRunner(
+            String defaultCatalog,
+            Map<String, String> additionalConfigProperties,
+            Map<String, String> hiveProperties,
+            Map<String, String> additionalSparkProperties,
+            Optional<Path> dataDirectory,
+            ImmutableList<Module> additionalModules,
+            int availableCpuCount,
+            Map<String, String> defaultSessionProperties)
+    {
         setupLogging();
 
         ImmutableMap.Builder<String, String> configProperties = ImmutableMap.builder();
@@ -334,7 +355,7 @@ public class PrestoSparkQueryRunner
 
         Injector injector = injectorFactory.create(new PrestoSparkBootstrapTimer(systemTicker(), false));
 
-        defaultSession = testSessionBuilder(injector.getInstance(SessionPropertyManager.class))
+        Session.SessionBuilder sessionBuilder = testSessionBuilder(injector.getInstance(SessionPropertyManager.class))
                 .setCatalog(defaultCatalog)
                 .setSchema("tpch")
                 // Sql-Standard Access Control Checker
@@ -348,8 +369,9 @@ public class PrestoSparkQueryRunner
                                 ImmutableMap.of(),
                                 ImmutableMap.of(),
                                 Optional.empty(),
-                                Optional.empty()))
-                .build();
+                                Optional.empty()));
+        defaultSessionProperties.forEach(sessionBuilder::setSystemProperty);
+        defaultSession = sessionBuilder.build();
 
         transactionManager = injector.getInstance(TransactionManager.class);
         metadata = injector.getInstance(Metadata.class);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -80,7 +80,7 @@ public class TestNativeExecutionSystemConfig
                 .put("order-by-spill-enabled", "true")
                 .put("max-spill-bytes", String.valueOf(600L << 30))
                 .put("plan-consistency-check-enabled", "true")
-                .put("exchange.materialization.enabled", "false")
+                .put("exchange.materialization.enabled", "true")
                 .build();
         assertEquals(nativeExecutionSystemConfig.getAllProperties(), expectedConfigs);
 


### PR DESCRIPTION
Summary:

Set native_exchange_materialization_enabled session property default to
true. This enables MaterializedOutput/MaterializedExchange operators in
Velox by default for native execution, replacing the legacy
PartitionAndSerialize + ShuffleWrite path.

The property remains overridable per-session (set to false to revert).
Only affects native execution mode — no impact on Java execution.

Differential Revision: D108381528


