### PR TITLE
feat(spi): Add DynamicFilter SPI for connector split pruning

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
@@ -33,6 +33,16 @@ public interface ConnectorSplitManager
             ConnectorTableLayoutHandle layout,
             SplitSchedulingContext splitSchedulingContext);
 
+    default ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext,
+            DynamicFilter dynamicFilter)
+    {
+        return getSplits(transactionHandle, session, layout, splitSchedulingContext);
+    }
+
     enum SplitSchedulingStrategy
     {
         UNGROUPED_SCHEDULING,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/DynamicFilter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/DynamicFilter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A dynamic filter collected from a join build side at runtime and passed to a
+ * connector during split scheduling, so the connector can skip partitions and files
+ * that cannot match the join.
+ *
+ * <p>Usage: wait on {@link #isBlocked()}, read {@link #getCurrentPredicate()}, repeat
+ * until {@link #isComplete()}. The predicate narrows monotonically — unresolved
+ * filters contribute {@link TupleDomain#all()}, so re-reading it picks up
+ * later-arriving filters without blocking on the slowest one.
+ *
+ * <p>The {@code relevantColumns} overloads restrict waiting to filters over the given
+ * columns; {@code Optional.empty()} means all columns.
+ */
+public interface DynamicFilter
+{
+    CompletableFuture<?> NOT_BLOCKED = CompletableFuture.completedFuture(null);
+
+    /** A complete filter that applies no filtering; use when dynamic filtering is disabled or not applicable. */
+    DynamicFilter EMPTY = new DynamicFilter()
+    {
+        @Override
+        public Duration getWaitTimeout()
+        {
+            return new Duration(0, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public boolean isComplete()
+        {
+            return true;
+        }
+
+        @Override
+        public TupleDomain<ColumnHandle> getCurrentPredicate()
+        {
+            return TupleDomain.all();
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return NOT_BLOCKED;
+        }
+
+        @Override
+        public int getTaskCountHint()
+        {
+            return 0;
+        }
+
+        @Override
+        public Set<ColumnHandle> getPendingFilterColumns()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked(Optional<Set<ColumnHandle>> relevantColumns)
+        {
+            return NOT_BLOCKED;
+        }
+
+        @Override
+        public boolean isComplete(Optional<Set<ColumnHandle>> relevantColumns)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean hasAnyComplete(Optional<Set<ColumnHandle>> relevantColumns)
+        {
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "DynamicFilter.EMPTY";
+        }
+    };
+
+    Duration getWaitTimeout();
+
+    boolean isComplete();
+
+    /** Returns {@link TupleDomain#all()} until the filter resolves. */
+    TupleDomain<ColumnHandle> getCurrentPredicate();
+
+    /** Completes when the predicate changes; starts the wait timeout on first call. */
+    CompletableFuture<?> isBlocked();
+
+    /** Hint for the number of tasks consuming this scan's splits, for warmup budgets; 0 if unknown. */
+    int getTaskCountHint();
+
+    /** Column handles targeted by pending (unresolved) filters. */
+    Set<ColumnHandle> getPendingFilterColumns();
+
+    CompletableFuture<?> isBlocked(Optional<Set<ColumnHandle>> relevantColumns);
+
+    boolean isComplete(Optional<Set<ColumnHandle>> relevantColumns);
+
+    /**
+     * True if at least one filter over {@code relevantColumns} is complete, or none are relevant.
+     * Lets a warmup scan exit on the first useful constraint rather than blocking on the slowest filter.
+     */
+    boolean hasAnyComplete(Optional<Set<ColumnHandle>> relevantColumns);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
 
 import static java.util.Objects.requireNonNull;
@@ -40,6 +41,19 @@ public final class ClassLoaderSafeConnectorSplitManager
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getSplits(transactionHandle, session, layout, splitSchedulingContext);
+        }
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext,
+            DynamicFilter dynamicFilter)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSplits(transactionHandle, session, layout, splitSchedulingContext, dynamicFilter);
         }
     }
 


### PR DESCRIPTION
## Description
Adds the `DynamicFilter` SPI interface and a backward-compatible `ConnectorSplitManager.getSplits(…, DynamicFilter)` default overload (delegates to the existing signature). Mirrors Trino's well-known `DynamicFilter` SPI.

## Motivation and Context
Foundation for distributed dynamic partition pruning (RFC-0022). Connectors use the `isBlocked()` / `getCurrentPredicate()` loop to receive runtime join-build-side filters and skip non-matching partitions/files during split scheduling. This SPI lands first so the coordinator, scheduler, and Iceberg PRs that consume it can be reviewed against a stable interface.

## Impact
New opt-in SPI interface in `presto-spi`.

## Test Plan
`presto-spi` compiles and passes checkstyle. Behavioral tests ship with subsequent PRs.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a DynamicFilter SPI and extend connector split management to accept dynamic filters for future dynamic partition pruning.

New Features:
- Add a DynamicFilter SPI interface for passing runtime join filters to connectors during split scheduling.
- Extend ConnectorSplitManager with a backward-compatible getSplits overload that accepts a DynamicFilter.
- Update ClassLoaderSafeConnectorSplitManager to delegate the new DynamicFilter-aware getSplits call to the underlying split manager.

## Summary by Sourcery

Introduce a dynamic filtering SPI and extend connector split management to accept dynamic filters during split scheduling.

New Features:
- Add a DynamicFilter SPI interface for passing runtime join predicates to connectors.
- Extend ConnectorSplitManager with a new getSplits overload that accepts a DynamicFilter while keeping the existing method as a backward-compatible default.
- Update ClassLoaderSafeConnectorSplitManager to delegate the DynamicFilter-aware getSplits call to the underlying split manager.