### PR TITLE
fix(security): Upgrade reactor-netty to 1.3.6 to address CVE-2026-41715

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dep.protobuf-java.version>4.34.1</dep.protobuf-java.version>
         <dep.jetty.version>12.0.34</dep.jetty.version>
         <dep.netty.version>4.2.15.Final</dep.netty.version>
-        <dep.reactor-netty.version>1.3.3</dep.reactor-netty.version>
+        <dep.reactor-netty.version>1.3.6</dep.reactor-netty.version>
         <dep.snakeyaml.version>2.5</dep.snakeyaml.version>
         <dep.gson.version>2.14.0</dep.gson.version>
         <dep.commons.lang3.version>3.18.0</dep.commons.lang3.version>


### PR DESCRIPTION
## Description
Upgrade reactor-netty to 1.3.6 to address CVE-2026-41715

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

