### PR TITLE
Native deps fbthrift arrow patches

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -33,8 +33,10 @@ COPY velox/scripts /velox/scripts
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
 COPY CMake/arrow/arrow-flight.patch /scripts
+COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
 ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
+ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 RUN bash -c "mkdir build && \
     (cd build && ../scripts/setup-centos.sh && \
                  ../scripts/setup-adapters.sh && \

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -32,9 +32,15 @@ COPY velox/scripts /velox/scripts
 # Copy extra script called during setup.
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
+COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /velox
 COPY CMake/arrow/arrow-flight.patch /scripts
 COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
-ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
+# NOTE: VELOX_ARROW_CMAKE_PATCH is a space-separated list and, when
+# set, OVERRIDES velox's auto-resolution in install_arrow — every
+# patch velox would have applied must be COPYed above and listed here.
+# Adding a new patch to velox/CMake/resolve_dependency_modules/arrow/
+# without also adding it below will silently fail to apply.
+ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
 ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 RUN bash -c "mkdir build && \

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -35,7 +35,9 @@ COPY velox/scripts /velox/scripts
 # Copy extra script called during setup.
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
+COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
 ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
+ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 # install rpm needed for minio install.
 RUN mkdir build && \
     (cd build && ../scripts/setup-ubuntu.sh && \

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -35,8 +35,14 @@ COPY velox/scripts /velox/scripts
 # Copy extra script called during setup.
 # from https://github.com/facebookincubator/velox/pull/14016
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
+COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /velox
 COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
-ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
+# NOTE: VELOX_ARROW_CMAKE_PATCH is a space-separated list and, when
+# set, OVERRIDES velox's auto-resolution in install_arrow — every
+# patch velox would have applied must be COPYed above and listed here.
+# Adding a new patch to velox/CMake/resolve_dependency_modules/arrow/
+# without also adding it below will silently fail to apply.
+ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
 ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 # install rpm needed for minio install.
 RUN mkdir build && \


### PR DESCRIPTION
## Description
Fix the Presto C++ build errors on CentOS9

## Motivation and Context
Two problems

1. After the previous commit unblocks install_fbthrift, building the
    dependency dockerfile against a velox submodule containing
    facebookincubator/velox PR #16019 ("build: Use FBThrift instead of
    Apache Thrift") fails next at install_arrow with:

      CMake Error at cmake_modules/BuildUtils.cmake:297 (target_link_libraries):
        Target "arrow_testing_objlib" links to:
          Boost::process
        but the target was not found.
      Call Stack (most recent call first):
        src/arrow/CMakeLists.txt:1124 (add_arrow_lib)

    Root cause: velox PR #16019 also added a second arrow patch
    (arrow-testing-boost.patch — replaces the header-only Boost::process
    with Boost::filesystem + Boost::system, fixing Arrow 18 against the
    boost build velox installs) and extended install_arrow's
    auto-resolution in scripts/setup-common.sh to apply BOTH that patch
    and cmake-compatibility.patch:

        if [ -z "$VELOX_ARROW_CMAKE_PATCH" ]; then
            ABSOLUTE_SCRIPTDIR=$(realpath "$SCRIPT_DIR")
            VELOX_ARROW_CMAKE_PATCH="$ABSOLUTE_SCRIPTDIR/.../arrow-testing-boost.patch"
            VELOX_ARROW_CMAKE_PATCH+=" $ABSOLUTE_SCRIPTDIR/.../cmake-compatibility.patch"
        fi

    The dependency dockerfiles pin VELOX_ARROW_CMAKE_PATCH to the single
    cmake-compatibility path. That was correct against pre-#16019 velox
    (where auto-resolution returned only that one patch), but is now a
    silent superset bug — the env override fully replaces the list, so
    arrow-testing-boost.patch is never applied and Arrow's CMake errors
    out on the missing Boost::process target.

    Solution:
    COPY the boost patch into /velox/ and list both patches in
    VELOX_ARROW_CMAKE_PATCH. Add a comment near the ENV line so the next
    developer adding a velox-side patch updates this list.

2. When the velox submodule advances to include facebookincubator/velox
    PR #16019 ("build: Use FBThrift instead of Apache Thrift"), building
    either dependency dockerfile fails during install_velox_deps with:

      + git apply /velox/scripts/../CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch
      error: can't open patch '/velox/scripts/../CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch': No such file or directory

    Root cause: velox PR #16019 added a new install_fbthrift step in
    scripts/setup-common.sh that, before building fbthrift, applies
    velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch
    to fix the CompactV1 protocol refiller. When VELOX_FBTHRIFT_CMAKE_PATCH
    is unset the step auto-resolves the path as
    "${realpath SCRIPT_DIR}/../CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch"
    which inside the dependency images resolves to /velox/CMake/... — but
    only /velox/scripts is COPYed into the image, so the file is absent and
    git apply fails.

    Solution:
    Mirror the existing arrow-patch wiring three lines up: COPY the patch
    file into /velox/ and point VELOX_FBTHRIFT_CMAKE_PATCH at the copied
    location so install_fbthrift skips its auto-resolution.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update native dependency Dockerfiles to include new Velox Arrow and FBThrift patch files so builds succeed with the updated Velox submodule.

Bug Fixes:
- Ensure Arrow builds correctly by copying the arrow-testing-boost patch into the images and applying it alongside the existing CMake compatibility patch.
- Prevent fbthrift setup failures by copying the compactv1 protocol refiller patch into the images and pointing Velox to the copied file via VELOX_FBTHRIFT_CMAKE_PATCH.

Enhancements:
- Document in the Dockerfiles how VELOX_ARROW_CMAKE_PATCH overrides Velox's auto-resolution and must list all required patches.