### PR TITLE
fix: Fix missing column lineage for UNNEST operations

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestOutputColumnTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestOutputColumnTypes.java
@@ -254,6 +254,67 @@ public class TestOutputColumnTypes
     }
 
     @Test
+    public void testOutputColumnsForSingleUnnestWithTwoExpressions()
+            throws Exception
+    {
+        runQueryAndWaitForEvents(
+                "CREATE TABLE student_scores( student_name VARCHAR, subjects ARRAY(VARCHAR), scores ARRAY(INTEGER))", 2);
+        runQueryAndWaitForEvents(
+                "INSERT INTO  student_scores VALUES('Alice', ARRAY['Math', 'Science', 'English'], ARRAY[95, 88, 92]), ('Bob',   ARRAY['Math', 'Science', 'English'], ARRAY[78, 85, 90]),('Carol', ARRAY['Math', 'Science'], ARRAY[88, 91])", 2);
+        runQueryAndWaitForEvents(
+                "CREATE TABLE student_scores_details AS SELECT student_name, u.subject, u.score FROM  student_scores\n" +
+                        "CROSS JOIN UNNEST(subjects, scores) AS u(subject, score)", 2);
+
+        QueryCompletedEvent event = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(
+                        new OutputColumnMetadata("student_name", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_scores"), "student_name"))),
+                        new OutputColumnMetadata("subject", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_scores"), "subjects"))),
+                        new OutputColumnMetadata("score", "integer", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_scores"), "scores"))));
+    }
+
+    @Test
+    public void testOutputColumnsForSingleUnnestWithTwoMapExpressions()
+            throws Exception
+    {
+        runQueryAndWaitForEvents(
+                "CREATE TABLE student_grade_map(" +
+                        "student_name VARCHAR, " +
+                        "subject_scores MAP(VARCHAR, INTEGER), " +
+                        "subject_grades MAP(VARCHAR, VARCHAR))", 2);
+        runQueryAndWaitForEvents(
+                "INSERT INTO student_grade_map VALUES" +
+                        "('Alice', MAP(ARRAY['Math', 'Science', 'English'], ARRAY[95, 88, 92]), " +
+                        "          MAP(ARRAY['Math', 'Science', 'English'], ARRAY['A', 'B+', 'A+']))," +
+                        "('Bob',   MAP(ARRAY['Math', 'Science'], ARRAY[78, 85]), " +
+                        "          MAP(ARRAY['Math', 'Science'], ARRAY['B+', 'A+']))", 2);
+        runQueryAndWaitForEvents(
+                "CREATE TABLE student_grade_map_details AS " +
+                        "SELECT student_name, u.subject1, u.score, u.subject2, u.grade " +
+                        "FROM student_grade_map " +
+                        "CROSS JOIN UNNEST(subject_scores, subject_grades) AS u(subject1, score, subject2, grade)", 2);
+
+        QueryCompletedEvent event = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(
+                        new OutputColumnMetadata("student_name", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_grade_map"), "student_name"))),
+                        new OutputColumnMetadata("subject1", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_grade_map"), "subject_scores"))),
+                        new OutputColumnMetadata("score", "integer", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_grade_map"), "subject_scores"))),
+                        new OutputColumnMetadata("subject2", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_grade_map"), "subject_grades"))),
+                        new OutputColumnMetadata("grade", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "student_grade_map"), "subject_grades"))));
+    }
+
+    @Test
     public void testOutputColumnsForCreateTableAsSelectWithColumns()
             throws Exception
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestOutputColumnTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestOutputColumnTypes.java
@@ -200,6 +200,60 @@ public class TestOutputColumnTypes
     }
 
     @Test
+    public void testOutputColumnsForUnnest()
+            throws Exception
+    {
+        runQueryAndWaitForEvents("CREATE TABLE create_update_table22 (orderkey bigint, custkey bigint, orderstatus ARRAY(varchar))", 2);
+        runQueryAndWaitForEvents("INSERT INTO create_update_table22 VALUES (10, 20, ARRAY['SUCCESS', 'FAILED']), (22, 30, ARRAY['FAILED', 'PENDING'])", 2);
+        runQueryAndWaitForEvents("CREATE TABLE create_update_table22_new AS  SELECT o.orderkey, o.custkey, s1.orderstatus AS status FROM create_update_table22 o CROSS JOIN UNNEST(o.orderstatus) AS s1(orderstatus)", 2);
+
+        QueryCompletedEvent event = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+
+        assertThat(event.getIoMetadata().getOutput().get().getCatalogName()).isEqualTo("iceberg");
+        assertThat(event.getIoMetadata().getOutput().get().getSchema()).isEqualTo("tpch");
+        assertThat(event.getIoMetadata().getOutput().get().getTable()).isEqualTo("create_update_table22_new");
+        assertThat(event.getMetadata().getUpdateQueryType().get()).isEqualTo("CREATE TABLE");
+
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(
+                        new OutputColumnMetadata("orderkey", "bigint", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "create_update_table22"), "orderkey"))),
+                        new OutputColumnMetadata("custkey", "bigint", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "create_update_table22"), "custkey"))),
+                        new OutputColumnMetadata("status", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "create_update_table22"), "orderstatus"))));
+    }
+
+    @Test
+    public void testOutputColumnsForMultipleUnnest()
+            throws Exception
+    {
+        runQueryAndWaitForEvents("CREATE TABLE employee_details (emp_id int,emp_name varchar(100),skills ARRAY(varchar),certifications ARRAY(varchar),projects ARRAY(varchar))", 2);
+        runQueryAndWaitForEvents("INSERT INTO employee_details VALUES(1, 'John Doe', ARRAY['SQL', 'Python', 'Kubernetes'], ARRAY['AWS Certified', 'Azure Certified'],ARRAY['Project A', 'Project B']),(2, 'Jane Smith', ARRAY['Java', 'Docker'], ARRAY['GCP Certified'],ARRAY['Project C'])", 2);
+        runQueryAndWaitForEvents("CREATE TABLE employee_skills_certs AS SELECT e.emp_id,e.emp_name,t1.skill AS employee_skill,t2.cert AS employee_certification FROM employee_details e\n" +
+                "CROSS JOIN UNNEST(e.skills) AS t1(skill)\n" +
+                "CROSS JOIN UNNEST(e.certifications) AS t2(cert)", 2);
+
+        QueryCompletedEvent event = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+
+        assertThat(event.getIoMetadata().getOutput().get().getCatalogName()).isEqualTo("iceberg");
+        assertThat(event.getIoMetadata().getOutput().get().getSchema()).isEqualTo("tpch");
+        assertThat(event.getIoMetadata().getOutput().get().getTable()).isEqualTo("employee_skills_certs");
+        assertThat(event.getMetadata().getUpdateQueryType().get()).isEqualTo("CREATE TABLE");
+
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(
+                        new OutputColumnMetadata("emp_id", "integer", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "employee_details"), "emp_id"))),
+                        new OutputColumnMetadata("emp_name", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "employee_details"), "emp_name"))),
+                        new OutputColumnMetadata("employee_skill", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "employee_details"), "skills"))),
+                        new OutputColumnMetadata("employee_certification", "varchar", ImmutableSet.of(
+                                new SourceColumn(new QualifiedObjectName("iceberg", "tpch", "employee_details"), "certifications"))));
+    }
+
+    @Test
     public void testOutputColumnsForCreateTableAsSelectWithColumns()
             throws Exception
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1661,6 +1661,8 @@ class StatementAnalyzer
                 else {
                     throw new PrestoException(StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
                 }
+                ImmutableList<Field> fields = outputFields.build();
+                fields.forEach(field -> analysis.addSourceColumns(field, analysis.getExpressionSourceColumns(expression)));
             }
             if (node.isWithOrdinality()) {
                 outputFields.add(Field.newUnqualified(node.getLocation(), Optional.empty(), BIGINT));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1634,6 +1634,7 @@ class StatementAnalyzer
         protected Scope visitUnnest(Unnest node, Optional<Scope> scope)
         {
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+            int fieldsBefore = 0;
             for (Expression expression : node.getExpressions()) {
                 ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, createScope(scope));
                 if (!expressionAnalysis.getScalarSubqueries().isEmpty()) {
@@ -1661,8 +1662,13 @@ class StatementAnalyzer
                 else {
                     throw new PrestoException(StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
                 }
-                ImmutableList<Field> fields = outputFields.build();
-                fields.forEach(field -> analysis.addSourceColumns(field, analysis.getExpressionSourceColumns(expression)));
+
+                ImmutableList<Field> allFields = outputFields.build();
+                Set<SourceColumn> sourceColumns = analysis.getExpressionSourceColumns(expression);
+                for (int i = fieldsBefore; i < allFields.size(); i++) {
+                    analysis.addSourceColumns(allFields.get(i), sourceColumns);
+                }
+                fieldsBefore = allFields.size();
             }
             if (node.isWithOrdinality()) {
                 outputFields.add(Field.newUnqualified(node.getLocation(), Optional.empty(), BIGINT));


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/26559
Co-authored-by: qbhan

## Description
<!---Describe your changes in detail-->
Columns referenced within UNNEST expressions are not included as input fields when generating column lineage.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure column lineage captures source columns used in UNNEST operations and extend test coverage for UNNEST output column metadata.

Bug Fixes:
- Fix missing source column tracking for columns referenced in UNNEST expressions when computing column lineage.

Tests:
- Add integration tests verifying output column metadata and lineage for single and multiple UNNEST operations in CREATE TABLE AS SELECT queries.