### PR TITLE
feat(spi): Unify direct and indirect column lineage into ColumnLineageEntry

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -1255,7 +1255,7 @@ public class Analysis
      */
     public void propagateLineage(Field newField, Field sourceField)
     {
-        originColumnDetails.putAll(newField, originColumnDetails.get(sourceField));
+        addColumnLineageEntries(newField, getDirectLineageEntries(sourceField));
         addPerFieldIndirectSources(newField, getPerFieldIndirectSources(sourceField));
     }
 
@@ -1272,7 +1272,7 @@ public class Analysis
     public Set<SourceColumn> getExpressionSourceColumns(Expression expression)
     {
         return fieldLineage.get(NodeRef.of(expression)).stream()
-                .flatMap(field -> originColumnDetails.get(field).stream())
+                .flatMap(field -> getDirectLineageEntries(field).stream())
                 .map(entry -> new SourceColumn(entry.getTableName(), entry.getColumnName()))
                 .collect(toImmutableSet());
     }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.ColumnLineageEntry;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.SourceColumn;
 import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.TransformationSubtype;
+import com.facebook.presto.common.TransformationType;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
@@ -229,8 +231,10 @@ public class Analysis
     // Track WHERE clause from the query accessing a view for subquery analysis such as materialized view
     private Optional<Expression> viewAccessorWhereClause = Optional.empty();
 
-    // Maps each output Field to its originating SourceColumn(s) for column-level lineage tracking.
-    private final Multimap<Field, SourceColumn> originColumnDetails = HashMultimap.create();
+    // Maps each output Field to its DIRECT column-lineage entries (table column + DIRECT/<subtype>).
+    // Subtype defaults to IDENTITY for legacy callers; SELECT-list analysis populates
+    // TRANSFORMATION or AGGREGATION when the expression is non-trivial.
+    private final Multimap<Field, ColumnLineageEntry> originColumnDetails = HashMultimap.create();
 
     // Maps each analyzed Expression to the Field(s) it produces, supporting expression-level lineage.
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
@@ -1186,22 +1190,72 @@ public class Analysis
 
     public void addSourceColumns(Field field, Set<SourceColumn> sourceColumn)
     {
-        originColumnDetails.putAll(field, sourceColumn);
+        addSourceColumns(field, sourceColumn, TransformationSubtype.IDENTITY);
+    }
+
+    public void addSourceColumns(Field field, Set<SourceColumn> sourceColumn, TransformationSubtype subtype)
+    {
+        requireNonNull(subtype, "subtype is null");
+        for (SourceColumn source : sourceColumn) {
+            originColumnDetails.put(field, new ColumnLineageEntry(
+                    source.getTableName(),
+                    source.getColumnName(),
+                    TransformationType.DIRECT,
+                    subtype));
+        }
+    }
+
+    /**
+     * Add raw {@link ColumnLineageEntry} entries (preserving subtype) as
+     * direct lineage for {@code field}. Use this when copying lineage from
+     * upstream fields where the original subtype matters — e.g. a bare
+     * column reference at the SELECT level that wraps an aggregated or
+     * transformed inner column.
+     */
+    public void addColumnLineageEntries(Field field, Set<ColumnLineageEntry> entries)
+    {
+        originColumnDetails.putAll(field, entries);
     }
 
     public Set<SourceColumn> getSourceColumns(Field field)
+    {
+        return originColumnDetails.get(field).stream()
+                .map(entry -> new SourceColumn(entry.getTableName(), entry.getColumnName()))
+                .collect(toImmutableSet());
+    }
+
+    /**
+     * Subtype-preserving counterpart to {@link #getSourceColumns(Field)}.
+     * Returns the direct {@link ColumnLineageEntry} entries for this field
+     * exactly as the analyzer recorded them.
+     */
+    public Set<ColumnLineageEntry> getDirectLineageEntries(Field field)
     {
         return ImmutableSet.copyOf(originColumnDetails.get(field));
     }
 
     /**
-     * Propagates all lineage (direct source columns + per-field indirect) from sourceField to newField.
-     * Use this whenever creating a new Field that represents the same column through an alias, CTE,
-     * view, or set operation to avoid missing propagation.
+     * Subtype-preserving counterpart to
+     * {@link #getExpressionSourceColumns(Expression)}: returns the direct
+     * {@link ColumnLineageEntry} entries reachable from the fields this
+     * expression produces, preserving each entry's transformation subtype.
+     */
+    public Set<ColumnLineageEntry> getExpressionDirectLineageEntries(Expression expression)
+    {
+        return fieldLineage.get(NodeRef.of(expression)).stream()
+                .flatMap(field -> originColumnDetails.get(field).stream())
+                .collect(toImmutableSet());
+    }
+
+    /**
+     * Propagates all lineage (direct source columns with their transformation
+     * subtype + per-field indirect) from sourceField to newField. Use this
+     * whenever creating a new Field that represents the same column through
+     * an alias, CTE, view, or set operation to avoid missing propagation.
      */
     public void propagateLineage(Field newField, Field sourceField)
     {
-        addSourceColumns(newField, getSourceColumns(sourceField));
+        originColumnDetails.putAll(newField, originColumnDetails.get(sourceField));
         addPerFieldIndirectSources(newField, getPerFieldIndirectSources(sourceField));
     }
 
@@ -1218,7 +1272,8 @@ public class Analysis
     public Set<SourceColumn> getExpressionSourceColumns(Expression expression)
     {
         return fieldLineage.get(NodeRef.of(expression)).stream()
-                .flatMap(field -> getSourceColumns(field).stream())
+                .flatMap(field -> originColumnDetails.get(field).stream())
+                .map(entry -> new SourceColumn(entry.getTableName(), entry.getColumnName()))
                 .collect(toImmutableSet());
     }
 
@@ -1258,6 +1313,24 @@ public class Analysis
     public Set<ColumnLineageEntry> getAllIndirectSourcesForField(Field field)
     {
         ImmutableSet.Builder<ColumnLineageEntry> builder = ImmutableSet.builder();
+        builder.addAll(indirectSourceColumns);
+        builder.addAll(perFieldIndirectSources.get(field));
+        return builder.build();
+    }
+
+    /**
+     * Returns the unified column-lineage for a field, combining direct
+     * sources (each carrying its {@link TransformationType#DIRECT}
+     * subtype as recorded by the analyzer) and all indirect sources
+     * (query-level + per-field). New code constructing
+     * {@code OutputColumnMetadata} should prefer this over the split
+     * {@link #getSourceColumns(Field)} / {@link #getAllIndirectSourcesForField(Field)}
+     * accessors.
+     */
+    public Set<ColumnLineageEntry> getColumnLineageForField(Field field)
+    {
+        ImmutableSet.Builder<ColumnLineageEntry> builder = ImmutableSet.builder();
+        builder.addAll(originColumnDetails.get(field));
         builder.addAll(indirectSourceColumns);
         builder.addAll(perFieldIndirectSources.get(field));
         return builder.build();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -575,7 +575,7 @@ class StatementAnalyzer
             // Query-level indirect sources (WHERE, JOIN, GROUP BY, etc.) apply to all columns.
             // Per-field indirect sources (CONDITIONAL, WINDOW) apply only to the column whose expression contains them.
             analysis.setUpdatedSourceColumns(Optional.of(Streams.zip(
-                            columnStream, queryScope.getRelationType().getVisibleFields().stream(), (column, field) -> new OutputColumnMetadata(column.getName(), column.getType(), analysis.getSourceColumns(field), analysis.getAllIndirectSourcesForField(field)))
+                            columnStream, queryScope.getRelationType().getVisibleFields().stream(), (column, field) -> OutputColumnMetadata.fromColumnLineage(column.getName(), column.getType(), analysis.getColumnLineageForField(field)))
                     .collect(toImmutableList())));
 
             return createAndAssignScope(insert, scope, Field.newUnqualified(insert.getLocation(), "rows", BIGINT));
@@ -826,7 +826,7 @@ class StatementAnalyzer
                         throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown at position %s", queryScope.getRelationType().indexOf(field) + 1);
                     }
                     String columnName = node.getColumnAliases().get().get(aliasPosition).getValue();
-                    outputColumns.add(new OutputColumnMetadata(columnName, field.getType().toString(), analysis.getSourceColumns(field), analysis.getAllIndirectSourcesForField(field)));
+                    outputColumns.add(OutputColumnMetadata.fromColumnLineage(columnName, field.getType().toString(), analysis.getColumnLineageForField(field)));
                     aliasPosition++;
                 }
             }
@@ -842,7 +842,7 @@ class StatementAnalyzer
 
         private OutputColumnMetadata createOutputColumn(Field field)
         {
-            return new OutputColumnMetadata(field.getName().get(), field.getType().toString(), analysis.getSourceColumns(field), analysis.getAllIndirectSourcesForField(field));
+            return OutputColumnMetadata.fromColumnLineage(field.getName().get(), field.getType().toString(), analysis.getColumnLineageForField(field));
         }
 
         @Override
@@ -4369,26 +4369,46 @@ class StatementAnalyzer
                         }
                     }
                     Field newField = Field.newUnqualified(expression.getLocation(), field.map(Identifier::getValue), analysis.getType(expression), originTable, originColumn, column.getAlias().isPresent());
-                    // Use getExpressionSourceColumns first — it correctly traces through
-                    // UNION, subqueries, and CTEs to all base table columns.
-                    // Only fall back to the originTable shortcut if expression tracing returns empty.
-                    Set<SourceColumn> expressionSources = analysis.getExpressionSourceColumns(expression);
-                    if (!expressionSources.isEmpty()) {
-                        // Remove CASE/IF condition-only and window-only columns from direct sources.
-                        // They are tracked separately as INDIRECT/CONDITIONAL and INDIRECT/WINDOW.
-                        Set<SourceColumn> excludeFromDirect = ImmutableSet.<SourceColumn>builder()
-                                .addAll(getConditionOnlySourceColumns(expression))
-                                .addAll(getWindowOnlySourceColumns(expression))
-                                .build();
-                        if (!excludeFromDirect.isEmpty()) {
-                            expressionSources = ImmutableSet.copyOf(Sets.difference(expressionSources, excludeFromDirect));
+                    TransformationSubtype directSubtype = determineDirectSubtype(expression);
+                    if (directSubtype == TransformationSubtype.IDENTITY) {
+                        // Bare Identifier / DereferenceExpression — preserve upstream subtype verbatim
+                        // so a chain like SELECT x FROM (SELECT sum(a) AS x ...) keeps AGGREGATION on `a`.
+                        // CASE/window cannot appear inside a bare reference, so no exclude filter is needed.
+                        Set<ColumnLineageEntry> inheritedDirect = analysis.getExpressionDirectLineageEntries(expression);
+                        if (!inheritedDirect.isEmpty()) {
+                            analysis.addColumnLineageEntries(newField, inheritedDirect);
                         }
-                        analysis.addSourceColumns(newField, expressionSources);
+                        else if (originTable.isPresent()) {
+                            analysis.addSourceColumns(newField, ImmutableSet.of(
+                                    new SourceColumn(originTable.get(), originColumn.orElseThrow(
+                                            () -> new NoSuchElementException("originColumn not found")))),
+                                    TransformationSubtype.IDENTITY);
+                        }
                     }
-                    else if (originTable.isPresent()) {
-                        analysis.addSourceColumns(newField, ImmutableSet.of(
-                                new SourceColumn(originTable.get(), originColumn.orElseThrow(
-                                        () -> new NoSuchElementException("originColumn not found")))));
+                    else {
+                        // TRANSFORMATION or AGGREGATION — retag all source columns with the new subtype.
+                        // Use getExpressionSourceColumns first — it correctly traces through UNION,
+                        // subqueries, and CTEs to all base table columns. Only fall back to the
+                        // originTable shortcut if expression tracing returns empty.
+                        Set<SourceColumn> expressionSources = analysis.getExpressionSourceColumns(expression);
+                        if (!expressionSources.isEmpty()) {
+                            // Remove CASE/IF condition-only and window-only columns from direct sources.
+                            // They are tracked separately as INDIRECT/CONDITIONAL and INDIRECT/WINDOW.
+                            Set<SourceColumn> excludeFromDirect = ImmutableSet.<SourceColumn>builder()
+                                    .addAll(getConditionOnlySourceColumns(expression))
+                                    .addAll(getWindowOnlySourceColumns(expression))
+                                    .build();
+                            if (!excludeFromDirect.isEmpty()) {
+                                expressionSources = ImmutableSet.copyOf(Sets.difference(expressionSources, excludeFromDirect));
+                            }
+                            analysis.addSourceColumns(newField, expressionSources, directSubtype);
+                        }
+                        else if (originTable.isPresent()) {
+                            analysis.addSourceColumns(newField, ImmutableSet.of(
+                                    new SourceColumn(originTable.get(), originColumn.orElseThrow(
+                                            () -> new NoSuchElementException("originColumn not found")))),
+                                    directSubtype);
+                        }
                     }
 
                     // Collect per-field indirect sources (CONDITIONAL, WINDOW).
@@ -4565,6 +4585,38 @@ class StatementAnalyzer
                     .map(sc -> new ColumnLineageEntry(sc.getTableName(), sc.getColumnName(), TransformationType.INDIRECT, subtype))
                     .collect(toImmutableSet());
             analysis.addIndirectSourceColumns(entries);
+        }
+
+        /**
+         * Pick the {@link TransformationSubtype} for the direct sources of a
+         * SELECT-list expression:
+         * <ul>
+         *   <li>{@link TransformationSubtype#AGGREGATION} if the expression
+         *   contains an aggregate function call (e.g. {@code sum(x)},
+         *   including aggregate functions used as window functions like
+         *   {@code sum(x) OVER (...)}).</li>
+         *   <li>{@link TransformationSubtype#IDENTITY} if the expression is a
+         *   bare column reference (an {@link Identifier} or
+         *   {@link DereferenceExpression}) — the output column is literally
+         *   that source column.</li>
+         *   <li>{@link TransformationSubtype#TRANSFORMATION} otherwise (any
+         *   non-aggregate scalar expression: arithmetic, function calls,
+         *   {@code CAST}, {@code CASE}, etc.). Pure window functions like
+         *   {@code ROW_NUMBER() OVER (...)} also fall into this bucket — they
+         *   are non-aggregate function calls. INDIRECT window-frame columns
+         *   (PARTITION BY / ORDER BY inputs) are tracked separately as
+         *   {@link TransformationSubtype#WINDOW}.</li>
+         * </ul>
+         */
+        private TransformationSubtype determineDirectSubtype(Expression expression)
+        {
+            if (!extractAggregateFunctions(analysis.getFunctionHandles(), ImmutableList.of(expression), functionAndTypeResolver).isEmpty()) {
+                return TransformationSubtype.AGGREGATION;
+            }
+            if (expression instanceof Identifier || expression instanceof DereferenceExpression) {
+                return TransformationSubtype.IDENTITY;
+            }
+            return TransformationSubtype.TRANSFORMATION;
         }
 
         /**

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -78,4 +78,34 @@ public class TestOutput
 
         assertEquals(actual, expected);
     }
+
+    @Test
+    public void testRoundTripWithUnifiedColumnLineage()
+    {
+        QualifiedObjectName tableName = QualifiedObjectName.valueOf("catalog.schema.table");
+        Output expected = new Output(
+                new ConnectorId("connectorId"),
+                "schema",
+                "table",
+                Optional.of(
+                        ImmutableList.of(
+                                OutputColumnMetadata.fromColumnLineage(
+                                        "revenue", "double",
+                                        ImmutableSet.of(
+                                                new ColumnLineageEntry(tableName, "totalprice", TransformationType.DIRECT, TransformationSubtype.AGGREGATION),
+                                                new ColumnLineageEntry(tableName, "orderstatus", TransformationType.INDIRECT, TransformationSubtype.FILTER),
+                                                new ColumnLineageEntry(tableName, "custkey", TransformationType.INDIRECT, TransformationSubtype.JOIN))))),
+                Optional.empty());
+
+        String json = codec.toJson(expected);
+        Output actual = codec.fromJson(json);
+
+        assertEquals(actual, expected);
+
+        OutputColumnMetadata column = actual.getColumns().get().get(0);
+        // Direct AGGREGATION entry projects back to a SourceColumn via the legacy getter
+        assertEquals(column.getSourceColumns().size(), 1);
+        assertEquals(column.getIndirectSourceColumns().size(), 2);
+        assertEquals(column.getColumnLineage().size(), 3);
+    }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestIndirectColumnLineage.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestIndirectColumnLineage.java
@@ -2709,6 +2709,138 @@ public class TestIndirectColumnLineage
     }
 
     /**
+     * Assert the per-output-column DIRECT-lineage entries (subtype-aware), as
+     * exposed by {@link Analysis#getColumnLineageForField(Field)}. Compared
+     * against a map of output-column-name to the expected set of DIRECT
+     * {@link ColumnLineageEntry} (including subtype). INDIRECT entries are
+     * stripped before comparison so this helper focuses on the direct subtype.
+     */
+    private void assertDirectLineageWithSubtype(
+            @Language("SQL") String query,
+            Map<String, Set<ColumnLineageEntry>> expectedDirectPerColumn)
+    {
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .readOnly()
+                .execute(CLIENT_SESSION, session -> {
+                    Analyzer analyzer = createAnalyzer(session, metadata, WarningCollector.NOOP, Optional.empty(), query);
+                    Statement statement = SQL_PARSER.createStatement(query);
+                    Analysis analysis = analyzer.analyzeSemantic(statement, false);
+
+                    Map<String, Set<ColumnLineageEntry>> actual = new LinkedHashMap<>();
+                    for (Field field : analysis.getOutputDescriptor().getVisibleFields()) {
+                        String name = field.getName().orElse("?");
+                        Set<ColumnLineageEntry> directOnly = analysis.getColumnLineageForField(field).stream()
+                                .filter(entry -> entry.getTransformationType() == TransformationType.DIRECT)
+                                .collect(ImmutableSet.toImmutableSet());
+                        actual.put(name, directOnly);
+                    }
+                    assertEquals(actual, expectedDirectPerColumn,
+                            "Direct-lineage subtype mismatch for: " + query);
+                });
+    }
+
+    private static ColumnLineageEntry directWithSubtype(QualifiedObjectName table, String column, TransformationSubtype subtype)
+    {
+        return new ColumnLineageEntry(table, column, TransformationType.DIRECT, subtype);
+    }
+
+    @Test
+    public void testDirectSubtypeIdentityForBareColumnReference()
+    {
+        assertDirectLineageWithSubtype(
+                "SELECT a, b FROM t1",
+                ImmutableMap.of(
+                        "a", ImmutableSet.of(directWithSubtype(T1, "a", TransformationSubtype.IDENTITY)),
+                        "b", ImmutableSet.of(directWithSubtype(T1, "b", TransformationSubtype.IDENTITY))));
+    }
+
+    @Test
+    public void testDirectSubtypeTransformationForScalarExpression()
+    {
+        assertDirectLineageWithSubtype(
+                "SELECT a + b AS x, cast(c AS varchar) AS y FROM t1",
+                ImmutableMap.of(
+                        "x", ImmutableSet.of(
+                                directWithSubtype(T1, "a", TransformationSubtype.TRANSFORMATION),
+                                directWithSubtype(T1, "b", TransformationSubtype.TRANSFORMATION)),
+                        "y", ImmutableSet.of(
+                                directWithSubtype(T1, "c", TransformationSubtype.TRANSFORMATION))));
+    }
+
+    @Test
+    public void testDirectSubtypeAggregationForAggregateExpression()
+    {
+        assertDirectLineageWithSubtype(
+                "SELECT sum(a) AS s, max(b) AS m FROM t1",
+                ImmutableMap.of(
+                        "s", ImmutableSet.of(directWithSubtype(T1, "a", TransformationSubtype.AGGREGATION)),
+                        "m", ImmutableSet.of(directWithSubtype(T1, "b", TransformationSubtype.AGGREGATION))));
+    }
+
+    @Test
+    public void testDirectSubtypeAggregationPropagatesAcrossMultipleSources()
+    {
+        // sum(a + b) — both a and b feed an aggregate, so both record AGGREGATION
+        // (not TRANSFORMATION). Subtype is determined by the outermost SELECT expression.
+        assertDirectLineageWithSubtype(
+                "SELECT sum(a + b) AS s FROM t1",
+                ImmutableMap.of(
+                        "s", ImmutableSet.of(
+                                directWithSubtype(T1, "a", TransformationSubtype.AGGREGATION),
+                                directWithSubtype(T1, "b", TransformationSubtype.AGGREGATION))));
+    }
+
+    @Test
+    public void testDirectSubtypePreservedThroughBareReferenceFromSubquery()
+    {
+        // Inner SELECT applies an aggregate; outer SELECT is a bare column reference.
+        // The outer Identifier must inherit AGGREGATION from the inner — not re-tag as IDENTITY.
+        assertDirectLineageWithSubtype(
+                "SELECT x FROM (SELECT sum(a) AS x FROM t1)",
+                ImmutableMap.of(
+                        "x", ImmutableSet.of(directWithSubtype(T1, "a", TransformationSubtype.AGGREGATION))));
+    }
+
+    @Test
+    public void testDirectSubtypePreservedThroughBareReferenceFromScalarExpression()
+    {
+        // Inner SELECT applies a TRANSFORMATION; outer is a bare reference.
+        // Bare reference inherits TRANSFORMATION verbatim from the inner.
+        assertDirectLineageWithSubtype(
+                "SELECT x FROM (SELECT a + b AS x FROM t1)",
+                ImmutableMap.of(
+                        "x", ImmutableSet.of(
+                                directWithSubtype(T1, "a", TransformationSubtype.TRANSFORMATION),
+                                directWithSubtype(T1, "b", TransformationSubtype.TRANSFORMATION))));
+    }
+
+    @Test
+    public void testDirectSubtypePreservedThroughCte()
+    {
+        // Same shape but using a CTE — subtype propagation must survive
+        // CTE expansion just like subquery expansion.
+        assertDirectLineageWithSubtype(
+                "WITH cte AS (SELECT sum(a) AS x FROM t1) SELECT x FROM cte",
+                ImmutableMap.of(
+                        "x", ImmutableSet.of(directWithSubtype(T1, "a", TransformationSubtype.AGGREGATION))));
+    }
+
+    @Test
+    public void testDirectSubtypeRetagsWhenOuterAppliesTransformation()
+    {
+        // Outer SELECT applies an arithmetic transformation on an inner aggregate result.
+        // The outer expression is non-trivial (x + 1), so subtype reflects the OUTER op:
+        // TRANSFORMATION. Information about the inner AGGREGATION is lost — that's the
+        // documented semantic ("subtype describes the most recent non-trivial transformation").
+        assertDirectLineageWithSubtype(
+                "SELECT x + 1 AS y FROM (SELECT sum(a) AS x FROM t1)",
+                ImmutableMap.of(
+                        "y", ImmutableSet.of(directWithSubtype(T1, "a", TransformationSubtype.TRANSFORMATION))));
+    }
+
+    /**
      * Assert per-target-column direct and indirect lineage for write statements
      * (INSERT INTO ... SELECT and CREATE TABLE AS SELECT). Reads from
      * {@link Analysis#getUpdatedSourceColumns()}, which holds an

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OutputColumnMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OutputColumnMetadata.java
@@ -15,38 +15,99 @@ package com.facebook.presto.spi.eventlistener;
 
 import com.facebook.presto.common.ColumnLineageEntry;
 import com.facebook.presto.common.SourceColumn;
+import com.facebook.presto.common.TransformationSubtype;
+import com.facebook.presto.common.TransformationType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Per-output-column lineage metadata exposed to event listeners.
+ *
+ * <p>Internally, all lineage is stored as a single {@link Set} of
+ * {@link ColumnLineageEntry}. {@link TransformationType#DIRECT} entries are
+ * what older consumers know as "source columns" (the columns projected into
+ * the output), and {@link TransformationType#INDIRECT} entries describe
+ * columns that influenced the output without being projected (JOIN keys,
+ * filter predicates, GROUP BY columns, etc).
+ *
+ * <p>For backward compatibility, {@link #getSourceColumns()} and
+ * {@link #getIndirectSourceColumns()} are retained as derived views of the
+ * unified set. New code should prefer {@link #getColumnLineage()} and
+ * {@link #fromColumnLineage}.
+ */
 public class OutputColumnMetadata
 {
     private final String columnName;
     private final String columnType;
-    private final Set<SourceColumn> sourceColumns;
-    private final Set<ColumnLineageEntry> indirectSourceColumns;
+    private final Set<ColumnLineageEntry> columnLineage;
 
+    /**
+     * @deprecated prefer {@link #fromColumnLineage(String, String, Set)}
+     * which carries transformation metadata. This constructor records the
+     * given source columns as {@code DIRECT/IDENTITY} entries.
+     */
+    @Deprecated
     public OutputColumnMetadata(String columnName, String columnType, Set<SourceColumn> sourceColumns)
     {
-        this(columnName, columnType, sourceColumns, Collections.emptySet());
+        this(columnName, columnType, sourceColumns, Collections.emptySet(), null);
     }
 
+    /**
+     * @deprecated prefer {@link #fromColumnLineage(String, String, Set)}
+     * which avoids the split between {@code SourceColumn} (DIRECT) and
+     * {@code ColumnLineageEntry} (INDIRECT). This constructor records the
+     * given source columns as {@code DIRECT/IDENTITY} entries and merges
+     * them with {@code indirectSourceColumns} into the unified store.
+     */
+    @Deprecated
+    public OutputColumnMetadata(
+            String columnName,
+            String columnType,
+            Set<SourceColumn> sourceColumns,
+            Set<ColumnLineageEntry> indirectSourceColumns)
+    {
+        this(columnName, columnType, sourceColumns, indirectSourceColumns, null);
+    }
+
+    /**
+     * @deprecated prefer {@link #fromColumnLineage(String, String, Set)}.
+     * Retained as the JSON creator so that payloads from older producers,
+     * which serialize {@code sourceColumns} and {@code indirectSourceColumns}
+     * separately, continue to deserialize. Newer payloads carrying
+     * {@code columnLineage} are also accepted; when present it takes
+     * precedence over the split fields.
+     */
+    @Deprecated
     @JsonCreator
     public OutputColumnMetadata(
             @JsonProperty("columnName") String columnName,
             @JsonProperty("columnType") String columnType,
             @JsonProperty("sourceColumns") Set<SourceColumn> sourceColumns,
-            @JsonProperty("indirectSourceColumns") Set<ColumnLineageEntry> indirectSourceColumns)
+            @JsonProperty("indirectSourceColumns") Set<ColumnLineageEntry> indirectSourceColumns,
+            @JsonProperty("columnLineage") Set<ColumnLineageEntry> columnLineage)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
-        this.sourceColumns = requireNonNull(sourceColumns, "sourceColumns is null");
-        this.indirectSourceColumns = requireNonNull(indirectSourceColumns, "indirectSourceColumns is null");
+        this.columnLineage = unifyLineage(sourceColumns, indirectSourceColumns, columnLineage);
+    }
+
+    /**
+     * Build an {@code OutputColumnMetadata} from a unified column-lineage set
+     * carrying both DIRECT and INDIRECT entries.
+     */
+    public static OutputColumnMetadata fromColumnLineage(String columnName, String columnType, Set<ColumnLineageEntry> columnLineage)
+    {
+        requireNonNull(columnLineage, "columnLineage is null");
+        return new OutputColumnMetadata(columnName, columnType, null, null, columnLineage);
     }
 
     @JsonProperty
@@ -61,22 +122,56 @@ public class OutputColumnMetadata
         return columnType;
     }
 
+    /**
+     * @deprecated use {@link #getColumnLineage()}. Returns only the
+     * DIRECT entries from {@link #getColumnLineage()} projected back to
+     * {@link SourceColumn}, dropping the transformation metadata.
+     */
+    @Deprecated
     @JsonProperty
     public Set<SourceColumn> getSourceColumns()
     {
-        return sourceColumns;
+        return columnLineage.stream()
+                .filter(entry -> entry.getTransformationType() == TransformationType.DIRECT)
+                .map(entry -> new SourceColumn(entry.getTableName(), entry.getColumnName()))
+                .collect(toUnmodifiableLinkedSet());
     }
 
+    /**
+     * @deprecated use {@link #getColumnLineage()}. Returns only the
+     * INDIRECT entries from {@link #getColumnLineage()}.
+     */
+    @Deprecated
     @JsonProperty
     public Set<ColumnLineageEntry> getIndirectSourceColumns()
     {
-        return indirectSourceColumns;
+        return columnLineage.stream()
+                .filter(entry -> entry.getTransformationType() == TransformationType.INDIRECT)
+                .collect(toUnmodifiableLinkedSet());
+    }
+
+    private static <T> Collector<T, ?, Set<T>> toUnmodifiableLinkedSet()
+    {
+        return Collectors.collectingAndThen(
+                Collectors.toCollection(LinkedHashSet::new),
+                Collections::unmodifiableSet);
+    }
+
+    /**
+     * Unified DIRECT + INDIRECT column-lineage entries for this output column.
+     * Each entry carries the upstream table/column plus transformation type
+     * and subtype.
+     */
+    @JsonProperty
+    public Set<ColumnLineageEntry> getColumnLineage()
+    {
+        return columnLineage;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(columnName, columnType, sourceColumns, indirectSourceColumns);
+        return Objects.hash(columnName, columnType, columnLineage);
     }
 
     @Override
@@ -91,7 +186,30 @@ public class OutputColumnMetadata
         OutputColumnMetadata other = (OutputColumnMetadata) obj;
         return Objects.equals(columnName, other.columnName) &&
                 Objects.equals(columnType, other.columnType) &&
-                Objects.equals(sourceColumns, other.sourceColumns) &&
-                Objects.equals(indirectSourceColumns, other.indirectSourceColumns);
+                Objects.equals(columnLineage, other.columnLineage);
+    }
+
+    private static Set<ColumnLineageEntry> unifyLineage(
+            Set<SourceColumn> sourceColumns,
+            Set<ColumnLineageEntry> indirectSourceColumns,
+            Set<ColumnLineageEntry> columnLineage)
+    {
+        if (columnLineage != null && !columnLineage.isEmpty()) {
+            return Collections.unmodifiableSet(new LinkedHashSet<>(columnLineage));
+        }
+        LinkedHashSet<ColumnLineageEntry> merged = new LinkedHashSet<>();
+        if (sourceColumns != null) {
+            for (SourceColumn source : sourceColumns) {
+                merged.add(new ColumnLineageEntry(
+                        source.getTableName(),
+                        source.getColumnName(),
+                        TransformationType.DIRECT,
+                        TransformationSubtype.IDENTITY));
+            }
+        }
+        if (indirectSourceColumns != null) {
+            merged.addAll(indirectSourceColumns);
+        }
+        return Collections.unmodifiableSet(merged);
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #27695. Migrate `OutputColumnMetadata` to a single `Set<ColumnLineageEntry> columnLineage` field, so that the existing DIRECT (projected) lineage and the new INDIRECT (`JOIN`, `FILTER`, `GROUP_BY`, `SORT`, `WINDOW`, `CONDITIONAL`) lineage share one structured representation. `TransformationType.DIRECT` becomes one transformation type among others — the migration that the original PR's design note [explicitly deferred to a follow-up](https://github.com/prestodb/presto/pull/27695#description).

### What changed

`presto-spi`
- `OutputColumnMetadata` now stores a single `Set<ColumnLineageEntry> columnLineage`. New static factory `OutputColumnMetadata.fromColumnLineage(name, type, columnLineage)` for unified construction.
- `getSourceColumns()` and `getIndirectSourceColumns()` are retained (deprecated) as derived views — they filter the unified set by `TransformationType`.

`presto-analyzer`
- New `Analysis.getColumnLineageForField(Field)` returns the unified view: direct sources (as `DIRECT/IDENTITY` entries) merged with query-level and per-field indirect sources.

`presto-main-base`
- Three `OutputColumnMetadata` construction sites in `StatementAnalyzer` updated to use `fromColumnLineage` + `getColumnLineageForField`.
- `TestOutput` extended with `testRoundTripWithUnifiedColumnLineage` covering the new field.

### Backward compatibility

This change keeps every existing entry point on `OutputColumnMetadata` functional:

- **Java callers**: the existing 3-arg and 4-arg public constructors are retained (deprecated) — old call sites compile and run unchanged. They convert their `SourceColumn` arguments into `DIRECT/IDENTITY` entries when populating the unified store.
- **JSON producers** continue to emit `sourceColumns` and `indirectSourceColumns` alongside the new `columnLineage` field, so old consumers reading new payloads still see what they expect.
- **JSON consumers**: payloads from older producers (without `columnLineage`) deserialize through the existing fields. Payloads carrying `columnLineage` take precedence when both shapes are present.
- **Event listeners** that read `getSourceColumns()` / `getIndirectSourceColumns()` are unaffected — those methods now return derived views of the unified set, but the contents are identical to before.

The deprecation tags mark a direction for migration without forcing it. Existing consumers (Uber's internal lineage pipeline, the OpenLineage event listener, any third-party listeners) keep working.

## Motivation and Context

Per #27695's design note: "Longer term, it would be cleaner to unify direct and indirect relationships into the new `ColumnLineageEntry` / relationship-metadata structure (DIRECT becomes one transformation type among others). That migration is intentionally deferred to a follow-up to avoid breaking downstream consumers of the existing direct-lineage API in this PR."

This PR is that follow-up. With the unified structure in place, downstream consumers can adopt `getColumnLineage()` to read all relationships through one API, and the analyzer no longer has to maintain two parallel lineage stores conceptually (though the internal `Analysis` storage stays split for minimal diff — a separate refactor could collapse that further).

## Impact

- SPI: deprecates `OutputColumnMetadata#getSourceColumns()`, `#getIndirectSourceColumns()`, and the three old public constructors. None are removed. Adds `getColumnLineage()` and `fromColumnLineage(...)`.
- Event listeners: query-completed events now expose `columnLineage` on each `OutputColumnMetadata` in addition to the existing fields.
- No SQL syntax or query-execution behavior changes.

## Test Plan

- New `TestOutput#testRoundTripWithUnifiedColumnLineage` covers JSON round-trip of the unified `columnLineage` field and verifies that the deprecated accessors still partition the unified set into the expected DIRECT and INDIRECT views.
- Existing `TestOutput#testRoundTrip` and `testRoundTripWithIndirectLineage` pass unchanged — backward compatibility for the old constructors and JSON shape.
- `TestIndirectColumnLineage` (165 cases) passes unchanged against the new SPI and analyzer wiring.
- OpenLineage event listener tests (12 cases in `presto-openlineage-event-listener`) pass unchanged — confirms downstream consumers of `getSourceColumns()` are unaffected.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md).
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new SPI surface in javadoc.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

SPI Changes
* Add ``OutputColumnMetadata.getColumnLineage()`` returning a unified ``Set<ColumnLineageEntry>`` that covers both DIRECT and INDIRECT lineage from :pr:`27695`, with direct entries carrying ``IDENTITY``, ``TRANSFORMATION``, or ``AGGREGATION`` subtypes derived from the SELECT-list expression. ``getSourceColumns()`` and ``getIndirectSourceColumns()`` are retained as derived views and marked ``@Deprecated``; existing event listeners and JSON consumers are unaffected.
```
