### PR TITLE
feat: Support index columns in toHiveTableHandle conversion (#28009)

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
@@ -385,6 +385,7 @@ HivePrestoToVeloxConnector::toVeloxTableHandle(
       hiveLayout->remainingPredicate,
       tableName,
       hiveLayout->dataColumns,
+      /*indexColumns=*/{},
       tableHandle,
       columnHandles,
       hiveLayout->tableParameters,

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -831,11 +831,38 @@ connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
   }
 }
 
+// DEPRECATED: delegates to the overload that takes `indexColumns`; retained for
+// backward compatibility while callers are migrated, and will be removed.
 std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
     const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
     const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
     const std::string& tableName,
     const protocol::List<protocol::Column>& dataColumns,
+    const protocol::TableHandle& tableHandle,
+    const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
+        columnHandles,
+    const protocol::Map<protocol::String, protocol::String>& tableParameters,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser) {
+  return toHiveTableHandle(
+      domainPredicate,
+      remainingPredicate,
+      tableName,
+      dataColumns,
+      /*indexColumns=*/{},
+      tableHandle,
+      columnHandles,
+      tableParameters,
+      exprConverter,
+      typeParser);
+}
+
+std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
+    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
+    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
+    const std::string& tableName,
+    const protocol::List<protocol::Column>& dataColumns,
+    const std::vector<std::string>& indexColumns,
     const protocol::TableHandle& tableHandle,
     const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
         columnHandles,
@@ -889,6 +916,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
       std::move(subfieldFilters),
       remainingFilter,
       finalDataColumns,
+      indexColumns,
       finalTableParameters,
       columnHandles);
 }

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
@@ -52,11 +52,30 @@ velox::common::CompressionKind toFileCompressionKind(
 velox::connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
     protocol::hive::ColumnType type);
 
+/// DEPRECATED: prefer the overload below that takes `indexColumns`. This
+/// signature is retained only for backward compatibility while callers are
+/// migrated, and will be removed.
 std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
     const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
     const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
     const std::string& tableName,
     const protocol::List<protocol::Column>& dataColumns,
+    const protocol::TableHandle& tableHandle,
+    const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
+        columnHandles,
+    const protocol::Map<protocol::String, protocol::String>& tableParameters,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser);
+
+/// Threads index columns into the resulting handle so index lookups can reuse
+/// this conversion path. Index columns are placed right after dataColumns to
+/// mirror the velox HiveTableHandle constructor ordering.
+std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
+    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
+    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
+    const std::string& tableName,
+    const protocol::List<protocol::Column>& dataColumns,
+    const std::vector<std::string>& indexColumns,
     const protocol::TableHandle& tableHandle,
     const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
         columnHandles,


### PR DESCRIPTION
Summary:
Add an overload of the shared `toHiveTableHandle` conversion that takes `indexColumns` (placed right after `dataColumns`, mirroring the Velox `HiveTableHandle` constructor order) and forwards them into the resulting handle. This lets index-lookup table handles reuse the normal Hive table-handle conversion path — preserving subfield filters, the remaining filter, data columns, table parameters, and filter column handles — rather than a hand-rolled construction that dropped them.

Callers in this codebase are migrated to the new overload. The previous signature (without `indexColumns`) is kept for backward compatibility, marked deprecated, and removed in a follow-up change.

Reviewed By: xiaoxmeng

## Release Notes

```
== NO RELEASE NOTE ==
```



