### PR TITLE
feat(native-pos): Chunk RowGroup flushing in MaterializedOutput (#28012)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -119,6 +119,7 @@ MaterializedOutput::MaterializedOutput(
               kMinTargetSize,
               SystemConfig::instance()
                   ->exchangeMaterializationPartitioningRowBatchBufferSize())),
+      rowGroupMaxBytes_(buffer_->partitionDrainThreshold()),
       fixedRowSize_(
           row::CompactRow::fixedRowSize(
               std::dynamic_pointer_cast<const RowType>(
@@ -396,8 +397,9 @@ void MaterializedOutput::addInput(RowVectorPtr input) {
   }
 }
 
-std::unique_ptr<folly::IOBuf> MaterializedOutput::buildRowGroup(
-    const std::vector<int32_t>& rowIndices) {
+void MaterializedOutput::flushRowGroup(
+    int32_t partition,
+    std::vector<int32_t>& rowIndices) {
   using TRowSize = serializer::TRowSize;
   const auto kHeaderSize = serializer::detail::RowGroupHeader::size();
 
@@ -429,7 +431,8 @@ std::unique_ptr<folly::IOBuf> MaterializedOutput::buildRowGroup(
     dest += rowSizes_[idx];
   }
   iobuf->append(totalBytes);
-  return iobuf;
+  buffer_->enqueue(partition, std::move(iobuf));
+  rowIndices.clear();
 }
 
 void MaterializedOutput::flushBatch() {
@@ -449,9 +452,24 @@ void MaterializedOutput::flushBatch() {
       continue;
     }
 
-    auto iobuf = buildRowGroup(rows);
+    std::vector<int32_t> rowGroupRows;
+    rowGroupRows.reserve(rows.size());
+    int64_t rowGroupBytes = serializer::detail::RowGroupHeader::size();
+    for (auto row : rows) {
+      const auto rowBytes =
+          static_cast<int64_t>(sizeof(serializer::TRowSize)) + rowSizes_[row];
+      if (!rowGroupRows.empty() &&
+          rowGroupBytes + rowBytes > rowGroupMaxBytes_) {
+        flushRowGroup(partition, rowGroupRows);
+        rowGroupBytes = serializer::detail::RowGroupHeader::size();
+      }
+      rowGroupRows.push_back(row);
+      rowGroupBytes += rowBytes;
+    }
 
-    buffer_->enqueue(partition, std::move(iobuf));
+    if (!rowGroupRows.empty()) {
+      flushRowGroup(partition, rowGroupRows);
+    }
   }
 
   // Reset accumulated state.

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -163,10 +163,10 @@ class MaterializedOutput : public velox::exec::Operator {
   // Grow the flat buffer if needed to accommodate additionalBytes.
   void ensureFlatBufferCapacity(int64_t additionalBytes);
 
-  // Build a contiguous IOBuf with RowGroupHeader + TRowSize-framed CompactRow
-  // data for the given row indices belonging to one partition.
-  std::unique_ptr<folly::IOBuf> buildRowGroup(
-      const std::vector<int32_t>& rowIndices);
+  // Build and enqueue a contiguous RowGroup with RowGroupHeader +
+  // TRowSize-framed CompactRow data for the given row indices belonging to one
+  // partition.
+  void flushRowGroup(int32_t partition, std::vector<int32_t>& rowIndices);
 
   // True when the plan requested replicateNullsAndAny AND broadcasting
   // would actually produce extra entries (i.e., more than one destination).
@@ -202,6 +202,11 @@ class MaterializedOutput : public velox::exec::Operator {
 
   // Flush threshold: clamp(numPartitions * kDefaultAvgRowSize, 1MB, 10MB).
   int64_t targetSizeInBytes_;
+
+  // Maximum target size for a multi-row RowGroup sent to the shared
+  // MaterializedOutputBuffer. A single row larger than this still emits as one
+  // RowGroup.
+  int64_t rowGroupMaxBytes_;
 
   // Fixed row size for all-fixed-width schemas (avoids per-row rowSize()).
   std::optional<int32_t> fixedRowSize_;

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -88,21 +88,30 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
   std::lock_guard<std::mutex> lock(mutex_);
   VELOX_CHECK(!closed_, "enqueue called on closed partition");
   auto dataSize = static_cast<int64_t>(rowGroup->computeChainDataLength());
+  auto drain = [&]() {
+    std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
+    toDrain.swap(rowGroups_);
+    auto drainedBytes = bufferedBytes_.load();
+    bufferedBytes_ = 0;
+
+    auto coalesced = buffer_->coalesceRowGroups(toDrain);
+    buffer_->flushToWriter(partition, std::move(coalesced));
+    return drainedBytes;
+  };
+
+  int64_t drainedBytes = 0;
+  if (!rowGroups_.empty() && bufferedBytes_ + dataSize > drainThreshold_) {
+    drainedBytes += drain();
+  }
+
   rowGroups_.push_back(std::move(rowGroup));
   bufferedBytes_ += dataSize;
 
   if (bufferedBytes_ < drainThreshold_) {
-    return 0;
+    return drainedBytes;
   }
 
-  // Drain: coalesce + flush under the same lock.
-  std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
-  toDrain.swap(rowGroups_);
-  auto drainedBytes = bufferedBytes_.load();
-  bufferedBytes_ = 0;
-
-  auto coalesced = buffer_->coalesceRowGroups(toDrain);
-  buffer_->flushToWriter(partition, std::move(coalesced));
+  drainedBytes += drain();
   return drainedBytes;
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -191,9 +191,14 @@ class MaterializedOutputBuffer {
     return bufferedBytes_;
   }
 
+  /// Maximum bytes buffered per partition before draining to the writer.
+  int64_t partitionDrainThreshold() const {
+    return partitionDrainThreshold_;
+  }
+
   /// For testing: returns the current per-partition drain threshold.
   int64_t testingCurrentDrainThreshold() const {
-    return partitionDrainThreshold_;
+    return partitionDrainThreshold();
   }
 
   /// Returns combined writer + buffer stats with typed units

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -158,6 +158,62 @@ class FailingCloseShuffleFactory : public ShuffleInterfaceFactory {
   ShuffleInterfaceFactory* delegate_;
 };
 
+class RecordingShuffleWriter : public ShuffleWriter {
+ public:
+  RecordingShuffleWriter(
+      std::shared_ptr<ShuffleWriter> delegate,
+      std::shared_ptr<std::vector<size_t>> collectSizes)
+      : delegate_(std::move(delegate)),
+        collectSizes_(std::move(collectSizes)) {}
+
+  void collect(int32_t partition, std::string_view key, std::string_view data)
+      override {
+    collectSizes_->push_back(data.size());
+    delegate_->collect(partition, key, data);
+  }
+
+  void noMoreData(bool success) override {
+    delegate_->noMoreData(success);
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return delegate_->stats();
+  }
+
+ private:
+  std::shared_ptr<ShuffleWriter> delegate_;
+  std::shared_ptr<std::vector<size_t>> collectSizes_;
+};
+
+class RecordingShuffleFactory : public ShuffleInterfaceFactory {
+ public:
+  explicit RecordingShuffleFactory(ShuffleInterfaceFactory* delegate)
+      : delegate_(delegate),
+        collectSizes_(std::make_shared<std::vector<size_t>>()) {}
+
+  std::shared_ptr<ShuffleReader> createReader(
+      const std::string& serializedShuffleInfo,
+      int32_t partition,
+      velox::memory::MemoryPool* pool) override {
+    return delegate_->createReader(serializedShuffleInfo, partition, pool);
+  }
+
+  std::shared_ptr<ShuffleWriter> createWriter(
+      const std::string& serializedShuffleInfo,
+      velox::memory::MemoryPool* pool) override {
+    return std::make_shared<RecordingShuffleWriter>(
+        delegate_->createWriter(serializedShuffleInfo, pool), collectSizes_);
+  }
+
+  const std::vector<size_t>& collectSizes() const {
+    return *collectSizes_;
+  }
+
+ private:
+  ShuffleInterfaceFactory* delegate_;
+  std::shared_ptr<std::vector<size_t>> collectSizes_;
+};
+
 } // namespace
 
 class MaterializedExchangeTest : public exec::test::OperatorTestBase {
@@ -363,6 +419,75 @@ TEST_F(MaterializedExchangeTest, largeDataEndToEnd) {
   auto actual = runExchangeRead(numPartitions, asRowType(data->type()));
 
   exec::test::assertEqualResults(expected, actual);
+  cleanupDirectory(tempDir_->getPath());
+}
+
+TEST_F(MaterializedExchangeTest, boundsCollectSizeForLargeInputBatch) {
+  constexpr int numRows = 128;
+  constexpr int valueBytes = 8 * 1024;
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(numRows, [](auto /*row*/) { return 0; }),
+      makeFlatVector<std::string>(
+          numRows,
+          [](auto row) {
+            return std::string(valueBytes, static_cast<char>('a' + row % 26));
+          }),
+  });
+  auto dataType = asRowType(data->type());
+
+  constexpr int numPartitions = 1;
+  constexpr int numDrivers = 1;
+  auto writeInfoStr = localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
+  RecordingShuffleFactory recordingFactory(
+      ShuffleInterfaceFactory::factory(shuffleName_));
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfoStr,
+      &recordingFactory,
+      "split.0.0.0.0",
+      rootPool_.get());
+
+  std::vector<core::TypedExprPtr> keys{
+      std::make_shared<core::FieldAccessTypedExpr>(
+          dataType->childAt(0), dataType->nameOf(0))};
+  auto partitionFunctionSpec =
+      std::make_shared<exec::HashPartitionFunctionSpec>(
+          dataType, std::vector<column_index_t>{0});
+
+  auto valuesNode = exec::test::PlanBuilder().values({data}, true).planNode();
+  auto exchangeWriteNode = std::make_shared<MaterializedOutputNode>(
+      "exchangeWrite",
+      keys,
+      numPartitions,
+      dataType,
+      partitionFunctionSpec,
+      /*replicateNullsAndAny=*/false,
+      ShuffleWriterMetadata{},
+      valuesNode);
+
+  auto taskId = makeTaskId("write", 0);
+  MaterializedOutputBuffer::registerBuffer(taskId, buffer);
+  auto task = makeTask(taskId, exchangeWriteNode, 0);
+  task->start(numDrivers);
+
+  EXPECT_TRUE(exec::test::waitForTaskCompletion(task.get(), 10'000'000));
+  MaterializedOutputBuffer::removeBuffer(taskId);
+
+  auto stats = buffer->stats();
+  const auto collectCount =
+      stats.at(std::string(MaterializedOutputBuffer::kTotalCollectCalls)).sum;
+  const auto collectSizeLimit =
+      stats.at(std::string(MaterializedOutputBuffer::kCurrentDrainThreshold))
+          .sum;
+  EXPECT_GT(collectCount, 1);
+  ASSERT_EQ(recordingFactory.collectSizes().size(), collectCount);
+  for (auto collectSize : recordingFactory.collectSizes()) {
+    EXPECT_LE(collectSize, collectSizeLimit);
+  }
+
+  auto actual = runExchangeRead(numPartitions, dataType);
+  exec::test::assertEqualResults({data}, actual);
   cleanupDirectory(tempDir_->getPath());
 }
 


### PR DESCRIPTION
Summary:

MaterializedOutput currently builds one RowGroup per partition for the entire accumulated input batch before handing it to MaterializedOutputBuffer. That can make Cosco see a large multi-row RowGroup as a single collect record, unlike the older ShuffleWrite path that collected each serialized row independently.

This changes MaterializedOutput::flushBatch() to split each partition into RowGroups bounded by the same per-partition target used by MaterializedOutputBuffer. Single rows larger than the target still emit as one RowGroup, preserving true large-row behavior.

Differential Revision: D109001202

```
== NO RELEASE NOTE ==
```


