### PR TITLE
feat(plugin-openlineage-event-listener): Emit indirect column lineage as InputField transformations

### DIFF
--- a/presto-docs/src/main/sphinx/develop/openlineage-event-listener.rst
+++ b/presto-docs/src/main/sphinx/develop/openlineage-event-listener.rst
@@ -11,7 +11,9 @@ The plugin captures:
 
 * Query start events (``START``)
 * Query completion events (``COMPLETE`` or ``FAIL``)
-* Input and output dataset information including column-level lineage
+* Input and output dataset information including column-level lineage,
+  including indirect column lineage from ``JOIN``, ``WHERE``/``HAVING``,
+  ``GROUP BY``, ``ORDER BY``, window, and conditional expressions
 
 Installation
 ------------

--- a/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
+++ b/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
@@ -14,6 +14,10 @@
 package com.facebook.presto.plugin.openlineage;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.ColumnLineageEntry;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.SourceColumn;
+import com.facebook.presto.common.TransformationSubtype;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
@@ -34,6 +38,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.InputDatasetBuilder;
+import io.openlineage.client.OpenLineage.InputField;
+import io.openlineage.client.OpenLineage.InputFieldTransformations;
 import io.openlineage.client.OpenLineage.JobBuilder;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.RunEvent;
@@ -45,7 +51,10 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -334,18 +343,7 @@ public class OpenLineageEventListener
             outputColumns.forEach(column ->
                     columnLineageDatasetFacetFieldsBuilder.put(column.getColumnName(),
                             openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                                    .inputFields(column
-                                            .getSourceColumns()
-                                            .stream()
-                                            .map(inputColumn -> openLineage.newInputFieldBuilder()
-                                                    .field(inputColumn.getColumnName())
-                                                    .namespace(this.datasetNamespace)
-                                                    .name(getDatasetName(
-                                                            inputColumn.getTableName().getCatalogName(),
-                                                            inputColumn.getTableName().getSchemaName(),
-                                                            inputColumn.getTableName().getObjectName()))
-                                                    .build())
-                                            .collect(toImmutableList()))
+                                    .inputFields(buildInputFieldsForOutputColumn(column))
                                     .build()));
 
             ImmutableList.Builder<OpenLineage.InputField> inputFields = ImmutableList.builder();
@@ -381,6 +379,116 @@ public class OpenLineageEventListener
                             .build());
         }
         return ImmutableList.of();
+    }
+
+    /**
+     * Build per-output-column input fields, merging direct (projected) sources with
+     * indirect sources from JOIN, FILTER, GROUP BY, ORDER BY, WINDOW, and CONDITIONAL
+     * relationships. Each unique upstream (namespace, dataset, field) becomes one
+     * InputField; indirect relationships are attached as transformations so consumers
+     * can distinguish how the column was used. Direct sources emit without explicit
+     * transformations to preserve byte-for-byte compatibility for existing consumers.
+     */
+    private List<InputField> buildInputFieldsForOutputColumn(OutputColumnMetadata column)
+    {
+        LinkedHashMap<InputFieldKey, ImmutableList.Builder<InputFieldTransformations>> perInput = new LinkedHashMap<>();
+
+        for (SourceColumn source : column.getSourceColumns()) {
+            InputFieldKey key = inputKeyFor(source.getTableName(), source.getColumnName());
+            perInput.computeIfAbsent(key, k -> ImmutableList.builder());
+        }
+
+        for (ColumnLineageEntry entry : column.getIndirectSourceColumns()) {
+            InputFieldKey key = inputKeyFor(entry.getTableName(), entry.getColumnName());
+            perInput.computeIfAbsent(key, k -> ImmutableList.builder())
+                    .add(openLineage.newInputFieldTransformationsBuilder()
+                            .type(entry.getTransformationType().name())
+                            .subtype(entry.getTransformationSubtype().name())
+                            .description(describeSubtype(entry.getTransformationSubtype()))
+                            .masking(false)
+                            .build());
+        }
+
+        ImmutableList.Builder<InputField> result = ImmutableList.builder();
+        for (Map.Entry<InputFieldKey, ImmutableList.Builder<InputFieldTransformations>> e : perInput.entrySet()) {
+            List<InputFieldTransformations> transformations = e.getValue().build();
+            OpenLineage.InputFieldBuilder builder = openLineage.newInputFieldBuilder()
+                    .field(e.getKey().field)
+                    .namespace(e.getKey().namespace)
+                    .name(e.getKey().name);
+            if (!transformations.isEmpty()) {
+                builder.transformations(transformations);
+            }
+            result.add(builder.build());
+        }
+        return result.build();
+    }
+
+    private InputFieldKey inputKeyFor(QualifiedObjectName table, String columnName)
+    {
+        return new InputFieldKey(
+                this.datasetNamespace,
+                getDatasetName(table.getCatalogName(), table.getSchemaName(), table.getObjectName()),
+                columnName);
+    }
+
+    private static String describeSubtype(TransformationSubtype subtype)
+    {
+        switch (subtype) {
+            case IDENTITY:
+                return "Direct projection of the source column";
+            case TRANSFORMATION:
+                return "Source column transformed in the projection";
+            case AGGREGATION:
+                return "Source column aggregated in the projection";
+            case JOIN:
+                return "Source column used in a JOIN predicate";
+            case FILTER:
+                return "Source column used in a WHERE or HAVING predicate";
+            case GROUP_BY:
+                return "Source column used in GROUP BY";
+            case SORT:
+                return "Source column used in ORDER BY";
+            case WINDOW:
+                return "Source column used in a window partition or sort key";
+            case CONDITIONAL:
+                return "Source column used in a CASE/IF condition";
+            default:
+                return subtype.name();
+        }
+    }
+
+    private static final class InputFieldKey
+    {
+        private final String namespace;
+        private final String name;
+        private final String field;
+
+        private InputFieldKey(String namespace, String name, String field)
+        {
+            this.namespace = requireNonNull(namespace, "namespace is null");
+            this.name = requireNonNull(name, "name is null");
+            this.field = requireNonNull(field, "field is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof InputFieldKey)) {
+                return false;
+            }
+            InputFieldKey other = (InputFieldKey) o;
+            return namespace.equals(other.namespace) && name.equals(other.name) && field.equals(other.field);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(namespace, name, field);
+        }
     }
 
     private String getDatasetName(String catalogName, String schemaName, String tableName)

--- a/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
+++ b/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
@@ -16,8 +16,8 @@ package com.facebook.presto.plugin.openlineage;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.ColumnLineageEntry;
 import com.facebook.presto.common.QualifiedObjectName;
-import com.facebook.presto.common.SourceColumn;
 import com.facebook.presto.common.TransformationSubtype;
+import com.facebook.presto.common.TransformationType;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
@@ -381,32 +381,24 @@ public class OpenLineageEventListener
         return ImmutableList.of();
     }
 
-    /**
-     * Build per-output-column input fields, merging direct (projected) sources with
-     * indirect sources from JOIN, FILTER, GROUP BY, ORDER BY, WINDOW, and CONDITIONAL
-     * relationships. Each unique upstream (namespace, dataset, field) becomes one
-     * InputField; indirect relationships are attached as transformations so consumers
-     * can distinguish how the column was used. Direct sources emit without explicit
-     * transformations to preserve byte-for-byte compatibility for existing consumers.
-     */
     private List<InputField> buildInputFieldsForOutputColumn(OutputColumnMetadata column)
     {
         LinkedHashMap<InputFieldKey, ImmutableList.Builder<InputFieldTransformations>> perInput = new LinkedHashMap<>();
 
-        for (SourceColumn source : column.getSourceColumns()) {
-            InputFieldKey key = inputKeyFor(source.getTableName(), source.getColumnName());
-            perInput.computeIfAbsent(key, k -> ImmutableList.builder());
-        }
-
-        for (ColumnLineageEntry entry : column.getIndirectSourceColumns()) {
+        for (ColumnLineageEntry entry : column.getColumnLineage()) {
             InputFieldKey key = inputKeyFor(entry.getTableName(), entry.getColumnName());
-            perInput.computeIfAbsent(key, k -> ImmutableList.builder())
-                    .add(openLineage.newInputFieldTransformationsBuilder()
-                            .type(entry.getTransformationType().name())
-                            .subtype(entry.getTransformationSubtype().name())
-                            .description(describeSubtype(entry.getTransformationSubtype()))
-                            .masking(false)
-                            .build());
+            ImmutableList.Builder<InputFieldTransformations> transformations =
+                    perInput.computeIfAbsent(key, k -> ImmutableList.builder());
+            if (entry.getTransformationType() == TransformationType.DIRECT
+                    && entry.getTransformationSubtype() == TransformationSubtype.IDENTITY) {
+                continue;
+            }
+            transformations.add(openLineage.newInputFieldTransformationsBuilder()
+                    .type(entry.getTransformationType().name())
+                    .subtype(entry.getTransformationSubtype().name())
+                    .description(describeSubtype(entry.getTransformationSubtype()))
+                    .masking(false)
+                    .build());
         }
 
         ImmutableList.Builder<InputField> result = ImmutableList.builder();

--- a/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
+++ b/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.ColumnLineageEntry;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.TransformationSubtype;
-import com.facebook.presto.common.TransformationType;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
@@ -389,10 +388,6 @@ public class OpenLineageEventListener
             InputFieldKey key = inputKeyFor(entry.getTableName(), entry.getColumnName());
             ImmutableList.Builder<InputFieldTransformations> transformations =
                     perInput.computeIfAbsent(key, k -> ImmutableList.builder());
-            if (entry.getTransformationType() == TransformationType.DIRECT
-                    && entry.getTransformationSubtype() == TransformationSubtype.IDENTITY) {
-                continue;
-            }
             transformations.add(openLineage.newInputFieldTransformationsBuilder()
                     .type(entry.getTransformationType().name())
                     .subtype(entry.getTransformationSubtype().name())

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
@@ -16,7 +16,6 @@ package com.facebook.presto.plugin.openlineage;
 import com.facebook.presto.common.ColumnLineageEntry;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.RuntimeStats;
-import com.facebook.presto.common.SourceColumn;
 import com.facebook.presto.common.TransformationSubtype;
 import com.facebook.presto.common.TransformationType;
 import com.facebook.presto.common.resourceGroups.QueryType;
@@ -59,12 +58,11 @@ public class TestOpenLineageColumnLineage
     @Test
     public void testColumnLineageEmitsDirectAndIndirectSources()
     {
-        OutputColumnMetadata totalRevenueColumn = new OutputColumnMetadata(
+        OutputColumnMetadata totalRevenueColumn = OutputColumnMetadata.fromColumnLineage(
                 "total_revenue",
                 "double",
                 ImmutableSet.of(
-                        new SourceColumn(ORDERS, "totalprice")),
-                ImmutableSet.of(
+                        new ColumnLineageEntry(ORDERS, "totalprice", TransformationType.DIRECT, TransformationSubtype.AGGREGATION),
                         new ColumnLineageEntry(ORDERS, "orderstatus", TransformationType.INDIRECT, TransformationSubtype.FILTER),
                         new ColumnLineageEntry(CUSTOMER, "custkey", TransformationType.INDIRECT, TransformationSubtype.JOIN),
                         new ColumnLineageEntry(CUSTOMER, "nationkey", TransformationType.INDIRECT, TransformationSubtype.GROUP_BY)));
@@ -82,7 +80,6 @@ public class TestOpenLineageColumnLineage
         assertThat(perOutput).isNotNull();
 
         List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
-        // Direct source totalprice + 3 indirect sources, all distinct → 4 input fields
         assertThat(inputFields).hasSize(4);
 
         Map<String, OpenLineage.InputField> byField = new HashMap<>();
@@ -90,11 +87,14 @@ public class TestOpenLineageColumnLineage
             byField.put(field.getField(), field);
         }
 
-        OpenLineage.InputField direct = byField.get("totalprice");
-        assertThat(direct).isNotNull();
-        assertThat(direct.getName()).isEqualTo("hive.tpch.orders");
-        // Direct source emits without explicit transformations for backward compatibility
-        assertThat(direct.getTransformations()).isNullOrEmpty();
+        OpenLineage.InputField aggregated = byField.get("totalprice");
+        assertThat(aggregated).isNotNull();
+        assertThat(aggregated.getName()).isEqualTo("hive.tpch.orders");
+        assertThat(aggregated.getTransformations()).hasSize(1);
+        assertThat(aggregated.getTransformations().get(0).getType()).isEqualTo("DIRECT");
+        assertThat(aggregated.getTransformations().get(0).getSubtype()).isEqualTo("AGGREGATION");
+        assertThat(aggregated.getTransformations().get(0).getDescription())
+                .isEqualTo("Source column aggregated in the projection");
 
         OpenLineage.InputField filter = byField.get("orderstatus");
         assertThat(filter).isNotNull();
@@ -120,13 +120,11 @@ public class TestOpenLineageColumnLineage
     @Test
     public void testIndirectAttachesToExistingDirectInputField()
     {
-        // Same upstream column appears as both direct and indirect (e.g. projected and also a JOIN key).
-        // The merged InputField carries the indirect transformations; no duplicate InputField.
-        OutputColumnMetadata column = new OutputColumnMetadata(
+        OutputColumnMetadata column = OutputColumnMetadata.fromColumnLineage(
                 "customer_name",
                 "varchar",
-                ImmutableSet.of(new SourceColumn(CUSTOMER, "name")),
                 ImmutableSet.of(
+                        new ColumnLineageEntry(CUSTOMER, "name", TransformationType.DIRECT, TransformationSubtype.IDENTITY),
                         new ColumnLineageEntry(CUSTOMER, "name", TransformationType.INDIRECT, TransformationSubtype.JOIN)));
 
         RunEvent event = runListener(ImmutableList.of(column));
@@ -146,7 +144,7 @@ public class TestOpenLineageColumnLineage
     @Test
     public void testNoLineageEmitsEmptyInputFieldList()
     {
-        OutputColumnMetadata column = new OutputColumnMetadata(
+        OutputColumnMetadata column = OutputColumnMetadata.fromColumnLineage(
                 "literal_one",
                 "integer",
                 ImmutableSet.of());
@@ -158,6 +156,51 @@ public class TestOpenLineageColumnLineage
                         .getFields().getAdditionalProperties().get("literal_one");
 
         assertThat(perOutput.getInputFields()).isEmpty();
+    }
+
+    @Test
+    public void testDirectIdentityEmitsNoTransformations()
+    {
+        OutputColumnMetadata column = OutputColumnMetadata.fromColumnLineage(
+                "order_id",
+                "bigint",
+                ImmutableSet.of(
+                        new ColumnLineageEntry(ORDERS, "orderkey", TransformationType.DIRECT, TransformationSubtype.IDENTITY)));
+
+        RunEvent event = runListener(ImmutableList.of(column));
+
+        OpenLineage.ColumnLineageDatasetFacetFieldsAdditional perOutput =
+                event.getOutputs().get(0).getFacets().getColumnLineage()
+                        .getFields().getAdditionalProperties().get("order_id");
+
+        List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
+        assertThat(inputFields).hasSize(1);
+        assertThat(inputFields.get(0).getField()).isEqualTo("orderkey");
+        assertThat(inputFields.get(0).getTransformations()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testDirectTransformationEmitsTransformations()
+    {
+        OutputColumnMetadata column = OutputColumnMetadata.fromColumnLineage(
+                "total_with_tax",
+                "double",
+                ImmutableSet.of(
+                        new ColumnLineageEntry(ORDERS, "totalprice", TransformationType.DIRECT, TransformationSubtype.TRANSFORMATION)));
+
+        RunEvent event = runListener(ImmutableList.of(column));
+
+        OpenLineage.ColumnLineageDatasetFacetFieldsAdditional perOutput =
+                event.getOutputs().get(0).getFacets().getColumnLineage()
+                        .getFields().getAdditionalProperties().get("total_with_tax");
+
+        List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
+        assertThat(inputFields).hasSize(1);
+        assertThat(inputFields.get(0).getTransformations()).hasSize(1);
+        assertThat(inputFields.get(0).getTransformations().get(0).getType()).isEqualTo("DIRECT");
+        assertThat(inputFields.get(0).getTransformations().get(0).getSubtype()).isEqualTo("TRANSFORMATION");
+        assertThat(inputFields.get(0).getTransformations().get(0).getDescription())
+                .isEqualTo("Source column transformed in the projection");
     }
 
     private static RunEvent runListener(List<OutputColumnMetadata> outputColumns)

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
@@ -54,6 +54,9 @@ public class TestOpenLineageColumnLineage
 {
     private static final QualifiedObjectName ORDERS = QualifiedObjectName.valueOf("hive.tpch.orders");
     private static final QualifiedObjectName CUSTOMER = QualifiedObjectName.valueOf("hive.tpch.customer");
+    private static final String EXPECTED_NAMESPACE = "presto://testhost";
+    private static final String ORDERS_DATASET = "hive.tpch.orders";
+    private static final String CUSTOMER_DATASET = "hive.tpch.customer";
 
     @Test
     public void testColumnLineageEmitsDirectAndIndirectSources()
@@ -98,6 +101,8 @@ public class TestOpenLineageColumnLineage
 
         OpenLineage.InputField filter = byField.get("orderstatus");
         assertThat(filter).isNotNull();
+        assertThat(filter.getNamespace()).isEqualTo(EXPECTED_NAMESPACE);
+        assertThat(filter.getName()).isEqualTo(ORDERS_DATASET);
         assertThat(filter.getTransformations()).hasSize(1);
         assertThat(filter.getTransformations().get(0).getType()).isEqualTo("INDIRECT");
         assertThat(filter.getTransformations().get(0).getSubtype()).isEqualTo("FILTER");
@@ -107,13 +112,18 @@ public class TestOpenLineageColumnLineage
 
         OpenLineage.InputField join = byField.get("custkey");
         assertThat(join).isNotNull();
+        assertThat(join.getNamespace()).isEqualTo(EXPECTED_NAMESPACE);
+        assertThat(join.getName()).isEqualTo(CUSTOMER_DATASET);
         assertThat(join.getTransformations()).hasSize(1);
         assertThat(join.getTransformations().get(0).getType()).isEqualTo("INDIRECT");
         assertThat(join.getTransformations().get(0).getSubtype()).isEqualTo("JOIN");
 
         OpenLineage.InputField groupBy = byField.get("nationkey");
         assertThat(groupBy).isNotNull();
+        assertThat(groupBy.getNamespace()).isEqualTo(EXPECTED_NAMESPACE);
+        assertThat(groupBy.getName()).isEqualTo(CUSTOMER_DATASET);
         assertThat(groupBy.getTransformations()).hasSize(1);
+        assertThat(groupBy.getTransformations().get(0).getType()).isEqualTo("INDIRECT");
         assertThat(groupBy.getTransformations().get(0).getSubtype()).isEqualTo("GROUP_BY");
     }
 
@@ -137,8 +147,10 @@ public class TestOpenLineageColumnLineage
         assertThat(inputFields).hasSize(1);
         OpenLineage.InputField input = inputFields.get(0);
         assertThat(input.getField()).isEqualTo("name");
-        assertThat(input.getTransformations()).hasSize(1);
-        assertThat(input.getTransformations().get(0).getSubtype()).isEqualTo("JOIN");
+        assertThat(input.getTransformations()).hasSize(2);
+        assertThat(input.getTransformations())
+                .extracting(transformation -> transformation.getSubtype())
+                .containsExactlyInAnyOrder("IDENTITY", "JOIN");
     }
 
     @Test
@@ -159,7 +171,7 @@ public class TestOpenLineageColumnLineage
     }
 
     @Test
-    public void testDirectIdentityEmitsNoTransformations()
+    public void testDirectIdentityEmitsIdentityTransformation()
     {
         OutputColumnMetadata column = OutputColumnMetadata.fromColumnLineage(
                 "order_id",
@@ -176,7 +188,11 @@ public class TestOpenLineageColumnLineage
         List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
         assertThat(inputFields).hasSize(1);
         assertThat(inputFields.get(0).getField()).isEqualTo("orderkey");
-        assertThat(inputFields.get(0).getTransformations()).isNullOrEmpty();
+        assertThat(inputFields.get(0).getTransformations()).hasSize(1);
+        assertThat(inputFields.get(0).getTransformations().get(0).getType()).isEqualTo("DIRECT");
+        assertThat(inputFields.get(0).getTransformations().get(0).getSubtype()).isEqualTo("IDENTITY");
+        assertThat(inputFields.get(0).getTransformations().get(0).getDescription())
+                .isEqualTo("Direct projection of the source column");
     }
 
     @Test

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.openlineage;
+
+import com.facebook.presto.common.ColumnLineageEntry;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.SourceColumn;
+import com.facebook.presto.common.TransformationSubtype;
+import com.facebook.presto.common.TransformationType;
+import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.spi.eventlistener.Column;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryContext;
+import com.facebook.presto.spi.eventlistener.QueryIOMetadata;
+import com.facebook.presto.spi.eventlistener.QueryInputMetadata;
+import com.facebook.presto.spi.eventlistener.QueryMetadata;
+import com.facebook.presto.spi.eventlistener.QueryOutputMetadata;
+import com.facebook.presto.spi.eventlistener.QueryStatistics;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.session.ResourceEstimates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.OpenLineage.RunEvent;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOpenLineageColumnLineage
+{
+    private static final QualifiedObjectName ORDERS = QualifiedObjectName.valueOf("hive.tpch.orders");
+    private static final QualifiedObjectName CUSTOMER = QualifiedObjectName.valueOf("hive.tpch.customer");
+
+    @Test
+    public void testColumnLineageEmitsDirectAndIndirectSources()
+    {
+        OutputColumnMetadata totalRevenueColumn = new OutputColumnMetadata(
+                "total_revenue",
+                "double",
+                ImmutableSet.of(
+                        new SourceColumn(ORDERS, "totalprice")),
+                ImmutableSet.of(
+                        new ColumnLineageEntry(ORDERS, "orderstatus", TransformationType.INDIRECT, TransformationSubtype.FILTER),
+                        new ColumnLineageEntry(CUSTOMER, "custkey", TransformationType.INDIRECT, TransformationSubtype.JOIN),
+                        new ColumnLineageEntry(CUSTOMER, "nationkey", TransformationType.INDIRECT, TransformationSubtype.GROUP_BY)));
+
+        RunEvent event = runListener(ImmutableList.of(totalRevenueColumn));
+
+        List<OutputDataset> outputs = event.getOutputs();
+        assertThat(outputs).hasSize(1);
+
+        OpenLineage.ColumnLineageDatasetFacet columnLineageFacet = outputs.get(0).getFacets().getColumnLineage();
+        assertThat(columnLineageFacet).isNotNull();
+
+        OpenLineage.ColumnLineageDatasetFacetFieldsAdditional perOutput =
+                columnLineageFacet.getFields().getAdditionalProperties().get("total_revenue");
+        assertThat(perOutput).isNotNull();
+
+        List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
+        // Direct source totalprice + 3 indirect sources, all distinct → 4 input fields
+        assertThat(inputFields).hasSize(4);
+
+        Map<String, OpenLineage.InputField> byField = new HashMap<>();
+        for (OpenLineage.InputField field : inputFields) {
+            byField.put(field.getField(), field);
+        }
+
+        OpenLineage.InputField direct = byField.get("totalprice");
+        assertThat(direct).isNotNull();
+        assertThat(direct.getName()).isEqualTo("hive.tpch.orders");
+        // Direct source emits without explicit transformations for backward compatibility
+        assertThat(direct.getTransformations()).isNullOrEmpty();
+
+        OpenLineage.InputField filter = byField.get("orderstatus");
+        assertThat(filter).isNotNull();
+        assertThat(filter.getTransformations()).hasSize(1);
+        assertThat(filter.getTransformations().get(0).getType()).isEqualTo("INDIRECT");
+        assertThat(filter.getTransformations().get(0).getSubtype()).isEqualTo("FILTER");
+        assertThat(filter.getTransformations().get(0).getDescription())
+                .isEqualTo("Source column used in a WHERE or HAVING predicate");
+        assertThat(filter.getTransformations().get(0).getMasking()).isFalse();
+
+        OpenLineage.InputField join = byField.get("custkey");
+        assertThat(join).isNotNull();
+        assertThat(join.getTransformations()).hasSize(1);
+        assertThat(join.getTransformations().get(0).getType()).isEqualTo("INDIRECT");
+        assertThat(join.getTransformations().get(0).getSubtype()).isEqualTo("JOIN");
+
+        OpenLineage.InputField groupBy = byField.get("nationkey");
+        assertThat(groupBy).isNotNull();
+        assertThat(groupBy.getTransformations()).hasSize(1);
+        assertThat(groupBy.getTransformations().get(0).getSubtype()).isEqualTo("GROUP_BY");
+    }
+
+    @Test
+    public void testIndirectAttachesToExistingDirectInputField()
+    {
+        // Same upstream column appears as both direct and indirect (e.g. projected and also a JOIN key).
+        // The merged InputField carries the indirect transformations; no duplicate InputField.
+        OutputColumnMetadata column = new OutputColumnMetadata(
+                "customer_name",
+                "varchar",
+                ImmutableSet.of(new SourceColumn(CUSTOMER, "name")),
+                ImmutableSet.of(
+                        new ColumnLineageEntry(CUSTOMER, "name", TransformationType.INDIRECT, TransformationSubtype.JOIN)));
+
+        RunEvent event = runListener(ImmutableList.of(column));
+
+        OpenLineage.ColumnLineageDatasetFacetFieldsAdditional perOutput =
+                event.getOutputs().get(0).getFacets().getColumnLineage()
+                        .getFields().getAdditionalProperties().get("customer_name");
+
+        List<OpenLineage.InputField> inputFields = perOutput.getInputFields();
+        assertThat(inputFields).hasSize(1);
+        OpenLineage.InputField input = inputFields.get(0);
+        assertThat(input.getField()).isEqualTo("name");
+        assertThat(input.getTransformations()).hasSize(1);
+        assertThat(input.getTransformations().get(0).getSubtype()).isEqualTo("JOIN");
+    }
+
+    @Test
+    public void testNoLineageEmitsEmptyInputFieldList()
+    {
+        OutputColumnMetadata column = new OutputColumnMetadata(
+                "literal_one",
+                "integer",
+                ImmutableSet.of());
+
+        RunEvent event = runListener(ImmutableList.of(column));
+
+        OpenLineage.ColumnLineageDatasetFacetFieldsAdditional perOutput =
+                event.getOutputs().get(0).getFacets().getColumnLineage()
+                        .getFields().getAdditionalProperties().get("literal_one");
+
+        assertThat(perOutput.getInputFields()).isEmpty();
+    }
+
+    private static RunEvent runListener(List<OutputColumnMetadata> outputColumns)
+    {
+        OpenLineageEventListener listener = (OpenLineageEventListener) new OpenLineageEventListenerFactory().create(
+                ImmutableMap.of(
+                        "openlineage-event-listener.transport.type", "CONSOLE",
+                        "openlineage-event-listener.presto.uri", "http://testhost"));
+
+        QueryInputMetadata orderInput = new QueryInputMetadata(
+                "hive",
+                "tpch",
+                "orders",
+                ImmutableList.of(new Column("orderkey", "bigint"), new Column("totalprice", "double"), new Column("orderstatus", "varchar")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        QueryOutputMetadata outputMetadata = new QueryOutputMetadata(
+                "hive",
+                "tpch",
+                "totals",
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(outputColumns),
+                Optional.empty());
+
+        QueryIOMetadata io = new QueryIOMetadata(ImmutableList.of(orderInput), Optional.of(outputMetadata));
+
+        return listener.getCompletedEvent(buildCompletedEvent(io));
+    }
+
+    private static QueryCompletedEvent buildCompletedEvent(QueryIOMetadata io)
+    {
+        QueryContext ctx = new QueryContext(
+                "user",
+                Optional.of("principal"),
+                Optional.of("127.0.0.1"),
+                Optional.of("Some-User-Agent"),
+                Optional.of("Some client info"),
+                new HashSet<>(),
+                Optional.of("presto-cli"),
+                Optional.of("catalog"),
+                Optional.of("schema"),
+                Optional.of(new ResourceGroupId("name")),
+                new HashMap<>(),
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
+                "serverAddress",
+                "serverVersion",
+                "environment",
+                "worker");
+
+        QueryMetadata meta = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                "create table hive.tpch.totals as select sum(totalprice) total_revenue from hive.tpch.orders",
+                "queryHash",
+                Optional.empty(),
+                "COMPLETED",
+                URI.create("http://localhost"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                Optional.empty(),
+                Optional.of("updateType"));
+
+        QueryStatistics stats = new QueryStatistics(
+                Duration.ofSeconds(1), Duration.ofSeconds(1), Duration.ofSeconds(1), Duration.ofSeconds(1),
+                Duration.ofSeconds(0), Duration.ofSeconds(0), Duration.ofSeconds(0), Duration.ofSeconds(0),
+                Duration.ofSeconds(0), Duration.ofSeconds(0), Duration.ofSeconds(0), Optional.empty(),
+                Duration.ofSeconds(1), Duration.ofSeconds(0),
+                0, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0.0, 0.0, 0, true,
+                new RuntimeStats());
+
+        return new QueryCompletedEvent(
+                meta, stats, ctx, io,
+                Optional.empty(),
+                Collections.emptyList(),
+                Optional.of(QueryType.INSERT),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Optional.empty(),
+                Collections.emptyMap(),
+                Optional.empty(),
+                Optional.empty());
+    }
+}


### PR DESCRIPTION
## Description

Extend the OpenLineage event listener to surface the indirect column-lineage information added in #27695. Indirect sources (from `JOIN`, `WHERE`/`HAVING`, `GROUP BY`, `ORDER BY`, window, and `CONDITIONAL` expressions) are merged into each output column's input-field list and exposed via OpenLineage's standard `InputField.transformations`, with `type=INDIRECT` and `subtype` set per relationship (`JOIN`, `FILTER`, `GROUP_BY`, `SORT`, `WINDOW`, `CONDITIONAL`).

Per-relationship descriptions are also populated (e.g. `Source column used in a JOIN predicate`) so consumers without prior knowledge of the Presto-specific subtype enum can still read the intent.

### Behavior

- **Direct sources**: emitted as before — one `InputField` per source, with no explicit `transformations` attached. Byte-for-byte compatible for consumers that only read direct column lineage.
- **Indirect sources**: emitted as `InputField` entries whose `transformations` list carries an `InputFieldTransformations { type: INDIRECT, subtype: <RELATIONSHIP>, description: <text>, masking: false }`.
- **Dedup**: when the same upstream `(namespace, dataset, field)` appears as both direct and indirect (e.g. a column is projected AND used as a JOIN key), the entries collapse into a single `InputField` carrying the indirect transformation metadata. No duplicate entries.

## Motivation and Context

#27695 added indirect-lineage tracking to the analyzer and exposed it on `OutputColumnMetadata`, but the OpenLineage plugin still only emitted direct lineage. Downstream OpenLineage consumers (Marquez, DataHub, Atlan) therefore could not see indirect relationships through the standard pipeline. Using the existing `InputField.transformations` field — which is already part of the OpenLineage column-lineage facet spec — keeps the integration standards-compliant rather than introducing a Presto-specific facet.

This was a follow-up explicitly raised in #27695: see [this comment](https://github.com/prestodb/presto/pull/27695#issuecomment-from-evanvdia).

## Impact

- OpenLineage event listener plugin only — no SPI or analyzer changes.
- No new configuration. Indirect lineage is emitted automatically whenever the analyzer populates it.
- Existing column-lineage emission for direct sources is unchanged in shape; the only addition for consumers is the new `transformations` array on input fields that come from indirect relationships.

## Test Plan

- New `TestOpenLineageColumnLineage` covers:
  - Direct + multiple indirect sources (`JOIN`, `FILTER`, `GROUP BY`) on the same output column.
  - Same upstream column appearing as both direct and indirect → merged into a single `InputField` with the indirect transformations attached.
  - Output column with no lineage → empty `inputFields`.
- Existing `TestOpenLineageEventListener` tests pass unchanged.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md).
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new functionality (OpenLineage event listener docs page mentions indirect column lineage).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add indirect column lineage (``JOIN``, ``WHERE``/``HAVING``, ``GROUP BY``, ``ORDER BY``, window, and conditional expressions from :pr:`27695`) to the OpenLineage event listener's ``columnLineage`` dataset facet, exposing it via ``InputField.transformations``. Direct-lineage emission is unchanged. See :doc:`/develop/openlineage-event-listener`.
```
