### PR TITLE
revert: Update jackson version to 2.18.6 (#27293)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dep.ratis.version>3.2.2</dep.ratis.version>
         <dep.errorprone.version>2.37.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
-        <dep.jackson.version>2.18.6</dep.jackson.version>
+        <dep.jackson.version>2.15.4</dep.jackson.version>
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.12.1</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.common.block;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
@@ -376,7 +375,6 @@ public interface Block
      * This allows streaming data sources to skip sections that are not
      * accessed in a query.
      */
-    @JsonIgnore
     default Block getLoadedBlock()
     {
         return this;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -17,7 +17,6 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -142,7 +141,6 @@ public final class Domain
         return values.isNone() && nullAllowed;
     }
 
-    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -151,7 +149,6 @@ public final class Domain
         return values.getSingleValue();
     }
 
-    @JsonIgnore
     public Object getNullableSingleValue()
     {
         if (!isNullableSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
@@ -16,7 +16,6 @@ package com.facebook.presto.common.predicate;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -161,7 +160,6 @@ public final class Range
         return low.getBound() == Marker.Bound.EXACTLY && low.equals(high);
     }
 
-    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
@@ -17,7 +17,6 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -162,7 +161,6 @@ public final class SortedRangeSet
     }
 
     @Override
-    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -242,7 +240,6 @@ public final class SortedRangeSet
     }
 
     @Override
-    @JsonIgnore
     public ValuesProcessor getValuesProcessor()
     {
         return new ValuesProcessor()

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
@@ -15,7 +15,6 @@ package com.facebook.presto.common.predicate;
 
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -103,7 +102,6 @@ public interface ValueSet
 
     boolean isSingleValue();
 
-    @JsonIgnore
     Object getSingleValue();
 
     boolean containsValue(Object value);
@@ -111,7 +109,6 @@ public interface ValueSet
     /**
      * @return value predicates for equatable Types (but not orderable)
      */
-    @JsonIgnore
     default DiscreteValues getDiscreteValues()
     {
         throw new UnsupportedOperationException();
@@ -125,7 +122,6 @@ public interface ValueSet
         throw new UnsupportedOperationException();
     }
 
-    @JsonIgnore
     ValuesProcessor getValuesProcessor();
 
     ValueSet intersect(ValueSet other);

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>17</project.build.targetJdk>
-        <dep.nessie.version>0.105.0</dep.nessie.version>
+        <dep.nessie.version>0.103.0</dep.nessie.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
@@ -116,8 +116,6 @@ public class TestIcebergSystemTablesNessieWithBearerAuth
     @Test
     public void testInvalidBearerToken()
     {
-        // With Jackson 2.18.6, Nessie client may fail to deserialize error responses
-        // Accept either the proper "Unauthorized (HTTP/401)" error or the Jackson deserialization error
-        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "(Unauthorized \\(HTTP/401\\).*|Cannot invoke \"org\\.projectnessie\\.error\\.NessieError\\.getErrorCode\\(\\)\" because \"error\" is null)", true);
+        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "Unauthorized \\(HTTP/401\\).*", true);
     }
 }

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>2.18.6</version>
+                <version>2.16.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -23,12 +23,9 @@ import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Inject;
 
 import java.util.List;
@@ -55,27 +52,7 @@ public class HistoryBasedPlanStatisticsManager
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
-        ObjectMapper newObjectMapper = objectMapper.copy()
-                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                .registerModule(new Jdk8Module());
-
-        // Increasing max nesting depth for Jackson 2.18.6
-        newObjectMapper.getFactory().setStreamWriteConstraints(
-                StreamWriteConstraints.builder()
-                        .maxNestingDepth(2000)
-                        .build());
-
-        // Added MixIn for Slice circular reference, it's an external library
-        try {
-            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
-            newObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
-        }
-        catch (ClassNotFoundException e) {
-        }
-
+        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
         this.isNativeExecution = featuresConfig.isNativeExecutionEnabled();
@@ -109,15 +86,5 @@ public class HistoryBasedPlanStatisticsManager
     public static List<PlanCanonicalizationStrategy> historyBasedPlanCanonicalizationStrategyList(Session session)
     {
         return getHistoryOptimizationPlanCanonicalizationStrategies(session);
-    }
-
-    /**
-     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
-     * This is needed for external library io.airlift.slice where we cannot modify the source code.
-     */
-    private abstract static class SliceMixIn
-    {
-        @JsonIgnore
-        abstract Object getOutput();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -231,11 +231,7 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.VariableToChannelTranslator;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ContiguousSet;
@@ -470,22 +466,7 @@ public class LocalExecutionPlanner
         this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
         this.sortedMapObjectMapper = requireNonNull(objectMapper, "objectMapper is null")
                 .copy()
-                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true)
-                .registerModule(new Jdk8Module())
-                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-
-        // Increasing max nesting depth
-        this.sortedMapObjectMapper.getFactory().setStreamWriteConstraints(
-                StreamWriteConstraints.builder()
-                        .maxNestingDepth(2000)
-                        .build());
-        try {
-            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
-            this.sortedMapObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
-        }
-        catch (ClassNotFoundException e) {
-        }
+                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
         this.tableFinishOperatorMemoryTrackingEnabled = requireNonNull(memoryManagerConfig, "memoryManagerConfig is null").isTableFinishOperatorMemoryTrackingEnabled();
         this.standaloneSpillerFactory = requireNonNull(standaloneSpillerFactory, "standaloneSpillerFactory is null");
     }
@@ -850,15 +831,6 @@ public class LocalExecutionPlanner
             }
             this.driverInstanceCount = OptionalInt.of(driverInstanceCount);
         }
-    }
-    /**
-     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
-     * The circular reference chain: Slice -> BasicSliceOutput.underlyingSlice -> Slice -> ...
-     */
-    private abstract static class SliceMixIn
-    {
-        @JsonIgnore
-        abstract Object getOutput();
     }
 
     private static class IndexSourceContext

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -243,8 +243,6 @@ import com.facebook.presto.ttl.clusterttlprovidermanagers.ThrowingClusterTtlProv
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -388,11 +386,7 @@ public class LocalQueryRunner
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory)
     {
-        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory,
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false));
+        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory, new ObjectMapper());
     }
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory, ObjectMapper objectMapper)
@@ -647,12 +641,7 @@ public class LocalQueryRunner
 
     public static LocalQueryRunner queryRunnerWithFakeNodeCountForStats(Session defaultSession, int nodeCount)
     {
-        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount,
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
-                new TaskManagerConfig().setTaskConcurrency(4));
+        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount, new ObjectMapper(), new TaskManagerConfig().setTaskConcurrency(4));
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -73,8 +73,6 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -187,10 +185,7 @@ public final class TaskTestUtils
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
+                new ObjectMapper(),
                 (session) -> {
                     throw new UnsupportedOperationException();
                 });

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -43,8 +43,6 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -340,10 +338,7 @@ public class TestSqlTaskManager
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
+                new ObjectMapper(),
                 new SpoolingOutputBufferFactory(new FeaturesConfig()));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -44,8 +44,6 @@ import com.facebook.presto.testing.PageConsumerOperator;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -125,10 +123,7 @@ public class TestDriver
                     Optional.empty()),
             new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
             testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
-            new ObjectMapper()
-                    .registerModule(new Jdk8Module())
-                    .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
-                    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)).get();
+            new ObjectMapper()).get();
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/plan/TestAssignments.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/plan/TestAssignments.java
@@ -13,16 +13,21 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
 public class TestAssignments
@@ -41,5 +46,22 @@ public class TestAssignments
     public void testOutputsMemoized()
     {
         assertSame(assignments.getOutputs(), assignments.getOutputs());
+    }
+
+    @Test
+    public void testJsonCodecHandlesLongMapKeys()
+    {
+        // Guards against a regression where the JSON codec used to deserialize
+        // PlanFragment -> ProjectNode -> Assignments failed when an
+        // auto-generated variable name in the Assignments map exceeded the
+        // default JSON-property-name length cap. Assignments map keys carry
+        // VariableReferenceExpression names; for complex projection chains over
+        // deeply nested struct schemas the planner can synthesize names well
+        // over 50 KB, so the codec must tolerate them.
+        String longName = Strings.repeat("a", 60_000);
+        JsonCodec<Map<String, String>> codec = JsonCodec.mapJsonCodec(String.class, String.class);
+        String json = codec.toJson(ImmutableMap.of(longName, "value"));
+        Map<String, String> roundTripped = codec.fromJson(json);
+        assertEquals(roundTripped.get(longName), "value");
     }
 }


### PR DESCRIPTION
## Description

Reverts the jackson-databind upgrade from 2.16.x to 2.18.6 introduced in #27293, and the coupled `jackson-datatype-jdk8` follow-on in #27809.

## Motivation and Context

Jackson 2.18 enabled `StreamReadConstraints` by default with `maxNameLength = 50000`. The JSON codec used to deserialize `PlanFragment` on the worker (`TaskResource.createOrUpdateTask` -> `JsonCodec.fromJson`) fails with a `StreamConstraintsException` when an `Assignments` map key exceeds that length. The map keys are `VariableReferenceExpression` names; the planner can synthesize names well over 50000 characters for complex projection chains over deeply nested struct schemas.

Observed failure on a worker after the upgrade:

```
PrestoException: Expected response code from https://<worker>:7778/v1/task/<id>?summarize to be 200, but was 500: null
  Caused by: com.fasterxml.jackson.databind.JsonMappingException: Invalid JSON bytes for [simple type, class com.facebook.presto.sql.planner.PlanFragment]
    Caused by: com.fasterxml.jackson.core.exc.StreamConstraintsException:
      Name length (65536) exceeds the maximum allowed (50000, from `StreamReadConstraints.getMaxNameLength()`)
    through reference chain:
      PlanFragment["root"] -> ProjectNode["assignments"] -> Assignments["assignments"]
```

The coordinator then surfaces this as `REMOTE_TASK_ERROR` and, after retries exhaust, `TOO_MANY_REQUESTS_FAILED`.

#27293 added `StreamWriteConstraints.maxNestingDepth(2000)` plus a `SliceMixIn` on one named `ObjectMapper` in `LocalExecutionPlanner` but did not touch `StreamReadConstraints`, so the deserialization path on every other `ObjectMapper` (including the one behind every `JsonCodec<T>`) remained exposed to the new caps. Reverting until a follow-up applies appropriate `StreamReadConstraints` to the central `ObjectMapperProvider` (or the codec factory) on the deserialization side as well.

## Impact

No public API change. Reverts to the jackson 2.16.x baseline that was in place before #27293. Workers and coordinators must be on matching jackson versions, so consumers should redeploy the whole cluster together.

## Test Plan

- Added `testJsonCodecHandlesLongMapKeys` in `TestAssignments` that round-trips a 60000-character JSON property name through `JsonCodec.mapJsonCodec(String.class, String.class)`. On the 2.16.x baseline (this revert) the test passes; on 2.18.6 it would fail with `StreamConstraintsException` from `StreamReadConstraints.getMaxNameLength()`.
- Ran the test locally on the reverted tree: `mvn -pl presto-main-base test -Dtest=TestAssignments` passes.
- Reproduced the regression end-to-end on a cluster running the 2.18.6 build with the self-contained CTAS attached to the linked task, and confirmed the same CTAS succeeds against a build with this revert applied.

Repro query here: https://pastebin.com/gzYz1u04

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==

```
Differential Revision: D108574381