### PR TITLE
feat(ci): Publish presto images to configurable container registry

### DIFF
--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -324,14 +324,14 @@ jobs:
             exit 1
           fi
 
-      - name: Login to Docker Hub
+      - name: Login to docker.io
         if: ${{ env.REGISTRY == 'dockerhub' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GHCR
+      - name: Login to ghcr.io
         if: ${{ env.REGISTRY == 'ghcr' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
@@ -412,14 +412,14 @@ jobs:
             exit 1
           fi
 
-      - name: Login to Docker Hub
+      - name: Login to docker.io
         if: ${{ env.REGISTRY == 'dockerhub' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GHCR
+      - name: Login to ghcr.io
         if: ${{ env.REGISTRY == 'ghcr' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -56,6 +56,7 @@ env:
   DOCKER_REPO: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   IMAGE_NAME: presto-native
+  REGISTRY: ${{ vars.REGISTRY || 'dockerhub' }}
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
   RELEASE_TAG: ${{ inputs.RELEASE_VERSION }}
   RELEASE_NOTES_COMMIT: ${{ inputs.release-notes-commit }}
@@ -208,6 +209,7 @@ jobs:
         run: ./mvnw clean install -DskipTests
 
       - name: Set up GPG key
+        if: ${{ github.event.inputs.publish_maven == 'true' }}
         env:
           GPG_TTY: $(tty)
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
@@ -303,6 +305,13 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Validate REGISTRY
+        run: |
+          if [[ "${REGISTRY}" != "dockerhub" && "${REGISTRY}" != "ghcr" ]]; then
+            echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'dockerhub' or 'ghcr'."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -315,11 +324,28 @@ jobs:
           name: presto-artifacts-${{ env.RELEASE_TAG }}
           path: ./
 
-      - name: Login to dockerhub
+      - name: Login to Docker Hub
+        if: env.REGISTRY == 'dockerhub'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: env.REGISTRY == 'ghcr'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image prefix
+        run: |
+          if [[ "$REGISTRY" == "ghcr" ]]; then
+            echo "IMAGE_PREFIX=ghcr.io/" >> $GITHUB_ENV
+          else
+            echo "IMAGE_PREFIX=docker.io/" >> $GITHUB_ENV
+          fi
 
       - name: Set up qemu
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -349,8 +375,8 @@ jobs:
             PRESTO_VERSION=${{ env.RELEASE_TAG }}
             JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
           tags: |
-            ${{ env.DOCKER_REPO }}:${{ env.RELEASE_TAG }}
-            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}:latest', env.DOCKER_REPO) || '' }}
+            ${{ env.IMAGE_PREFIX }}${{ github.repository }}:${{ env.RELEASE_TAG }}
+            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}{1}:latest', env.IMAGE_PREFIX, github.repository) || '' }}
 
   publish-native-image:
     needs: publish-release-tag
@@ -372,6 +398,13 @@ jobs:
           docker-images: false
           swap-storage: false
 
+      - name: Validate REGISTRY
+        run: |
+          if [[ "${REGISTRY}" != "dockerhub" && "${REGISTRY}" != "ghcr" ]]; then
+            echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'dockerhub' or 'ghcr'."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -385,11 +418,28 @@ jobs:
           cd presto-native-execution && make submodules
           echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
+        if: env.REGISTRY == 'dockerhub'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: env.REGISTRY == 'ghcr'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image prefix
+        run: |
+          if [[ "$REGISTRY" == "ghcr" ]]; then
+            echo "IMAGE_PREFIX=ghcr.io/" >> $GITHUB_ENV
+          else
+            echo "IMAGE_PREFIX=docker.io/" >> $GITHUB_ENV
+          fi
 
       - name: Set dependency image tag
         env:
@@ -399,7 +449,7 @@ jobs:
           if [[ -n "$DEPENDENCY_IMAGE" ]]; then
             echo "DEPENDENCY_IMAGE=$DEPENDENCY_IMAGE" >> $GITHUB_ENV
           else
-            echo "DEPENDENCY_IMAGE=${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}" >> $GITHUB_ENV
+            echo "DEPENDENCY_IMAGE=${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}" >> $GITHUB_ENV
           fi
 
       - name: Build Dependency Image
@@ -417,12 +467,12 @@ jobs:
             echo "Building new depedency image"
             docker compose build centos-native-dependency
             if [[ "$PUBLISH_NATIVE_IMAGE" == "true" ]]; then
-              docker tag presto/prestissimo-dependency:centos9 ${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
-              docker push ${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
+              docker tag presto/prestissimo-dependency:centos9 ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
+              docker push ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
 
               if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-                docker tag presto/prestissimo-dependency:centos9 ${{ github.repository_owner }}/presto-native-dependency:latest
-                docker push ${{ github.repository_owner }}/presto-native-dependency:latest
+                docker tag presto/prestissimo-dependency:centos9 ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:latest
+                docker push ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:latest
               fi
             fi
           fi
@@ -451,21 +501,21 @@ jobs:
           ORG_NAME: ${{ env.ORG_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          docker tag presto/prestissimo-runtime:centos9 $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
+          docker tag presto/prestissimo-runtime:centos9 ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
           if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag presto/prestissimo-runtime:centos9 $ORG_NAME/${{ env.IMAGE_NAME }}:latest
+            docker tag presto/prestissimo-runtime:centos9 ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
           fi
 
-      - name: Push to DockerHub
+      - name: Push image
         env:
           TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
           ORG_NAME: ${{ env.ORG_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          docker push $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
+          docker push ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
           if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG $ORG_NAME/${{ env.IMAGE_NAME }}:latest
-            docker push $ORG_NAME/${{ env.IMAGE_NAME }}:latest
+            docker tag ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
+            docker push ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
           fi
 
   publish-docs:

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -53,7 +53,7 @@ env:
   JAVA_VERSION: ${{ vars.JAVA_VERSION || '17' }}
   JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
   MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
-  DOCKER_REPO: ${{ github.repository }}
+  IMAGE_REPO: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   IMAGE_NAME: presto-native
   REGISTRY: ${{ vars.REGISTRY || 'dockerhub' }}
@@ -305,13 +305,6 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Validate REGISTRY
-        run: |
-          if [[ "${REGISTRY}" != "dockerhub" && "${REGISTRY}" != "ghcr" ]]; then
-            echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'dockerhub' or 'ghcr'."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -324,15 +317,22 @@ jobs:
           name: presto-artifacts-${{ env.RELEASE_TAG }}
           path: ./
 
+      - name: Validate REGISTRY
+        run: |
+          if [[ "$REGISTRY" != "dockerhub" && "$REGISTRY" != "ghcr" ]]; then
+            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'dockerhub' or 'ghcr'."
+            exit 1
+          fi
+
       - name: Login to Docker Hub
-        if: env.REGISTRY == 'dockerhub'
+        if: ${{ env.REGISTRY == 'dockerhub' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        if: env.REGISTRY == 'ghcr'
+        if: ${{ env.REGISTRY == 'ghcr' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -375,8 +375,8 @@ jobs:
             PRESTO_VERSION=${{ env.RELEASE_TAG }}
             JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
           tags: |
-            ${{ env.IMAGE_PREFIX }}${{ github.repository }}:${{ env.RELEASE_TAG }}
-            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}{1}:latest', env.IMAGE_PREFIX, github.repository) || '' }}
+            ${{ env.IMAGE_PREFIX }}${{ env.IMAGE_REPO }}:${{ env.RELEASE_TAG }}
+            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}{1}:latest', env.IMAGE_PREFIX, env.IMAGE_REPO) || '' }}
 
   publish-native-image:
     needs: publish-release-tag
@@ -398,13 +398,6 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - name: Validate REGISTRY
-        run: |
-          if [[ "${REGISTRY}" != "dockerhub" && "${REGISTRY}" != "ghcr" ]]; then
-            echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'dockerhub' or 'ghcr'."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -412,21 +405,22 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - name: Initialize Prestissimo submodules
+      - name: Validate REGISTRY
         run: |
-          df -h
-          cd presto-native-execution && make submodules
-          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          if [[ "$REGISTRY" != "dockerhub" && "$REGISTRY" != "ghcr" ]]; then
+            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'dockerhub' or 'ghcr'."
+            exit 1
+          fi
 
       - name: Login to Docker Hub
-        if: env.REGISTRY == 'dockerhub'
+        if: ${{ env.REGISTRY == 'dockerhub' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        if: env.REGISTRY == 'ghcr'
+        if: ${{ env.REGISTRY == 'ghcr' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -440,6 +434,12 @@ jobs:
           else
             echo "IMAGE_PREFIX=docker.io/" >> $GITHUB_ENV
           fi
+
+      - name: Initialize Prestissimo submodules
+        run: |
+          df -h
+          cd presto-native-execution && make submodules
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Set dependency image tag
         env:

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -56,7 +56,7 @@ env:
   IMAGE_REPO: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   IMAGE_NAME: presto-native
-  REGISTRY: ${{ vars.REGISTRY || 'dockerhub' }}
+  REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
   RELEASE_TAG: ${{ inputs.RELEASE_VERSION }}
   RELEASE_NOTES_COMMIT: ${{ inputs.release-notes-commit }}
@@ -319,20 +319,20 @@ jobs:
 
       - name: Validate REGISTRY
         run: |
-          if [[ "$REGISTRY" != "dockerhub" && "$REGISTRY" != "ghcr" ]]; then
-            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'dockerhub' or 'ghcr'."
+          if [[ "$REGISTRY" != "docker.io" && "$REGISTRY" != "ghcr.io" ]]; then
+            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'docker.io' or 'ghcr.io'."
             exit 1
           fi
 
       - name: Login to docker.io
-        if: ${{ env.REGISTRY == 'dockerhub' }}
+        if: ${{ env.REGISTRY == 'docker.io' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io
-        if: ${{ env.REGISTRY == 'ghcr' }}
+        if: ${{ env.REGISTRY == 'ghcr.io' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -340,12 +340,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set image prefix
-        run: |
-          if [[ "$REGISTRY" == "ghcr" ]]; then
-            echo "IMAGE_PREFIX=ghcr.io/" >> $GITHUB_ENV
-          else
-            echo "IMAGE_PREFIX=docker.io/" >> $GITHUB_ENV
-          fi
+        run: echo "IMAGE_PREFIX=${REGISTRY}/" >> $GITHUB_ENV
 
       - name: Set up qemu
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -407,20 +402,20 @@ jobs:
 
       - name: Validate REGISTRY
         run: |
-          if [[ "$REGISTRY" != "dockerhub" && "$REGISTRY" != "ghcr" ]]; then
-            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'dockerhub' or 'ghcr'."
+          if [[ "$REGISTRY" != "docker.io" && "$REGISTRY" != "ghcr.io" ]]; then
+            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'docker.io' or 'ghcr.io'."
             exit 1
           fi
 
       - name: Login to docker.io
-        if: ${{ env.REGISTRY == 'dockerhub' }}
+        if: ${{ env.REGISTRY == 'docker.io' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io
-        if: ${{ env.REGISTRY == 'ghcr' }}
+        if: ${{ env.REGISTRY == 'ghcr.io' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -428,12 +423,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set image prefix
-        run: |
-          if [[ "$REGISTRY" == "ghcr" ]]; then
-            echo "IMAGE_PREFIX=ghcr.io/" >> $GITHUB_ENV
-          else
-            echo "IMAGE_PREFIX=docker.io/" >> $GITHUB_ENV
-          fi
+        run: echo "IMAGE_PREFIX=${REGISTRY}/" >> $GITHUB_ENV
 
       - name: Initialize Prestissimo submodules
         run: |


### PR DESCRIPTION
Description
-----------

Add support for publishing Presto and Presto-native Docker images to a configurable container registry (Docker Hub or GitHub Container Registry), selected via the `REGISTRY` GitHub repository variable.

This enables organizations that cannot use Docker Hub to publish release images to GHCR instead.

Motivation and Context
----------------------

The current release publish workflow only supports publishing Docker images to Docker Hub. This limits organizations and forks that:

* Cannot use Docker Hub due to rate limits or organizational policies.
* Want to publish their own images for production or testing on GitHub Container Registry (GHCR), which is available to all GitHub users and orgs.

This change makes the registry configurable via a `REGISTRY` repository variable (`docker.io` or `ghcr.io`), defaulting to Docker Hub for backward compatibility. Forks can simply set `REGISTRY=ghcr.io` and use their existing `GITHUB_TOKEN` to publish images to their own GHCR namespace.

Impact
------

### User-facing changes

* Added `REGISTRY` repository variable to select container registry (`docker.io` or `ghcr.io`, defaults to `docker.io`).
* When `REGISTRY=ghcr.io`, images are published to `ghcr.io/<owner>/<image>` instead of Docker Hub.
* GPG key setup is now conditional on `publish_maven` — previously GPG was always set up even when only publishing images, now it is gated behind the flag that actually uses it.

### Compatibility

Fully backward compatible. Default behavior (Docker Hub) is unchanged.

Test Plan
---------

Validated by publishing images from a fork to GHCR: [workflow run](https://github.com/y-scope/presto/actions/runs/27735974607)

All 3 images published successfully:
* [presto](https://github.com/y-scope/presto/pkgs/container/presto)
* [presto-native](https://github.com/y-scope/presto/pkgs/container/presto-native)
* [presto-native-dependency](https://github.com/y-scope/presto/pkgs/container/presto-native-dependency)

Additional configuration logic validation:

* `REGISTRY` unset or `dockerhub` → Docker Hub login, `docker.io/` prefix, same behavior as before.
* `REGISTRY=ghcr` → GHCR login with `GITHUB_TOKEN`, `ghcr.io/` prefix.
* `REGISTRY` set to invalid value → `Validate REGISTRY` step fails with clear error message.

Contributor checklist
---------------------

* [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
* [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
* [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
* [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
* [x] Adequate tests were added if applicable.
* [x] CI passed.
* [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

Release Notes
--------------

```
== RELEASE NOTES ==

General Changes
* Add support for publishing release Docker images to GitHub Container Registry (GHCR) via the REGISTRY repository variable.
```

## Summary by Sourcery

Add support for publishing Presto release Docker images to either Docker Hub or GitHub Container Registry based on a configurable registry setting in the release workflow.

CI:
- Introduce a REGISTRY workflow variable (defaulting to Docker Hub) to control whether release images are published to Docker Hub or GHCR, including validation and registry-specific login steps.
- Prefix published image tags with the appropriate registry host and repository owner, updating all Presto and Presto-native image build and push steps to honor the selected registry.
- Gate GPG key setup in the release workflow behind the publish_maven input so it only runs when Maven artifacts are being published.