### PR TITLE
feat(optimizer): Add AUTOMATIC rpc_streaming_mode via a pluggable RpcExecutionPolicy (#27984)

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -209,6 +209,59 @@ When enabled, JSON objects are cast to ROW types by matching fields by name inst
 
 For more information and examples, see :ref:`functions/json:cast to json`.
 
+Remote Function (RPC) Properties
+--------------------------------
+
+These properties control execution of remote (RPC) functions, which dispatch each
+invocation to an external service.
+
+``rpc_function_optimizer_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Enables the RPC function optimizer, which rewrites RPC function calls to use
+asynchronous ``RPCNode`` execution.
+
+``rpc_streaming_mode``
+^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Allowed values:** ``PER_ROW``, ``BATCH``, ``AUTOMATIC``
+* **Default value:** ``PER_ROW``
+
+Controls how RPC function calls are dispatched. ``PER_ROW`` dispatches each row
+individually. ``BATCH`` accumulates rows and dispatches them in batches (see
+``rpc_dispatch_batch_size``). ``AUTOMATIC`` is resolved to ``PER_ROW`` or ``BATCH``
+at query planning time from the estimated input row count (see
+``rpc_batch_min_rows``); if the planner has no row-count estimate, it falls back to
+``PER_ROW``. The default deployment resolves ``AUTOMATIC`` to ``PER_ROW``; a
+deployment may install a custom ``RpcExecutionPolicy`` to enable stats-driven
+resolution.
+
+``rpc_batch_min_rows``
+^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Restrictions:** must be greater than ``0``
+* **Default value:** ``2000``
+
+When ``rpc_streaming_mode`` is ``AUTOMATIC``, the estimated input row count at or
+above which ``BATCH`` is chosen; below it, ``PER_ROW`` is chosen. Has no effect
+unless a deployment installs a stats-driven RPC execution policy: the default
+policy ignores this value and always resolves ``AUTOMATIC`` to ``PER_ROW``.
+
+``rpc_dispatch_batch_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``128``
+
+Batch size for RPC function dispatch in ``BATCH`` streaming mode. ``0`` collects all
+rows and dispatches once at the end; values greater than ``0`` flush every N rows
+during input processing.
+
 Spilling Properties
 -------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -245,6 +245,9 @@ public final class SystemSessionProperties
     public static final String RPC_FUNCTION_OPTIMIZER_ENABLED = "rpc_function_optimizer_enabled";
     public static final String RPC_STREAMING_MODE = "rpc_streaming_mode";
     public static final String RPC_DISPATCH_BATCH_SIZE = "rpc_dispatch_batch_size";
+    // Coordinator-only: consumed at plan time by RpcExecutionPolicy; the resolved PER_ROW/BATCH
+    // mode is what ships to workers, so this needs no native SessionProperties.cpp mapping.
+    public static final String RPC_BATCH_MIN_ROWS = "rpc_batch_min_rows";
     public static final String CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY = "check_access_control_on_utilized_columns_only";
     public static final String CHECK_ACCESS_CONTROL_WITH_SUBFIELDS = "check_access_control_with_subfields";
     public static final String SKIP_REDUNDANT_SORT = "skip_redundant_sort";
@@ -1371,7 +1374,8 @@ public final class SystemSessionProperties
                 new PropertyMetadata<>(
                         RPC_STREAMING_MODE,
                         format("Streaming mode for RPC function execution. Options are %s. "
-                                        + "PER_ROW dispatches each row individually, BATCH accumulates rows and dispatches in batches.",
+                                        + "PER_ROW dispatches each row individually, BATCH accumulates rows and dispatches in batches, "
+                                        + "AUTOMATIC picks PER_ROW or BATCH from the estimated input row count (see rpc_batch_min_rows).",
                                 Stream.of(RPCNode.StreamingMode.values())
                                         .map(RPCNode.StreamingMode::name)
                                         .collect(joining(","))),
@@ -1388,6 +1392,24 @@ public final class SystemSessionProperties
                                 + "Values > 0 flush every N rows during input processing.",
                         128,
                         false),
+                // Coordinator-only: consumed at plan time by RpcExecutionPolicy.translateIntent().
+                // The resolved PER_ROW/BATCH mode is what ships to workers, so this needs no native
+                // SessionProperties.cpp mapping. Uses the raw PropertyMetadata form (not the
+                // integerProperty() helper) because that helper does not accept the custom > 0
+                // validator below.
+                new PropertyMetadata<>(
+                        RPC_BATCH_MIN_ROWS,
+                        "When rpc_streaming_mode=AUTOMATIC, the estimated input row count at or above which "
+                                + "BATCH is chosen (below it, PER_ROW). Seeded at the measured per-row/batch crossover. "
+                                + "If the planner has no row estimate, AUTOMATIC falls back to PER_ROW. Must be greater than 0. "
+                                + "Honored only by a deployment-specific RpcExecutionPolicy; the OSS DefaultRpcExecutionPolicy "
+                                + "ignores it and resolves AUTOMATIC to PER_ROW.",
+                        INTEGER,
+                        Integer.class,
+                        2000,
+                        false,
+                        value -> validateIntegerValue(value, RPC_BATCH_MIN_ROWS, 1, false),
+                        value -> value),
                 booleanProperty(
                         CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY,
                         "Apply access control rules on only those columns that are required to produce the query output",
@@ -3251,6 +3273,14 @@ public final class SystemSessionProperties
     public static int getRpcDispatchBatchSize(Session session)
     {
         return session.getSystemProperty(RPC_DISPATCH_BATCH_SIZE, Integer.class);
+    }
+
+    // Coordinator-only: read by RpcExecutionPolicy to resolve AUTOMATIC streaming mode at plan
+    // time. The OSS DefaultRpcExecutionPolicy ignores it, so it has no effect without a custom
+    // deployment policy.
+    public static int getRpcBatchMinRows(Session session)
+    {
+        return session.getSystemProperty(RPC_BATCH_MIN_ROWS, Integer.class);
     }
 
     public static boolean isCheckAccessControlOnUtilizedColumnsOnly(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -185,6 +185,7 @@ import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.ApplyConnectorOptimization;
 import com.facebook.presto.sql.planner.optimizations.CheckSubqueryNodesAreRewritten;
 import com.facebook.presto.sql.planner.optimizations.CteProjectionAndPredicatePushDown;
+import com.facebook.presto.sql.planner.optimizations.DefaultRpcExecutionPolicy;
 import com.facebook.presto.sql.planner.optimizations.GroupInnerJoinsByConnectorRuleSet;
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.sql.planner.optimizations.HistoricalStatisticsEquivalentPlanMarkingOptimizer;
@@ -214,6 +215,7 @@ import com.facebook.presto.sql.planner.optimizations.ReplaceConstantVariableRefe
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.RewriteWriterTarget;
+import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
 import com.facebook.presto.sql.planner.optimizations.RpcFunctionOptimizer;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.ShardJoins;
@@ -267,7 +269,8 @@ public class PlanOptimizers
             ExpressionOptimizerManager expressionOptimizerManager,
             TaskManagerConfig taskManagerConfig,
             AccessControl accessControl,
-            @Named("rpcFunctionNames") Supplier<Set<String>> rpcFunctionNames)
+            @Named("rpcFunctionNames") Supplier<Set<String>> rpcFunctionNames,
+            RpcExecutionPolicy rpcExecutionPolicy)
     {
         this(metadata,
                 sqlParser,
@@ -286,7 +289,8 @@ public class PlanOptimizers
                 expressionOptimizerManager,
                 taskManagerConfig,
                 accessControl,
-                rpcFunctionNames);
+                rpcFunctionNames,
+                rpcExecutionPolicy);
     }
 
     @PostConstruct
@@ -303,6 +307,11 @@ public class PlanOptimizers
         optimizerStats.unexport(exporter);
     }
 
+    // Non-injected convenience constructor (no RPC functions configured): used by callers that
+    // build PlanOptimizers outside Guice, e.g. tests. It hardcodes an empty rpc-function set and
+    // the no-op DefaultRpcExecutionPolicy; the production path uses the @Inject constructor, which
+    // receives the (possibly deployment-overridden) RpcExecutionPolicy binding. Since no RPC
+    // function is registered here, the policy is never consulted anyway.
     public PlanOptimizers(
             Metadata metadata,
             SqlParser sqlParser,
@@ -339,7 +348,8 @@ public class PlanOptimizers
                 expressionOptimizerManager,
                 taskManagerConfig,
                 accessControl,
-                ImmutableSet::of);
+                ImmutableSet::of,
+                new DefaultRpcExecutionPolicy());
     }
 
     public PlanOptimizers(
@@ -360,7 +370,8 @@ public class PlanOptimizers
             ExpressionOptimizerManager expressionOptimizerManager,
             TaskManagerConfig taskManagerConfig,
             AccessControl accessControl,
-            Supplier<Set<String>> rpcFunctionNames)
+            Supplier<Set<String>> rpcFunctionNames,
+            RpcExecutionPolicy rpcExecutionPolicy)
     {
         this.exporter = exporter;
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
@@ -655,7 +666,7 @@ public class PlanOptimizers
 
         builder.add(new IterativeOptimizer(metadata, ruleStats, statsCalculator, estimatedExchangesCostCalculator,
                 new RewriteRowExpressions(expressionOptimizerManager).rules()));
-        builder.add(new RpcFunctionOptimizer(rpcFunctionNames));
+        builder.add(new RpcFunctionOptimizer(rpcFunctionNames, statsCalculator, rpcExecutionPolicy));
 
         builder.add(new IterativeOptimizer(
                 metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/DefaultRpcExecutionPolicy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/DefaultRpcExecutionPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.plan.RPCNode;
+
+/**
+ * Default {@link RpcExecutionPolicy}: carries no batching heuristic, so it ignores the input
+ * stats. Explicit PER_ROW/BATCH pass through unchanged; AUTOMATIC degrades to PER_ROW (a safe
+ * fallback). A deployment that wants stats-driven AUTOMATIC resolution binds an override of
+ * {@link RpcExecutionPolicy} via a Guice module.
+ */
+public class DefaultRpcExecutionPolicy
+        implements RpcExecutionPolicy
+{
+    @Override
+    public RpcExecutionProperties translateIntent(RpcExecutionIntent intent)
+    {
+        RPCNode.StreamingMode requested = intent.getRequestedMode();
+        RPCNode.StreamingMode resolved = requested == RPCNode.StreamingMode.AUTOMATIC
+                ? RPCNode.StreamingMode.PER_ROW
+                : requested;
+        return RpcExecutionProperties.of(resolved);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionIntent.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionIntent.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.sql.planner.plan.RPCNode;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The planning intent for a single RPC function call: the requested streaming mode plus the
+ * context a policy may use to resolve it.
+ *
+ * This is the input to {@link RpcExecutionPolicy#translateIntent}. It is built via {@link
+ * #builder} and is intentionally growable — new context fields can be added here (a new builder
+ * setter) without changing the policy method signature or breaking existing implementations.
+ *
+ * Scope note: this models the <em>plan-time execution axis</em> (streaming mode, and in future
+ * dispatch parallelism / batch size), which the optimizer fixes on the {@link RPCNode}. Runtime
+ * concerns (error policy, deadlines, model-quality/cost) are carried separately via query config
+ * read by the worker and are deliberately NOT part of this intent.
+ */
+public class RpcExecutionIntent
+{
+    private final RPCNode.StreamingMode requestedMode;
+    private final PlanNodeStatsEstimate inputStats;
+    private final Session session;
+    private final String functionName;
+
+    private RpcExecutionIntent(
+            RPCNode.StreamingMode requestedMode,
+            PlanNodeStatsEstimate inputStats,
+            Session session,
+            String functionName)
+    {
+        this.requestedMode = requireNonNull(requestedMode, "requestedMode is null");
+        this.inputStats = requireNonNull(inputStats, "inputStats is null");
+        this.session = requireNonNull(session, "session is null");
+        this.functionName = requireNonNull(functionName, "functionName is null");
+    }
+
+    /**
+     * The streaming mode requested for the call (PER_ROW, BATCH, or AUTOMATIC).
+     */
+    public RPCNode.StreamingMode getRequestedMode()
+    {
+        return requestedMode;
+    }
+
+    /**
+     * Estimated stats of the RPC node's input; an unknown estimate (e.g.
+     * {@link PlanNodeStatsEstimate#unknown()}) reports NaN for individual statistics.
+     */
+    public PlanNodeStatsEstimate getInputStats()
+    {
+        return inputStats;
+    }
+
+    public Session getSession()
+    {
+        return session;
+    }
+
+    /**
+     * The RPC function being called (e.g. {@code fb_llm_inference}), for policies that vary by
+     * function.
+     */
+    public String getFunctionName()
+    {
+        return functionName;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private RPCNode.StreamingMode requestedMode;
+        private PlanNodeStatsEstimate inputStats = PlanNodeStatsEstimate.unknown();
+        private Session session;
+        private String functionName;
+
+        public Builder setRequestedMode(RPCNode.StreamingMode requestedMode)
+        {
+            this.requestedMode = requestedMode;
+            return this;
+        }
+
+        public Builder setInputStats(PlanNodeStatsEstimate inputStats)
+        {
+            this.inputStats = inputStats;
+            return this;
+        }
+
+        public Builder setSession(Session session)
+        {
+            this.session = session;
+            return this;
+        }
+
+        public Builder setFunctionName(String functionName)
+        {
+            this.functionName = functionName;
+            return this;
+        }
+
+        public RpcExecutionIntent build()
+        {
+            return new RpcExecutionIntent(requestedMode, inputStats, session, functionName);
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionPolicy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionPolicy.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+/**
+ * Translates the planning intent for an RPC function call into its resolved execution
+ * properties (streaming mode, and in future dispatch parallelism / batch size, etc.).
+ *
+ * The engine builds an {@link RpcExecutionIntent} (requested mode + input stats + session) and
+ * delegates the decision to this policy, so a deployment can plug in a richer, stats-driven
+ * strategy without changing the engine. Both the intent and the returned
+ * {@link RpcExecutionProperties} are growable value objects, so new signals or knobs can be
+ * added without changing this method signature. The decision is made at plan time, so the
+ * returned streaming mode must be concrete (never AUTOMATIC).
+ *
+ * The default implementation ({@link DefaultRpcExecutionPolicy}) carries no batching
+ * heuristic; bind an override to enable AUTOMATIC.
+ */
+public interface RpcExecutionPolicy
+{
+    /**
+     * @param intent the planning intent for one RPC call (requested mode, input stats, session)
+     * @return the resolved execution properties; the streaming mode must be concrete (never
+     *     AUTOMATIC)
+     */
+    RpcExecutionProperties translateIntent(RpcExecutionIntent intent);
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionProperties.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.plan.RPCNode;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The resolved plan-time execution properties for a single RPC function call, produced by
+ * {@link RpcExecutionPolicy#translateIntent} and applied by the optimizer to the
+ * {@link RPCNode}.
+ *
+ * Immutable and built via {@link #builder}. Today it carries the resolved {@code streamingMode};
+ * additional plan-time properties (e.g. dispatch parallelism / batch size) can be added here as a
+ * new builder setter + getter without changing the policy method signature.
+ *
+ * Scope note: this is the plan-time execution axis only. Runtime concerns (error policy,
+ * deadlines, model-quality/cost) ride query config read by the worker and do NOT belong here.
+ */
+public class RpcExecutionProperties
+{
+    private final RPCNode.StreamingMode streamingMode;
+
+    private RpcExecutionProperties(RPCNode.StreamingMode streamingMode)
+    {
+        this.streamingMode = requireNonNull(streamingMode, "streamingMode is null");
+    }
+
+    /**
+     * The resolved streaming mode. Must be concrete (PER_ROW or BATCH); never AUTOMATIC.
+     */
+    public RPCNode.StreamingMode getStreamingMode()
+    {
+        return streamingMode;
+    }
+
+    /**
+     * Convenience for the common case: just a resolved streaming mode.
+     */
+    public static RpcExecutionProperties of(RPCNode.StreamingMode streamingMode)
+    {
+        return builder().setStreamingMode(streamingMode).build();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private RPCNode.StreamingMode streamingMode;
+
+        public Builder setStreamingMode(RPCNode.StreamingMode streamingMode)
+        {
+            this.streamingMode = streamingMode;
+            return this;
+        }
+
+        public RpcExecutionProperties build()
+        {
+            return new RpcExecutionProperties(streamingMode);
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -14,6 +14,10 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.spi.VariableAllocator;
@@ -52,6 +56,7 @@ import java.util.function.Supplier;
 import static com.facebook.presto.SystemSessionProperties.getRpcDispatchBatchSize;
 import static com.facebook.presto.SystemSessionProperties.getRpcStreamingMode;
 import static com.facebook.presto.SystemSessionProperties.isRpcFunctionOptimizerEnabled;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class RpcFunctionOptimizer
@@ -59,15 +64,30 @@ public class RpcFunctionOptimizer
 {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final Supplier<Set<String>> rpcFunctionNamesSupplier;
+    // Nullable: when absent, the execution policy receives a NaN row estimate.
+    private final StatsCalculator statsCalculator;
+    private final RpcExecutionPolicy executionPolicy;
 
     public RpcFunctionOptimizer()
     {
-        this(ImmutableSet::of);
+        this(ImmutableSet::of, null, new DefaultRpcExecutionPolicy());
     }
 
     public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier)
     {
+        this(rpcFunctionNamesSupplier, null, new DefaultRpcExecutionPolicy());
+    }
+
+    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, StatsCalculator statsCalculator)
+    {
+        this(rpcFunctionNamesSupplier, statsCalculator, new DefaultRpcExecutionPolicy());
+    }
+
+    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, StatsCalculator statsCalculator, RpcExecutionPolicy executionPolicy)
+    {
         this.rpcFunctionNamesSupplier = requireNonNull(rpcFunctionNamesSupplier, "rpcFunctionNamesSupplier is null");
+        this.statsCalculator = statsCalculator;
+        this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
     }
 
     public boolean isRpcFunction(CallExpression call)
@@ -95,7 +115,10 @@ public class RpcFunctionOptimizer
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 
-        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get());
+        StatsProvider statsProvider = statsCalculator != null
+                ? new CachingStatsProvider(statsCalculator, session, types)
+                : null;
+        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get(), statsProvider, executionPolicy);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -107,14 +130,19 @@ public class RpcFunctionOptimizer
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final Set<String> rpcFunctionNames;
+        // Nullable: when null, the execution policy receives a NaN row estimate.
+        private final StatsProvider statsProvider;
+        private final RpcExecutionPolicy executionPolicy;
         private boolean planChanged;
 
-        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames)
+        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames, StatsProvider statsProvider, RpcExecutionPolicy executionPolicy)
         {
             this.session = requireNonNull(session, "session is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
             this.rpcFunctionNames = requireNonNull(rpcFunctionNames, "rpcFunctionNames is null");
+            this.statsProvider = statsProvider;
+            this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
         }
 
         public boolean isPlanChanged()
@@ -164,7 +192,13 @@ public class RpcFunctionOptimizer
             //    constants.
             PlanNode currentSource = rewrittenSource;
             for (ExtractedRpcCall extracted : extractedCalls) {
-                RPCNode.StreamingMode streamingMode = parseStreamingMode(extracted.originalCall);
+                // Resolve the streaming mode against rewrittenSource (the input feeding the whole
+                // chain). Every RPC call in this ProjectNode, and the projections interleaved
+                // between them, are row-count-preserving, so they all share rewrittenSource's
+                // cardinality. Using rewrittenSource (rather than walking currentSource onto the
+                // prior RPCNode) keeps the estimate well-defined even if no stats rule exists for
+                // RPCNode.
+                RPCNode.StreamingMode streamingMode = resolveExecutionProperties(extracted.originalCall, rewrittenSource).getStreamingMode();
                 int dispatchBatchSize = parseDispatchBatchSize(extracted.originalCall);
 
                 List<RowExpression> substitutedArgs = extracted.substitutedCall.getArguments();
@@ -513,6 +547,36 @@ public class RpcFunctionOptimizer
             catch (IOException e) {
                 return Optional.empty();
             }
+        }
+
+        // Resolves the plan-time execution properties for one RPC call. The requested mode (from
+        // options JSON or the session property), the requested dispatch size, and the estimated
+        // input stats are handed to the injected RpcExecutionPolicy as an RpcExecutionIntent; the
+        // policy returns the resolved RpcExecutionProperties. AUTOMATIC is resolved here so the
+        // RPCNode never carries it. The default policy carries no batching heuristic
+        // (AUTOMATIC -> PER_ROW, no overrides); a deployment may bind a stats-driven policy.
+        private RpcExecutionProperties resolveExecutionProperties(CallExpression rpcCall, PlanNode source)
+        {
+            RPCNode.StreamingMode requested = parseStreamingMode(rpcCall);
+            PlanNodeStatsEstimate sourceStats = statsProvider == null
+                    ? PlanNodeStatsEstimate.unknown()
+                    : statsProvider.getStats(source);
+            RpcExecutionIntent intent = RpcExecutionIntent.builder()
+                    .setRequestedMode(requested)
+                    .setInputStats(sourceStats)
+                    .setSession(session)
+                    .setFunctionName(rpcCall.getDisplayName())
+                    .build();
+            RpcExecutionProperties properties = executionPolicy.translateIntent(intent);
+            // Enforce the policy contract at plan time: AUTOMATIC is coordinator-only and must
+            // be resolved to a concrete mode here. A custom policy that returns AUTOMATIC (e.g.
+            // by passing the requested mode through) would otherwise leak it into the serialized
+            // RPCNode and fail at the native worker, far from the offending policy.
+            checkArgument(
+                    properties.getStreamingMode() != RPCNode.StreamingMode.AUTOMATIC,
+                    "RpcExecutionPolicy must return a concrete streaming mode, not AUTOMATIC (call %s)",
+                    rpcCall.getDisplayName());
+            return properties;
         }
 
         private RPCNode.StreamingMode parseStreamingMode(CallExpression rpcCall)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/RPCNode.java
@@ -34,10 +34,16 @@ import static java.util.Objects.requireNonNull;
 public class RPCNode
         extends InternalPlanNode
 {
+    // AUTOMATIC is a coordinator-only planning value. RpcFunctionOptimizer resolves it to
+    // PER_ROW or BATCH from the estimated input cardinality before constructing the node, so
+    // a serialized RPCNode never carries AUTOMATIC (the native protocol only understands
+    // PER_ROW / BATCH). The comment is kept outside the enum body because the native protocol
+    // generator (java-to-struct-json.py) mis-parses interior enum comments.
     public enum StreamingMode
     {
         PER_ROW,
-        BATCH
+        BATCH,
+        AUTOMATIC
     }
 
     private final PlanNode source;
@@ -90,6 +96,9 @@ public class RPCNode
                 this.argumentColumns.size());
         this.outputVariable = requireNonNull(outputVariable, "outputVariable is null");
         this.streamingMode = streamingMode != null ? streamingMode : StreamingMode.PER_ROW;
+        checkArgument(
+                this.streamingMode != StreamingMode.AUTOMATIC,
+                "RPCNode streamingMode must be PER_ROW or BATCH, not AUTOMATIC (coordinator-only value); resolve it before constructing the node");
         this.dispatchBatchSize = dispatchBatchSize;
 
         ImmutableList.Builder<VariableReferenceExpression> outputs = ImmutableList.builder();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -14,6 +14,9 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -29,6 +32,7 @@ import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 import com.facebook.presto.testing.TestingSession;
@@ -43,9 +47,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestRpcFunctionOptimizer
@@ -137,13 +143,15 @@ public class TestRpcFunctionOptimizer
         for (Class<?> inner : innerClasses) {
             if (inner.getSimpleName().equals("Rewriter")) {
                 for (java.lang.reflect.Constructor<?> ctor : inner.getDeclaredConstructors()) {
-                    if (ctor.getParameterCount() == 4) {
+                    if (ctor.getParameterCount() == 6) {
                         ctor.setAccessible(true);
                         return ctor.newInstance(
                                 session,
                                 new com.facebook.presto.spi.plan.PlanNodeIdAllocator(),
                                 new com.facebook.presto.spi.VariableAllocator(),
-                                com.google.common.collect.ImmutableSet.of());
+                                com.google.common.collect.ImmutableSet.of(),
+                                null,
+                                new DefaultRpcExecutionPolicy());
                     }
                 }
             }
@@ -589,5 +597,225 @@ public class TestRpcFunctionOptimizer
             return true;
         }
         return node.getSources().stream().anyMatch(source -> containsPlanNode(source, targetClass));
+    }
+
+    // ── RpcExecutionPolicy delegation (rpc_streaming_mode resolution) ──
+    // The engine computes the estimated input cardinality and delegates the concrete
+    // PER_ROW/BATCH decision to the injected RpcExecutionPolicy. These verify the OSS default
+    // (no batching heuristic: AUTOMATIC -> PER_ROW) and that the optimizer applies whatever an
+    // injected policy returns. The cardinality/threshold business logic lives in a deployment's
+    // policy implementation and is unit-tested there.
+
+    // Builds SELECT test_rpc_function(input_col, ...) over a ValuesNode, runs the optimizer
+    // with the given session + execution policy, and returns the produced RPCNode.
+    private RPCNode optimizeToRpcNode(Session session, RpcExecutionPolicy policy)
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        CallExpression rpcCall = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(inputVar, varchar("model"), varchar("system"), varchar("{}")));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, rpcCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(() -> ImmutableSet.of("test_rpc_function"), null, policy);
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+
+        RPCNode rpcNode = (RPCNode) findPlanNode(result.getPlanNode(), RPCNode.class);
+        assertTrue(rpcNode != null, "Optimized plan should contain an RPCNode");
+        return rpcNode;
+    }
+
+    private RPCNode.StreamingMode optimizeWithPolicy(Session session, RpcExecutionPolicy policy)
+    {
+        return optimizeToRpcNode(session, policy).getStreamingMode();
+    }
+
+    private static Session streamingModeSession(String mode)
+    {
+        return TestingSession.testSessionBuilder()
+                .setSystemProperty("rpc_streaming_mode", mode)
+                .build();
+    }
+
+    // Runs a policy's translateIntent for the given requested mode + input stats and returns the
+    // resolved streaming mode.
+    private static RPCNode.StreamingMode resolvedMode(RpcExecutionPolicy policy, RPCNode.StreamingMode requested, PlanNodeStatsEstimate stats, Session session)
+    {
+        RpcExecutionIntent intent = RpcExecutionIntent.builder()
+                .setRequestedMode(requested)
+                .setInputStats(stats)
+                .setSession(session)
+                .setFunctionName("test_rpc_function")
+                .build();
+        return policy.translateIntent(intent).getStreamingMode();
+    }
+
+    @Test
+    public void testDefaultPolicyResolvesAutomaticToPerRow()
+    {
+        // OSS default carries no batching heuristic: AUTOMATIC -> PER_ROW; explicit modes pass through.
+        DefaultRpcExecutionPolicy policy = new DefaultRpcExecutionPolicy();
+        Session session = TestingSession.testSessionBuilder().build();
+        PlanNodeStatsEstimate largeStats = PlanNodeStatsEstimate.builder().setOutputRowCount(1_000_000).build();
+        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.AUTOMATIC, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.AUTOMATIC, PlanNodeStatsEstimate.unknown(), session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.BATCH, PlanNodeStatsEstimate.builder().setOutputRowCount(1).build(), session), RPCNode.StreamingMode.BATCH);
+        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.PER_ROW, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+    }
+
+    @Test
+    public void testOptimizerDelegatesToExecutionPolicy()
+    {
+        // The optimizer applies whatever the injected policy returns to the produced RPCNode.
+        RpcExecutionPolicy toBatch = intent -> RpcExecutionProperties.of(RPCNode.StreamingMode.BATCH);
+        RpcExecutionPolicy toPerRow = intent -> RpcExecutionProperties.of(RPCNode.StreamingMode.PER_ROW);
+        assertEquals(optimizeWithPolicy(streamingModeSession("AUTOMATIC"), toBatch), RPCNode.StreamingMode.BATCH);
+        assertEquals(optimizeWithPolicy(streamingModeSession("AUTOMATIC"), toPerRow), RPCNode.StreamingMode.PER_ROW);
+    }
+
+    @Test
+    public void testOptimizerRejectsPolicyReturningAutomatic()
+    {
+        // The optimizer enforces the policy contract at plan time: a policy that returns
+        // AUTOMATIC (e.g. by passing the requested mode through unchanged) must fail loudly
+        // here rather than leak AUTOMATIC into the serialized RPCNode and fail at the worker.
+        RpcExecutionPolicy passthrough = intent -> RpcExecutionProperties.of(intent.getRequestedMode());
+        try {
+            optimizeWithPolicy(streamingModeSession("AUTOMATIC"), passthrough);
+            fail("expected rejection when policy returns AUTOMATIC");
+        }
+        catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("AUTOMATIC"), "message should mention AUTOMATIC: " + expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testRpcNodeConstructorRejectsAutomatic()
+    {
+        // Defense in depth: even outside the optimizer, an RPCNode must never be constructed with
+        // AUTOMATIC (this guard also covers the @JsonCreator deserialization path), so the value
+        // can never reach a native worker that only understands PER_ROW / BATCH.
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+        try {
+            new RPCNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    source,
+                    "test_rpc_function",
+                    ImmutableList.of(inputVar),
+                    ImmutableList.of("input_col"),
+                    outputVar,
+                    RPCNode.StreamingMode.AUTOMATIC,
+                    0);
+            fail("expected rejection when constructing RPCNode with AUTOMATIC");
+        }
+        catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("AUTOMATIC"), "message should mention AUTOMATIC: " + expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testRpcNodeJsonCreatorRejectsAutomatic()
+    {
+        // The @JsonCreator constructor (the deserialization entry point) must route through the
+        // same guard, so a JSON plan payload carrying streamingMode=AUTOMATIC is rejected at the
+        // worker boundary. Guards against a future refactor that splits the @JsonCreator path
+        // from the full constructor.
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+        try {
+            // 9-arg @JsonCreator constructor (no statsEquivalentPlanNode; boxed dispatchBatchSize).
+            new RPCNode(
+                    Optional.empty(),
+                    idAllocator.getNextId(),
+                    source,
+                    "test_rpc_function",
+                    ImmutableList.of(inputVar),
+                    ImmutableList.of("input_col"),
+                    outputVar,
+                    RPCNode.StreamingMode.AUTOMATIC,
+                    Integer.valueOf(0));
+            fail("expected rejection when deserializing an RPCNode with AUTOMATIC");
+        }
+        catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("AUTOMATIC"), "message should mention AUTOMATIC: " + expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testRpcBatchMinRowsRejectsNonPositive()
+    {
+        // rpc_batch_min_rows must be > 0: 0 or negative would make (rowCount >= threshold)
+        // always true and silently force BATCH on every query under AUTOMATIC.
+        PropertyMetadata<?> meta = new SystemSessionProperties().getSessionProperties().stream()
+                .filter(p -> p.getName().equals(SystemSessionProperties.RPC_BATCH_MIN_ROWS))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("rpc_batch_min_rows property not registered"));
+
+        // A positive value decodes through unchanged.
+        assertEquals(meta.decode(2000), 2000);
+
+        // 0 and negative are rejected with INVALID_SESSION_PROPERTY.
+        for (int bad : new int[] {0, -1}) {
+            try {
+                meta.decode(bad);
+                fail("expected rejection for rpc_batch_min_rows=" + bad);
+            }
+            catch (PrestoException expected) {
+                assertEquals(expected.getErrorCode(), INVALID_SESSION_PROPERTY.toErrorCode());
+            }
+        }
+    }
+
+    private static PlanNode findPlanNode(PlanNode node, Class<? extends PlanNode> targetClass)
+    {
+        if (targetClass.isInstance(node)) {
+            return node;
+        }
+        for (PlanNode source : node.getSources()) {
+            PlanNode found = findPlanNode(source, targetClass);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -239,6 +239,8 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.optimizations.DefaultRpcExecutionPolicy;
+import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -376,6 +378,10 @@ public class ServerMainModule
         binder.bind(BuiltInQueryAnalyzer.class).in(Scopes.SINGLETON);
         binder.bind(BuiltInAnalyzerProvider.class).in(Scopes.SINGLETON);
         binder.bind(AnalyzerProviderManager.class).in(Scopes.SINGLETON);
+
+        // RPC execution policy: the OSS default carries no batching heuristic (AUTOMATIC ->
+        // PER_ROW); a deployment may bind an override to enable stats-driven resolution.
+        newOptionalBinder(binder, RpcExecutionPolicy.class).setDefault().to(DefaultRpcExecutionPolicy.class).in(Scopes.SINGLETON);
 
         jaxrsBinder(binder).bind(ThrowableMapper.class);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -200,6 +200,8 @@ import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
+import com.facebook.presto.sql.planner.optimizations.DefaultRpcExecutionPolicy;
+import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -485,6 +487,10 @@ public class PrestoSparkModule
                 .annotatedWith(Names.named("rpcFunctionNames"))
                 .toInstance(ImmutableSet::of);
         binder.bind(PlanOptimizers.class).in(Scopes.SINGLETON);
+        // PlanOptimizers injects an RpcExecutionPolicy. Presto-on-Spark has no RPC functions
+        // (empty rpcFunctionNames above), so bind the no-op OSS default; AUTOMATIC resolves to
+        // PER_ROW and the policy is never consulted here.
+        newOptionalBinder(binder, RpcExecutionPolicy.class).setDefault().to(DefaultRpcExecutionPolicy.class).in(Scopes.SINGLETON);
         binder.bind(AdaptivePlanOptimizers.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPlanOptimizerManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Summary:

RPC functions (`fb_llm_inference`, `fb_text_embedding`) require users to choose `rpc_streaming_mode` = PER_ROW or BATCH, but the right choice depends on input cardinality the user can't see (crossover ~2000 rows). This adds an `AUTOMATIC` mode resolved at plan time by a pluggable policy, so a deployment can supply a stats-driven strategy without engine changes.

- `RPCNode.StreamingMode.AUTOMATIC`: a coordinator-only planning value, resolved before the `RPCNode` is built (never serialized; native protocol unchanged).
- `RpcExecutionPolicy` hook: `RpcExecutionProperties translateIntent(RpcExecutionIntent)`. `RpcFunctionOptimizer` builds the intent (requested mode + input `PlanNodeStatsEstimate` + session + function) and the policy returns the resolved properties (streaming mode). Both are builder-based, growable value objects scoped to the plan-time execution axis, so future plan-time knobs (dispatch parallelism / batch size) are added without changing the method signature; runtime concerns (error/deadline/quality) ride query config and are out of this hook. Two `checkArgument` guards (optimizer + `RPCNode` constructor, incl. the `JsonCreator` path) reject a leaked AUTOMATIC.
- `DefaultRpcExecutionPolicy` (OSS default): no batching heuristic — AUTOMATIC -> PER_ROW; explicit modes pass through. Bound via `OptionalBinder.setDefault` in `ServerMainModule`; a deployment overrides with `setBinding`.
- `rpc_batch_min_rows` session property (validated > 0, coordinator-only): a generic knob; the OSS default ignores it.

Default `rpc_streaming_mode` stays PER_ROW (opt-in). The decision logic lives in the deployment policy, keeping the engine free of any specific heuristic.

== RELEASE NOTES ==

General Changes
* Add the ``AUTOMATIC`` value for the ``rpc_streaming_mode`` session property, the ``rpc_batch_min_rows`` session property, and a pluggable ``RpcExecutionPolicy`` so deployments can resolve per-row vs batch RPC dispatch from the estimated input stats.

Reviewed By: sebastianopeluso, abhinavmuk04

Differential Revision: D108442564


