### PR TITLE
feat(connector): Add support for Redshift views

### DIFF
--- a/presto-docs/src/main/sphinx/connector/redshift.rst
+++ b/presto-docs/src/main/sphinx/connector/redshift.rst
@@ -60,6 +60,11 @@ Property Name                                      Description                  
 ``case-sensitive-name-matching``                   Enable case sensitive identifier support for schema and table        ``false``
                                                    names for the connector. When disabled, names are matched
                                                    case-insensitively using lowercase normalization.
+
+``enable-datasource-managed-views``                Delegate view resolution to Redshift instead of allowing Presto      ``false``
+                                                   to analyze view definitions. Useful for views containing
+                                                   Redshift-specific SQL syntax or functions. See
+                                                   :ref:`redshift-datasource-managed-views` for details.
 ================================================== ==================================================================== ===========
 
 
@@ -119,6 +124,68 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``redshift`` in the above examples.
+
+View Support
+------------
+
+The Redshift connector supports creating, querying, displaying, and dropping Redshift views.
+
+CREATE VIEW
+
+.. code-block:: sql
+
+    CREATE VIEW redshift.schema.view AS
+    SELECT col FROM redshift.schema.table;
+
+SHOW CREATE VIEW
+
+.. code-block:: sql
+
+    SHOW CREATE VIEW redshift.schema.view;
+
+DROP VIEW
+
+.. code-block:: sql
+
+    DROP VIEW redshift.schema.view;
+
+Views created through the connector can be queried using standard Presto SQL.
+
+.. _redshift-datasource-managed-views:
+
+Datasource-managed views
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the Redshift connector retrieves Redshift view definitions and allows Presto to analyze and resolve the underlying view SQL.
+
+Some Redshift views may contain Redshift-specific functions or syntax that cannot be analyzed by Presto.
+In these cases, view analysis can be disabled and view resolution delegated to Redshift.
+
+Typical use cases include views that contain Redshift-specific functions or SQL syntax that cannot be analyzed by Presto.
+
+To enable datasource-managed views:
+
+.. code-block:: none
+
+    enable-datasource-managed-views=true
+
+
+Default value:
+
+.. code-block:: none
+
+    enable-datasource-managed-views=false
+
+When datasource-managed views are enabled:
+
+* Presto does not analyze Redshift view definitions.
+* View resolution is delegated to Redshift.
+* Queries against views continue to be executed by Redshift.
+
+Limitations
+^^^^^^^^^^^
+* ``SHOW CREATE VIEW`` and ``DROP VIEW`` are not supported when datasource-managed views are enabled.
+* Views may reference only objects within the same Redshift catalog. Cross-catalog references are not supported.
 
 Redshift Connector Limitations
 ------------------------------

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -30,6 +30,31 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -42,6 +67,11 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
 
         <dependency>
@@ -105,6 +135,19 @@
             <artifactId>presto-main-base</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -115,6 +158,7 @@
                 <configuration>
                     <ignoredNonTestScopedDependencies>
                         <ignoredNonTestScopedDependency>com.google.guava:guava</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>javax.inject:javax.inject</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
                 </configuration>
             </plugin>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -30,6 +30,31 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -14,35 +14,76 @@
 package com.facebook.presto.plugin.redshift;
 
 import com.amazon.redshift.jdbc.Driver;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
-import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
 import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
 import com.facebook.presto.plugin.jdbc.mapping.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.WithQuery;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.plugin.jdbc.mapping.ReadMapping.varbinaryReadMapping;
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class RedshiftClient
         extends BaseJdbcClient
 {
+    private static final Logger log = Logger.get(RedshiftClient.class);
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().build();
+    private final JsonCodec<ViewDefinition> viewCodec;
+
+    private enum ViewRewriteMode
+    {
+        STRIP_CATALOG, ADD_SCHEMA
+    }
+
     @Inject
-    public RedshiftClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
+    public RedshiftClient(JdbcConnectorId connectorId, RedshiftConfig config, JsonCodec<ViewDefinition> viewCodec)
     {
         super(connectorId, config, "\"", new DriverConnectionFactory(new Driver(), config));
+        this.viewCodec = requireNonNull(viewCodec, "viewCodec is null");
     }
 
     @Override
@@ -88,5 +129,317 @@ public class RedshiftClient
     public String normalizeIdentifier(ConnectorSession session, String identifier)
     {
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            ResultSet resultSet = getTables(
+                    connection,
+                    Optional.ofNullable(handle.getSchemaName()),
+                    Optional.ofNullable(handle.getTableName()),
+                    new String[]{"VIEW"});
+
+            if (resultSet.next()) {
+                throw new PrestoException(JDBC_ERROR, format("Relation '%s' is a view, not a table", handle.getTableName()));
+            }
+
+            StringBuilder sql = new StringBuilder()
+                    .append("DROP TABLE ")
+                    .append(quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()));
+
+            execute(connection, sql.toString());
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        return getTables(connection, schemaName, tableName, new String[] {"TABLE", "VIEW"});
+    }
+
+    private ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName, String[] tableTypes)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
+        return metadata.getTables(
+                connection.getCatalog(),
+                escapeNamePattern(schemaName, escape).orElse(null),
+                escapeNamePattern(tableName, escape).orElse(null),
+                tableTypes);
+    }
+
+    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String schema = toRemoteSchemaName(session, identity, connection, viewName.getSchemaName());
+            String view = toRemoteTableName(session, identity, connection, schema, viewName.getTableName());
+            String catalog = connection.getCatalog();
+
+            if (!replace) {
+                ResultSet resultSet = getTables(connection, Optional.ofNullable(schema), Optional.ofNullable(view));
+                if (resultSet.next()) {
+                    throw new PrestoException(ALREADY_EXISTS, format("The view/table '%s' already exists", viewName.getTableName()));
+                }
+            }
+
+            String viewSql = viewCodec.fromJson(viewData).getOriginalSql();
+            viewSql = rewriteViewSql(session, identity, connection, viewSql, ViewRewriteMode.STRIP_CATALOG);
+            String sql = format("%s VIEW %s AS %s", replace ? "CREATE OR REPLACE" : "CREATE", quoted(catalog, schema, view), viewSql);
+            log.debug("Execute: %s", sql);
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Determines whether the specified object is a view.
+     *
+     * Metadata lookup failures are treated as views so that view
+     * resolution can be attempted through {@code getViews()}.
+     */
+    public boolean isView(ConnectorSession session, String schemaName, String tableName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet rs = metaData.getTables(connection.getCatalog(), schemaName, tableName, new String[]{"VIEW"})) {
+                return rs.next();
+            }
+        }
+        catch (SQLException e) {
+            log.debug("isView metadata check failed for %s.%s, proceeding with view resolution: %s", schemaName, tableName, e.getMessage());
+            return true;
+        }
+    }
+
+    /**
+     * Retrieves Redshift view definitions and converts them to
+     * ConnectorViewDefinition instances.
+     */
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> viewNames)
+    {
+        JdbcIdentity identity = new JdbcIdentity(session.getUser(), session.getIdentity().getExtraCredentials());
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            for (SchemaTableName schemaTableName : viewNames) {
+                String schemaName = toRemoteSchemaName(session, identity, connection, schemaTableName.getSchemaName());
+                String viewName = toRemoteTableName(session, identity, connection, schemaName, schemaTableName.getTableName());
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "SELECT viewowner, definition FROM pg_views WHERE schemaname = ? AND viewname = ?")) {
+                    statement.setString(1, schemaName);
+                    statement.setString(2, viewName);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (!resultSet.next()) {
+                            continue;
+                        }
+                        String viewOwner = resultSet.getString(1);
+                        String viewSql = resultSet.getString(2);
+                        if (viewSql == null) {
+                            log.warn("Empty view definition for %s.%s - skipping", schemaName, viewName);
+                            continue;
+                        }
+                        viewSql = viewSql.trim();
+                        if (viewSql.endsWith(";")) {
+                            viewSql = viewSql.substring(0, viewSql.length() - 1);
+                        }
+
+                        viewSql = rewriteViewSql(session, identity, connection, viewSql, ViewRewriteMode.ADD_SCHEMA);
+
+                        SchemaTableName schemaViewName = new SchemaTableName(schemaName, viewName);
+                        ViewDefinition viewDefinition = buildViewDefinition(connection, session, schemaViewName, viewSql, viewOwner);
+                        String viewData = viewCodec.toJson(viewDefinition);
+                        views.put(schemaTableName, new ConnectorViewDefinition(schemaViewName, Optional.ofNullable(viewOwner), viewData));
+                    }
+                }
+                catch (SQLException e) {
+                    log.warn("Failed to fetch view %s: %s", schemaTableName, e.getMessage());
+                }
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return views.build();
+    }
+
+    private ViewDefinition buildViewDefinition(
+            Connection connection,
+            ConnectorSession session,
+            SchemaTableName schemaViewName,
+            String viewSql,
+            String viewOwner)
+            throws SQLException
+    {
+        String schema = schemaViewName.getSchemaName();
+        String view = schemaViewName.getTableName();
+
+        JdbcTableHandle tableHandle = new JdbcTableHandle(connectorId, schemaViewName, connection.getCatalog(), schema, view);
+        List<JdbcColumnHandle> jdbcColumnHandles = super.getColumns(session, tableHandle);
+
+        List<ViewDefinition.ViewColumn> columns = jdbcColumnHandles.stream()
+                .map(jdbcColumn -> new ViewDefinition.ViewColumn(normalizeIdentifier(session, jdbcColumn.getColumnName()), jdbcColumn.getColumnType()))
+                .collect(toImmutableList());
+
+        return new ViewDefinition(
+                viewSql,
+                Optional.of(connectorId),
+                Optional.of(schema),
+                columns,
+                Optional.of(viewOwner),
+                false);
+    }
+
+    public List<SchemaTableName> listViewsFromAllSchemas(ConnectorSession session)
+    {
+        List<SchemaTableName> allViewNames = new ArrayList<>();
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            Collection<String> schemaNames = listSchemas(connection);
+            for (String schema : schemaNames) {
+                List<SchemaTableName> viewNames = listViews(session, Optional.ofNullable(schema));
+                allViewNames.addAll(viewNames);
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return allViewNames;
+    }
+
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity);
+                ResultSet resultSet = getTables(connection, schemaName, Optional.empty(), new String[]{"VIEW"})) {
+            ImmutableList.Builder<SchemaTableName> builder = ImmutableList.builder();
+            while (resultSet.next()) {
+                String tableName = resultSet.getString("TABLE_NAME");
+                String schema = schemaName.orElse(resultSet.getString("TABLE_SCHEM"));
+                builder.add(new SchemaTableName(normalizeIdentifier(session, schema), normalizeIdentifier(session, tableName)));
+            }
+            return builder.build();
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String sql = "DROP VIEW " + (quoted(connection.getCatalog(), viewName.getSchemaName(), viewName.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Rewrites table references in view SQL.
+     *
+     * STRIP_CATALOG removes catalog qualifiers from three-part names.
+     * ADD_SCHEMA qualifies unqualified table references with the current schema.
+     */
+    private String rewriteViewSql(ConnectorSession session, JdbcIdentity identity, Connection connection, String rawSql, ViewRewriteMode mode)
+            throws SQLException
+    {
+        requireNonNull(rawSql, "rawSql is null");
+        String schemaName = requireNonNull(connection.getSchema(), "schemaName is null");
+
+        Statement parsed;
+        try {
+            parsed = SQL_PARSER.createStatement(rawSql, PARSING_OPTIONS);
+        }
+        catch (Exception e) {
+            log.warn("Failed to parse Redshift view definition, returning original view SQL. Error: %s", e.getMessage());
+            return rawSql;
+        }
+
+        Set<String> cteNames = new HashSet<>();
+        Set<String> tableReferences = new HashSet<>();
+        Set<String> sourceCatalogs = new HashSet<>();
+
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitWithQuery(WithQuery node, Void context)
+            {
+                String cteName = node.getName().getValue();
+                // Process WITH body FIRST (before adding CTE name)
+                Void result = super.visitWithQuery(node, context);
+                cteNames.add(cteName);
+                return result;
+            }
+
+            @Override
+            protected Void visitTable(Table node, Void context)
+            {
+                if (mode == ViewRewriteMode.ADD_SCHEMA && node.getName().getParts().size() == 1) {
+                    String name = node.getName().getOriginalParts().stream().map(Object::toString).collect(Collectors.joining("."));
+                    if (!cteNames.contains(name)) {
+                        tableReferences.add(name);
+                    }
+                }
+                else if (mode == ViewRewriteMode.STRIP_CATALOG && node.getName().getParts().size() == 3) {
+                    // Presto's analyzer always serializes resolved table references in
+                    // originalSql as fully-qualified catalog.schema.table (3 parts).
+                    // Two-part or bare references are not expected here.
+                    List<Identifier> parts = node.getName().getOriginalParts();
+                    tableReferences.add(parts.stream()
+                            .map(Object::toString)
+                            .collect(Collectors.joining(".")));
+                    sourceCatalogs.add(parts.get(0).getValue());
+                }
+                return super.visitTable(node, context);
+            }
+        }.process(parsed, null);
+
+        if (tableReferences.isEmpty()) {
+            // All tables are already fully qualified - return canonical form directly.
+            return rawSql;
+        }
+
+        String result = rawSql;
+        for (String name : tableReferences) {
+            if (mode == ViewRewriteMode.ADD_SCHEMA) {
+                // Match unqualified table references while preserving identifier casing.
+                String table = name.replaceAll("^\"|\"$", "");
+                String qualified = quoted(schemaName) + '.' + quoted(toRemoteTableName(session, identity, connection, schemaName, table));
+                Pattern namePattern = Pattern.compile(
+                        "(?<![\\.\\w\"])\"?" + Pattern.quote(name) + "\"?(?![\\.\"])(?![\\w])");
+                result = namePattern.matcher(result).replaceAll(Matcher.quoteReplacement(qualified));
+            }
+            else if (mode == ViewRewriteMode.STRIP_CATALOG) {
+                List<String> parts = Arrays.asList(name.split("\\."));
+                if (parts.size() != 3) {
+                    log.warn("Expected 3-part name, got %d parts: %s", parts.size(), name);
+                    continue;
+                }
+                boolean containsCrossCatalogReferences = sourceCatalogs.size() > 1 || (sourceCatalogs.size() == 1 && !sourceCatalogs.contains(connectorId));
+                if (containsCrossCatalogReferences) {
+                    throw new PrestoException(NOT_SUPPORTED,
+                            "You can create the view for a table only if that table is in the same catalog.");
+                }
+                String schema = toRemoteSchemaName(session, identity, connection, parts.get(1)).replaceAll("^\"|\"$", "");
+                String table = toRemoteTableName(session, identity, connection, schema, parts.get(2)).replaceAll("^\"|\"$", "");
+                String stripped = quoted(normalizeIdentifier(session, schema)) + '.' + quoted(normalizeIdentifier(session, table));
+                result = result.replace(name, stripped);
+            }
+        }
+        return result;
     }
 }

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -14,35 +14,75 @@
 package com.facebook.presto.plugin.redshift;
 
 import com.amazon.redshift.jdbc.Driver;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
-import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
 import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
 import com.facebook.presto.plugin.jdbc.mapping.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.WithQuery;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.plugin.jdbc.mapping.ReadMapping.varbinaryReadMapping;
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class RedshiftClient
         extends BaseJdbcClient
 {
+    private static final Logger log = Logger.get(RedshiftClient.class);
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().build();
+    private final JsonCodec<ViewDefinition> viewCodec;
+
+    enum ViewRewriteMode
+    {
+        STRIP_CATALOG, ADD_SCHEMA
+    }
+
     @Inject
-    public RedshiftClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
+    public RedshiftClient(JdbcConnectorId connectorId, RedshiftConfig config, JsonCodec<ViewDefinition> viewCodec)
     {
         super(connectorId, config, "\"", new DriverConnectionFactory(new Driver(), config));
+        this.viewCodec = requireNonNull(viewCodec, "viewCodec is null");
     }
 
     @Override
@@ -88,5 +128,325 @@ public class RedshiftClient
     public String normalizeIdentifier(ConnectorSession session, String identifier)
     {
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, JdbcIdentity identity, JdbcTableHandle handle)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            ResultSet resultSet = getTables(
+                    connection,
+                    Optional.ofNullable(handle.getSchemaName()),
+                    Optional.ofNullable(handle.getTableName()),
+                    new String[]{"VIEW"});
+
+            if (resultSet.next()) {
+                throw new PrestoException(NOT_SUPPORTED, format("Relation '%s' is a view, not a table", handle.getTableName()));
+            }
+
+            StringBuilder sql = new StringBuilder()
+                    .append("DROP TABLE ")
+                    .append(quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()));
+
+            execute(connection, sql.toString());
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        return getTables(connection, schemaName, tableName, new String[] {"TABLE", "VIEW"});
+    }
+
+    private ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName, String[] tableTypes)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
+        return metadata.getTables(
+                connection.getCatalog(),
+                escapeNamePattern(schemaName, escape).orElse(null),
+                escapeNamePattern(tableName, escape).orElse(null),
+                tableTypes);
+    }
+
+    void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String schema = toRemoteSchemaName(session, identity, connection, viewName.getSchemaName());
+            String view = toRemoteTableName(session, identity, connection, schema, viewName.getTableName());
+            String catalog = connection.getCatalog();
+
+            if (!replace) {
+                ResultSet resultSet = getTables(connection, Optional.ofNullable(schema), Optional.ofNullable(view));
+                if (resultSet.next()) {
+                    throw new PrestoException(ALREADY_EXISTS, format("The view/table '%s' already exists", viewName.getTableName()));
+                }
+            }
+
+            String viewSql = viewCodec.fromJson(viewData).getOriginalSql();
+            viewSql = rewriteViewSql(session, identity, connection, viewSql, ViewRewriteMode.STRIP_CATALOG);
+            String sql = format("%s VIEW %s AS %s", replace ? "CREATE OR REPLACE" : "CREATE", quoted(catalog, schema, view), viewSql);
+            log.debug("Execute: %s", sql);
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Determines whether the specified object is a view.
+     *
+     * Metadata lookup failures are treated as views so that view
+     * resolution can be attempted through {@code getViews()}.
+     */
+    boolean isView(ConnectorSession session, String schemaName, String tableName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String remoteSchema = toRemoteSchemaName(session, identity, connection, schemaName);
+            String remoteTable = toRemoteTableName(session, identity, connection, remoteSchema, tableName);
+            try (ResultSet rs = getTables(connection, Optional.of(remoteSchema), Optional.of(remoteTable), new String[]{"VIEW"})) {
+                return rs.next();
+            }
+        }
+        catch (SQLException e) {
+            log.debug("isView metadata check failed for %s.%s, proceeding with view resolution: %s", schemaName, tableName, e.getMessage());
+            return true;
+        }
+    }
+
+    /**
+     * Retrieves Redshift view definitions and converts them to
+     * ConnectorViewDefinition instances.
+     */
+    Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> viewNames)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            for (SchemaTableName schemaTableName : viewNames) {
+                String schemaName = toRemoteSchemaName(session, identity, connection, schemaTableName.getSchemaName());
+                String viewName = toRemoteTableName(session, identity, connection, schemaName, schemaTableName.getTableName());
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "SELECT viewowner, definition FROM pg_views WHERE schemaname = ? AND viewname = ?")) {
+                    statement.setString(1, schemaName);
+                    statement.setString(2, viewName);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (!resultSet.next()) {
+                            continue;
+                        }
+                        String viewOwner = resultSet.getString(1);
+                        String viewSql = resultSet.getString(2);
+                        if (viewSql == null) {
+                            log.warn("Empty view definition for %s.%s - skipping", schemaName, viewName);
+                            continue;
+                        }
+                        viewSql = viewSql.trim();
+                        if (viewSql.endsWith(";")) {
+                            viewSql = viewSql.substring(0, viewSql.length() - 1);
+                        }
+
+                        viewSql = rewriteViewSql(session, identity, connection, viewSql, ViewRewriteMode.ADD_SCHEMA);
+
+                        SchemaTableName schemaViewName = new SchemaTableName(schemaName, viewName);
+                        ViewDefinition viewDefinition = buildViewDefinition(connection, session, schemaViewName, viewSql, viewOwner);
+                        String viewData = viewCodec.toJson(viewDefinition);
+                        views.put(schemaTableName, new ConnectorViewDefinition(schemaViewName, Optional.ofNullable(viewOwner), viewData));
+                    }
+                }
+                catch (SQLException e) {
+                    log.warn("Failed to fetch view %s: %s", schemaTableName, e.getMessage());
+                }
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return views.build();
+    }
+
+    private ViewDefinition buildViewDefinition(
+            Connection connection,
+            ConnectorSession session,
+            SchemaTableName schemaViewName,
+            String viewSql,
+            String viewOwner)
+            throws SQLException
+    {
+        String schema = schemaViewName.getSchemaName();
+        String view = schemaViewName.getTableName();
+
+        JdbcTableHandle tableHandle = new JdbcTableHandle(connectorId, schemaViewName, connection.getCatalog(), schema, view);
+        List<JdbcColumnHandle> jdbcColumnHandles = super.getColumns(session, tableHandle);
+
+        List<ViewDefinition.ViewColumn> columns = jdbcColumnHandles.stream()
+                .map(jdbcColumn -> new ViewDefinition.ViewColumn(normalizeIdentifier(session, jdbcColumn.getColumnName()), jdbcColumn.getColumnType()))
+                .collect(toImmutableList());
+
+        return new ViewDefinition(
+                viewSql,
+                Optional.of(connectorId),
+                Optional.of(schema),
+                columns,
+                Optional.of(viewOwner),
+                false);
+    }
+
+    List<SchemaTableName> listViewsFromAllSchemas(ConnectorSession session)
+    {
+        List<SchemaTableName> allViewNames = new ArrayList<>();
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            for (String schema : listSchemas(connection)) {
+                List<SchemaTableName> viewNames = listViews(session, identity, connection, Optional.ofNullable(schema));
+                allViewNames.addAll(viewNames);
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return allViewNames;
+    }
+
+    List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            return listViews(session, identity, connection, schemaName);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    private List<SchemaTableName> listViews(ConnectorSession session, JdbcIdentity identity, Connection connection, Optional<String> schemaName)
+            throws SQLException
+    {
+        Optional<String> remoteSchema = schemaName.map(schema -> toRemoteSchemaName(session, identity, connection, schema));
+        try (ResultSet resultSet = getTables(connection, remoteSchema, Optional.empty(), new String[]{"VIEW"})) {
+            ImmutableList.Builder<SchemaTableName> builder = ImmutableList.builder();
+            while (resultSet.next()) {
+                String tableSchema = getTableSchemaName(resultSet);
+                String tableName = resultSet.getString("TABLE_NAME");
+                builder.add(new SchemaTableName(normalizeIdentifier(session, tableSchema), normalizeIdentifier(session, tableName)));
+            }
+            return builder.build();
+        }
+    }
+
+    void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String sql = "DROP VIEW " + (quoted(connection.getCatalog(), viewName.getSchemaName(), viewName.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Rewrites table references in view SQL.
+     *
+     * STRIP_CATALOG removes catalog qualifiers from three-part names.
+     * ADD_SCHEMA qualifies unqualified table references with the current schema.
+     */
+    String rewriteViewSql(ConnectorSession session, JdbcIdentity identity, Connection connection, String rawSql, ViewRewriteMode mode)
+            throws SQLException
+    {
+        requireNonNull(rawSql, "rawSql is null");
+
+        Statement parsed;
+        try {
+            parsed = SQL_PARSER.createStatement(rawSql, PARSING_OPTIONS);
+        }
+        catch (Exception e) {
+            log.warn("Failed to parse Redshift view definition, returning original view SQL. Error: %s", e.getMessage());
+            return rawSql;
+        }
+
+        Set<String> cteNames = new HashSet<>();
+        Set<String> tableReferences = new HashSet<>();
+        Set<String> sourceCatalogs = new HashSet<>();
+
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitWithQuery(WithQuery node, Void context)
+            {
+                String cteName = node.getName().getValue();
+                // Process WITH body FIRST (before adding CTE name)
+                Void result = super.visitWithQuery(node, context);
+                cteNames.add(cteName);
+                return result;
+            }
+
+            @Override
+            protected Void visitTable(Table node, Void context)
+            {
+                if (mode == ViewRewriteMode.ADD_SCHEMA && node.getName().getParts().size() == 1) {
+                    String name = node.getName().getOriginalParts().stream().map(Object::toString).collect(Collectors.joining("."));
+                    if (!cteNames.contains(name)) {
+                        tableReferences.add(name);
+                    }
+                }
+                else if (mode == ViewRewriteMode.STRIP_CATALOG && node.getName().getParts().size() == 3) {
+                    // Presto's analyzer always serializes resolved table references in
+                    // originalSql as fully-qualified catalog.schema.table (3 parts).
+                    // Two-part or bare references are not expected here.
+                    List<Identifier> parts = node.getName().getOriginalParts();
+                    tableReferences.add(parts.stream().map(Object::toString).collect(Collectors.joining(".")));
+                    sourceCatalogs.add(parts.get(0).getValue());
+                }
+                return super.visitTable(node, context);
+            }
+        }.process(parsed, null);
+
+        if (tableReferences.isEmpty()) {
+            // All tables are already fully qualified - return canonical form directly.
+            return rawSql;
+        }
+
+        if (mode == ViewRewriteMode.STRIP_CATALOG) {
+            boolean containsCrossCatalogReferences = sourceCatalogs.size() > 1 || (sourceCatalogs.size() == 1 && !sourceCatalogs.contains(connectorId));
+            if (containsCrossCatalogReferences) {
+                throw new PrestoException(NOT_SUPPORTED, "You can create the view for a table only if that table is in the same catalog.");
+            }
+        }
+
+        String schemaName = mode == ViewRewriteMode.ADD_SCHEMA ? requireNonNull(connection.getSchema(), "schemaName is null") : null;
+
+        String result = rawSql;
+        for (String name : tableReferences) {
+            if (mode == ViewRewriteMode.ADD_SCHEMA) {
+                // Match unqualified table references while preserving identifier casing.
+                String table = name.replaceAll("^\"|\"$", "");
+                String qualified = quoted(schemaName) + '.' + quoted(toRemoteTableName(session, identity, connection, schemaName, table));
+                Pattern namePattern = Pattern.compile("(?<![\\.\\w\"])\"?" + Pattern.quote(name) + "\"?(?![\\.\"])(?![\\w])");
+                result = namePattern.matcher(result).replaceAll(Matcher.quoteReplacement(qualified));
+            }
+            else if (mode == ViewRewriteMode.STRIP_CATALOG) {
+                List<String> parts = Arrays.asList(name.split("\\."));
+                if (parts.size() != 3) {
+                    log.warn("Expected 3-part name, got %d parts: %s", parts.size(), name);
+                    continue;
+                }
+                String schema = toRemoteSchemaName(session, identity, connection, parts.get(1)).replaceAll("^\"|\"$", "");
+                String table = toRemoteTableName(session, identity, connection, schema, parts.get(2)).replaceAll("^\"|\"$", "");
+                String stripped = quoted(normalizeIdentifier(session, schema)) + '.' + quoted(normalizeIdentifier(session, table));
+                result = result.replace(name, stripped);
+            }
+        }
+        return result;
     }
 }

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClientModule.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClientModule.java
@@ -13,13 +13,24 @@
  */
 package com.facebook.presto.plugin.redshift;
 
-import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import jakarta.inject.Inject;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public class RedshiftClientModule
         implements Module
@@ -28,6 +39,34 @@ public class RedshiftClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).to(RedshiftClient.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        binder.bind(RedshiftClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(RedshiftConfig.class);
+
+        binder.install(new JsonModule());
+        jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);
+        jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+    }
+
+    private static final class TypeDeserializer
+            extends FromStringDeserializer<Type>
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final TypeManager typeManager;
+
+        @Inject
+        public TypeDeserializer(TypeManager typeManager)
+        {
+            super(Type.class);
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
+        @Override
+        protected Type _deserialize(String value, DeserializationContext context)
+        {
+            Type type = typeManager.getType(parseTypeSignature(value));
+            checkArgument(type != null, "Unknown type %s", value);
+            return type;
+        }
     }
 }

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftConfig.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+
+public class RedshiftConfig
+        extends BaseJdbcConfig
+{
+    private boolean datasourceManagedViewsEnabled;
+
+    public boolean isDatasourceManagedViewsEnabled()
+    {
+        return datasourceManagedViewsEnabled;
+    }
+
+    @Config("enable-datasource-managed-views")
+    @ConfigDescription("Enable datasource-managed view handling. When disabled, Presto retrieves and analyzes Redshift view definitions. " +
+            "When enabled, view resolution is delegated to Redshift and Presto does not analyze underlying view definitions.")
+    public RedshiftConfig setDatasourceManagedViewsEnabled(boolean datasourceManagedViewsEnabled)
+    {
+        this.datasourceManagedViewsEnabled = datasourceManagedViewsEnabled;
+        return this;
+    }
+}

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftConnectorFactory.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftConnectorFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcHandleResolver;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.JdbcModule;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
+
+import java.util.Map;
+
+import static com.facebook.presto.plugin.redshift.RedshiftPlugin.REDSHIFT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftConnectorFactory
+        implements ConnectorFactory
+{
+    private final ClassLoader classLoader;
+
+    public RedshiftConnectorFactory(ClassLoader classLoader)
+    {
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return REDSHIFT;
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new JdbcHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        checkArgument(!isNullOrEmpty(catalogName), "catalogName is null or empty");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            // Override JdbcModule's JdbcMetadataFactory binding with RedshiftMetadataFactory
+            Module jdbcModuleWithOverride = Modules.override(new JdbcModule(catalogName))
+                    .with(binder -> binder.bind(JdbcMetadataFactory.class)
+                            .to(RedshiftMetadataFactory.class)
+                            .in(Scopes.SINGLETON));
+
+            Bootstrap app = new Bootstrap(
+                    binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
+                        binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
+                        binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                    },
+                    jdbcModuleWithOverride,
+                    new RedshiftClientModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(JdbcConnector.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftMetadata.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftMetadata.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftMetadata
+        extends JdbcMetadata
+{
+    private final RedshiftClient redshiftClient;
+    private final boolean datasourceManagedViewsEnabled;
+
+    public RedshiftMetadata(
+            JdbcMetadataCache jdbcMetadataCache,
+            RedshiftClient redshiftClient,
+            boolean allowDropTable,
+            TableLocationProvider tableLocationProvider,
+            RedshiftConfig redshiftConfig)
+    {
+        super(jdbcMetadataCache, redshiftClient, allowDropTable, tableLocationProvider);
+        this.redshiftClient = requireNonNull(redshiftClient, "redshiftClient is null");
+        this.datasourceManagedViewsEnabled = redshiftConfig.isDatasourceManagedViewsEnabled();
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        redshiftClient.createView(session, viewMetadata.getTable(), viewData, replace);
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (datasourceManagedViewsEnabled) {
+            return ImmutableMap.of();
+        }
+
+        List<SchemaTableName> viewNames;
+        if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
+            if (!redshiftClient.isView(session, prefix.getSchemaName(), prefix.getTableName())) {
+                return ImmutableMap.of();
+            }
+            viewNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else {
+            viewNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
+        }
+        return redshiftClient.getViews(session, viewNames);
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        if (schemaName.isEmpty()) {
+            return redshiftClient.listViewsFromAllSchemas(session);
+        }
+        return redshiftClient.listViews(session, schemaName);
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        redshiftClient.dropView(session, viewName);
+    }
+}

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftMetadataFactory.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftMetadataFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import jakarta.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftMetadataFactory
+        extends JdbcMetadataFactory
+{
+    private final JdbcMetadataCache jdbcMetadataCache;
+    private final RedshiftClient redshiftClient;
+    private final boolean allowDropTable;
+    private final TableLocationProvider tableLocationProvider;
+    private final RedshiftConfig redshiftConfig;
+
+    @Inject
+    public RedshiftMetadataFactory(
+            JdbcMetadataCache jdbcMetadataCache,
+            RedshiftClient redshiftClient,
+            JdbcMetadataConfig config,
+            TableLocationProvider tableLocationProvider,
+            RedshiftConfig redshiftConfig)
+    {
+        super(jdbcMetadataCache, redshiftClient, config, tableLocationProvider);
+        this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
+        this.redshiftClient = requireNonNull(redshiftClient, "jdbcClient is null");
+        this.allowDropTable = requireNonNull(config, "config is null").isAllowDropTable();
+        this.tableLocationProvider = requireNonNull(tableLocationProvider, "tableLocationProvider is null");
+        this.redshiftConfig = requireNonNull(redshiftConfig, "redshiftConfig is null");
+    }
+
+    @Override
+    public JdbcMetadata create()
+    {
+        return new RedshiftMetadata(jdbcMetadataCache, redshiftClient, allowDropTable, tableLocationProvider, redshiftConfig);
+    }
+}

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftPlugin.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftPlugin.java
@@ -13,13 +13,25 @@
  */
 package com.facebook.presto.plugin.redshift;
 
-import com.facebook.presto.plugin.jdbc.JdbcPlugin;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class RedshiftPlugin
-        extends JdbcPlugin
+        implements Plugin
 {
-    public RedshiftPlugin()
+    public static final String REDSHIFT = "redshift";
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        super("redshift", new RedshiftClientModule());
+        return ImmutableList.of(new RedshiftConnectorFactory(getClassLoader()));
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        return firstNonNull(Thread.currentThread().getContextClassLoader(), RedshiftPlugin.class.getClassLoader());
     }
 }

--- a/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftClient.java
+++ b/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftClient.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.TestingTypeDeserializer;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.h2.Driver;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.facebook.presto.plugin.redshift.RedshiftClient.ViewRewriteMode.ADD_SCHEMA;
+import static com.facebook.presto.plugin.redshift.RedshiftClient.ViewRewriteMode.STRIP_CATALOG;
+import static org.testng.Assert.assertEquals;
+
+public class TestRedshiftClient
+{
+    private static final TestingConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+    private static final JdbcIdentity IDENTITY = JdbcIdentity.from(SESSION);
+
+    private static final JsonCodec<ViewDefinition> VIEW_DEFINITION_JSON_CODEC = buildViewDefinitionCodec();
+    private static final JsonCodec<ViewDefinition> STUB_VIEW_CODEC = JsonCodec.jsonCodec(ViewDefinition.class);
+
+    private static JsonCodec<ViewDefinition> buildViewDefinitionCodec()
+    {
+        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
+        provider.setJsonDeserializers(ImmutableMap.of(Type.class, new TestingTypeDeserializer(FunctionAndTypeManager.createTestFunctionAndTypeManager())));
+        return new JsonCodecFactory(provider, true).jsonCodec(ViewDefinition.class);
+    }
+
+    @DataProvider
+    public static Object[][] viewDefinitionCases()
+    {
+        ImmutableList<ViewDefinition.ViewColumn> columns = ImmutableList.of(new ViewDefinition.ViewColumn("id", BigintType.BIGINT));
+        return new Object[][] {
+                // definer-security: owner present, runAsInvoker = false
+                {new ViewDefinition("SELECT id FROM public.orders", Optional.of("redshift"), Optional.of("public"), columns, Optional.of("test_user"), false)},
+                // invoker-security: no owner, runAsInvoker = true
+                {new ViewDefinition("SELECT id FROM public.orders", Optional.of("redshift"), Optional.of("public"), columns, Optional.empty(), true)},
+        };
+    }
+
+    @Test(dataProvider = "viewDefinitionCases")
+    public void testViewDefinitionCodecRoundTrip(ViewDefinition expected)
+    {
+        ViewDefinition actual = VIEW_DEFINITION_JSON_CODEC.fromJson(VIEW_DEFINITION_JSON_CODEC.toJson(expected));
+
+        assertEquals(actual.getOriginalSql(), expected.getOriginalSql());
+        assertEquals(actual.getCatalog(), expected.getCatalog());
+        assertEquals(actual.getSchema(), expected.getSchema());
+        assertEquals(actual.getOwner(), expected.getOwner());
+        assertEquals(actual.isRunAsInvoker(), expected.isRunAsInvoker());
+        assertEquals(actual.getColumns().size(), expected.getColumns().size());
+        for (int i = 0; i < expected.getColumns().size(); i++) {
+            assertEquals(actual.getColumns().get(i).getName(), expected.getColumns().get(i).getName());
+            assertEquals(actual.getColumns().get(i).getType(), expected.getColumns().get(i).getType());
+        }
+    }
+
+    @DataProvider
+    public static Object[][] stripCatalogCases()
+    {
+        return new Object[][] {
+                // single table
+                {
+                    "SELECT * FROM \"redshift\".\"public\".\"orders\"",
+                    "SELECT * FROM \"public\".\"orders\""
+                },
+                // multiple tables joined
+                {
+                    "SELECT * FROM redshift.public.orders o JOIN \"redshift\".\"public\".\"customers\" c ON o.customer_id = c.id",
+                    "SELECT * FROM \"public\".\"orders\" o JOIN \"public\".\"customers\" c ON o.customer_id = c.id"
+                },
+                // CTE - temp is not rewritten; base table inside CTE is
+                {
+                    "WITH temp AS (SELECT * FROM \"redshift\".public.\"orders\") SELECT * FROM temp",
+                    "WITH temp AS (SELECT * FROM \"public\".\"orders\") SELECT * FROM temp"
+                },
+                // already two-part (no catalog)
+                {
+                    "SELECT * FROM public.orders",
+                    "SELECT * FROM public.orders"
+                },
+        };
+    }
+
+    @Test(dataProvider = "stripCatalogCases")
+    public void testRewriteViewSqlStripCatalog(String input, String expected)
+            throws SQLException
+    {
+        try (Connection connection = createH2Connection("public")) {
+            assertEquals(createRedshiftClient().rewriteViewSql(SESSION, IDENTITY, connection, input, STRIP_CATALOG), expected);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] crossCatalogCases()
+    {
+        return new Object[][] {
+                // single reference to a foreign catalog
+                {"SELECT * FROM \"other_catalog\".\"public\".\"orders\""},
+                // mixed: one own-catalog + one foreign
+                {"SELECT * FROM \"redshift\".\"public\".\"orders\" o JOIN other_catalog.public.customers c ON o.id = c.id"},
+        };
+    }
+
+    @Test(dataProvider = "crossCatalogCases",
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "You can create the view for a table only if that table is in the same catalog\\.")
+    public void testRewriteViewSqlStripCatalogRejectsCrossCatalog(String sql)
+            throws SQLException
+    {
+        try (Connection connection = createH2Connection("public")) {
+            createRedshiftClient().rewriteViewSql(SESSION, IDENTITY, connection, sql, STRIP_CATALOG);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] addSchemaCases()
+    {
+        return new Object[][] {
+                // unqualified bare name - schema prepended from connection
+                {"sales", "SELECT * FROM orders", "SELECT * FROM \"sales\".\"orders\""},
+                // unqualified bare name - default H2 schema "public"
+                {"public", "SELECT * FROM orders", "SELECT * FROM \"public\".\"orders\""},
+                // CTE name must NOT be qualified; only the real table inside it is
+                {"public", "WITH temp AS (SELECT * FROM orders) SELECT * FROM temp", "WITH temp AS (SELECT * FROM \"public\".\"orders\") SELECT * FROM temp"},
+                // already two-part - no-op (already qualified)
+                {"public", "SELECT * FROM public.orders", "SELECT * FROM public.orders"},
+                // invalid SQL - returned unchanged
+                {"public", "SELECT FROM WHERE", "SELECT FROM WHERE"},
+        };
+    }
+
+    @Test(dataProvider = "addSchemaCases")
+    public void testRewriteViewSqlAddSchema(String schema, String input, String expected)
+            throws SQLException
+    {
+        try (Connection connection = createH2Connection(schema)) {
+            assertEquals(createRedshiftClient().rewriteViewSql(SESSION, IDENTITY, connection, input, ADD_SCHEMA), expected);
+        }
+    }
+
+    private static Connection createH2Connection(String schema)
+            throws SQLException
+    {
+        String h2Url = "jdbc:h2:mem:test_" + System.nanoTime() + ";DATABASE_TO_LOWER=TRUE";
+        Connection connection = new Driver().connect(h2Url, new Properties());
+        // H2 only accepts SET SCHEMA for schemas that already exist.
+        // PUBLIC is always present, any other schema must be created first.
+        String normalizedSchema = schema.toLowerCase(Locale.ENGLISH);
+        if (!normalizedSchema.equals("public")) {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("CREATE SCHEMA IF NOT EXISTS " + normalizedSchema);
+            }
+        }
+        connection.setSchema(normalizedSchema);
+        return connection;
+    }
+
+    private static RedshiftClient createRedshiftClient()
+    {
+        RedshiftConfig config = new RedshiftConfig();
+        config.setConnectionUrl("jdbc:redshift://unused.invalid:5439/dev");
+        return new RedshiftClient(new JdbcConnectorId("redshift"), config, STUB_VIEW_CODEC);
+    }
+}

--- a/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftClient.java
+++ b/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftClient.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.plugin.jdbc.DefaultTableLocationProvider;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCacheStats;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.WithQuery;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestRedshiftClient
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().build();
+    private static final TestingConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+    private static final JsonCodec<ViewDefinition> VIEW_DEFINITION_JSON_CODEC = JsonCodec.jsonCodec(ViewDefinition.class);
+
+    @Test
+    public void testViewDefinitionCodecSerializesCorrectly()
+    {
+        ViewDefinition viewDefinition = new ViewDefinition(
+                "SELECT id FROM public.orders",
+                Optional.of("redshift"),
+                Optional.of("public"),
+                ImmutableList.of(new ViewDefinition.ViewColumn("id", BigintType.BIGINT)),
+                Optional.of("test_user"),
+                false);
+
+        String json = VIEW_DEFINITION_JSON_CODEC.toJson(viewDefinition);
+
+        assertTrue(json.contains("\"originalSql\""), "JSON should contain originalSql field");
+        assertTrue(json.contains("\"catalog\""), "JSON should contain catalog field");
+        assertTrue(json.contains("\"schema\""), "JSON should contain schema field");
+        assertTrue(json.contains("\"columns\""), "JSON should contain columns field");
+        assertTrue(json.contains("\"owner\""), "JSON should contain owner field");
+        assertTrue(json.contains("\"runAsInvoker\""), "JSON should contain runAsInvoker field");
+        assertTrue(json.contains("SELECT id FROM public.orders"), "JSON should contain originalSql value");
+        assertTrue(json.contains("\"name\" : \"id\""), "JSON should contain column name");
+        assertTrue(json.contains("\"type\" : \"bigint\""), "JSON should contain column type as string");
+    }
+
+    @Test
+    public void testParsesSimpleSelect()
+    {
+        String sql = "SELECT * FROM orders";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        assertNotNull(statement, "Parser should successfully parse simple SELECT");
+    }
+
+    @Test
+    public void testParsesThreePartTableName()
+    {
+        String sql = "SELECT * FROM \"catalog\".\"schema\".\"table\"";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("\"catalog\".\"schema\".\"table\""));
+    }
+
+    @Test
+    public void testParsesTwoPartTableName()
+    {
+        String sql = "SELECT * FROM \"schema\".\"table\"";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("\"schema\".\"table\""));
+    }
+
+    @Test
+    public void testParsesOnePartTableName()
+    {
+        String sql = "SELECT * FROM orders";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("orders"));
+    }
+
+    @Test
+    public void testCteNamesAreIdentified()
+    {
+        String sql = "WITH temp AS (SELECT 1) SELECT * FROM temp";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> cteNames = extractCteNames(statement);
+        assertEquals(cteNames.size(), 1);
+        assertTrue(cteNames.contains("temp"));
+    }
+
+    @Test
+    public void testNestedCtes()
+    {
+        String sql = "WITH outer_cte AS (WITH inner_cte AS (SELECT 1) SELECT * FROM inner_cte) SELECT * FROM outer_cte";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> cteNames = extractCteNames(statement);
+        assertEquals(cteNames.size(), 2);
+        assertTrue(cteNames.contains("outer_cte"));
+        assertTrue(cteNames.contains("inner_cte"));
+    }
+
+    @Test
+    public void testMultipleCtes()
+    {
+        String sql = "WITH cte1 AS (SELECT 1), cte2 AS (SELECT 2) SELECT * FROM cte1 JOIN cte2 ON true";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> cteNames = extractCteNames(statement);
+        assertEquals(cteNames.size(), 2);
+        assertTrue(cteNames.contains("cte1"));
+        assertTrue(cteNames.contains("cte2"));
+    }
+
+    @Test
+    public void testCteWithRealTable()
+    {
+        String sql = "WITH temp AS (SELECT * FROM orders) SELECT * FROM temp";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> cteNames = extractCteNames(statement);
+        Set<String> tableNames = extractTableNames(statement);
+
+        assertTrue(cteNames.contains("temp"));
+        assertTrue(tableNames.contains("orders"));
+        assertTrue(tableNames.contains("temp"));
+    }
+
+    @Test
+    public void testJoinWithMultipleTables()
+    {
+        String sql = "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 2);
+        assertTrue(tableNames.contains("orders"));
+        assertTrue(tableNames.contains("customers"));
+    }
+
+    @Test
+    public void testSubquery()
+    {
+        String sql = "SELECT * FROM (SELECT * FROM orders) subq";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertTrue(tableNames.contains("orders"));
+    }
+
+    @Test
+    public void testUnion()
+    {
+        String sql = "SELECT * FROM orders UNION ALL SELECT * FROM archived_orders";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 2);
+        assertTrue(tableNames.contains("orders"));
+        assertTrue(tableNames.contains("archived_orders"));
+    }
+
+    @Test
+    public void testQuotedIdentifiers()
+    {
+        String sql = "SELECT * FROM \"Orders\"";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("\"Orders\""));
+    }
+
+    @Test
+    public void testMixedQuotedAndUnquoted()
+    {
+        String sql = "SELECT * FROM \"Orders\" o JOIN customers c ON o.customer_id = c.customer_id";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 2);
+        assertTrue(tableNames.contains("\"Orders\""));
+        assertTrue(tableNames.contains("customers"));
+    }
+
+    @Test
+    public void testFederatedQueryDetectionMultipleCatalogs()
+    {
+        String sql = "SELECT * FROM catalog1.schema.table1 t1 JOIN catalog2.schema.table2 t2 ON t1.col=t2.col";
+
+        assertTrue(isFederatedQuery(sql, "catalog1"),
+                "Query with multiple catalogs should be detected as federated");
+    }
+
+    @Test
+    public void testFederatedQueryDetectionSameCatalog()
+    {
+        String sql = "SELECT * FROM catalog1.schema.table1 t1 JOIN catalog1.schema.table2 t2 ON t1.col=t2.col";
+
+        assertFalse(isFederatedQuery(sql, "catalog1"),
+                "Query with same catalog should not be federated");
+    }
+
+    @Test
+    public void testFederatedQueryDetectionNoCatalog()
+    {
+        String sql = "SELECT * FROM schema.table1 t1 JOIN schema.table2 t2 ON t1.col=t2.col";
+
+        assertFalse(isFederatedQuery(sql, "catalog1"),
+                "Query without catalog prefix should not be federated");
+    }
+
+    @Test
+    public void testComplexQueryWithWindowFunction()
+    {
+        String sql = "SELECT *, ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date) FROM orders";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("orders"));
+    }
+
+    @Test
+    public void testComplexQueryWithGroupBy()
+    {
+        String sql = "SELECT customer_id, COUNT(*) FROM orders GROUP BY customer_id HAVING COUNT(*) > 5";
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+
+        Set<String> tableNames = extractTableNames(statement);
+        assertEquals(tableNames.size(), 1);
+        assertTrue(tableNames.contains("orders"));
+    }
+
+    @Test
+    public void testGetViewsShortCircuitsToEmptyForSpecificViewWhenDatasourceManaged()
+    {
+        RedshiftMetadata metadata = metadataWithDatasourceManagedViews(true);
+
+        Map<SchemaTableName, ConnectorViewDefinition> views =
+                metadata.getViews(SESSION, new SchemaTablePrefix("test_schema", "test_view"));
+
+        assertNotNull(views, "views should not be null");
+        assertTrue(views.isEmpty(),
+                "getViews must short-circuit to an empty map before touching "
+                        + "redshiftClient when datasource-managed views is enabled");
+    }
+
+    @Test
+    public void testGetViewsShortCircuitsToEmptyForWholeSchemaWhenDatasourceManaged()
+    {
+        RedshiftMetadata metadata = metadataWithDatasourceManagedViews(true);
+
+        Map<SchemaTableName, ConnectorViewDefinition> views =
+                metadata.getViews(SESSION, new SchemaTablePrefix("test_schema"));
+
+        assertNotNull(views, "views should not be null");
+        assertTrue(views.isEmpty(),
+                "Schema-level getViews must also short-circuit to an empty map");
+    }
+
+    @Test
+    public void testGetViewsShortCircuitsToEmptyForCatalogWideQueryWhenDatasourceManaged()
+    {
+        RedshiftMetadata metadata = metadataWithDatasourceManagedViews(true);
+
+        Map<SchemaTableName, ConnectorViewDefinition> views =
+                metadata.getViews(SESSION, new SchemaTablePrefix());
+
+        assertNotNull(views, "views should not be null");
+        assertTrue(views.isEmpty(),
+                "Catalog-wide (empty prefix) getViews must also short-circuit "
+                        + "to an empty map");
+    }
+
+    private static RedshiftMetadata metadataWithDatasourceManagedViews(boolean enabled)
+    {
+        RedshiftConfig config = new RedshiftConfig();
+        config.setDatasourceManagedViewsEnabled(enabled);
+        // A syntactically valid but unreachable URL, never dialed for these tests.
+        config.setConnectionUrl("jdbc:redshift://unused.invalid:5439/dev");
+
+        RedshiftClient client = new RedshiftClient(new JdbcConnectorId("test"), config, VIEW_DEFINITION_JSON_CODEC);
+        JdbcMetadataCache cache = new JdbcMetadataCache(client, new JdbcMetadataConfig(), new JdbcMetadataCacheStats());
+
+        return new RedshiftMetadata(
+                cache,
+                client,
+                false,
+                new DefaultTableLocationProvider(config),
+                config);
+    }
+
+    private Set<String> extractTableNames(Statement statement)
+    {
+        Set<String> tableNames = new HashSet<>();
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitTable(Table node, Void context)
+            {
+                List<Identifier> parts = node.getName().getOriginalParts();
+                String tableName = parts.stream()
+                        .map(Object::toString)
+                        .collect(Collectors.joining("."));
+                tableNames.add(tableName);
+                return super.visitTable(node, context);
+            }
+        }.process(statement, null);
+        return tableNames;
+    }
+
+    private Set<String> extractCteNames(Statement statement)
+    {
+        Set<String> cteNames = new HashSet<>();
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitWithQuery(WithQuery node, Void context)
+            {
+                cteNames.add(node.getName().getValue());
+                return super.visitWithQuery(node, context);
+            }
+        }.process(statement, null);
+        return cteNames;
+    }
+
+    private boolean isFederatedQuery(String sql, String currentCatalog)
+    {
+        Statement statement = SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
+        Set<String> sourceCatalogs = new HashSet<>();
+
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitTable(Table node, Void context)
+            {
+                List<String> parts = node.getName().getParts();
+                if (parts.size() == 3) {
+                    sourceCatalogs.add(parts.get(0));
+                }
+                return super.visitTable(node, context);
+            }
+        }.process(statement, null);
+
+        return sourceCatalogs.size() > 1 ||
+                (sourceCatalogs.size() == 1 && !sourceCatalogs.contains(currentCatalog));
+    }
+}

--- a/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftConfig.java
+++ b/presto-redshift/src/test/java/com/facebook/presto/plugin/redshift/TestRedshiftConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.redshift;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.airlift.units.Duration;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestRedshiftConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        RedshiftConfig config = ConfigAssertions.recordDefaults(RedshiftConfig.class);
+
+        // Set BaseJdbcConfig inherited properties
+        config.setConnectionUrl(null)
+                .setConnectionUser(null)
+                .setConnectionPassword(null)
+                .setUserCredentialName(null)
+                .setPasswordCredentialName(null)
+                .setCaseInsensitiveNameMatching(false)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setlistSchemasIgnoredSchemas("information_schema")
+                .setCaseSensitiveNameMatching(false)
+                .setFetchSize(20000);
+
+        // Set RedshiftConfig specific properties
+        config.setDatasourceManagedViewsEnabled(false);
+
+        ConfigAssertions.assertRecordedDefaults(config);
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("connection-url", "jdbc:redshift://host:port/database")
+                .put("connection-user", "user")
+                .put("connection-password", "password")
+                .put("user-credential-name", "foo")
+                .put("password-credential-name", "bar")
+                .put("case-insensitive-name-matching", "true")
+                .put("case-insensitive-name-matching.cache-ttl", "1s")
+                .put("list-schemas-ignored-schemas", "test,test2")
+                .put("case-sensitive-name-matching", "true")
+                .put("jdbc-fetch-size", "5000")
+                .put("enable-datasource-managed-views", "true")
+                .build();
+
+        RedshiftConfig expected = new RedshiftConfig();
+
+        // Set BaseJdbcConfig inherited properties
+        expected.setConnectionUrl("jdbc:redshift://host:port/database")
+                .setConnectionUser("user")
+                .setConnectionPassword("password")
+                .setUserCredentialName("foo")
+                .setPasswordCredentialName("bar")
+                .setCaseInsensitiveNameMatching(true)
+                .setlistSchemasIgnoredSchemas("test,test2")
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
+                .setCaseSensitiveNameMatching(true)
+                .setFetchSize(5000);
+
+        // Set RedshiftConfig specific properties
+        expected.setDatasourceManagedViewsEnabled(true);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
## Description
Add support for Redshift views, including **`CREATE VIEW`**, **`DROP VIEW`**, **`SHOW CREATE VIEW`**, view discovery, and view definition retrieval.

This change also introduces datasource-managed view handling to allow Redshift to resolve views containing Redshift-specific syntax that cannot be analyzed by Presto.

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/28006

The Redshift connector has limited support for Redshift views and does not support operations that require access to view definitions, such as `SHOW CREATE VIEW`.

This change adds support for view creation, deletion, discovery, and definition retrieval. It also introduces datasource-managed view handling for views containing Redshift-specific syntax that cannot be analyzed by Presto.

## Impact
### User-facing changes
- Added support for **`CREATE VIEW`**.
- Added support for **`DROP VIEW`**.
- Added support for **`SHOW CREATE VIEW`**.
- Added the `enable-datasource-managed-views` configuration property.

### Compatibility

When `enable-datasource-managed-views=true`, view resolution is delegated to Redshift and operations that require access to view definitions, such as `DROP VIEW` and `SHOW CREATE VIEW`, are not supported.

## Test Plan
```
presto> CREATE TABLE redshift.test.orders_table (orderkey INT, custkey INT, totalprice DOUBLE);
CREATE TABLE

Query 20260617_143804_00009_npdk9, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:14, server-side: 0:14] [0 rows, 0B] [0 rows/s, 0B/s]

presto> INSERT INTO redshift.test.orders_table VALUES (1, 101, 100.50), (2, 102, 200.75), (3, 103, 300.25);
INSERT: 3 rows

Query 20260617_143827_00010_npdk9, FINISHED, 1 node
Splits: 35 total, 35 done (100.00%)
[Latency: client-side: 1:01, server-side: 1:01] [0 rows, 0B] [0 rows/s, 0B/s]

presto> CREATE VIEW redshift.test.orders_view AS SELECT orderkey, totalprice FROM redshift.test.orders_table;
CREATE VIEW

Query 20260617_144126_00011_npdk9, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:15, server-side: 0:15] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT * FROM redshift.test.orders_view;
 orderkey | totalprice 
----------+------------
        1 |      100.5 
        2 |     200.75 
        3 |     300.25 
(3 rows)

Query 20260617_144147_00012_npdk9, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:26, server-side: 0:26] [3 rows, 0B] [0 rows/s, 0B/s]

presto> SHOW CREATE VIEW redshift.test.orders_view;
                        Create View                        
-----------------------------------------------------------
 CREATE VIEW redshift.test.orders_view SECURITY DEFINER AS 
 SELECT                                                    
   orders_table.orderkey                                   
 , orders_table.totalprice                                 
 FROM                                                      
   test.orders_table                                       
(1 row)

Query 20260617_144219_00013_npdk9, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 0:07, server-side: 0:07] [0 rows, 0B] [0 rows/s, 0B/s]


## verified enable-datasource-managed-views usecase 

presto> SELECT * FROM redshift.test.orders_summary_view;

Query 20260617_150701_00018_npdk9, FAILED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:08, server-side: 0:08] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260617_150701_00018_npdk9 failed: line 1:15: Failed parsing stored view 'redshift.test.orders_summary_view': line 1:73: mismatched input ':'. Expecting: <expression>
SELECT * FROM redshift.test.orders_summary_view

presto> SELECT * FROM redshift2.test.orders_summary_view;
 custkey | order_ids | total_amount 
---------+-----------+--------------
     102 | 3, 4      |       700.75 
     101 | 1, 2      |       301.25 
(2 rows)

Query 20260617_150743_00019_npdk9, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:17, server-side: 0:17] [2 rows, 0B] [0 rows/s, 0B/s]


presto> DROP VIEW redshift.test.orders_view;
DROP VIEW

Query 20260617_144251_00014_npdk9, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:09, server-side: 0:09] [0 rows, 0B] [0 rows/s, 0B/s]

presto> DROP TABLE redshift.test.orders_table
     -> ;
DROP TABLE

Query 20260617_144314_00015_npdk9, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:04, server-side: 0:04] [0 rows, 0B] [0 rows/s, 0B/s]

```
### Additional Validation
- Verified schema-qualified table references in view definitions.
- Verified cross-catalog view references are rejected.
- Verified datasource-managed views using enable-datasource-managed-views=true.
- Added unit tests covering configuration, plugin initialization, datasource-managed view handling, SQL rewriting, and view definition processing.

**_Note_**: Integration tests were not added because Amazon Redshift does not provide a publicly available container image suitable for Presto connector testing, and the functionality depends on Redshift-specific JDBC behavior that cannot be validated using H2.


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Redshift Connector Changes
* Add support for CREATE VIEW, DROP VIEW, and SHOW CREATE VIEW.
* Add support for datasource-managed views through the enable-datasource-managed-views configuration property.
```

## Summary by Sourcery

Enable comprehensive view support in the Redshift connector, including an option to delegate view resolution to Redshift.

New Features:
- Add Redshift support for creating, dropping, discovering, and retrieving view definitions, including SHOW CREATE VIEW.
- Support datasource-managed views through the enable-datasource-managed-views configuration property for Redshift-specific view syntax.

Enhancements:
- Customize Redshift metadata and connector initialization to provide Redshift-specific view handling and SQL compatibility.

Build:
- Add dependencies and test support required for view definition serialization, parsing, and validation.

Documentation:
- Document Redshift view operations and datasource-managed view configuration.

Tests:
- Add unit coverage for view definition serialization, SQL rewriting, cross-catalog validation, datasource-managed view configuration, and connector behavior.