### PR TITLE
feat(planner): Support expression GROUP BY keys and conditional aggregates in materialized view query rewriting

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -366,6 +366,24 @@ public final class ExpressionUtils
         return expression;
     }
 
+    public static Expression deepRemoveExpressionPrefix(Expression expression, Optional<Identifier> removablePrefix)
+    {
+        if (!removablePrefix.isPresent()) {
+            return expression;
+        }
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (removablePrefix.get().equals(node.getBase())) {
+                    return node.getField();
+                }
+                return treeRewriter.defaultRewrite(node, context);
+            }
+        }, expression);
+    }
+
     private static Expression removeDereferenceExpressionElementPrefix(DereferenceExpression dereferenceExpression, Optional<Identifier> removablePrefix)
     {
         if (removablePrefix.isPresent() && removablePrefix.get().equals(dereferenceExpression.getBase())) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -92,8 +92,9 @@ public final class MaterializedViewUtils
     public static final QualifiedName MERGE = QualifiedName.of("MERGE");
     public static final QualifiedName APPROX_DISTINCT = QualifiedName.of("APPROX_DISTINCT");
     public static final QualifiedName APPROX_SET = QualifiedName.of("APPROX_SET");
+    public static final QualifiedName SET_UNION = QualifiedName.of("SET_UNION");
 
-    public static final Set<QualifiedName> ASSOCIATIVE_REWRITE_FUNCTIONS = ImmutableSet.of(MIN, MAX, SUM, COUNT);
+    public static final Set<QualifiedName> ASSOCIATIVE_REWRITE_FUNCTIONS = ImmutableSet.of(MIN, MAX, SUM, COUNT, SET_UNION);
 
     // TODO: Add count to NonAssociativeFunctionHandler, add more functions
     public static final Map<QualifiedName, MaterializedViewUtils.NonAssociativeFunctionHandler> NON_ASSOCIATIVE_REWRITE_FUNCTIONS = ImmutableMap.of(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.sql.ExpressionUtils.deepRemoveExpressionPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeGroupingElementPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeSingleColumnPrefix;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
@@ -107,7 +108,7 @@ public class MaterializedViewInformationExtractor
         private void addBaseToViewColumn(SingleColumn singleColumn)
         {
             singleColumn = removeSingleColumnPrefix(singleColumn, removablePrefix);
-            Expression key = singleColumn.getExpression();
+            Expression key = deepRemoveExpressionPrefix(singleColumn.getExpression(), removablePrefix);
             if (key instanceof FunctionCall && !singleColumn.getAlias().isPresent()) {
                 throw new SemanticException(NOT_SUPPORTED, singleColumn, "Derived field in materialized view must have an alias");
             }
@@ -119,7 +120,9 @@ public class MaterializedViewInformationExtractor
             if (!groupBy.isPresent()) {
                 groupBy = Optional.of(new HashSet<>());
             }
-            groupBy.get().addAll(removeGroupingElementPrefix(groupingElement, removablePrefix).getExpressions());
+            for (Expression expr : removeGroupingElementPrefix(groupingElement, removablePrefix).getExpressions()) {
+                groupBy.get().add(deepRemoveExpressionPrefix(expr, removablePrefix));
+            }
         }
 
         private void setBaseTable(Relation baseTable)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -106,7 +106,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.and;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.relation.DomainTranslator.BASIC_COLUMN_EXTRACTOR;
 import static com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
-import static com.facebook.presto.sql.ExpressionUtils.removeExpressionPrefix;
+import static com.facebook.presto.sql.ExpressionUtils.deepRemoveExpressionPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeGroupingElementPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeSingleColumnPrefix;
 import static com.facebook.presto.sql.ExpressionUtils.removeSortItemPrefix;
@@ -525,7 +525,7 @@ public class MaterializedViewQueryOptimizer
                     if (groupByOfMaterializedView.isPresent()) {
                         for (Expression expression : element.getExpressions()) {
                             // Resolve ordinal references (e.g. GROUP BY 1) to the corresponding SELECT expression
-                            Expression resolved = expression;
+                            Expression resolved = deepRemoveExpressionPrefix(expression, removablePrefix);
                             if (expression instanceof LongLiteral) {
                                 int ordinal = toIntExact(((LongLiteral) expression).getValue());
                                 if (ordinal < 1 || ordinal > selectItems.size()) {
@@ -533,7 +533,7 @@ public class MaterializedViewQueryOptimizer
                                 }
                                 SelectItem selectItem = selectItems.get(ordinal - 1);
                                 if (selectItem instanceof SingleColumn) {
-                                    resolved = removeExpressionPrefix(((SingleColumn) selectItem).getExpression(), removablePrefix);
+                                    resolved = deepRemoveExpressionPrefix(((SingleColumn) selectItem).getExpression(), removablePrefix);
                                 }
                                 else {
                                     throw new IllegalStateException("GROUP BY ordinal references non-single-column select item");
@@ -616,7 +616,7 @@ public class MaterializedViewQueryOptimizer
             // For relations other than single table, it needs to be reserved to differentiate columns from different tables.
             // One way to do so is to process the prefix within `visitDereferenceExpression()` since the prefix information is saved as `base` in `DereferenceExpression` node.
             node = removeSingleColumnPrefix(node, removablePrefix);
-            Expression expression = node.getExpression();
+            Expression expression = deepRemoveExpressionPrefix(node.getExpression(), removablePrefix);
             Optional<Set<Expression>> groupByOfMaterializedView = materializedViewInfo.getGroupBy();
             // TODO: Replace this logic with rule-based validation framework.
             if (groupByOfMaterializedView.isPresent() &&
@@ -625,12 +625,28 @@ public class MaterializedViewQueryOptimizer
                 throw new IllegalStateException("Query a column presents in materialized view group by: " + expression.toString());
             }
 
-            Expression processedColumn = (Expression) process(expression, context);
+            Expression processedColumn;
+            // A non-aggregate expression that is a grouping key stored as an MV column maps directly to that column.
+            // Aggregate function calls must still go through process() so they are rolled up (e.g. SUM -> SUM(partial)).
+            boolean scalarGroupingKey = expression instanceof FunctionCall
+                    && expressionRewriter.isScalarFunction((FunctionCall) expression)
+                    && expressionsInGroupBy.isPresent()
+                    && expressionsInGroupBy.get().contains(expression);
+            if (!(expression instanceof Identifier)
+                    && (!(expression instanceof FunctionCall) || scalarGroupingKey)
+                    && materializedViewInfo.getBaseToViewColumnMap().containsKey(expression)) {
+                processedColumn = materializedViewInfo.getBaseToViewColumnMap().get(expression);
+            }
+            else {
+                processedColumn = (Expression) process(expression, context);
+            }
             Optional<Identifier> alias = node.getAlias();
 
             // If a column name was rewritten, make sure we re-alias to same name as base query
             if (!alias.isPresent() && processedColumn instanceof Identifier && !processedColumn.equals(node.getExpression())) {
-                alias = Optional.of((Identifier) node.getExpression());
+                if (node.getExpression() instanceof Identifier) {
+                    alias = Optional.of((Identifier) node.getExpression());
+                }
             }
             return new SingleColumn(processedColumn, alias);
         }
@@ -659,7 +675,7 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitExpression(Expression node, Void context)
         {
-            Expression stripped = removeExpressionPrefix(node, removablePrefix);
+            Expression stripped = deepRemoveExpressionPrefix(node, removablePrefix);
             if (stripped != node) {
                 return process(stripped, context);
             }
@@ -809,7 +825,13 @@ public class MaterializedViewQueryOptimizer
             for (GroupingElement element : node.getGroupingElements()) {
                 rewrittenGroupBy.add(MaterializedViewUtils.rewriteGroupingElement(
                         removeGroupingElementPrefix(element, removablePrefix),
-                        expr -> (Expression) process(removeExpressionPrefix(expr, removablePrefix), context)));
+                        expr -> {
+                            Expression stripped = deepRemoveExpressionPrefix(expr, removablePrefix);
+                            if (materializedViewInfo.getBaseToViewColumnMap().containsKey(stripped)) {
+                                return materializedViewInfo.getBaseToViewColumnMap().get(stripped);
+                            }
+                            return (Expression) process(stripped, context);
+                        }));
             }
             return new GroupBy(node.isDistinct(), rewrittenGroupBy.build());
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -984,6 +984,137 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testExpressionGroupByKeys()
+    {
+        // CAST in GROUP BY
+        String originalViewSql = format("SELECT CAST(a AS VARCHAR) AS a_str, SUM(b) AS sum_b FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT CAST(a AS VARCHAR), SUM(b) FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a_str, SUM(sum_b) FROM %s GROUP BY a_str", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Rollup: query GROUP BY is subset of MV expression GROUP BY
+        originalViewSql = format("SELECT CAST(a AS VARCHAR) AS a_str, c, SUM(b) AS sum_b FROM %s GROUP BY CAST(a AS VARCHAR), c", BASE_TABLE_1);
+        baseQuerySql = format("SELECT CAST(a AS VARCHAR), SUM(b) FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a_str, SUM(sum_b) FROM %s GROUP BY a_str", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: different cast type
+        originalViewSql = format("SELECT CAST(a AS VARCHAR) AS a_str, SUM(b) AS sum_b FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        baseQuerySql = format("SELECT CAST(a AS BIGINT), SUM(b) FROM %s GROUP BY CAST(a AS BIGINT)", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: expression GROUP BY without GROUP BY in query
+        originalViewSql = format("SELECT CAST(a AS VARCHAR) AS a_str, SUM(b) AS sum_b FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        baseQuerySql = format("SELECT CAST(a AS VARCHAR) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Aggregate-only rollup with expression GROUP BY
+        originalViewSql = format("SELECT CAST(a AS VARCHAR) AS a_str, SUM(b) AS sum_b FROM %s GROUP BY CAST(a AS VARCHAR)", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(b) FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(sum_b) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Multiple expression GROUP BY keys (substr + CAST together)
+        originalViewSql = format("SELECT substr(c, 1, 1) AS c_pre, CAST(a AS VARCHAR) AS a_str, SUM(b) AS sum_b FROM %s GROUP BY substr(c, 1, 1), CAST(a AS VARCHAR)", BASE_TABLE_1);
+        baseQuerySql = format("SELECT substr(c, 1, 1), CAST(a AS VARCHAR), SUM(b) FROM %s GROUP BY substr(c, 1, 1), CAST(a AS VARCHAR)", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT c_pre, a_str, SUM(sum_b) FROM %s GROUP BY c_pre, a_str", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // GROUP BY ordinal that resolves to an expression key (ordinal preserved, select item rewritten)
+        originalViewSql = format("SELECT substr(c, 1, 1) AS c_pre, SUM(b) AS sum_b FROM %s GROUP BY substr(c, 1, 1)", BASE_TABLE_1);
+        baseQuerySql = format("SELECT substr(c, 1, 1), SUM(b) FROM %s GROUP BY 1", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT c_pre, SUM(sum_b) FROM %s GROUP BY 1", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarFunctionGroupByKeyInSelect()
+    {
+        // Scalar function (substr) as a GROUP BY key, selected in the output: must map to the MV column.
+        String originalViewSql = format("SELECT substr(c, 1, 1) AS c_pre, SUM(b) AS sum_b FROM %s GROUP BY substr(c, 1, 1)", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT substr(c, 1, 1), SUM(b) FROM %s GROUP BY substr(c, 1, 1)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT c_pre, SUM(sum_b) FROM %s GROUP BY c_pre", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Scalar function GROUP BY key plus a rolled-up plain key (mimics ds partition).
+        originalViewSql = format("SELECT substr(c, 1, 1) AS c_pre, d, SUM(b) AS sum_b FROM %s GROUP BY substr(c, 1, 1), d", BASE_TABLE_1);
+        baseQuerySql = format("SELECT substr(c, 1, 1), SUM(b) FROM %s GROUP BY substr(c, 1, 1)", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT c_pre, SUM(sum_b) FROM %s GROUP BY c_pre", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testConditionalAggregates()
+    {
+        // SUM(IF(...)) with matching MV
+        String originalViewSql = format("SELECT a, SUM(IF(a > 0, b, 0)) AS cond_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, SUM(IF(a > 0, b, 0)) FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a, SUM(cond_sum) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // SUM(CASE WHEN ... THEN ... ELSE ... END)
+        originalViewSql = format("SELECT a, SUM(CASE WHEN a > 0 THEN b ELSE 0 END) AS case_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, SUM(CASE WHEN a > 0 THEN b ELSE 0 END) FROM %s GROUP BY a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a, SUM(case_sum) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Rollup: conditional aggregate without GROUP BY
+        originalViewSql = format("SELECT a, SUM(IF(a > 0, b, 0)) AS cond_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(IF(a > 0, b, 0)) FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(cond_sum) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: SUM(IF(...)) when MV only has SUM(b)
+        originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, SUM(IF(a > 0, b, 0)) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Multiple conditional aggregates
+        originalViewSql = format("SELECT a, SUM(IF(a > 0, b, 0)) AS pos_sum, SUM(IF(a <= 0, b, 0)) AS neg_sum FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, SUM(IF(a > 0, b, 0)), SUM(IF(a <= 0, b, 0)) FROM %s GROUP BY a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a, SUM(pos_sum), SUM(neg_sum) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // MIN(CASE WHEN ... THEN ... END) — associative with conditional
+        originalViewSql = format("SELECT a, MIN(CASE WHEN a > 0 THEN b END) AS min_pos FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, MIN(CASE WHEN a > 0 THEN b END) FROM %s GROUP BY a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a, MIN(min_pos) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Conditional COUNT: COUNT(IF(cond, 1, NULL)) rolls up to SUM of the stored conditional count
+        originalViewSql = format("SELECT a, COUNT(IF(a > 0, 1, NULL)) AS cond_cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, COUNT(IF(a > 0, 1, NULL)) FROM %s GROUP BY a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a, SUM(cond_cnt) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // REJECT: COUNT(IF(cond, 1, 0)) differs from the MV's COUNT(IF(cond, 1, NULL)) (counts all rows) — fallback
+        originalViewSql = format("SELECT a, COUNT(IF(a > 0, 1, NULL)) AS cond_cnt FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, COUNT(IF(a > 0, 1, 0)) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testSetUnionRollup()
+    {
+        // SET_UNION is an associative set monoid — rolls up to SET_UNION of the stored set column.
+        String originalViewSql = format("SELECT a, SET_UNION(c) AS union_c FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, SET_UNION(c) FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a, SET_UNION(union_c) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // Rollup: MV grouped by a, query aggregates globally.
+        originalViewSql = format("SELECT a, SET_UNION(c) AS union_c FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SET_UNION(c) FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SET_UNION(union_c) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // SET_UNION(DISTINCT ...) is rejected like other DISTINCT aggregates.
+        originalViewSql = format("SELECT a, SET_UNION(c) AS union_c FROM %s GROUP BY a", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, SET_UNION(DISTINCT c) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithGroupByCube()
     {
         String originalViewSql = format("SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
@@ -2297,6 +2428,26 @@ public class TestMaterializedViewQueryOptimizer
                 VIEW_1, BASE_TABLE_2,
                 VIEW_1, BASE_TABLE_2);
 
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinSetUnion()
+    {
+        // SET_UNION is associative — rewritten directly to SET_UNION of the stored set column on the swapped leaf.
+        String originalViewSql = format("SELECT a, SET_UNION(b) AS union_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a, SET_UNION(%s.b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                BASE_TABLE_1, BASE_TABLE_1,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2,
+                BASE_TABLE_1, BASE_TABLE_2);
+        String expectedRewrittenSql = format(
+                "SELECT %s.a, SET_UNION(%s.union_b) FROM %s JOIN %s ON %s.a = %s.a GROUP BY %s.a, %s.a",
+                VIEW_1, VIEW_1,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2,
+                VIEW_1, BASE_TABLE_2);
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 


### PR DESCRIPTION
Summary:
Extend materialized view query rewriting to cover three more aggregation patterns, so that queries using them can be served from a materialized view instead of scanning the base tables:

- Expression `GROUP BY` keys such as `CAST(a AS VARCHAR)` or `DATE_TRUNC('day', ts)`, when the materialized view groups by the same expression.
- Conditional aggregates: `SUM(IF(...))`, `SUM(CASE WHEN ...)`, and `COUNT(IF(...))`, when the materialized view pre-computes the same expression.
- `SET_UNION`, which rolls up as `SET_UNION` over the stored set (it is associative and idempotent), for both single-table and join rewrites.

Each pattern is rewritten only when the materialized view provably yields the same result; `DISTINCT` variants and mismatched expressions fall back to the base tables, so existing queries are unaffected. No new configuration or SQL syntax is added.

== RELEASE NOTES ==

General Changes
* Improve materialized view query rewriting to support expression ``GROUP BY`` keys (for example ``CAST`` and ``DATE_TRUNC``), conditional aggregates (``SUM(IF(...))``, ``SUM(CASE WHEN ...)``, ``COUNT(IF(...))``), and ``SET_UNION`` rollups.

Differential Revision: D104869048

## Summary by Sourcery

Extend materialized view query rewriting to handle additional aggregation patterns and expression-based grouping keys while ensuring correctness through fallback to base tables when patterns do not match.

New Features:
- Allow query rewrites when GROUP BY uses scalar expression keys that are also grouped and stored in the materialized view, including support for rollups and ordinals.
- Support rewrites for conditional aggregates such as SUM(IF ...), SUM(CASE WHEN ...), MIN(CASE WHEN ...), and COUNT(IF ...) when the materialized view precomputes the same expressions, including rollups.
- Enable SET_UNION aggregates to be rewritten and rolled up from materialized views, including in join-based rewrites.

Tests:
- Add optimizer tests covering expression-based GROUP BY keys, scalar function keys in SELECT, conditional aggregate rewrites and rejection cases, and SET_UNION rollups for both single-table and join queries.