### PR TITLE
docs: Fix use of Latin abbreviations in Presto doc (part 4)

### DIFF
--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -69,7 +69,7 @@ Unsupported Features
 
 The following features are not supported:
 
-* Adding columns via ``ALTER TABLE``: While you cannot add columns via SQL, you can using a tool.
+* Adding columns with ``ALTER TABLE``: While you cannot add columns through SQL, you can using a tool.
   See the below section on `Adding Columns <#adding-columns>`__ for more details.
 * ``DELETE``: Deletion of rows is not yet implemented for the connector.
 
@@ -181,7 +181,7 @@ You can then issue ``INSERT`` statements to put data into Accumulo.
      row2      | Alan Turing  | 103 | 1912-06-23
     (2 rows)
 
-As you'd expect, rows inserted into Accumulo via the shell or
+As you'd expect, rows inserted into Accumulo through the shell or
 programmatically will also show up when queried. (The Accumulo shell
 thinks "-5321" is an option and not a number... so we'll just make TBL a
 little younger.)
@@ -221,7 +221,7 @@ Indexing Columns
 
 Internally, the connector creates an Accumulo ``Range`` and packs it in
 a split. This split gets passed to a Presto Worker to read the data from
-the ``Range`` via a ``BatchScanner``. When issuing a query that results
+the ``Range`` through a ``BatchScanner``. When issuing a query that results
 in a full table scan, each Presto Worker gets a single ``Range`` that
 maps to a single tablet of the table. When issuing a query with a
 predicate such as a ``WHERE x = 10`` clause, Presto passes the values
@@ -234,8 +234,8 @@ But what about the other columns? If you're frequently querying on
 non-row ID columns, you should consider using the **indexing**
 feature built into the Accumulo connector. This feature can drastically
 reduce query runtime when selecting a handful of values from the table,
-and the heavy lifting is done for you when loading data via Presto
-``INSERT`` statements (though, keep in mind writing data to Accumulo via
+and the heavy lifting is done for you when loading data with Presto
+``INSERT`` statements (though, keep in mind writing data to Accumulo by using 
 ``INSERT`` does not have high throughput).
 
 To enable indexing, add the ``index_columns`` table property and specify
@@ -311,7 +311,7 @@ scans the data table.
 Loading Data
 ------------
 
-The Accumulo connector supports loading data via INSERT statements, however
+The Accumulo connector supports loading data with INSERT statements, however
 this method tends to be low-throughput and should not be relied on when throughput
 is a concern. Instead, users of the connector should use the ``PrestoBatchWriter``
 tool that is provided as part of the presto-accumulo-tools subproject in the
@@ -325,12 +325,12 @@ Usage of the tool is provided in the README in the `repository <https://github.c
 External Tables
 ---------------
 
-By default, the tables created using SQL statements via Presto are
+By default, the tables created using SQL statements with Presto are
 *internal* tables, that is both the Presto table metadata and the
 Accumulo tables are managed by Presto. When you create an internal
 table, the Accumulo table is created as well. You will receive an error
 if the Accumulo table already exists. When an internal table is dropped
-via Presto, the Accumulo table (and any index tables) are dropped as
+through Presto, the Accumulo table (and any index tables) are dropped as
 well.
 
 To change this behavior, set the ``external`` property to ``true`` when
@@ -501,7 +501,7 @@ Property Name                                 Default Value Description
 Adding Columns
 --------------
 
-Adding a new column to an existing table cannot be done today via
+Adding a new column to an existing table cannot be done today by using 
 ``ALTER TABLE [table] ADD COLUMN [name] [type]`` because of the additional
 metadata required for the columns to work; the column family, qualifier,
 and if the column is indexed.

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -224,7 +224,7 @@ a split. This split gets passed to a Presto Worker to read the data from
 the ``Range`` via a ``BatchScanner``. When issuing a query that results
 in a full table scan, each Presto Worker gets a single ``Range`` that
 maps to a single tablet of the table. When issuing a query with a
-predicate (i.e. ``WHERE x = 10`` clause), Presto passes the values
+predicate such as a ``WHERE x = 10`` clause, Presto passes the values
 within the predicate (``10``) to the connector so it can use this
 information to scan less data. When the Accumulo row ID is used as part
 of the predicate clause, this narrows down the ``Range`` lookup to quickly
@@ -465,11 +465,11 @@ Property Name        Default Value    Description
                                       Otherwise, Presto will create and drop Accumulo tables where appropriate.
 ``locality_groups``  (none)           List of locality groups to set on the Accumulo table. Only valid on internal tables.
                                       String format is locality group name, colon, comma delimited list of column families in the group.
-                                      Groups are delimited by pipes. Example: ``group1:famA,famB,famC|group2:famD,famE,famF|etc...``
+                                      Groups are delimited by pipes. Example: ``group1:famA,famB,famC|group2:famD,famE,famF|(...)``
 ``row_id``           (first column)   Presto column name that maps to the Accumulo row ID.
-``serializer``       ``default``      Serializer for Accumulo data encodings. Can either be ``default``, ``string``, ``lexicoder``
-                                      or a Java class name. Default is ``default``,
-                                      i.e. the value from ``AccumuloRowSerializer.getDefault()``, i.e. ``lexicoder``.
+``serializer``       ``default``      Serializer for Accumulo data encodings. Default is ``default``. Can either be ``default``, 
+                                      ``string``, ``lexicoder``, or a Java class name that is 
+                                      the value from ``AccumuloRowSerializer.getDefault()``, such as ``lexicoder``.
 ``scan_auths``       (user auths)     Scan-time authorizations set on the batch scanner.
 ==================== ================ ======================================================================================================
 

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -69,7 +69,7 @@ Unsupported Features
 
 The following features are not supported:
 
-* Adding columns with ``ALTER TABLE``: While you cannot add columns through SQL, you can using a tool.
+* Adding columns with ``ALTER TABLE``: While you cannot add columns through SQL, you can do so using a tool.
   See the below section on `Adding Columns <#adding-columns>`__ for more details.
 * ``DELETE``: Deletion of rows is not yet implemented for the connector.
 

--- a/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
+++ b/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
@@ -73,7 +73,7 @@ To enable mTLS, the following properties must be configured:
 - ``arrow-flight.client-ssl-certificate``: Path to the client's SSL certificate.
 - ``arrow-flight.client-ssl-key``: Path to the client's SSL private key.
 
-These properties must be used alongside the existing SSL configurations for the server, such as ``arrow-flight.server-ssl-certificate`` and ``arrow-flight.server-ssl-enabled=true``. Make sure the server is configured to trust the client certificates (typically via a shared CA).
+These properties must be used alongside the existing SSL configurations for the server, such as ``arrow-flight.server-ssl-certificate`` and ``arrow-flight.server-ssl-enabled=true``. Make sure the server is configured to trust the client certificates (typically through a shared CA).
 
 Below is an example code snippet to configure the Arrow Flight server with mTLS:
 

--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -22,7 +22,7 @@ Changes may include, but are not limited to:
 BigQuery Storage API
 --------------------
 
-The Storage API streams data in parallel directly from BigQuery via gRPC without
+The Storage API streams data in parallel directly from BigQuery with gRPC without
 using Google Cloud Storage as an intermediary.
 It has a number of advantages over using the previous export-based read flow
 that should generally lead to better read performance:

--- a/presto-docs/src/main/sphinx/connector/blackhole.rst
+++ b/presto-docs/src/main/sphinx/connector/blackhole.rst
@@ -6,7 +6,7 @@ Primarily Black Hole connector is designed for high performance testing of
 other components. It works like the ``/dev/null`` device on Unix-like
 operating systems for data writing and like ``/dev/null`` or ``/dev/zero``
 for data reading. However, it also has some other features that allow testing Presto
-in a more controlled manner. Metadata for any tables created via this connector
+in a more controlled manner. Metadata for any tables created with this connector
 is kept in memory on the coordinator and discarded when Presto restarts.
 Created tables are by default always empty, and any data written to them
 will be ignored and data reads will return no rows.

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -62,7 +62,7 @@ Property Name                                      Description
                                                    ``THREE``, ``LOCAL_ONE``, ``ANY``, ``SERIAL``, ``LOCAL_SERIAL``.
 
 ``cassandra.allow-drop-table``                     Set to ``true`` to allow dropping Cassandra tables from Presto
-                                                   via :doc:`/sql/drop-table` (defaults to ``false``).
+                                                   by using :doc:`/sql/drop-table` (defaults to ``false``).
 
 ``cassandra.username``                             Username used for authentication to the Cassandra cluster.
                                                    This is a global setting used for all connections, regardless

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -17,7 +17,7 @@ data warehouse. Hive is a combination of three components:
   Hadoop Distributed File System (HDFS) or in Amazon S3.
 * Metadata about how the data files are mapped to schemas and tables.
   This metadata is stored in a database such as MySQL and is accessed
-  via the Hive metastore service.
+  by using the Hive metastore service.
 * A query language called HiveQL. This query language is executed
   on a distributed computing framework such as MapReduce or Tez.
 
@@ -469,7 +469,7 @@ For cache invalidation procedures, see `Invalidate Metastore Cache`_.
 .. note::
 
     All 14 caches are enabled by default when metastore caching is configured. Metrics are automatically 
-    exposed via JMX without additional configuration.
+    exposed through JMX without additional configuration.
 
 AWS Glue Catalog Configuration Properties
 -----------------------------------------
@@ -852,9 +852,9 @@ Understanding and Tuning the Maximum Connections
 ################################################
 
 Presto can use its native S3 file system or EMRFS. When using the native FS, the
-maximum connections is configured via the ``hive.s3.max-connections``
+maximum connections is configured with the ``hive.s3.max-connections``
 configuration property. When using EMRFS, the maximum connections is configured
-via the ``fs.s3.maxConnections`` Hadoop configuration property.
+with the ``fs.s3.maxConnections`` Hadoop configuration property.
 
 S3 Select Pushdown bypasses the file systems when accessing Amazon S3 for
 predicate operations. In this case, the value of
@@ -1045,7 +1045,7 @@ the single ``alluxio-site.properties`` file. For details, see `Customize Alluxio
 
 Alternatively, add Alluxio configuration properties to the Hadoop configuration
 files (``core-site.xml``, ``hdfs-site.xml``) and configure the Hive connector
-to use the `Hadoop configuration files <#hdfs-configuration>`__ via the
+to use the `Hadoop configuration files <#hdfs-configuration>`__ with the
 ``hive.config.resources`` connector property.
 
 Deploy Alluxio with Presto
@@ -1060,7 +1060,7 @@ for more details.
 Alluxio Catalog Service
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-An alternative way for Presto to interact with Alluxio is via the
+An alternative way for Presto to interact with Alluxio is through the
 `Alluxio Catalog Service. <https://docs.alluxio.io/os/user/stable/en/core-services/Catalog.html?utm_source=prestodb&utm_medium=prestodocs>`_.
 The primary benefits for using the Alluxio Catalog Service are simpler
 deployment of Alluxio with Presto, and enabling schema-aware optimizations
@@ -1134,8 +1134,8 @@ Collecting table and column statistics
 --------------------------------------
 
 The Hive connector supports collection of table and partition statistics
-via the :doc:`/sql/analyze` statement. When analyzing a partitioned table,
-the partitions to analyze can be specified via the optional ``partitions``
+by using the :doc:`/sql/analyze` statement. When analyzing a partitioned table,
+the partitions to analyze can be specified with the optional ``partitions``
 property, which is an array containing the values of the partition keys
 in the order they are declared in the table schema::
 
@@ -1357,7 +1357,7 @@ Invalidate Directory List Cache
 Invalidating directory list cache is useful when the files are added or deleted in the cache directory path and you want to make the changes visible to Presto immediately.
 There are a couple of ways for invalidating this cache:
 
-* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.CachingDirectoryLister#flushCache``) to invalidate the directory list cache. You can call this procedure to invalidate the directory list cache by connecting via jconsole or jmxterm. This procedure flushes all the cache entries.
+* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.CachingDirectoryLister#flushCache``) to invalidate the directory list cache. You can call this procedure to invalidate the directory list cache by connecting with jconsole or jmxterm. This procedure flushes all the cache entries.
 
 * The Hive connector exposes ``system.invalidate_directory_list_cache`` procedure which gives the flexibility to invalidate the list cache completely or partially as per the requirement and can be invoked in various ways.
 
@@ -1405,7 +1405,7 @@ How to invalidate metastore cache?
 Invalidating metastore cache is useful when the Hive metastore is updated outside of Presto and you want to make the changes visible to Presto immediately.
 There are a couple of ways for invalidating this cache and are listed below -
 
-* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore#invalidateAll``) to invalidate the metastore cache. You can call this procedure to invalidate the metastore cache by connecting via jconsole or jmxterm. However, this procedure flushes the cache for all the tables in all the schemas.
+* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore#invalidateAll``) to invalidate the metastore cache. You can call this procedure to invalidate the metastore cache by connecting with jconsole or jmxterm. However, this procedure flushes the cache for all the tables in all the schemas.
 
 * The Hive connector exposes ``system.invalidate_metastore_cache`` procedure which enables users to invalidate the metastore cache completely or partially as per the requirement and can be invoked with various arguments. See `Invalidate Metastore Cache`_ for more information.
 

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -549,7 +549,7 @@ Property Name                                Description
                                              connect to an S3-compatible storage system instead
                                              of AWS. When using v4 signatures, it is recommended to
                                              set this to the AWS region-specific endpoint
-                                             (e.g., ``http[s]://<bucket>.s3-<AWS-region>.amazonaws.com``).
+                                             (for example, ``http[s]://<bucket>.s3-<AWS-region>.amazonaws.com``).
 
 ``hive.s3.storage-class``                    The S3 storage class to use when writing the data. Currently only
                                              ``STANDARD`` and ``INTELLIGENT_TIERING`` storage classes are supported.
@@ -637,7 +637,7 @@ interface and provide a two-argument constructor that takes a
 as arguments. A custom credentials provider can be used to provide
 temporary credentials from STS (using ``STSSessionCredentialsProvider``),
 IAM role-based credentials (using ``STSAssumeRoleSessionCredentialsProvider``),
-or credentials for a specific use case (e.g., bucket/user specific credentials).
+or credentials for a specific use case (such as bucket/user specific credentials).
 This Hadoop configuration property must be set in the Hadoop configuration
 files referenced by the ``hive.config.resources`` Hive connector property.
 
@@ -1262,9 +1262,9 @@ from a valid Avro schema file located locally or remotely in HDFS/Web server.
 
 To specify that Avro schema should be used for interpreting table's data one must use ``avro_schema_url`` table property.
 The schema can be placed remotely in
-HDFS (e.g. ``avro_schema_url = 'hdfs://user/avro/schema/avro_data.avsc'``),
-S3 (e.g. ``avro_schema_url = 's3n:///schema_bucket/schema/avro_data.avsc'``),
-a web server (e.g. ``avro_schema_url = 'http://example.org/schema/avro_data.avsc'``)
+HDFS (for example, ``avro_schema_url = 'hdfs://user/avro/schema/avro_data.avsc'``),
+S3 (for example, ``avro_schema_url = 's3n:///schema_bucket/schema/avro_data.avsc'``),
+a web server (for example, ``avro_schema_url = 'http://example.org/schema/avro_data.avsc'``)
 as well as local file system. This url where the schema is located, must be accessible from the
 Hive metastore and Presto coordinator/worker nodes.
 
@@ -1348,7 +1348,7 @@ Sync Partition Metadata
 
   The ``case_sensitive`` argument is optional. The default value is ``true`` for compatibility
   with Hive's ``MSCK REPAIR TABLE`` behavior, which expects the partition column names in
-  file system paths to use lowercase (e.g. ``col_x=SomeValue``). Partitions on the file system
+  file system paths to use lowercase (for example, ``col_x=SomeValue``). Partitions on the file system
   not conforming to this convention are ignored, unless the argument is set to ``false``.
 
 Invalidate Directory List Cache

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -3125,7 +3125,7 @@ by using :doc:`/sql/alter-materialized-view`; properties not specified in the
        Valid values: ``FAIL`` (throw an error), ``USE_VIEW_QUERY`` (query base tables instead).
      - Yes
    * - ``staleness_window``
-     - Duration window for staleness tolerance (e.g., ``1h``, ``30m``, ``0s``).
+     - Duration window for staleness tolerance (for example, ``1h``, ``30m``, ``0s``).
        Defaults to ``0s`` if only ``stale_read_behavior`` is set.
        When set to ``0s``, any staleness triggers the configured behavior.
      - Yes
@@ -3203,7 +3203,7 @@ Bounded Refresh
 Bounded refresh caps how far each base table advances per ``REFRESH MATERIALIZED VIEW``,
 splitting catch-up into a series of smaller refreshes. Each refresh advances each base's
 watermark by at most N snapshots; subsequent refreshes consume the remainder until the view
-reaches HEAD. Use it when a single refresh would otherwise be too large to complete, e.g.:
+reaches HEAD. Use it when a single refresh would otherwise be too large to complete, such as:
 
 * Initial refresh over a base table with a long history.
 * Catch-up after the view has fallen far behind.
@@ -3245,7 +3245,7 @@ change this default using the ``materialized_view_stale_read_behavior`` session 
 To configure staleness handling per view, set both of these properties together:
 
 - ``stale_read_behavior``: What to do when reading stale data (``FAIL``, ``USE_VIEW_QUERY``, or ``USE_STITCHING``)
-- ``staleness_window``: How much staleness to tolerate (e.g., ``1h``, ``30m``, ``0s``)
+- ``staleness_window``: How much staleness to tolerate (for example, ``1h``, ``30m``, ``0s``)
 
 When ``USE_STITCHING`` is configured, the Iceberg connector tracks staleness at the
 partition level, enabling predicate stitching to recompute only affected partitions

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2512,7 +2512,7 @@ original state.
 Time Travel
 -----------
 
-Iceberg and Presto Iceberg connector support time travel via table snapshots
+Iceberg and Presto Iceberg connector support time travel by using table snapshots
 identified by unique snapshot IDs. The snapshot IDs are stored in the ``$snapshots``
 metadata table. You can rollback the state of a table to a previous snapshot ID.
 It also supports time travel query using SYSTEM_VERSION (VERSION) and SYSTEM_TIME (TIMESTAMP) options.

--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -6,7 +6,7 @@ The JMX connector provides the ability to query JMX information from all
 nodes in a Presto cluster. This is very useful for monitoring or debugging.
 Java Management Extensions (JMX) provides information about the Java
 Virtual Machine and all of the software running inside it. Presto itself
-is heavily instrumented via JMX.
+is heavily instrumented with JMX.
 
 This connector can also be configured so that chosen JMX information will
 be periodically dumped and stored in memory for later access.

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -15,7 +15,7 @@ Each message is presented as a row in Presto.
 
 Topics can be live: rows will appear as data arrives and disappear as
 messages get dropped. This can result in strange behavior if accessing the
-same table multiple times in a single query (e.g., performing a self join).
+same table multiple times in a single query (for example, performing a self join).
 
 .. note::
 
@@ -506,7 +506,7 @@ Presto does not support schema-less Avro decoding.
 
 For key/message, using ``avro`` decoder, the ``dataSchema`` must be defined.
 This should point to the location of a valid Avro schema file of the message which needs to be decoded. This location can be a remote web server
-(e.g.: ``dataSchema: 'http://example.org/schema/avro_data.avsc'``) or local file system(e.g.: ``dataSchema: '/usr/local/schema/avro_data.avsc'``).
+(such as ``dataSchema: 'http://example.org/schema/avro_data.avsc'``) or local file system (such as ``dataSchema: '/usr/local/schema/avro_data.avsc'``).
 The decoder will fail if this location is not accessible from the Presto coordinator node.
 
 For fields, the following attributes are supported:

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -448,7 +448,7 @@ used for standard table columns and a number of decoders for date and time
 based types.
 
 Table below lists Presto data types which can be used as in ``type`` and matching field decoders
-which can be specified via ``dataFormat`` attribute
+which can be specified with ``dataFormat`` attribute
 
 +-------------------------------------+--------------------------------------------------------------------------------+
 | Presto data type                    | Allowed ``dataFormat`` values                                                  |
@@ -489,7 +489,7 @@ To convert values from JSON objects into Presto ``DATE``, ``TIME``, ``TIME WITH 
 * ``iso8601`` - text based, parses a text field as an ISO 8601 timestamp.
 * ``rfc2822`` - text based, parses a text field as an :rfc:`2822` timestamp.
 * ``custom-date-time`` - text based, parses a text field according to Joda format pattern
-                         specified via ``formatHint`` attribute. Format pattern should conform
+                         specified with ``formatHint`` attribute. Format pattern should conform
                          to https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html.
 * ``milliseconds-since-epoch`` - number based, interprets a text or number as number of milliseconds since the epoch.
 * ``seconds-since-epoch`` - number based, interprets a text or number as number of milliseconds since the epoch.

--- a/presto-docs/src/main/sphinx/connector/kudu.rst
+++ b/presto-docs/src/main/sphinx/connector/kudu.rst
@@ -68,7 +68,7 @@ replacing the properties as appropriate:
 Querying Data
 -------------
 
-Apache Kudu does not support schemas, i.e. namespaces for tables.
+Apache Kudu does not support schemas: that is, namespaces for tables.
 The connector can optionally emulate schemas by table naming conventions.
 
 Default behaviour (without schema emulation)
@@ -139,7 +139,7 @@ Select the inserted data
 Behaviour With Schema Emulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If schema emulation has been enabled in the connector properties, i.e. ``etc/catalog/kudu.properties``,
+If schema emulation has been enabled in the connector properties, for example ``etc/catalog/kudu.properties``,
 tables are mapped to schemas depending on some conventions.
 
 With ``kudu.schema-emulation.enabled=true`` and ``kudu.schema-emulation.prefix=``, the mapping works like:

--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -69,8 +69,8 @@ Property Name                                               Description
 ``pinot.grpc-port``                                         Pinot gRPC port.
 ``pinot.secure-connection``                                 Use https for all connections is false.
 ``pinot.override-distinct-count-function``                  Override 'distinctCount' function name, default is "distinctCount".
-``pinot.extra-http-headers``                                Extra headers when sending HTTP based pinot requests to Pinot controller/broker. E.g. k1:v1,k2:v2.
-``pinot.extra-grpc-metadata``                               Extra metadata when sending gRPC based pinot requests to Pinot broker/server/proxy. E.g. k1:v1,k2:v2.
+``pinot.extra-http-headers``                                Extra headers when sending HTTP based pinot requests to Pinot controller/broker. For example, k1:v1,k2:v2.
+``pinot.extra-grpc-metadata``                               Extra metadata when sending gRPC based pinot requests to Pinot broker/server/proxy. For example, k1:v1,k2:v2.
 ``pinot.grpc-tls-key-store-path``                           TLS keystore file location for gRPC connection, default is empty (not needed)
 ``pinot.grpc-tls-key-store-type``                           TLS keystore type for gRPC connection, default is empty (not needed)
 ``pinot.grpc-tls-key-store-password``                       TLS keystore password, default is empty (not needed)
@@ -83,7 +83,7 @@ Property Name                                               Description
 ``pinot.broker-authentication-type``                        Pinot authentication method for broker requests. Allowed values are ``NONE`` and ``PASSWORD`` - defaults to ``NONE`` which is no authentication.
 ``pinot.broker-authentication-user``                        Broker username for basic authentication method.
 ``pinot.broker-authentication-password``                    Broker password for basic authentication method.
-``pinot.query-options``                                     Pinot query-related case-sensitive options. E.g. skipUpsert:true,enableNullHandling:true
+``pinot.query-options``                                     Pinot query-related case-sensitive options. For example, skipUpsert:true,enableNullHandling:true
 ``case-sensitive-name-matching``                            Enable case-sensitive identifier support for schema, table, and column names for the connector. When disabled,
                                                             names are matched case-insensitively using lowercase normalization. Default is ``false``.
 ==========================================================  =============================================================================================================
@@ -117,7 +117,7 @@ Property Name                                             Description
 ``pinot.controller_authentication_password``              Controller password for basic authentication method.
 ``pinot.broker_authentication_user``                      Broker username for basic authentication method.
 ``pinot.broker_authentication_password``                  Broker password for basic authentication method.
-``pinot.query_options``                                   Pinot query-related case-sensitive options. E.g. skipUpsert:true,enableNullHandling:true
+``pinot.query_options``                                   Pinot query-related case-sensitive options. For example, skipUpsert:true,enableNullHandling:true
 ========================================================  ==================================================================
 
 Map Pinot Schema to Presto Schema
@@ -274,8 +274,8 @@ How the Apache Pinot connector works
 ------------------------------------
 
 The connector tries to push the maximal sub-query inferred from the
-presto query into pinot. It can push down everything Pinot supports
-including aggregations, group by, all UDFs etc. It generates the
+presto query into pinot. It can push down everything Pinot supports,
+including aggregations, group by, and all UDFs. It generates the
 correct Pinot query keeping Pinot's quirks in mind.
 
 By default, it sends aggregation and limit queries to the Pinot broker

--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -293,7 +293,7 @@ There are a few configurations that control this behavior:
   aggregation and limit queries.
 * ``pinot.forbid-segment-queries``: This config is false by default.
   Setting it to true will forbid parallel querying and force all
-  querying to happen via the broker.
+  querying to happen through the broker.
 * ``pinot.non-aggregate-limit-for-broker-queries``: To prevent
   overwhelming the broker, the connector only allows querying the
   pinot broker for ``short`` queries. We define a ``short`` query to

--- a/presto-docs/src/main/sphinx/connector/system.rst
+++ b/presto-docs/src/main/sphinx/connector/system.rst
@@ -3,13 +3,13 @@ System Connector
 ================
 
 The System connector provides information and metrics about the currently
-running Presto cluster. It makes this available via normal SQL queries.
+running Presto cluster. It makes this available through normal SQL queries.
 
 Configuration
 -------------
 
 The System connector doesn't need to be configured: it is automatically
-available via a catalog named ``system``.
+available through a catalog named ``system``.
 
 Using the System Connector
 --------------------------

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -51,7 +51,7 @@ Other HTTP endpoints include:
 
 * GET: v1/status: Returns memory pool information.
 
-The request/response flow of Presto C++ is identical to Java workers. The tasks or new splits are registered via `TaskUpdateRequest`. Resource utilization and query progress are sent to the coordinator via task endpoints.
+The request/response flow of Presto C++ is identical to Java workers. The tasks or new splits are registered through `TaskUpdateRequest`. Resource utilization and query progress are sent to the coordinator through task endpoints.
 
 * GET: /v1/operation/server/clearCache?type=memory: It clears the memory cache on worker node. Here is an example:
 

--- a/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
@@ -180,7 +180,7 @@ The ``spatial_partitions`` scalar function is not supported in Presto C++.
 This function was an internal utility for spatial join optimization and was never
 fully documented or publicly supported. It worked with the ``spatial_partitioning``
 aggregate function (see `Aggregate Functions`_) by consuming a KD-tree representation
-loaded via a session property. The query optimizer would automatically use this
+loaded by using a session property. The query optimizer would automatically use this
 function to partition data for spatial joins.
 
 Due to its internal nature, lack of documentation, limited usage, and incompatibility


### PR DESCRIPTION
## Description
Revised the Presto documentation in
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/presto_cpp
https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/connector

to remove use of `e.g.`, `via`, `etc.`, and `i.e.` from the Presto documentation in these directories.

Building on the work in #27969, #27974, and #27977.

A followup PR will address `release`. I'm intentionally keeping these PRs smaller than they could be to make the reviewers' job easier. 

## Motivation and Context
Latin abbreviations should be avoided in documentation. See:

* the [GitLab documentation style guide recommended word list entry for e.g.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#eg)
* the [GitLab documentation style guide recommended word list entry for via](https://docs.gitlab.com/development/documentation/styleguide/word_list/#via)
* the [GitLab documentation style guide recommended word list entry for etc](https://docs.gitlab.com/development/documentation/styleguide/word_list/#etc)
* the [GitLab documentation style guide recommended word list entry for I.e.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#ie)

I've been applying these rules for a long while when editing new Presto documentation, and @dnskr's work on https://github.com/prestodb/presto/pull/27961 prompted me to make a start at the existing doc set for consistency. Thanks @dnskr!

## Impact
Improved readability of the Presto documentation.

## Test Plan
Local doc builds. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Update connector and Presto C++ documentation to replace Latin abbreviations with clearer English phrasing.