### PR TITLE
feat(native-pos): Add zero-copy collect path to shuffle writer (#27981)

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -242,6 +242,7 @@ SystemConfig::SystemConfig() {
               kExchangeMaterializationOutputBufferPerPartitionMaxBytes,
               130L * 1024),
           NUM_PROP(kExchangeMaterializationReclaimDrainThresholdRatio, 0.67),
+          BOOL_PROP(kExchangeMaterializationSkipCoalesceEnabled, false),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           BOOL_PROP(kHttpEnableAccessLog, false),
@@ -816,6 +817,11 @@ bool SystemConfig::exchangeMaterializationReclaimWaitForWriterDrainEnabled()
 
 bool SystemConfig::exchangeMaterializationReclaimHighPriority() const {
   return optionalProperty<bool>(kExchangeMaterializationReclaimHighPriority)
+      .value_or(false);
+}
+
+bool SystemConfig::exchangeMaterializationSkipCoalesceEnabled() const {
+  return optionalProperty<bool>(kExchangeMaterializationSkipCoalesceEnabled)
       .value_or(false);
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -249,6 +249,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(
               kExchangeMaterializationOutputBufferDrainChunkMultiplier, 2.0),
           NUM_PROP(kExchangeMaterializationReclaimDrainThresholdRatio, 0.67),
+          BOOL_PROP(kExchangeMaterializationUseZeroCopyCollect, true),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           BOOL_PROP(kHttpEnableAccessLog, false),
@@ -849,6 +850,11 @@ bool SystemConfig::exchangeMaterializationReclaimWaitForWriterDrainEnabled()
 bool SystemConfig::exchangeMaterializationReclaimHighPriority() const {
   return optionalProperty<bool>(kExchangeMaterializationReclaimHighPriority)
       .value_or(false);
+}
+
+bool SystemConfig::exchangeMaterializationUseZeroCopyCollect() const {
+  return optionalProperty<bool>(kExchangeMaterializationUseZeroCopyCollect)
+      .value_or(true);
 }
 
 bool SystemConfig::enableSerializedPageChecksum() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -715,6 +715,16 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeMaterializationReclaimHighPriority{
       "exchange.materialization.reclaim-high-priority"};
 
+  /// Skip coalescing a partition's buffered RowGroups into a single contiguous
+  /// buffer before handing them to the ShuffleWriter. When enabled, the
+  /// RowGroup IOBufs are linked into a chain and passed to the writer's
+  /// chain-aware collect(), eliminating the coalesce memcpy. Only writers that
+  /// can consume a chain without copying (Cosco) benefit; others fall back to
+  /// coalescing inside the default collect(). Applies to non-sort shuffle only.
+  /// Default: false.
+  static constexpr std::string_view kExchangeMaterializationSkipCoalesceEnabled{
+      "exchange.materialization.skip-coalesce-enabled"};
+
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
@@ -1187,6 +1197,8 @@ class SystemConfig : public ConfigBase {
   bool exchangeMaterializationReclaimWaitForWriterDrainEnabled() const;
 
   bool exchangeMaterializationReclaimHighPriority() const;
+
+  bool exchangeMaterializationSkipCoalesceEnabled() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -735,6 +735,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeMaterializationReclaimHighPriority{
       "exchange.materialization.reclaim-high-priority"};
 
+  /// Skip coalescing MaterializedOutput RowGroups before handing them to the
+  /// ShuffleWriter's owned-buffer collect path. When disabled, the existing
+  /// contiguous collect path is unchanged. Applies to non-sort shuffle only.
+  /// Default: true.
+  static constexpr std::string_view kExchangeMaterializationUseZeroCopyCollect{
+      "exchange.materialization.use-zero-copy-collect"};
+
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
@@ -1215,6 +1222,8 @@ class SystemConfig : public ConfigBase {
   bool exchangeMaterializationReclaimWaitForWriterDrainEnabled() const;
 
   bool exchangeMaterializationReclaimHighPriority() const;
+
+  bool exchangeMaterializationUseZeroCopyCollect() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   LocalShuffle.cpp
   PartitionAndSerialize.cpp
   ShuffleExchangeSource.cpp
+  ShuffleInterface.cpp
   ShuffleRead.cpp
   ShuffleWrite.cpp
 )

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -26,6 +26,7 @@
 #include <thread>
 
 #include "presto_cpp/main/common/Configs.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 
 #define MATERIALIZED_BUFFER_LOG(logEvent, pool, fmt_str, ...)           \
@@ -83,6 +84,14 @@ struct TrackedBufInfo {
   size_t size;
 };
 
+namespace {
+bool exchangeMaterializationUseZeroCopyCollect() {
+  SystemConfig* config = SystemConfig::instance();
+  VELOX_CHECK_NOT_NULL(config);
+  return config->exchangeMaterializationUseZeroCopyCollect();
+}
+} // namespace
+
 int64_t MaterializedOutputBuffer::PartitionBuffer::drainAvailable(
     std::deque<std::unique_ptr<folly::IOBuf>>& out) {
   int64_t drainedBytes = 0;
@@ -97,16 +106,16 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::drainAvailable(
 int64_t MaterializedOutputBuffer::PartitionBuffer::drainAndFlush() {
   // Drain all available RowGroups in bounded chunks to the writer.
   int64_t totalDrainedBytes = 0;
-  std::deque<std::unique_ptr<folly::IOBuf>> chunk;
+  std::deque<std::unique_ptr<folly::IOBuf>> chunks;
   int64_t chunkBytes = 0;
   const int64_t chunkThresholdBytes = buffer_->drainChunkThresholdBytes_;
 
   // Flush the current chunk and update its buffered-byte accounting.
   auto flushChunk = [&]() {
-    buffer_->flushToWriter(partition_, buffer_->coalesceRowGroups(chunk));
+    buffer_->flushToWriter(partition_, chunks);
     bufferedBytes_ -= chunkBytes;
     totalDrainedBytes += chunkBytes;
-    chunk.clear();
+    chunks.clear();
     chunkBytes = 0;
   };
 
@@ -119,10 +128,10 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::drainAndFlush() {
     if (chunkBytes > 0 && chunkBytes + itemBytes > chunkThresholdBytes) {
       flushChunk();
     }
-    chunk.push_back(std::move(item));
+    chunks.push_back(std::move(item));
     chunkBytes += itemBytes;
   }
-  if (!chunk.empty()) {
+  if (!chunks.empty()) {
     flushChunk();
   }
   return totalDrainedBytes;
@@ -240,6 +249,7 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
               partitionDrainThreshold_ *
               SystemConfig::instance()
                   ->exchangeMaterializationReclaimDrainThresholdRatio())),
+      useZeroCopyCollect_(exchangeMaterializationUseZeroCopyCollect()),
       drainChunkThresholdBytes_(
           static_cast<int64_t>(
               partitionDrainThreshold_ *
@@ -407,15 +417,44 @@ void MaterializedOutputBuffer::maybeWakeBlockedDrivers() {
   }
 }
 
+namespace {
+// Link a deque of RowGroup IOBufs into a single chain without copying.
+std::unique_ptr<folly::IOBuf> chainRowGroups(
+    std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) noexcept {
+  std::unique_ptr<folly::IOBuf> head;
+  for (auto& rowGroup : rowGroups) {
+    if (head == nullptr) {
+      head = std::move(rowGroup);
+    } else {
+      head->appendToChain(std::move(rowGroup));
+    }
+  }
+  return head;
+}
+} // namespace
+
 void MaterializedOutputBuffer::flushToWriter(
     int32_t partition,
-    std::unique_ptr<folly::IOBuf> data) {
-  auto dataSize = data->computeChainDataLength();
-  if (dataSize == 0) {
-    return;
+    std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) {
+  auto* writer = velox::checkedNotNull(writer_.get());
+  if (useZeroCopyCollect_) {
+    std::unique_ptr<folly::IOBuf> chain = chainRowGroups(rowGroups);
+    VELOX_CHECK_NOT_NULL(chain);
+    writer->collect(partition, /*key=*/"", std::move(chain));
+    ++zeroCopyCollectCount_;
+  } else {
+    std::unique_ptr<folly::IOBuf> coalesced = coalesceRowGroups(rowGroups);
+    auto* coalescedBuffer = velox::checkedNotNull(coalesced.get());
+    const size_t dataSize = coalescedBuffer->computeChainDataLength();
+    if (dataSize == 0) {
+      return;
+    }
+    writer->collect(
+        partition,
+        /*key=*/"",
+        std::string_view(
+            reinterpret_cast<const char*>(coalescedBuffer->data()), dataSize));
   }
-  std::string_view view(reinterpret_cast<const char*>(data->data()), dataSize);
-  writer_->collect(partition, /*key=*/"", view);
   ++collectCountPerPartition_[partition];
 }
 
@@ -428,12 +467,12 @@ void MaterializedOutputBuffer::updateDrainStats(int64_t drainedBytes) {
 std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::coalesceRowGroups(
     std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) {
   size_t totalBytes = 0;
-  for (const auto& rg : rowGroups) {
-    totalBytes += rg->computeChainDataLength();
+  for (const auto& rowGroup : rowGroups) {
+    totalBytes += rowGroup->computeChainDataLength();
   }
   auto coalesced = allocateTrackedIOBuf(totalBytes);
-  for (auto& rg : rowGroups) {
-    for (const auto& range : *rg) {
+  for (auto& rowGroup : rowGroups) {
+    for (const auto& range : *rowGroup) {
       std::memcpy(coalesced->writableTail(), range.data(), range.size());
       coalesced->append(range.size());
     }
@@ -586,6 +625,8 @@ MaterializedOutputBuffer::stats() const {
   result[std::string(kReclaimCount)] = velox::RuntimeMetric(reclaimCount_);
   result[std::string(kReclaimedBytes)] =
       velox::RuntimeMetric(reclaimedBytes_, Unit::kBytes);
+  result[std::string(kZeroCopyCollectCount)] =
+      velox::RuntimeMetric(zeroCopyCollectCount_);
   result[std::string(kConcurrentAppendCount)] =
       velox::RuntimeMetric(concurrentAppendCount_);
   result[std::string(kFlushAcquireCount)] =

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -101,8 +101,7 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
   auto drainedBytes = bufferedBytes_.load();
   bufferedBytes_ = 0;
 
-  auto coalesced = buffer_->coalesceRowGroups(toDrain);
-  buffer_->flushToWriter(partition, std::move(coalesced));
+  buffer_->flushDrained(partition, toDrain);
   return drainedBytes;
 }
 
@@ -147,6 +146,9 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
               partitionDrainThreshold_ *
               SystemConfig::instance()
                   ->exchangeMaterializationReclaimDrainThresholdRatio())),
+      skipCoalesce_(
+          SystemConfig::instance()
+              ->exchangeMaterializationSkipCoalesceEnabled()),
       pool_(pool->addLeafChild(
           fmt::format("materialized_output_buffer.{}", taskId),
           true,
@@ -224,15 +226,49 @@ void MaterializedOutputBuffer::enqueue(
   }
 }
 
-void MaterializedOutputBuffer::flushToWriter(
-    int32_t partition,
-    std::unique_ptr<folly::IOBuf> data) {
-  auto dataSize = data->computeChainDataLength();
-  if (dataSize == 0) {
-    return;
+namespace {
+// Link a deque of RowGroup IOBufs into a single chain (no copy). The chain's
+// concatenated bytes are identical to coalesceRowGroups()'s contiguous buffer.
+std::unique_ptr<folly::IOBuf> chainRowGroups(
+    std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) {
+  std::unique_ptr<folly::IOBuf> head;
+  for (auto& rowGroup : rowGroups) {
+    if (head == nullptr) {
+      head = std::move(rowGroup);
+    } else {
+      head->appendToChain(std::move(rowGroup));
+    }
   }
-  std::string_view view(reinterpret_cast<const char*>(data->data()), dataSize);
-  writer_->collect(partition, /*key=*/"", view);
+  return head;
+}
+} // namespace
+
+void MaterializedOutputBuffer::flushDrained(
+    int32_t partition,
+    std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) {
+  if (skipCoalesce_) {
+    // Link the RowGroups into a chain (no copy) and hand it to the writer's
+    // chain-aware collect(); Cosco consumes it zero-copy, other writers
+    // coalesce inside the default collect() overload.
+    auto chain = chainRowGroups(rowGroups);
+    if (chain == nullptr || chain->computeChainDataLength() == 0) {
+      return;
+    }
+    writer_->collect(partition, /*key=*/"", std::move(chain));
+  } else {
+    // Coalesce into a single contiguous (pool-tracked) buffer and send it as a
+    // string_view.
+    auto coalesced = coalesceRowGroups(rowGroups);
+    auto dataSize = coalesced->computeChainDataLength();
+    if (dataSize == 0) {
+      return;
+    }
+    writer_->collect(
+        partition,
+        /*key=*/"",
+        std::string_view(
+            reinterpret_cast<const char*>(coalesced->data()), dataSize));
+  }
   ++collectCountPerPartition_[partition];
 }
 
@@ -282,8 +318,7 @@ int64_t MaterializedOutputBuffer::drainPartition(
   }
 
   if (!toDrain.empty()) {
-    auto coalesced = coalesceRowGroups(toDrain);
-    flushToWriter(partition, std::move(coalesced));
+    flushDrained(partition, toDrain);
     updateDrainStats(drainedBytes);
   }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -79,6 +79,9 @@ class MaterializedOutputBuffer {
       "materializedOutputBuffer.reclaimCount";
   static constexpr std::string_view kReclaimedBytes =
       "materializedOutputBuffer.reclaimedBytes";
+  // Counts drains sent through the zero-copy collect path.
+  static constexpr std::string_view kZeroCopyCollectCount =
+      "materializedOutputBuffer.zeroCopyCollectCount";
   // Lock-free append / backpressure effectiveness counters.
   static constexpr std::string_view kConcurrentAppendCount =
       "materializedOutputBuffer.concurrentAppendCount";
@@ -312,8 +315,12 @@ class MaterializedOutputBuffer {
   /// Update drain stats and subtract from buffered bytes counter.
   void updateDrainStats(int64_t drainedBytes);
 
-  /// Coalesce data into a contiguous buffer and send to the ShuffleWriter.
-  void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
+  /// Send a partition's drained RowGroups to the ShuffleWriter. Coalesces into
+  /// a contiguous pool-tracked buffer by default. When useZeroCopyCollect_ is
+  /// set, links them into a chain and hands it to the owned-buffer collect.
+  void flushToWriter(
+      int32_t partition,
+      std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups);
 
   /// Wake parked producers after crossing the low watermark.
   void maybeWakeBlockedDrivers();
@@ -331,6 +338,8 @@ class MaterializedOutputBuffer {
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
   const int64_t reclaimDrainThresholdBytes_;
+  // Selects the owned-buffer collect path before any coalescing.
+  const bool useZeroCopyCollect_;
   // Per-collect cap for lock-free drain overshoot.
   const int64_t drainChunkThresholdBytes_;
   // Global backpressure high/low watermarks: block producers at ~90% of the
@@ -366,6 +375,8 @@ class MaterializedOutputBuffer {
 
   std::atomic_int64_t lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;
+  // Drains sent through the zero-copy collect path.
+  std::atomic_int64_t zeroCopyCollectCount_{0};
 
   // Producer promises parked by backpressure, fulfilled by
   // maybeWakeBlockedDrivers() once buffered drops below the low watermark.

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -261,8 +261,13 @@ class MaterializedOutputBuffer {
   /// Update drain stats and subtract from buffered bytes counter.
   void updateDrainStats(int64_t drainedBytes);
 
-  // Coalesce data into a contiguous buffer and send to the ShuffleWriter.
-  void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
+  // Send a partition's drained RowGroups to the ShuffleWriter. Coalesces into a
+  // contiguous pool-tracked buffer and sends it as a string_view by default;
+  // when skipCoalesce_ is set, links them into a chain (no copy) handed to the
+  // writer's chain-aware collect().
+  void flushDrained(
+      int32_t partition,
+      std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups);
 
   // Merge a deque of RowGroup IOBufs into a single contiguous IOBuf.
   std::unique_ptr<folly::IOBuf> coalesceRowGroups(
@@ -277,6 +282,9 @@ class MaterializedOutputBuffer {
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
   const int64_t reclaimDrainThresholdBytes_;
+  // When true, drain partitions by chaining RowGroup IOBufs and using the
+  // writer's chain-aware collect() instead of coalescing into one buffer.
+  const bool skipCoalesce_;
 
   // Pool created first so the writer can allocate from it.
   const std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.h
@@ -15,6 +15,7 @@
 
 #include "presto_cpp/main/operators/ShuffleInterface.h"
 #include "velox/core/PlanNode.h"
+#include "velox/exec/Exchange.h"
 #include "velox/exec/Operator.h"
 
 namespace facebook::presto::operators {

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.cpp
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/operators/ShuffleInterface.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::presto::operators {
+
+void ShuffleWriter::collect(
+    int32_t partition,
+    std::string_view key,
+    std::unique_ptr<folly::IOBuf> data) {
+  VELOX_CHECK_NOT_NULL(data);
+  data->coalesce();
+  collect(
+      partition,
+      key,
+      std::string_view(
+          reinterpret_cast<const char*>(data->data()), data->length()));
+}
+
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <folly/io/IOBuf.h>
 #include "velox/exec/Exchange.h"
 #include "velox/exec/Operator.h"
 
@@ -30,6 +31,23 @@ class ShuffleWriter {
   /// Write to the shuffle one row at a time.
   virtual void
   collect(int32_t partition, std::string_view key, std::string_view data) = 0;
+
+  /// Write to the shuffle one row at a time, taking ownership of a (possibly
+  /// multi-node) folly::IOBuf chain as the row value. The default coalesces the
+  /// chain and forwards to the string_view collect(); writers that can consume
+  /// a chain without copying (e.g. Cosco) override this. 'data' must be
+  /// non-null.
+  virtual void collect(
+      int32_t partition,
+      std::string_view key,
+      std::unique_ptr<folly::IOBuf> data) {
+    data->coalesce();
+    collect(
+        partition,
+        key,
+        std::string_view(
+            reinterpret_cast<const char*>(data->data()), data->length()));
+  }
 
   /// Tell the shuffle system the writer is done.
   /// @param success set to false to indicate aborted client.

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -13,9 +13,14 @@
  */
 #pragma once
 
+#include <memory>
+#include <string_view>
+
 #include <fmt/format.h>
-#include "velox/exec/Exchange.h"
+#include <folly/io/IOBuf.h>
+
 #include "velox/exec/Operator.h"
+#include "velox/exec/SerializedPage.h"
 
 namespace facebook::velox {
 class ByteInputStream;
@@ -30,6 +35,15 @@ class ShuffleWriter {
   /// Write to the shuffle one row at a time.
   virtual void
   collect(int32_t partition, std::string_view key, std::string_view data) = 0;
+
+  /// Write to the shuffle one row at a time, taking ownership of a (possibly
+  /// multi-node) folly::IOBuf chain as the row value. The default coalesces the
+  /// chain and forwards to the existing contiguous collect path. 'data' must
+  /// be non-null.
+  virtual void collect(
+      int32_t partition,
+      std::string_view key,
+      std::unique_ptr<folly::IOBuf> data);
 
   /// Tell the shuffle system the writer is done.
   /// @param success set to false to indicate aborted client.


### PR DESCRIPTION
Summary:

MaterializedOutputBuffer currently coalesces every drained partition RowGroup IOBufs into one contiguous allocation before calling the existing `ShuffleWriter::collect(..., std::string_view)` interface. That memcpy is unnecessary for a writer that can consume the chain directly.

This diff adds an ownership-taking path without replacing any existing API or caller. The original `string_view` collect method remains the required writer contract, and all existing LocalShuffle, deprecated ShuffleWrite, and test paths remain unchanged. A new `collect(..., std::unique_ptr<folly::IOBuf>)` overload defaults to coalescing and delegating to the old method, so writers that do not override it preserve their behavior.

`MaterializedOutputBuffer::flushToWriter` owns the configuration decision. `exchange.materialization.use-zero-copy-collect` is enabled by default: it links the drained RowGroups and calls the owned-buffer overload before any coalescing. Setting the property to false executes the original coalesce-and-`string_view` path as a rollback switch. `materializedOutputBuffer.zeroCopyCollectCount` increments only in the enabled branch. D111892399 supplies the Cosco override that forwards the chain directly and stream-compresses it. The serialized bytes and MaterializedExchange read path are unchanged.

Reviewed By: xiaoxmeng

Differential Revision: D108365677

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add ``exchange.materialization.use-zero-copy-collect`` configuration property to allow chain-capable shuffle backends to avoid an intermediate coalescing copy. This property is enabled by default and can be set to false to restore the contiguous path.
```


