### PR TITLE
docs: Fix use of Latin abbreviations in Presto doc (part 5)

### DIFF
--- a/presto-docs/src/main/sphinx/cache/local.rst
+++ b/presto-docs/src/main/sphinx/cache/local.rst
@@ -65,7 +65,7 @@ Additionally, Alluxio exports various JMX metrics while performing caching-relat
 System administrators can monitor cache usage across the cluster by checking the following metrics:
 
 * ``Client.CacheBytesEvicted``: Total number of bytes evicted from the client cache.
-* ``Client.CacheBytesReadCache``:  Total number of bytes read from the client cache (e.g., cache hit).
+* ``Client.CacheBytesReadCache``:  Total number of bytes read from the client cache (for example, cache hit).
 * ``Client.CacheBytesRequestedExternal``: Total number of bytes the user requested to read which resulted in a cache miss. This number may be smaller than Client.CacheBytesReadExternal due to chunk reads.
 * ``Client.CacheHitRate``: The hit rate measured by (# bytes read from cache) / (# bytes requested).
 * ``Client.CacheSpaceAvailable``: Amount of bytes available in the client cache.

--- a/presto-docs/src/main/sphinx/cache/service.rst
+++ b/presto-docs/src/main/sphinx/cache/service.rst
@@ -118,7 +118,7 @@ With Alluxio file system this approach supports the following features:
   `alluxio fs distributedLoad <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#distributedload>`_,
   in addition to caching data transparently based on the data access pattern.
 * **Read/write Types and Data Policies**: Users can customize read and write modes for Presto when reading from and writing to Alluxio.
-  For example, tell Presto read to skip caching data when reading from certain locations and avoid cache thrashing, or set TTLs on files in given locations using
+  For example, tell Presto read operations to skip caching data when reading from certain locations and avoid cache thrashing, or set TTLs on files in given locations using
   `alluxio fs setTtl <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#setttl>`_.
 * **Check Working Set**: Users can verify which files are cached to understand and optimize Presto performance. For example, users can check the output from Alluxio command line
   `alluxio fs ls <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#ls>`_,

--- a/presto-docs/src/main/sphinx/cache/service.rst
+++ b/presto-docs/src/main/sphinx/cache/service.rst
@@ -118,7 +118,7 @@ With Alluxio file system this approach supports the following features:
   `alluxio fs distributedLoad <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#distributedload>`_,
   in addition to caching data transparently based on the data access pattern.
 * **Read/write Types and Data Policies**: Users can customize read and write modes for Presto when reading from and writing to Alluxio.
-  E.g.  tell Presto read to skip caching data when reading from certain locations and avoid cache thrashing, or set TTLs on files in given locations using
+  For example, tell Presto read to skip caching data when reading from certain locations and avoid cache thrashing, or set TTLs on files in given locations using
   `alluxio fs setTtl <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#setttl>`_.
 * **Check Working Set**: Users can verify which files are cached to understand and optimize Presto performance. For example, users can check the output from Alluxio command line
   `alluxio fs ls <https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#ls>`_,

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -332,7 +332,7 @@ Accessors
 
 .. function:: ST_IsEmpty(Geometry) -> boolean
 
-    Returns ``true`` if this Geometry is an empty geometrycollection, polygon, point etc.
+    Returns ``true`` if this Geometry is an empty geometrycollection, polygon, or point.
 
 .. function:: ST_IsSimple(Geometry) -> boolean
 

--- a/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
+++ b/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
@@ -184,7 +184,7 @@ struct PrestoThriftBigintArray {
 /**
  * A set containing zero or more Ranges of the same type over a continuous space of possible values.
  * Ranges are coalesced into the most compact representation of non-overlapping Ranges.
- * This structure is used with comparable and orderable types like bigint, integer, double, varchar, etc.
+ * This structure is used with comparable and orderable types like bigint, integer, double, or varchar.
  */
 struct PrestoThriftRangeValueSet {
   1: list<PrestoThriftRange> ranges;

--- a/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
+++ b/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
@@ -184,7 +184,7 @@ struct PrestoThriftBigintArray {
 /**
  * A set containing zero or more Ranges of the same type over a continuous space of possible values.
  * Ranges are coalesced into the most compact representation of non-overlapping Ranges.
- * This structure is used with comparable and orderable types like bigint, integer, double, or varchar.
+ * This structure is used with comparable and orderable types like bigint, integer, double, varchar, etc.
  */
 struct PrestoThriftRangeValueSet {
   1: list<PrestoThriftRange> ranges;

--- a/presto-docs/src/main/sphinx/installation/deploy-docker.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-docker.rst
@@ -16,7 +16,7 @@ Otherwise, follow the instructions below to install Docker and Colima using Home
 
 1. Install `Homebrew <https://brew.sh/>`_ if it is not already present on the system.
 
-2. Install the Docker command line and `Colima <https://github.com/abiosoft/colima>`_ tools via the following command:
+2. Install the Docker command line and `Colima <https://github.com/abiosoft/colima>`_ tools by running the following command:
 
    .. code-block:: shell
 

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -16,7 +16,7 @@ Download the Presto server tarball, :maven_download:`server`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_server_release|, which we will call the *installation* directory.
 
-Presto needs a *data* directory for storing logs, etc.
+Presto needs a *data* directory for storing logs. 
 We recommend creating a data directory outside of the installation directory,
 which allows it to be easily preserved when upgrading Presto.
 

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -16,7 +16,7 @@ Download the Presto server tarball, :maven_download:`server`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_server_release|, which we will call the *installation* directory.
 
-Presto needs a *data* directory for storing logs. 
+Presto needs a *data* directory for storing logs and other data. 
 We recommend creating a data directory outside of the installation directory,
 which allows it to be easily preserved when upgrading Presto.
 

--- a/presto-docs/src/main/sphinx/presto-cpp.rst
+++ b/presto-docs/src/main/sphinx/presto-cpp.rst
@@ -34,7 +34,7 @@ A Presto C++ worker can be configured as a sidecar to customize the Java
 coordinator's functionality for Presto C++ clusters. The Presto C++ sidecar
 implements additional REST endpoints to provide the coordinator more
 information about the Presto C++ worker, such as session properties and
-functions, via the ``NativeSidecarPlugin``. It is recommended to configure
+functions, by using the ``NativeSidecarPlugin``. It is recommended to configure
 at least one worker in the Presto C++ cluster as a sidecar. See :doc:`presto_cpp/sidecar`
 and :ref:`native-sidecar-plugin` for more details.
 

--- a/presto-docs/src/main/sphinx/release/release-0.101.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.101.rst
@@ -24,7 +24,7 @@ General Changes
   (``errorCode`` previously existed but was always zero).
 * Fix ``DatabaseMetaData.getIdentifierQuoteString()`` in JDBC driver.
 * Handle thread interruption in JDBC driver ``ResultSet``.
-* Add ``history`` command and support for running previous commands via ``!n`` to the CLI.
+* Add ``history`` command and support for running previous commands with ``!n`` to the CLI.
 * Change Driver to make as much progress as possible before blocking.  This improves
   responsiveness of some limit queries.
 * Add predicate push down support to JMX connector.
@@ -39,7 +39,7 @@ Web UI Changes
 --------------
 
 The main page of the web UI has been completely rewritten to use ReactJS. It also has
-a number of new features, such as the ability to pause auto-refresh via the "Z" key and
+a number of new features, such as the ability to pause auto-refresh by using the "Z" key and
 also with a toggle in the UI.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.103.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.103.rst
@@ -5,12 +5,12 @@ Release 0.103
 Cluster Resource Management
 ---------------------------
 
-There is a new cluster resource manager, which can be enabled via the
+There is a new cluster resource manager, which can be enabled with the
 ``experimental.cluster-memory-manager-enabled`` flag. Currently, the only
 resource that's tracked is memory, and the cluster resource manager guarantees
 that the cluster will not deadlock waiting for memory. However, in a low memory
 situation it is possible that only one query will make progress. Memory limits can
-now be configured via ``query.max-memory`` which controls the total distributed
+now be configured by using ``query.max-memory`` which controls the total distributed
 memory a query may use and ``query.max-memory-per-node`` which limits the amount
 of memory a query may use on any one node. On each worker, the
 ``resources.reserved-system-memory`` flags controls how much memory is reserved

--- a/presto-docs/src/main/sphinx/release/release-0.109.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.109.rst
@@ -19,7 +19,7 @@ General Changes
 Remove "Big Query" Support
 --------------------------
 The experimental support for big queries has been removed in favor of
-the new resource manager which can be enabled via the
+the new resource manager which can be enabled by using the
 ``experimental.cluster-memory-manager-enabled`` config option.
 The ``experimental_big_query`` session property and the following config
 options are no longer supported: ``experimental.big-query-initial-hash-partitions``,

--- a/presto-docs/src/main/sphinx/release/release-0.111.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.111.rst
@@ -9,6 +9,6 @@ General Changes
 * Optimize ``CASE`` expressions on a constant.
 * Add basic support for ``IF NOT EXISTS`` for ``CREATE TABLE``.
 * Semi-joins are hash-partitioned if ``distributed_join`` is turned on.
-* Add support for partial cast from JSON. For example, ``json`` can be cast to ``array(json)``, ``map(varchar, json)``, etc.
+* Add support for partial cast from JSON. For example, ``json`` can be cast to ``array(json)`` or ``map(varchar, json)``.
 * Add implicit coercions for ``UNION``.
 * Expose query stats in the JDBC driver ``ResultSet``.

--- a/presto-docs/src/main/sphinx/release/release-0.113.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.113.rst
@@ -11,7 +11,7 @@ Cluster Resource Management
 
 The cluster resource manager announced in :doc:`/release/release-0.103` is now enabled by default.
 You can disable it with the ``experimental.cluster-memory-manager-enabled`` flag.
-Memory limits can now be configured via ``query.max-memory`` which controls the total distributed
+Memory limits can now be configured with ``query.max-memory`` which controls the total distributed
 memory a query may use and ``query.max-memory-per-node`` which limits the amount
 of memory a query may use on any one node. On each worker, the
 ``resources.reserved-system-memory`` config property controls how much memory is reserved

--- a/presto-docs/src/main/sphinx/release/release-0.125.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.125.rst
@@ -5,7 +5,7 @@ Release 0.125
 General Changes
 ---------------
 
-* Fix an issue where certain operations such as ``GROUP BY``, ``DISTINCT``, etc. on the
+* Fix an issue where certain operations such as ``GROUP BY`` or ``DISTINCT``, on the
   output of a ``RIGHT`` or ``FULL OUTER JOIN`` can return incorrect results if they reference columns
   from the left relation that are also used in the join clause, and not every row from the right relation
   has a match.

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -27,8 +27,8 @@ General Changes
 * Improve performance of queries that use an ``IN`` expression with a large
   list of constant values.
 * Enable connector predicate push down for all comparable and equatable types.
-* Fix query planning failure when using certain operations such as ``GROUP BY``,
-  ``DISTINCT``, etc. on the output columns of ``UNNEST``.
+* Fix query planning failure when using certain operations such as ``GROUP BY`` or
+  ``DISTINCT`` on the output columns of ``UNNEST``.
 * In ``ExchangeClient`` set ``maxResponseSize`` to be slightly smaller than
   the configured value. This reduces the possibility of encountering
   ``PageTooLargeException``.

--- a/presto-docs/src/main/sphinx/release/release-0.128.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.128.rst
@@ -20,7 +20,7 @@ General Changes
 * Optimize memory usage in TupleDomain.
 * Fix an issue that can occur when an ``INNER JOIN`` has equi-join clauses that
   align with the grouping columns used by a preceding operation such as
-  ``GROUP BY``, ``DISTINCT``, etc. When this triggers, the join may fail to
+  ``GROUP BY`` or ``DISTINCT``. When this triggers, the join may fail to
   produce some of the output rows.
 
 MySQL Changes

--- a/presto-docs/src/main/sphinx/release/release-0.130.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.130.rst
@@ -9,7 +9,7 @@ General Changes
   length of the keys is between 16 and 31 bytes.
 * Add :func:`!map_concat` function.
 * Performance improvements for filters, projections and dictionary encoded data.
-  This optimization is turned off by default. It can be configured via the
+  This optimization is turned off by default. It can be configured with the
   ``optimizer.columnar-processing-dictionary`` config property or the
   ``columnar_processing_dictionary`` session property.
 * Improve performance of aggregation queries with large numbers of groups.

--- a/presto-docs/src/main/sphinx/release/release-0.133.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.133.rst
@@ -11,7 +11,7 @@ General Changes
   and nothing else.
 * Fix possible deadlock in worker communication when task restart is detected.
 * Performance improvements for aggregations on dictionary encoded data.
-  This optimization is turned off by default. It can be configured via the
+  This optimization is turned off by default. It can be configured with the
   ``optimizer.dictionary-aggregation`` config property or the
   ``dictionary_aggregation`` session property.
 * Fix race which could cause queries to fail when using :func:`!concat` on

--- a/presto-docs/src/main/sphinx/release/release-0.140.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.140.rst
@@ -18,7 +18,7 @@ General Changes
   being evaluated more than once producing unexpected results.
 * Fix incorrect result for rare ``IN`` lists that contain certain combinations
   of non-constant expressions that are null and non-null.
-* Improve performance of joins, aggregations, and others by removing unnecessarily
+* Improve performance of joins, aggregations, and other operations by removing unnecessarily
   duplicated columns.
 * Optimize ``NOT IN`` queries to produce more compact predicates.
 

--- a/presto-docs/src/main/sphinx/release/release-0.140.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.140.rst
@@ -18,7 +18,7 @@ General Changes
   being evaluated more than once producing unexpected results.
 * Fix incorrect result for rare ``IN`` lists that contain certain combinations
   of non-constant expressions that are null and non-null.
-* Improve performance of joins, aggregations, etc. by removing unnecessarily
+* Improve performance of joins, aggregations, and others by removing unnecessarily
   duplicated columns.
 * Optimize ``NOT IN`` queries to produce more compact predicates.
 

--- a/presto-docs/src/main/sphinx/release/release-0.148.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.148.rst
@@ -14,7 +14,7 @@ General Changes
   would incorrectly use the first row as the window frame for the first two
   rows rather than using an empty frame.
 * Fix correctness issue when grouping on columns that are also arguments to aggregation functions.
-* Fix failure when chaining ``AT TIME ZONE``, e.g.
+* Fix failure when chaining ``AT TIME ZONE``, for example, 
   ``SELECT TIMESTAMP '2016-01-02 12:34:56' AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC'``.
 * Fix data duplication when ``task.writer-count`` configuration mismatches between coordinator and worker.
 * Fix bug where ``node-scheduler.max-pending-splits-per-node-per-task`` config is not always

--- a/presto-docs/src/main/sphinx/release/release-0.152.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.152.rst
@@ -55,7 +55,7 @@ SPI Changes
 
 * Remove ``owner`` from ``ConnectorTableMetadata``.
 * Replace the  generic ``getServices()`` method in ``Plugin`` with specific
-  methods such as ``getConnectorFactories()``, ``getTypes()``, etc.
+  methods such as ``getConnectorFactories()`` or ``getTypes()``.
   Dependencies like ``TypeManager`` are now provided directly rather
   than being injected into ``Plugin``.
 * Add first-class support for functions in the SPI. This replaces the old

--- a/presto-docs/src/main/sphinx/release/release-0.153.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.153.rst
@@ -11,7 +11,7 @@ General Changes
 * Fix null handling in :func:`!array_distinct` when applied to the ``array(bigint)`` type.
 * Fix handling of ``-2^63`` as the element index for :func:`!json_array_get`.
 * Fix correctness issue when the input to ``TRY_CAST`` evaluates to null.
-  For types such as booleans, numbers, dates, timestamps, etc., rather than
+  For types such as booleans, numbers, dates, or timestamps, rather than
   returning null, a default value specific to the type such as
   ``false``, ``0`` or ``1970-01-01`` was returned.
 * Fix potential thread deadlock in coordinator.
@@ -54,8 +54,8 @@ Pluggable Resource Groups
 -------------------------
 
 Resource group management is now pluggable. A ``Plugin`` can
-provide management factories via ``getResourceGroupConfigurationManagerFactories()``
-and the factory can be enabled via the ``etc/resource-groups.properties``
+provide management factories through ``getResourceGroupConfigurationManagerFactories()``
+and the factory can be enabled with the ``etc/resource-groups.properties``
 configuration file by setting the ``resource-groups.configuration-manager``
 property. See the ``presto-resource-group-managers`` plugin for an example
 and :doc:`/admin/resource-groups` for more details.

--- a/presto-docs/src/main/sphinx/release/release-0.156.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.156.rst
@@ -21,7 +21,7 @@ General Changes
 * Improve performance of ``GROUP BY`` queries that compute a mix of distinct
   and non-distinct aggregations. This optimization can be turned on by setting
   the ``optimizer.optimize-mixed-distinct-aggregations`` configuration option or
-  via the ``optimize_mixed_distinct_aggregations`` session property.
+  with the ``optimize_mixed_distinct_aggregations`` session property.
 * Change default task concurrency to 16.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.158.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.158.rst
@@ -26,7 +26,7 @@ Hive Changes
 
 * Add hidden ``$bucket`` column for bucketed tables that
   contains the bucket number for the current row.
-* Prevent inserting into non-managed (i.e., external) tables.
+* Prevent inserting into non-managed (that is, external) tables.
 * Add configurable size limit to Hive metastore cache to avoid using too much
   coordinator memory.
 

--- a/presto-docs/src/main/sphinx/release/release-0.162.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.162.rst
@@ -21,7 +21,7 @@ General Changes
 * Improve performance of window functions with similar ``PARTITION BY`` clauses.
 * Improve performance of certain multi-way JOINs by automatically choosing the
   best evaluation order. This feature is turned off by default and can be enabled
-  via the ``reorder-joins`` config option or ``reorder_joins`` session property.
+  with the ``reorder-joins`` config option or ``reorder_joins`` session property.
 * Add :func:`!xxhash64` and :func:`!to_big_endian_64` functions.
 * Add aggregated operator statistics to final query statistics.
 * Allow specifying column comments for :doc:`/sql/create-table`.

--- a/presto-docs/src/main/sphinx/release/release-0.166.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.166.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Fix failure due to implicit coercion issue in ``IN`` expressions for
-  certain combinations of data types (e.g., ``double`` and ``decimal``).
+  certain combinations of data types, such as ``double`` and ``decimal``.
 * Add ``query.max-length`` config flag to set the maximum length of a SQL query.
   The default maximum length is 1MB.
 * Improve performance of :func:`!approx_percentile`.

--- a/presto-docs/src/main/sphinx/release/release-0.168.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.168.rst
@@ -20,11 +20,11 @@ General Changes
 * Add :doc:`/connector/memory`.
 * Add :func:`!arrays_overlap` and :func:`!array_except` functions.
 * Allow concatenating more than two arrays with ``concat()`` or maps with :func:`!map_concat`.
-* Add a time limit for the iterative optimizer. It can be adjusted via the ``iterative_optimizer_timeout``
+* Add a time limit for the iterative optimizer. It can be adjusted with the ``iterative_optimizer_timeout``
   session property or ``experimental.iterative-optimizer-timeout`` configuration option.
 * ``ROW`` types are now orderable if all of the field types are orderable.
   This allows using them in comparison expressions, ``ORDER BY`` and
-  functions that require orderable types (e.g., :func:`!max`).
+  functions that require orderable types (for example, :func:`!max`).
 
 JDBC Driver Changes
 -------------------

--- a/presto-docs/src/main/sphinx/release/release-0.169.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.169.rst
@@ -19,7 +19,7 @@ JDBC Driver Changes
 CLI Changes
 -----------
 
-* Fix support for non-standard offset time zones (e.g., ``GMT+01:00``).
+* Fix support for non-standard offset time zones (for example, ``GMT+01:00``).
 
 Cassandra Changes
 -----------------

--- a/presto-docs/src/main/sphinx/release/release-0.170.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.170.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix race condition that could cause queries to fail with ``InterruptedException`` in rare cases.
 * Fix a performance regression for ``GROUP BY`` queries over ``UNION``.
 * Fix a performance regression that occurs when a significant number of exchange
-  sources produce no data during an exchange (e.g., in a skewed hash join).
+  sources produce no data during an exchange (for example, in a skewed hash join).
 
 Web UI Changes
 --------------
@@ -36,7 +36,7 @@ Cassandra Changes
   config options are no longer supported.
 * Remove partition key cache to improve consistency and reduce load on the Cassandra cluster due to background cache refresh.
 * Reduce the number of connections opened to the Cassandra cluster. Now Presto opens a single connection from each node.
-* Use exponential backoff for retries when Cassandra hosts are down. The retry timeout can be controlled via the
+* Use exponential backoff for retries when Cassandra hosts are down. The retry timeout can be controlled with the
   ``cassandra.no-host-available-retry-timeout`` config option, which has a default value of ``1m``.
   The ``cassandra.no-host-available-retry-count`` config option is no longer supported.
 

--- a/presto-docs/src/main/sphinx/release/release-0.171.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.171.rst
@@ -26,4 +26,4 @@ Hive Changes
 
 * Fix issue where some files are not deleted on cancellation of ``INSERT`` or ``CREATE`` queries.
 * Allow writing to non-managed (external) Hive tables. This is disabled by default but can be
-  enabled via the ``hive.non-managed-table-writes-enabled`` configuration option.
+  enabled with the ``hive.non-managed-table-writes-enabled`` configuration option.

--- a/presto-docs/src/main/sphinx/release/release-0.177.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.177.rst
@@ -20,7 +20,7 @@ General Changes
 * Check for duplicate columns in ``CREATE TABLE`` before asking the connector to create
   the table. This improves the error message for most connectors and will prevent errors
   for connectors that do not perform validation internally.
-* Add support for null values on the left-hand side of a semijoin (i.e., ``IN`` predicate
+* Add support for null values on the left-hand side of a semijoin (that is, ``IN`` predicate
   with subqueries).
 * Add ``SHOW STATS`` to display table and query statistics.
 * Improve implicit coercion support for functions involving lambda. Specifically, this makes
@@ -31,10 +31,10 @@ General Changes
   and ``ORDER BY`` clauses.
 * Improve performance of certain queries involving ``OUTER JOIN`` and aggregations, or
   containing certain forms of correlated subqueries. This optimization is experimental
-  and can be turned on via the ``push_aggregation_through_join`` session property or the
+  and can be turned on with the ``push_aggregation_through_join`` session property or the
   ``optimizer.push-aggregation-through-join`` config option.
 * Improve performance of certain queries involving joins and aggregations.  This optimization
-  is experimental and can be turned on via the ``push_partial_aggregation_through_join``
+  is experimental and can be turned on with the ``push_partial_aggregation_through_join``
   session property.
 * Improve error message when a lambda expression has a different number of arguments than expected.
 * Improve error message when certain invalid ``GROUP BY`` expressions containing lambda expressions.
@@ -45,7 +45,7 @@ Hive Changes
 * Fix handling of trailing spaces for the ``CHAR`` type when reading RCFile.
 * Allow inserts into tables that have more partitions than the partitions-per-scan limit.
 * Add support for exposing Hive table statistics to the engine. This option is experimental and
-  can be turned on via the ``statistics_enabled`` session property.
+  can be turned on with the ``statistics_enabled`` session property.
 * Ensure file name is always present for error messages about corrupt ORC files.
 
 Cassandra Changes

--- a/presto-docs/src/main/sphinx/release/release-0.181.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.181.rst
@@ -24,7 +24,7 @@ General Changes
   behavior is disabled by default and can be enabled by setting the
   config property ``task.level-absolute-priority=true``.
 * Improve the fairness of the local scheduler such that long-running queries
-  which spend more time on the CPU per scheduling quanta (e.g., due to
+  which spend more time on the CPU per scheduling quanta (for example, due to
   slow connectors) do not get a disproportionate share of CPU. The new
   behavior is disabled by default and can be enabled by setting the
   config property ``task.legacy-scheduling-behavior=false``.

--- a/presto-docs/src/main/sphinx/release/release-0.182.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.182.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix correctness issue that causes :func:`!corr` to return positive numbers for inverse correlations.
 * Fix the :doc:`/sql/explain` query plan for tables that are partitioned
   on ``TIMESTAMP`` or ``DATE`` columns.
-* Fix query failure when when using certain window functions that take arrays or maps as arguments (for example, :func:`!approx_percentile`).
+* Fix query failure when using certain window functions that take arrays or maps as arguments (for example, :func:`!approx_percentile`).
 * Implement subtraction for all ``TIME`` and ``TIMESTAMP`` types.
 * Improve planning performance for queries that join multiple tables with
   a large number columns.

--- a/presto-docs/src/main/sphinx/release/release-0.182.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.182.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix correctness issue that causes :func:`!corr` to return positive numbers for inverse correlations.
 * Fix the :doc:`/sql/explain` query plan for tables that are partitioned
   on ``TIMESTAMP`` or ``DATE`` columns.
-* Fix query failure when when using certain window functions that take arrays or maps as arguments (e.g., :func:`!approx_percentile`).
+* Fix query failure when when using certain window functions that take arrays or maps as arguments (for example, :func:`!approx_percentile`).
 * Implement subtraction for all ``TIME`` and ``TIMESTAMP`` types.
 * Improve planning performance for queries that join multiple tables with
   a large number columns.

--- a/presto-docs/src/main/sphinx/release/release-0.185.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.185.rst
@@ -18,7 +18,7 @@ General Changes
   checking if the table only has one column.
 * Improve performance of joins where the condition is a range over a function.
   For example: ``a JOIN b ON b.x < f(a.x) AND b.x > g(a.x)``
-* Improve performance of certain window functions (e.g., ``LAG``) with similar specifications.
+* Improve performance of certain window functions (for example, ``LAG``) with similar specifications.
 * Extend :func:`!substr` function to work on ``VARBINARY`` in addition to ``CHAR`` and ``VARCHAR``.
 * Add cast from ``JSON`` to ``ROW``.
 * Allow usage of ``TRY`` within lambda expressions.

--- a/presto-docs/src/main/sphinx/release/release-0.188.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.188.rst
@@ -11,7 +11,7 @@ General Changes
 * Improve performance of server logging and HTTP request logging.
 * Reduce GC spikes by compacting join memory over time instead of all at once
   when memory is low. This can increase reliability at the cost of additional
-  CPU. This can be enabled via the ``pages-index.eager-compaction-enabled``
+  CPU. This can be enabled with the ``pages-index.eager-compaction-enabled``
   config property.
 * Improve performance of and reduce GC overhead for compaction of in-memory data structures,
   primarily used in joins.

--- a/presto-docs/src/main/sphinx/release/release-0.190.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.190.rst
@@ -56,7 +56,7 @@ Hive Changes
 * Fix query failures for the file-based metastore implementation when partition
   column values contain a colon.
 * Improve performance for writing to bucketed tables when the data being written
-  is already partitioned appropriately (e.g., the output is from a bucketed join).
+  is already partitioned appropriately (for example, the output is from a bucketed join).
 * Add config property ``hive.max-outstanding-splits-size`` for the maximum
   amount of memory used to buffer splits for a single table scan. Additionally,
   the default value is substantially higher than the previous hard-coded limit,

--- a/presto-docs/src/main/sphinx/release/release-0.192.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.192.rst
@@ -48,8 +48,8 @@ Hive Changes
 * Do not treat file system errors as corruptions for ORC.
 * Prevent reads from tables or partitions with ``object_not_readable`` attribute set.
 * Add support for validating ORC files after they have been written. This behavior can
-  be turned on via the ``hive.orc.writer.validate`` configuration property.
-* Expose ORC writer statistics via JMX.
+  be turned on with the ``hive.orc.writer.validate`` configuration property.
+* Expose ORC writer statistics through JMX.
 * Add configuration options to control ORC writer min/max rows per stripe and row group,
   maximum stripe size, and memory limit for dictionaries.
 * Allow reading empty ORC files.

--- a/presto-docs/src/main/sphinx/release/release-0.193.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.193.rst
@@ -16,7 +16,7 @@ General Changes
 * Add :func:`!normal_cdf` function.
 * Add ``SET_DIGEST`` type and related functions.
 * Add query stat that tracks peak total memory.
-* Improve performance of queries that filter all data from a table up-front (e.g., due to partition pruning).
+* Improve performance of queries that filter all data from a table up-front (for example, due to partition pruning).
 * Turn on new local scheduling algorithm by default (see :doc:`release-0.181`).
 * Remove the ``information_schema.__internal_partitions__`` table.
 

--- a/presto-docs/src/main/sphinx/release/release-0.194.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.194.rst
@@ -34,8 +34,8 @@ JDBC Driver Changes
 -------------------
 
 * Allow configuring connection network timeout with ``setNetworkTimeout()``.
-* Allow setting client tags via the ``ClientTags`` client info property.
-* Expose update type via ``getUpdateType()`` on ``PrestoStatement``.
+* Allow setting client tags with the ``ClientTags`` client info property.
+* Expose update type with ``getUpdateType()`` on ``PrestoStatement``.
 
 Hive Changes
 ------------
@@ -43,7 +43,7 @@ Hive Changes
 * Consistently fail queries that attempt to read partitions that are offline.
   Previously, the query can have one of the following outcomes: fail as expected,
   skip those partitions and finish successfully, or hang indefinitely.
-* Allow setting username used to access Hive metastore via the ``hive.metastore.username`` config property.
+* Allow setting username used to access Hive metastore with the ``hive.metastore.username`` config property.
 * Add ``hive_storage_format`` and ``respect_table_format`` session properties, corresponding to
   the ``hive.storage-format`` and ``hive.respect-table-format`` config properties.
 * Reduce ORC file reader memory consumption by allocating buffers lazily.

--- a/presto-docs/src/main/sphinx/release/release-0.197.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.197.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix query scheduling hang when the ``concurrent_lifespans_per_task`` session property is set.
 * Fix failure when a query contains a ``TIMESTAMP`` literal corresponding to a local time that
   does not occur in the default time zone of the Presto JVM. For example, if Presto was running
-  in a CET zone (e.g., ``Europe/Brussels``) and the client session was in UTC, an expression
+  in a CET zone (such as ``Europe/Brussels``) and the client session was in UTC, an expression
   such as ``TIMESTAMP '2017-03-26 02:10:00'`` would cause a failure.
 * Extend predicate inference and pushdown for queries using a ``<symbol> IN <subquery>`` predicate.
 * Support predicate pushdown for the ``<column> IN <values list>`` predicate

--- a/presto-docs/src/main/sphinx/release/release-0.198.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.198.rst
@@ -8,8 +8,8 @@ General Changes
 * Perform semantic analysis before enqueuing queries.
 * Add support for selective aggregates (``FILTER``) with ``DISTINCT`` argument qualifiers.
 * Support ``ESCAPE`` for ``LIKE`` predicate in ``SHOW SCHEMAS`` and ``SHOW TABLES`` queries.
-* Parse decimal literals (e.g. ``42.0``) as ``DECIMAL`` by default. Previously, they were parsed as
-  ``DOUBLE``. This behavior can be turned off via the ``parse-decimal-literals-as-double`` config option or
+* Parse decimal literals (for example, ``42.0``) as ``DECIMAL`` by default. Previously, they were parsed as
+  ``DOUBLE``. This behavior can be turned off with the ``parse-decimal-literals-as-double`` config option or
   the ``parse_decimal_literals_as_double`` session property.
 * Fix ``current_date`` failure when the session time zone has a "gap" at ``1970-01-01 00:00:00``.
   The time zone ``America/Bahia_Banderas`` is one such example.

--- a/presto-docs/src/main/sphinx/release/release-0.199.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.199.rst
@@ -21,11 +21,11 @@ General Changes
   ``d`` is of type ``INTEGER``. Previously, ``d`` could be of type ``BIGINT``.
   This behavior can be restored with the ``deprecated.legacy-round-n-bigint`` config option
   or the ``legacy_round_n_bigint`` session property.
-* Accessing anonymous row fields via ``.field0``, ``.field1``, etc., is no longer allowed.
+* Accessing anonymous row fields by using ``.field0``, ``.field1``, ``.field(n)`` is no longer allowed.
   This behavior can be restored with the ``deprecated.legacy-row-field-ordinal-access``
   config option or the ``legacy_row_field_ordinal_access`` session property.
 * Optimize the :func:`!ST_Intersection` function for rectangles aligned with coordinate axes
-  (e.g., polygons produced by the :func:`!ST_Envelope` and :func:`!bing_tile_polygon` functions).
+  (for example, polygons produced by the :func:`!ST_Envelope` and :func:`!bing_tile_polygon` functions).
 * Finish joins early when possible if one side has no rows. This happens for
   either side of an inner join, for the left side of a left join, and for the
   right side of a right join.
@@ -65,10 +65,10 @@ Hive Changes
 * Partitioned tables now have a hidden system table that contains the partition values.
   A table named ``example`` will have a partitions table named ``example$partitions``.
   This provides the same functionality and data as ``SHOW PARTITIONS``.
-* Partition name listings, both via the ``$partitions`` table and using
+* Partition name listings, both by using the ``$partitions`` table and using
   ``SHOW PARTITIONS``, are no longer subject to the limit defined by the
   ``hive.max-partitions-per-scan`` config option.
-* Allow marking partitions as offline via the ``presto_offline`` partition property.
+* Allow marking partitions as offline with the ``presto_offline`` partition property.
 
 Thrift Connector Changes
 ------------------------

--- a/presto-docs/src/main/sphinx/release/release-0.202.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.202.rst
@@ -20,7 +20,7 @@ General Changes
 * Improve support for correlated subqueries containing equality predicates.
 * Improve performance of correlated ``EXISTS`` subqueries.
 * Limit the number of grouping sets in a ``GROUP BY`` clause.
-  The default limit is ``2048`` and can be set via the ``analyzer.max-grouping-sets``
+  The default limit is ``2048`` and can be set with the ``analyzer.max-grouping-sets``
   configuration property or the ``max_grouping_sets`` session property.
 * Allow coercion between row types regardless of field names.
   Previously, a row type is coercible to another only if the field name in the source type

--- a/presto-docs/src/main/sphinx/release/release-0.205.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.205.rst
@@ -50,7 +50,7 @@ JDBC Driver Changes
 -------------------
 
 * Add support for prepared statements.
-* Add partial query cancellation via ``partialCancel()`` on ``PrestoStatement``.
+* Add partial query cancellation with ``partialCancel()`` on ``PrestoStatement``.
 * Use ``VARCHAR`` rather than ``LONGNVARCHAR`` for the Presto ``varchar`` type.
 * Use ``VARBINARY`` rather than ``LONGVARBINARY`` for the Presto ``varbinary`` type.
 

--- a/presto-docs/src/main/sphinx/release/release-0.216.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.216.rst
@@ -30,7 +30,7 @@ Hive Connector Changes
 * Fix a corner case where the ORC writer fails with integer overflow when writing
   highly compressible data using dictionary encoding (:issue:`11930`).
 * Fail queries reading Parquet files if statistics in those Parquet files are
-  corrupt (e.g., min > max). To disable this behavior, set the configuration
+  corrupt (such as min > max). To disable this behavior, set the configuration
   property ``hive.parquet.fail-on-corrupted-statistics``
   or session property ``parquet_fail_with_corrupted_statistics`` to false.
 * Add support for :ref:`S3 select pushdown <s3selectpushdown>`, which enables pushing down

--- a/presto-docs/src/main/sphinx/release/release-0.217.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.217.rst
@@ -36,14 +36,14 @@ Hive Connector Changes
 
 * Fix an issue where a partially successful rollback of a write could cause data loss and corrupt the metastore.
   The ``hive.skip-target-cleanup-on-rollback`` configuration property can be used to skip deleting target directories when partition creation is rolled back.
-* Fix an issue where creating a table on S3 could fail for S3 prefixes without any associated objects (e.g., empty S3 directories).
+* Fix an issue where creating a table on S3 could fail for S3 prefixes without any associated objects (for example, empty S3 directories).
 * Add support for ``ANALYZE`` statement in the Hive connector.
   It's possible to specify a list of partitions to collect statistics for using the ``WITH`` properties of the ``ANALYZE`` statement.
 * Add configuration property ``hive.temporary-staging-directory-enabled`` and session property ``temporary_staging_directory_enabled``
   to control whether a temporary staging directory should be used for write operations.
 * Add configuration property ``hive.temporary-staging-directory-path`` and session property ``temporary_staging_directory_path``
   to control the location of temporary staging directory that is used for write operations.
-  The ``${USER}`` placeholder can be used to use a different location for each user (e.g., ``/tmp/${USER}``).
+  The ``${USER}`` placeholder can be used to use a different location for each user (for example, ``/tmp/${USER}``).
 
 
 JDBC Connector Changes

--- a/presto-docs/src/main/sphinx/release/release-0.218.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.218.rst
@@ -11,7 +11,7 @@ Release 0.218
 General Changes
 ---------------
 
-* Fix failures in regular expression functions for certain inputs where the pattern contains word boundaries (e.g. ``\b``).
+* Fix failures in regular expression functions for certain inputs where the pattern contains word boundaries (for example, ``\b``).
 * Fix an issue that may cause a crash when using plugins that provide an event listener. (:issue:`11951`)
 * Fix a memory leak that occurs when a query fails with a semantic or permission error.
 * Improve performance for queries with ``FULL OUTER JOIN`` where join keys have the :func:`!`COALESCE`` function applied.

--- a/presto-docs/src/main/sphinx/release/release-0.219.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.219.rst
@@ -52,7 +52,7 @@ Verifier Changes
   are introduced for retrying transient network failures when communicating with the coordinator. Intermediate failures are recorded and emitted in the output.
 * Add support for automatically resolving certain kinds of failures including exceeding the global memory limit and exceeding time limit.
 * Add configuration properties ``metadata-timeout`` and ``checksum-timeout`` to set the timeouts for metadata queries
-  (i.e., describe queries that read table schema) and checksum queries.
+  (that is, describe queries that read table schema) and checksum queries.
 * Add ``source-query.table-name`` configuration property to specify the name of the MySQL table from which the verifier queries will loaded.
 * Add configuration property ``human-readable.log-file`` to allow human-readable verification results to be logged into the specified file instead of ``stdout``.
 * Rename configuration properties ``query-database`` to ``source-query.database``, ``suites`` to ``source-query.suites``,

--- a/presto-docs/src/main/sphinx/release/release-0.220.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.220.rst
@@ -50,6 +50,6 @@ SPI Changes
 -----------
 * Move ``FunctionMetadata`` to SPI.
 * Add ``FunctionMetadataManager`` and ``StandardFunctionResolution`` in ``ConnectorContext``.
-  The two interfaces allow connectors to obtain the metadata of a Presto system function as well as to resolve standard functions, such as add, minus, and, or, etc.
+  The two interfaces allow connectors to obtain the metadata of a Presto system function as well as to resolve standard functions, such as add, minus, and, or.
 * Remove ``distributedPlanningTime`` from ``QueryStatistics``
 * Remove redundant offset parameter in ``Block#getByte``, ``Block#getShort``, and ``Block#getInt``.

--- a/presto-docs/src/main/sphinx/release/release-0.222.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.222.rst
@@ -47,7 +47,7 @@ SPI Changes
 -----------
 
 * Add experimental interface ``ConnectorPlanOptimizer`` to allow connectors to
-  participate in query plan optimization (e.g., filter pushdown) (:issue:`13102`).
+  participate in query plan optimization (for example, filter pushdown) (:issue:`13102`).
 * Rename ``LogicalRowExpressions::TRUE`` and ``LogicalRowExpressions::FALSE`` to
   ``LogicalRowExpressions::TRUE_CONSTANT`` and ``LogicalRowExpressions::FALSE_CONSTANT``
   respectively to avoid collision with ``java.lang.Boolean``.

--- a/presto-docs/src/main/sphinx/release/release-0.228.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.228.rst
@@ -6,7 +6,7 @@ General Changes
 _______________
 * Reduce excessive memory usage by ExchangeClient.
 * Improve coordinator stability on parsing functions that may create large constant
-  arrays/maps/rows (e.g., ``SEQUENCE``, ``REPEAT``, ``ARRAY[...]``, etc) by delaying the
+  arrays/maps/rows (for example, ``SEQUENCE``, ``REPEAT``, ``ARRAY[...]``, etc) by delaying the
   evaluation on these functions on workers.
 * Optimize queries with ``LIMIT 0``.
 * Allow Bing Tiles at zoom level 0.

--- a/presto-docs/src/main/sphinx/release/release-0.232.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.232.rst
@@ -34,7 +34,7 @@ ____________
 * Add session property ``shuffle_partitioned_columns_for_table_write`` to make Presto shuffle data on the partition columns before writing to partitioned unbucketed Hive tables.
   This increases the maximum number of partitions that can be written in a single query by a factor of the total number of writing workers.
   The property is ``false`` by default. (:pr:`14010`).
-* Expose Hive table properties via system table$properties table.
+* Expose Hive table properties through system table$properties table.
 * Change error code from ``HIVE_METASTORE_ERROR`` to ``HIVE_TABLE_DROPPED_DURING_QUERY`` when a ``DROP TABLE`` query fails due to another query dropping the table before this query has finished.
 * Upgrade Alluxio version from 2.1.1 to 2.1.2.
 

--- a/presto-docs/src/main/sphinx/release/release-0.233.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.233.rst
@@ -9,7 +9,7 @@ Release 0.233
 
 General Changes
 _______________
-* Fix an optimizer failure introduced in ``0.229``, where a ``LIKE`` pattern is deduced into a constant, e.g., ``col LIKE 'a' and col = 'b'``.
+* Fix an optimizer failure introduced in ``0.229``, where a ``LIKE`` pattern is deduced into a constant. For example: ``col LIKE 'a' and col = 'b'``.
 * Fix correctness issue in queries with joins over ``UNNEST``. (:issue:`14257`).
 * Fix ``ArbitraryOutputBuffer`` to avoid skewing output data distribution. (:pr:`14083`).
 * Fix an issue where :func:`!classification_fall_out` cannot be found.

--- a/presto-docs/src/main/sphinx/release/release-0.235.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.235.rst
@@ -22,8 +22,8 @@ _______________
 Pinot Connector Changes
 _______________________
 * Add support for mapping Pinot ``BYTES`` data type to Presto ``VARBINARY`` type.
-* Add support for mapping Pinot time fields with days since epoch value to Presto ``DATE`` type via the system property ``pinot.infer-date-type-in-schema``.
-* Add support for mapping Pinot time fields with milliseconds since epoch value to Presto ``TIMESTAMP`` type via the system prpoerty ``pinot.infer-timestamp-type-in-schema``.
+* Add support for mapping Pinot time fields with days since epoch value to Presto ``DATE`` type with the system property ``pinot.infer-date-type-in-schema``.
+* Add support for mapping Pinot time fields with milliseconds since epoch value to Presto ``TIMESTAMP`` type with the system prpoerty ``pinot.infer-timestamp-type-in-schema``.
 * Add Pinot Field type in to column comment field shown as ``DIMENSION``, ``METRIC``, ``TIME``, ``DATETIME``, to provide more information.
 * Add support for pushing down distinct count query to Pinot on a best-effort basis.
 * Add support for new Pinot Routing Table APIs.
@@ -45,7 +45,7 @@ Druid Connector Changes
 _______________________
 * Fix druid connector segment scan.
 * Fix an issue where distinct is not respected in count aggregation.
-* Add support for query processing pushdown via the ``druid.compute-pushdown-enabled`` configuration property.
+* Add support for query processing pushdown with the ``druid.compute-pushdown-enabled`` configuration property.
 
 Verifier Changes
 ________________

--- a/presto-docs/src/main/sphinx/release/release-0.235.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.235.rst
@@ -23,7 +23,7 @@ Pinot Connector Changes
 _______________________
 * Add support for mapping Pinot ``BYTES`` data type to Presto ``VARBINARY`` type.
 * Add support for mapping Pinot time fields with days since epoch value to Presto ``DATE`` type with the system property ``pinot.infer-date-type-in-schema``.
-* Add support for mapping Pinot time fields with milliseconds since epoch value to Presto ``TIMESTAMP`` type with the system prpoerty ``pinot.infer-timestamp-type-in-schema``.
+* Add support for mapping Pinot time fields with milliseconds since epoch value to Presto ``TIMESTAMP`` type with the system property ``pinot.infer-timestamp-type-in-schema``.
 * Add Pinot Field type in to column comment field shown as ``DIMENSION``, ``METRIC``, ``TIME``, ``DATETIME``, to provide more information.
 * Add support for pushing down distinct count query to Pinot on a best-effort basis.
 * Add support for new Pinot Routing Table APIs.

--- a/presto-docs/src/main/sphinx/release/release-0.239.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.239.rst
@@ -31,7 +31,7 @@ _______________
   common expressions only once. This can be disabled by the session property
   ``optimize_common_sub_expressions``.
 * Optimize queries containing only :func:`!min` and :func:`!max` on columns that can be
-  evaluated using metadata (e.g., Hive partitions). This is controlled by configuration property
+  evaluated using metadata (for example, Hive partitions). This is controlled by configuration property
   ``optimizer.optimize-metadata-queries`` and session property ``optimize_metadata_queries``.
   Note: Enabling this optimization might change query result if there are metadata that refers to
   empty data, see :pr:`14845` for examples.

--- a/presto-docs/src/main/sphinx/release/release-0.245.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.245.rst
@@ -22,7 +22,7 @@ _______________
 * Fix serialization bug causing maps with string-valued enum keys to be displayed as illegible strings in Presto CLI.
 * Fix parsing logic for prepared statements to be consistent with regular statements.
 * Improve memory usage for fragment result caching.
-* Add support for disabling query result compression via client and server-side configuration properties. Clients can disable compressed responses using the ``--disable-compression`` flag or ``disableCompression`` driver property. Compression can be disabled server-wide by using the configuration property: ``query-results.compression-enabled=false``
+* Add support for disabling query result compression with client and server-side configuration properties. Clients can disable compressed responses using the ``--disable-compression`` flag or ``disableCompression`` driver property. Compression can be disabled server-wide by using the configuration property: ``query-results.compression-enabled=false``
 * Add support in affinity scheduler to enable cache for bucketed table scan that has remote source.
 * Add ``enum_key`` to get the key corresponding to an enum value: `ENUM_KEY(EnumType) -> VARCHAR`.
 

--- a/presto-docs/src/main/sphinx/release/release-0.246.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.246.rst
@@ -19,7 +19,7 @@ _______________
 * Add listener-based revocation model for spilling strategy ``PER_TASK_MEMORY_THRESHOLD``.
 * Disable spill to disk for join queries where the probe side uses grouped execution and the build does not. Previously these queries would fail with ``GENERIC_INTERNAL_ERRORS``.
 * Disallow ``ORDER BY`` literals used with Window functions as it's not useful, expensive and most often used wrongly.
-* Add support for fragment result caching for queries with local exchange (e.g. intermediate aggregation).
+* Add support for fragment result caching for queries with local exchange (for example, intermediate aggregation).
 * Improve queries that have unnecessary limits and order bys.
   This feature is enabled by default and can be disabled by using the configuration property ``optimizer.skip-redundant-sort`` or session property ``skip_redundant_sort``.
 

--- a/presto-docs/src/main/sphinx/release/release-0.247.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.247.rst
@@ -21,7 +21,7 @@ _______________
 * Fix a race condition in enum key lookup which caused queries using ``enum_key`` to crash occasionally with an internal error. (:pr:`15607`).
 * Add an implementation of :func:`!array_intersect` that takes an array of arrays as input.
 * Add support for temporary (session-scoped) functions.
-* Add support for specifying session properties via regex matching on client info using :doc:`/admin/session-property-managers`.
+* Add support for specifying session properties by using regex matching on client info using :doc:`/admin/session-property-managers`.
 
 SPI Changes
 ___________

--- a/presto-docs/src/main/sphinx/release/release-0.253.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.253.rst
@@ -12,7 +12,7 @@ General Changes
 _______________
 * Fix amplified ``Cumulative User Memory`` metric in web UI.
 * Add tracking for system memory used by column statistics in ``TableFinishOperator``.
-* Add support for shutting down coordinator via ``/v1/info/state`` endpoint.
+* Add support for shutting down coordinator through ``/v1/info/state`` endpoint.
 * Add :func:`!binomial_cdf` and :func:`!inverse_binomial_cdf` functions.
 
 Security Changes

--- a/presto-docs/src/main/sphinx/release/release-0.264.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.264.rst
@@ -14,7 +14,7 @@ _______________
 * Add :func:`!murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++.
 * Add a new configuration property ``experimental.dedup-based-distinct-aggregation-spill-enabled`` to enable deduplication of input data before spilling for distinct aggregates. This can be overridden by ``dedup_based_distinct_aggregation_spill_enabled`` session property.
 * Add configuration properties ``simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback`` and ``simple-ttl-node-selector.default-execution-time-estimate``. The former configures ``SimpleTtlNodeSelector`` to use a default execution time estimate when there is no corresponding user-provided estimate. The latter configures the value of the default execution time estimate.
-* Add support for running task count ``runningTasks`` at the cluster level via ``v1/cluster`` endpoint.
+* Add support for running task count ``runningTasks`` at the cluster level through ``v1/cluster`` endpoint.
 
 Hive Changes
 ____________

--- a/presto-docs/src/main/sphinx/release/release-0.274.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.274.rst
@@ -22,7 +22,7 @@ _______________
 
 SPI Changes
 ___________
-* Add connector interface serde support to allow customized serde (e.g., thrift) beyond the default JSON ones.
+* Add connector interface serde support to allow customized serde (for example, thrift) beyond the default JSON ones.
 
 Hive Changes
 ____________

--- a/presto-docs/src/main/sphinx/release/release-0.278.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.278.rst
@@ -14,7 +14,7 @@ _______________
 * Fix :func:`!ROUND` to prevent returning incorrect results due to integer / double overflows.
 * Fix the compilation error when aggregation has order by clause and the input is a function.
 * Optimize ``IF(predicate, AGG(x))`` to aggregation with mask in plan level. This is controlled by system property ``optimize_conditional_aggregation_enabled`` and defaults to false.
-* Add new security API ``selectAuthorizedIdentity`` and new configuration property ``permissions.authorized-identity-selection-enable`` to enable ``selectAuthorizedIdentity``. ``selectAuthorizedIdentity`` prevents potential security loopholes, e.g., reading illegal data from a fake username.
+* Add new security API ``selectAuthorizedIdentity`` and new configuration property ``permissions.authorized-identity-selection-enable`` to enable ``selectAuthorizedIdentity``. ``selectAuthorizedIdentity`` prevents potential security loopholes, for example, reading illegal data from a fake username.
 * Add memory limit check for HashBuilderOperator during memory revoke.
 * Add null masking for the Parquet decryption feature. When this feature is enabled and the user is denied access encrypted column, the columns will be removed in the requested schema sent to Parquet. Then it is filled out with ``NULL``  when the result is returned.
 * Add optimization for :func:`!approx_percentile` functions evaluation. Multiple :func:`!approx_percentile` functions on the same field will be combined into one :func:`!approx_percentile` function which takes an array of percentile as arguments. The optimization is controlled by session property ``optimize_multiple_approx_percentile_on_same_field`` which is true by default.

--- a/presto-docs/src/main/sphinx/release/release-0.281.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.281.rst
@@ -49,7 +49,7 @@ ________________________________
 
 JDBC Changes
 ____________
-* Add ConnectorSession parameter to  all methods of ``JdbcClient`` interface. That makes it possible to pass specific options to JDBC driver implementation via session parameters.
+* Add ConnectorSession parameter to  all methods of ``JdbcClient`` interface. That makes it possible to pass specific options to JDBC driver implementation through session parameters.
 
 **Credits**
 ===========

--- a/presto-docs/src/main/sphinx/release/release-0.284.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.284.rst
@@ -28,7 +28,7 @@ _______________
 * Add session property ``optimizers_to_enable_verbose_runtime_stats`` to enable runtime tracking for a set of optimizers.
 * Add support for ``EXPLAIN (TYPE VALIDATE)`` of ``EXPLAIN`` queries. Previously such queries would fail with an error.
 * Improve performance of cluster statistics reporting in the Presto coordinator by adding the configuration property ``cluster-stats-cache-expiration-duration``. The property is ``0`` (disabled) by default.
-* Add support for serializing nested data structures via server-side configuration properties using the configuration property ``nested-data-serialization-enabled``. The property is enabled by default with the value ``TRUE``.
+* Add support for serializing nested data structures with server-side configuration properties using the configuration property ``nested-data-serialization-enabled``. The property is enabled by default with the value ``TRUE``.
 * Add a Redis-based historical statistics provider.  For more information, see :doc:`Redis HBO Provider </plugin/redis-hbo-provider>`.
 * Add principal name support in the resource group selection criteria.
 * Add ``noisy_count_if_gaussian(condition, noiseScale[, randomSeed])`` aggregation which calculates the number of ``TRUE`` input values, and then adds random Gaussian noise with 0 mean and standard deviation of ``noise_scale`` to the true count. Optional ``randomSeed`` is used to get a fixed value of noise, often for reproducibility purposes. If ``randomSeed`` is omitted, ``SecureRandom`` is used. If ``randomSeed`` is provided, ``Random`` is used.

--- a/presto-docs/src/main/sphinx/release/release-0.289.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.289.rst
@@ -62,7 +62,7 @@ ______________________
 * Fix filtering by info columns ``$file_size`` and ``$file_modified_time``, which were ignored before. :pr:`23411`
 * Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp.  :pr:`22980`
 * Add config ``hive.legacy-timestamp-bucketing`` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22980`
-* Add support for setting the max size in bytes for the directory listing cache. This can be set via the new ``hive.file-status-cache.max-retained-size`` configuration property. ``hive.file-status-cache-size`` is now deprecated. :pr:`23176`
+* Add support for setting the max size in bytes for the directory listing cache. This can be set with the new ``hive.file-status-cache.max-retained-size`` configuration property. ``hive.file-status-cache-size`` is now deprecated. :pr:`23176`
 * Add support to skip empty files using configuration property ``hive.skip_empty_files``. :pr:`22727`
 * Add support for decimal batch reader :pr:`22636`
 

--- a/presto-docs/src/main/sphinx/release/release-0.292.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.292.rst
@@ -31,7 +31,7 @@ _______________
 * Fix addition, subtraction, multiplication and division of ``INTERVAL YEAR MONTH`` values. `#24617 <https://github.com/prestodb/presto/pull/24617>`_
 * Fix index error when a map column is passed into an unnest function by using the column analyzer to correctly map key and value output fields back to correct input expression. `#24789 <https://github.com/prestodb/presto/pull/24789>`_
 * Fix silently returning incorrect results when trying to construct a TimestampWithTimeZone from a value that has a unix timestamp that is too large/small. `#24674 <https://github.com/prestodb/presto/pull/24674>`_
-* Fix a potential block by making the number of task event loop configurable via a configuration file. `#24565 <https://github.com/prestodb/presto/pull/24565>`_
+* Fix a potential block by making the number of task event loop configurable with a configuration file. `#24565 <https://github.com/prestodb/presto/pull/24565>`_
 * Improve analysis of utilized columns in a query by exploring view definitions and checking the utilized columns of the underlying tables. `#24638 <https://github.com/prestodb/presto/pull/24638>`_
 * Improve error handling of ``INTERVAL DAY``, ``INTERVAL HOUR``, and ``INTERVAL SECOND`` operators when experiencing overflows. `#24353 <https://github.com/prestodb/presto/pull/24353>`_
 * Improve scheduling by using long instead of DataSize for critical path. `#24582 <https://github.com/prestodb/presto/pull/24582>`_

--- a/presto-docs/src/main/sphinx/release/release-0.298.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.298.rst
@@ -17,7 +17,7 @@ Release 0.298
 * Add incremental refresh for materialized views in the Iceberg connector, enabling efficient partial refreshes instead of full recomputation. `#26959 <https://github.com/prestodb/presto/pull/26959>`_
 * Add support for Azure Blob Storage (``wasb[s]://``) and Azure Data Lake Storage Gen2 (``abfs[s]://``) in the Hive connector, with shared key and OAuth2 authentication. `#25107 <https://github.com/prestodb/presto/pull/25107>`_
 * Add ``ALTER MATERIALIZED VIEW <name> SET PROPERTIES (...)`` SQL statement to update materialized view properties after creation. `#27806 <https://github.com/prestodb/presto/pull/27806>`_
-* Add TopN late materialization optimization for ``ORDER BY ... LIMIT`` over wide tables with a unique ``$row_id`` column, sorting only sort keys first and fetching full rows via SemiJoin. `#27641 <https://github.com/prestodb/presto/pull/27641>`_
+* Add TopN late materialization optimization for ``ORDER BY ... LIMIT`` over wide tables with a unique ``$row_id`` column, sorting only sort keys first and fetching full rows with SemiJoin. `#27641 <https://github.com/prestodb/presto/pull/27641>`_
 * Add TLS/SSL configuration, i18n character set, and configurable JDBC fetch size support for the Oracle connector. `#27671 <https://github.com/prestodb/presto/pull/27671>`_ `#27670 <https://github.com/prestodb/presto/pull/27670>`_ `#27669 <https://github.com/prestodb/presto/pull/27669>`_
 * Add read support for Iceberg V3 row lineage hidden columns `_row_id` and `_last_updated_sequence_number`. `#27240 <https://github.com/prestodb/presto/pull/27240>`_
 * Add support for ``min/max/count`` aggregation push down based on file stats. This can be toggled with the ``aggregate_push_down_enabled`` session property or the ``iceberg.aggregate-push-down-enabled`` configuration property. See :ref:`connector/iceberg:session properties` and :ref:`connector/iceberg:configuration properties`. `#27085 <https://github.com/prestodb/presto/pull/27085>`_
@@ -66,7 +66,7 @@ _______________
 * Add :ref:`admin/properties:\`\`cluster-overload.bypass-resource-groups\`\`` configuration property to allow named resource groups to bypass cluster-overload throttling while continuing to honor per-group concurrency, memory, and CPU limits. `#27642 <https://github.com/prestodb/presto/pull/27642>`_
 * Add :ref:`admin/properties-session:\`\`optimize_row_in_predicate\`\`` session property (default off) that rewrites multi-column ``ROW IN`` / ``ROW NOT IN`` predicates to expose per-column ``IN`` / ``NOT IN`` predicates, enabling partition pruning and other domain-based optimizations. `#27708 <https://github.com/prestodb/presto/pull/27708>`_
 * Add :ref:`admin/properties-session:\`\`push_filter_through_selecting_aggregation\`\`` session property and ``optimizer.push-filter-through-selecting-aggregation`` configuration property (default ``false``) to push HAVING predicates beneath single-value aggregates (MAX/MIN/ARBITRARY) for earlier row reduction. `#27712 <https://github.com/prestodb/presto/pull/27712>`_
-* Add TopN late materialization optimization for ``ORDER BY ... LIMIT`` over wide tables with a unique ``$row_id`` column. Sorts only sort keys plus ``$row_id`` first, then fetches full rows via SemiJoin. `#27641 <https://github.com/prestodb/presto/pull/27641>`_
+* Add TopN late materialization optimization for ``ORDER BY ... LIMIT`` over wide tables with a unique ``$row_id`` column. Sorts only sort keys plus ``$row_id`` first, then fetches full rows with SemiJoin. `#27641 <https://github.com/prestodb/presto/pull/27641>`_
 * Add ``split_part_reverse`` as a global Presto SQL function, replacing the Velox C++ UDF with a SQL-invoked scalar function available in all queries. `#27480 <https://github.com/prestodb/presto/pull/27480>`_
 * Remove configuration property ``use-new-nan-definition``. `#27829 <https://github.com/prestodb/presto/pull/27829>`_
 * Remove ``warn-on-common-nan-patterns`` server config and ``warn_on_common_nan_patterns`` session property. The NaN definition migration is complete and these warnings are no longer needed. `#27830 <https://github.com/prestodb/presto/pull/27830>`_
@@ -140,7 +140,7 @@ _________________________
 Lance Connector Changes
 _______________________
 * Add SQL filter pushdown to reduce data read from disk for selective queries. Supports equality, comparisons, IN lists, IS NULL, and range predicates on Boolean, Integer, Bigint, Real, Double, Varchar, Date, and Timestamp types. See :ref:`connector/lance:predicate pushdown`. `#27430 <https://github.com/prestodb/presto/pull/27430>`_
-* Add configurable index and metadata cache sizes via lance.index-cache-size and lance.metadata-cache-size. `#27325 <https://github.com/prestodb/presto/pull/27325>`_
+* Add configurable index and metadata cache sizes by using lance.index-cache-size and lance.metadata-cache-size. `#27325 <https://github.com/prestodb/presto/pull/27325>`_
 * Add version-aware dataset caching with snapshot isolation for consistent query reads. `#27325 <https://github.com/prestodb/presto/pull/27325>`_
 
 MongoDB Connector Changes

--- a/presto-docs/src/main/sphinx/release/release-0.54.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.54.rst
@@ -12,7 +12,7 @@ Release 0.54
 
 * Add support for Snappy and LZ4 compression codecs for the ``hive-cdh4`` connector.
 
-* Add Example HTTP connector ``example-http`` that reads CSV data via HTTP.
+* Add Example HTTP connector ``example-http`` that reads CSV data by using HTTP.
   The connector requires a metadata URI that returns a JSON document
   describing the table metadata and the CSV files to read.
 

--- a/presto-docs/src/main/sphinx/release/release-0.55.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.55.rst
@@ -44,7 +44,7 @@ Range Predicate Pushdown
 
 We've modified the connector API to support range predicates in addition to simple equality predicates.
 This lays the ground work for adding connectors to systems that support range
-scans (e.g., HBase, Cassandra, JDBC, etc).
+scans such as HBase, Cassandra, or JDBC.
 
 In addition to receiving range predicates, the connector can also communicate
 back the ranges of each partition for use in the query optimizer.  This can be a

--- a/presto-docs/src/main/sphinx/release/release-0.60.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.60.rst
@@ -135,7 +135,7 @@ Bug fixes
 
 * Exchange client leak
 
-  When a query finished early (e.g., limit or failure) and the exchange operator
+  When a query finished early (for instance, from a limit or failure) and the exchange operator
   was blocked waiting for data from other nodes, the exchange was not be closed
   properly. This resulted in continuous failing HTTP requests which leaked
   resources and produced large log files.

--- a/presto-docs/src/main/sphinx/release/release-0.61.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.61.rst
@@ -63,7 +63,7 @@ Miscellaneous
 
 * General improvements to the JDBC driver, specifically with respect to metadata handling.
 
-* Fix division by zero errors in variance aggregation functions (``VARIANCE``, ``STDDEV``, etc.).
+* Fix division by zero errors in variance aggregation functions like ``VARIANCE`` or ``STDDEV``.
 
 * Fix a bug when using ``DISTINCT`` aggregations in the ``HAVING`` clause.
 
@@ -73,4 +73,4 @@ Miscellaneous
 
 * Fix handling of timestamps in maps and lists in Hive connector.
 
-* Add instrumentation for Hive metastore and HDFS API calls to track failures and latency. These metrics are exposed via JMX.
+* Add instrumentation for Hive metastore and HDFS API calls to track failures and latency. These metrics are exposed through JMX.

--- a/presto-docs/src/main/sphinx/release/release-0.66.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.66.rst
@@ -99,7 +99,7 @@ Both timestamps represent the same instant in time;
 they differ only in the time zone used to print them.
 
 The time zone of the session can be set on a per-query basis using the
-``X-Presto-Time-Zone`` HTTP header, or via the
+``X-Presto-Time-Zone`` HTTP header, or through the
 ``PrestoConnection.setTimeZoneId(String)`` method in the JDBC driver.
 
 Localization
@@ -118,7 +118,7 @@ If we set the language to Japanese::
     SELECT date_format(TIMESTAMP '2001-01-09 09:04', '%M'); -- 1月
 
 The language of the session can be set on a per-query basis using the
-``X-Presto-Language`` HTTP header, or via the
+``X-Presto-Language`` HTTP header, or by using the
 ``PrestoConnection.setLocale(Locale)`` method in the JDBC driver.
 
 Optimizations

--- a/presto-docs/src/main/sphinx/release/release-0.69.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.69.rst
@@ -51,9 +51,9 @@ and must be removed from ``etc/config.properties``.
 The Raptor connector stores data on the Presto machines in a
 columnar format using the same layout that Presto uses for in-memory
 data. Currently, it has major limitations: lack of replication,
-dropping a table does not reclaim the storage, etc. It is only
-suitable for experimentation, temporary tables, caching of data from
-slower connectors, etc. The metadata and data formats are subject to
+dropping a table does not reclaim the storage, and others. It is only
+suitable for experimentation, temporary tables, or caching of data from
+slower connectors. The metadata and data formats are subject to
 change in incompatible ways between releases.
 
 If you would like to experiment with the connector, create a catalog

--- a/presto-docs/src/main/sphinx/release/release-0.74.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.74.rst
@@ -13,7 +13,7 @@ old implementation in case of issues. To do so, add ``compiler.new-bytecode-gene
 Hive Storage Format
 -------------------
 
-The storage format to use when writing data to Hive can now be configured via the ``hive.storage-format`` option
+The storage format to use when writing data to Hive can now be configured with the ``hive.storage-format`` option
 in your Hive catalog properties file. Valid options are ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE`` and ``TEXTFILE``.
 The default format if the property is not set is ``RCBINARY``.
 

--- a/presto-docs/src/main/sphinx/release/release-0.76.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.76.rst
@@ -31,7 +31,7 @@ are now specified using a duration rather than milliseconds (this makes
 them consistent with all other such properties in Presto). If you were
 previously specifying a value such as ``25``, change it to ``25ms``.
 
-The retry policy for the Cassandra client is now configurable via the
+The retry policy for the Cassandra client is now configurable with the
 ``cassandra.retry-policy`` property. In particular, the custom ``BACKOFF``
 retry policy may be useful.
 

--- a/presto-docs/src/main/sphinx/release/release-0.78.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.78.rst
@@ -38,7 +38,7 @@ For JDBC, the properties can be set by unwrapping the ``Connection`` as follows:
     Specifically, we are planning to require preregistration of properties so
     the user can list available session properties and so the engine can verify
     property values. Additionally, the Presto grammar will be extended to
-    allow setting properties via a query.
+    allow setting properties with a query.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.80.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.80.rst
@@ -20,7 +20,7 @@ Hive Changes
 
 * The maximum retry time for the Hive S3 file system can be configured
   by setting ``hive.s3.max-retry-time``.
-* Fix Hive partition pruning for null keys (i.e. ``__HIVE_DEFAULT_PARTITION__``).
+* Fix Hive partition pruning for null keys (that is, ``__HIVE_DEFAULT_PARTITION__``).
 
 Cassandra Changes
 -----------------
@@ -49,7 +49,7 @@ Metadata-Only Query Optimization
 --------------------------------
 
 We now support an optimization that rewrites aggregation queries that are insensitive to the
-cardinality of the input (e.g., :func:`!max`, :func:`!min`, ``DISTINCT`` aggregates) to execute
+cardinality of the input (for example, :func:`!max`, :func:`!min`, ``DISTINCT`` aggregates) to execute
 against table metadata.
 
 For example, if ``key``, ``key1`` and ``key2`` are partition keys, the following queries
@@ -95,4 +95,4 @@ General Changes
   for the partial step of aggregations.
 * Fix exception when processing queries with an ``UNNEST`` operation where the output was not used.
 * Only show query progress in UI after the query has been fully scheduled.
-* Add query execution visualization to the coordinator UI. It can be accessed via the query details page.
+* Add query execution visualization to the coordinator UI. It can be accessed by using the query details page.

--- a/presto-docs/src/main/sphinx/release/release-0.86.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.86.rst
@@ -20,7 +20,7 @@ General Changes
 * Fix scheduling issue for queries involving tables from information_schema, which could result in
   inconsistent metadata.
 * Fix an issue with :func:`!min_by` and :func:`!max_by` that could result in an error when used with
-  a variable-length type (e.g., ``VARCHAR``) in a ``GROUP BY`` query.
+  a variable-length type (such as ``VARCHAR``) in a ``GROUP BY`` query.
 * Fix rendering of array attributes in JMX connector.
 * Input rows/bytes are now tracked properly for ``JOIN`` queries.
 * Fix case-sensitivity issue when resolving names of constant table expressions.

--- a/presto-docs/src/main/sphinx/rest/statement.rst
+++ b/presto-docs/src/main/sphinx/rest/statement.rst
@@ -27,7 +27,7 @@ Statement Resource
    stage identifier of "0" as shown in the following example response.
 
    This root stage aggregates the responses from other stages running
-   on Presto workers and delivers them to the client via the Presto
+   on Presto workers and delivers them to the client through the Presto
    coordinator. When a client receives a response to this POST it will
    contain a "nextUri" property which directs the client to query this
    address for additional results from the query.

--- a/presto-docs/src/main/sphinx/router/deployment.rst
+++ b/presto-docs/src/main/sphinx/router/deployment.rst
@@ -9,7 +9,7 @@ Download the Presto router tarball, :maven_download:`router`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_router_release|, which we will call the *installation* directory.
 
-Router needs a *data* directory for storing logs, etc.
+Router needs a *data* directory for storing logs. 
 We recommend creating a data directory outside of the installation directory,
 which allows it to be easily preserved when upgrading Presto.
 

--- a/presto-docs/src/main/sphinx/router/deployment.rst
+++ b/presto-docs/src/main/sphinx/router/deployment.rst
@@ -9,7 +9,7 @@ Download the Presto router tarball, :maven_download:`router`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_router_release|, which we will call the *installation* directory.
 
-Router needs a *data* directory for storing logs. 
+Router needs a *data* directory for storing logs and other data. 
 We recommend creating a data directory outside of the installation directory,
 which allows it to be easily preserved when upgrading Presto.
 


### PR DESCRIPTION
## Description
Revised the Presto documentation in

https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/release

to remove use of `e.g.`, `via`, `etc.`, and `i.e.` from the Presto documentation.

I also did a final check of the entire Presto documentation (in https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/) to catch instances that had been missed in the previous PRs. 

Building on the work in #27969, #27974, #27977, and #28001.



## Motivation and Context
Latin abbreviations should be avoided in documentation. See:

* the [GitLab documentation style guide recommended word list entry for e.g.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#eg)
* the [GitLab documentation style guide recommended word list entry for via](https://docs.gitlab.com/development/documentation/styleguide/word_list/#via)
* the [GitLab documentation style guide recommended word list entry for etc](https://docs.gitlab.com/development/documentation/styleguide/word_list/#etc)
* the [GitLab documentation style guide recommended word list entry for I.e.](https://docs.gitlab.com/development/documentation/styleguide/word_list/#ie)

I've been applying these rules for a long while when editing new Presto documentation, and @dnskr's work on https://github.com/prestodb/presto/pull/27961 prompted me to make a start at the existing doc set for consistency. Thanks @dnskr!

## Impact
Improved readability of the Presto documentation.

## Test Plan
Local doc builds and searches in Visual Studio Code.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Standardize wording in documentation and related comments to avoid Latin abbreviations and improve clarity across Presto docs.

Enhancements:
- Clarify a Thrift service comment describing supported comparable and orderable types.

Documentation:
- Update user and release documentation to replace Latin abbreviations (such as e.g., i.e., etc., and via) with clearer phrasing for better readability.