### PR TITLE
feat(planner): Extend optimize_top_n_using_row_id to TopN row_number

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -20,6 +20,7 @@ import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
@@ -30,6 +31,7 @@ import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNNode.Step;
+import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -38,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,6 +78,14 @@ import static java.util.Objects.requireNonNull;
  * The inner TopN sorts only the narrow clone (sort keys + $row_id).
  * The SemiJoin filters the full scan to only the N matching rows.
  * The outer TopN re-sorts only N rows (cheap).
+ *
+ * The same rewrite is also applied to {@link TopNRowNumberNode} (the
+ * row_number()/rank()/dense_rank() OVER (PARTITION BY ... ORDER BY ...) with
+ * WHERE rn &lt;= N pattern, produced by {@link WindowFilterPushDown}). There the
+ * narrow key set is partitionBy ∪ orderBy: the inner TopNRowNumber selects, per
+ * partition, the same $row_id set, the SemiJoin restricts the wide scan to those
+ * rows, and the outer TopNRowNumber recomputes the ranking column over only the
+ * kept rows.
  */
 public class OptimizeTopNUsingRowId
         implements PlanOptimizer
@@ -292,6 +303,171 @@ public class OptimizeTopNUsingRowId
                     topNNode.getCount(),
                     topNNode.getOrderingScheme(),
                     topNNode.getStep());
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getSource());
+
+            // Guard: only the final (non-partial) node, analogous to the Step.SINGLE guard for TopN
+            if (node.isPartial()) {
+                return replaceSource(node, source);
+            }
+
+            // Guard: source must be a scan-filter-project chain
+            if (!isScanFilterProject(source)) {
+                return replaceSource(node, source);
+            }
+
+            // Guard: source must be deterministic
+            if (!isDeterministicScanFilterProject(source, functionAndTypeManager)) {
+                return replaceSource(node, source);
+            }
+
+            // Find the underlying TableScanNode
+            Optional<TableScanNode> tableScanOpt = findTableScanNode(source);
+            if (!tableScanOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            TableScanNode tableScan = tableScanOpt.get();
+
+            // Check unique column from table layout
+            TableLayout layout = metadata.getLayout(session, tableScan.getTable());
+            Optional<ColumnHandle> uniqueColumnOpt = layout.getUniqueColumn();
+            if (!uniqueColumnOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            ColumnHandle uniqueColumnHandle = uniqueColumnOpt.get();
+
+            // Check heuristic: enough non-key columns to justify the rewrite.
+            // Narrow key set = partitionBy ∪ orderBy variables.
+            LinkedHashSet<VariableReferenceExpression> narrowKeySet = new LinkedHashSet<>();
+            narrowKeySet.addAll(node.getPartitionBy());
+            narrowKeySet.addAll(node.getOrderingScheme().getOrderByVariables());
+            List<VariableReferenceExpression> narrowKeys = ImmutableList.copyOf(narrowKeySet);
+            int totalColumns = source.getOutputVariables().size();
+            int columnSavings = totalColumns - narrowKeys.size();
+            if (columnSavings < minColumnSavings) {
+                return replaceSource(node, source);
+            }
+
+            // === Build the rewritten plan ===
+
+            // 1. Add $row_id to the original source
+            VariableReferenceExpression rowIdVar = variableAllocator.newVariable("$row_id",
+                    metadata.getColumnMetadata(session, tableScan.getTable(), uniqueColumnHandle).getType());
+            TableScanNode augmentedTableScan = addColumnToTableScan(tableScan, uniqueColumnHandle, rowIdVar, idAllocator);
+            Optional<PlanNode> augmentedSourceOpt = addPassThroughVariable(source, rowIdVar, idAllocator);
+            if (!augmentedSourceOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            augmentedSourceOpt = replaceTableScan(augmentedSourceOpt.get(), augmentedTableScan, idAllocator);
+            if (!augmentedSourceOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            PlanNode augmentedSource = augmentedSourceOpt.get();
+
+            // 2. Clone narrow source: partition/order keys only + $row_id
+            Map<VariableReferenceExpression, VariableReferenceExpression> varMap = new HashMap<>();
+            PlanNode narrowClone = clonePlanNode(source, session, metadata, idAllocator, narrowKeys, varMap);
+
+            // Add $row_id to the cloned narrow source too
+            Optional<TableScanNode> clonedTableScanOpt = findTableScanNode(narrowClone);
+            if (!clonedTableScanOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            VariableReferenceExpression clonedRowIdVar = variableAllocator.newVariable("$row_id_clone",
+                    metadata.getColumnMetadata(session, tableScan.getTable(), uniqueColumnHandle).getType());
+            TableScanNode clonedAugmentedTableScan = addColumnToTableScan(clonedTableScanOpt.get(), uniqueColumnHandle, clonedRowIdVar, idAllocator);
+            Optional<PlanNode> narrowCloneOpt = addPassThroughVariable(narrowClone, clonedRowIdVar, idAllocator);
+            if (!narrowCloneOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            narrowCloneOpt = replaceTableScan(narrowCloneOpt.get(), clonedAugmentedTableScan, idAllocator);
+            if (!narrowCloneOpt.isPresent()) {
+                return replaceSource(node, source);
+            }
+            narrowClone = narrowCloneOpt.get();
+
+            // Restrict narrow clone to only the mapped narrow keys + cloned $row_id
+            List<VariableReferenceExpression> narrowOutputs = ImmutableList.<VariableReferenceExpression>builder()
+                    .addAll(narrowKeys.stream().map(v -> varMap.getOrDefault(v, v)).collect(toImmutableList()))
+                    .add(clonedRowIdVar)
+                    .build();
+            narrowClone = restrictOutput(narrowClone, idAllocator, narrowOutputs);
+
+            // 3. Build inner TopNRowNumber over the narrow clone with mapped specification
+            List<VariableReferenceExpression> clonedPartitionBy = node.getPartitionBy().stream()
+                    .map(v -> varMap.getOrDefault(v, v))
+                    .collect(toImmutableList());
+            List<Ordering> clonedOrderings = node.getOrderingScheme().getOrderBy().stream()
+                    .map(o -> new Ordering(varMap.getOrDefault(o.getVariable(), o.getVariable()), o.getSortOrder()))
+                    .collect(toImmutableList());
+            DataOrganizationSpecification clonedSpecification = new DataOrganizationSpecification(
+                    clonedPartitionBy,
+                    Optional.of(new OrderingScheme(clonedOrderings)));
+            VariableReferenceExpression innerRowNumberVar = variableAllocator.newVariable("inner_row_number", node.getRowNumberVariable().getType());
+            TopNRowNumberNode innerTopNRowNumber = new TopNRowNumberNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    narrowClone,
+                    clonedSpecification,
+                    node.getRankingFunction(),
+                    innerRowNumberVar,
+                    node.getMaxRowCountPerPartition(),
+                    false,
+                    Optional.empty());
+
+            // 4. Build SemiJoinNode: source=$row_id from augmented original, filtering=$row_id_clone from inner node.
+            //    For small N (<= 100K), broadcast the inner result to all workers to avoid a full repartition.
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            Optional<SemiJoinNode.DistributionType> semiJoinDistribution = node.getMaxRowCountPerPartition() <= 100_000
+                    ? Optional.of(SemiJoinNode.DistributionType.REPLICATED)
+                    : Optional.empty();
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    augmentedSource,
+                    innerTopNRowNumber,
+                    rowIdVar,
+                    clonedRowIdVar,
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    semiJoinDistribution,
+                    ImmutableMap.of());
+
+            // 5. Filter on semiJoinOutput = true
+            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+
+            // 6. Build outer TopNRowNumber over the filtered result, reusing the original specification.
+            // Don't project away $row_id and semiJoinOutput here — PruneUnreferencedOutputs will handle it.
+            // Projecting them away here would break StreamPropertyDerivations' unique column consistency check.
+            TopNRowNumberNode outerTopNRowNumber = new TopNRowNumberNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    Optional.empty(),
+                    filtered,
+                    node.getSpecification(),
+                    node.getRankingFunction(),
+                    node.getRowNumberVariable(),
+                    node.getMaxRowCountPerPartition(),
+                    false,
+                    node.getHashVariable());
+
+            planChanged = true;
+            return outerTopNRowNumber;
+        }
+
+        private static PlanNode replaceSource(TopNRowNumberNode node, PlanNode newSource)
+        {
+            if (node.getSource() == newSource) {
+                return node;
+            }
+            return node.replaceChildren(ImmutableList.of(newSource));
         }
 
         /**

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
@@ -59,6 +59,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJo
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topNRowNumber;
 import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
 import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -179,6 +180,87 @@ public class TestOptimizeTopNUsingRowId
                                                                         tableScan("nation", ImmutableMap.of("NAME", "name", "ROW_ID", "$row_id"))),
                                                                 anyTree(
                                                                         tableScan("nation", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))))));
+    }
+
+    @Test
+    public void testTopNRowNumberBasicRewrite()
+    {
+        // lineitem has 16 columns; row_number() partitioned by orderkey ordered by linenumber
+        // narrows to 2 key columns, savings of 14 >= 10 threshold. With a unique column available,
+        // the optimization should produce an outer TopNRowNumber over a SemiJoin whose build side
+        // is an inner (narrow) TopNRowNumber.
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2",
+                enabledSession(),
+                true,
+                output(
+                        anyTree(
+                                topNRowNumber(outer -> outer.partial(false),
+                                        anyTree(
+                                                node(FilterNode.class,
+                                                        anyTree(
+                                                                semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
+                                                                        anyTree(
+                                                                                tableScan("lineitem", ImmutableMap.of("ROW_ID", "$row_id"))),
+                                                                        anyTree(
+                                                                                topNRowNumber(inner -> inner.partial(false),
+                                                                                        anyTree(
+                                                                                                tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id")))))))))))));
+    }
+
+    @Test
+    public void testTopNRowNumberNoRewriteWhenDisabled()
+    {
+        // With optimization disabled, should produce a plain TopNRowNumber directly over the scan.
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2",
+                disabledSession(),
+                true,
+                output(
+                        anyTree(
+                                topNRowNumber(outer -> outer.partial(false),
+                                        anyTree(
+                                                tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey", "LINENUMBER", "linenumber")))))));
+    }
+
+    @Test
+    public void testTopNRowNumberNoRewriteNarrowTable()
+    {
+        // nation has only 4 columns. Narrowing to regionkey + name gives savings of 2,
+        // below the default threshold of 10, so the rewrite should not fire.
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY regionkey ORDER BY name) rn FROM nation) WHERE rn <= 2",
+                enabledSession(),
+                true,
+                output(
+                        anyTree(
+                                topNRowNumber(outer -> outer.partial(false),
+                                        anyTree(
+                                                tableScan("nation", ImmutableMap.of("REGIONKEY", "regionkey", "NAME", "name")))))));
+    }
+
+    @Test
+    public void testTopNRowNumberRewriteUnpartitioned()
+    {
+        // Unpartitioned row_number() over the wide orders table (9 columns). With a low
+        // column-savings threshold the rewrite fires, producing the $row_id / $row_id_clone
+        // SemiJoin (the outer/inner TopNRowNumber nesting is asserted in testTopNRowNumberBasicRewrite).
+        Session lowThreshold = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, "1")
+                .build();
+
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT *, row_number() OVER (ORDER BY orderkey) rn FROM orders) WHERE rn <= 5",
+                lowThreshold,
+                true,
+                output(
+                        anyTree(
+                                semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ROW_ID", "$row_id"))),
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ROW_ID_CLONE", "$row_id")))))));
     }
 
     private Session enabledSession()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -236,6 +236,34 @@ public class TestLocalQueries
     }
 
     @Test
+    public void testOptimizeTopNRowNumberUsingRowId()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, "1")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "false")
+                .build();
+
+        // Partitioned row_number() over a wide table (lineitem has 16 columns)
+        String partitioned = "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2";
+        assertQuery(enabled, partitioned, disabled, partitioned);
+
+        // Unpartitioned row_number() over a wide table
+        String unpartitioned = "SELECT * FROM (SELECT *, row_number() OVER (ORDER BY orderkey) rn FROM orders) WHERE rn <= 5";
+        assertQuery(enabled, unpartitioned, disabled, unpartitioned);
+
+        // rank() variant to cover RankingFunction.RANK
+        String ranked = "SELECT * FROM (SELECT *, rank() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2";
+        assertQuery(enabled, ranked, disabled, ranked);
+
+        // dense_rank() variant to cover RankingFunction.DENSE_RANK
+        String denseRanked = "SELECT * FROM (SELECT *, dense_rank() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2";
+        assertQuery(enabled, denseRanked, disabled, denseRanked);
+    }
+
+    @Test
     public void testJoinPrefilterUnionAll()
     {
         String sql = "SELECT * FROM " +


### PR DESCRIPTION
## Description

Extends the `OptimizeTopNUsingRowId` optimizer (gated by the existing `optimize_top_n_using_row_id` session property, default off) to also handle `TopNRowNumberNode`. No new session property and no `PlanOptimizers` change.

`OptimizeTopNUsingRowId` performs **late materialization** for TopN over wide tables: it sorts only the narrow sort keys plus a unique `$row_id`, then `SemiJoin`s back to the full scan to fetch just the N winning rows, avoiding carrying every wide column through the sort.

Previously the optimizer only visited `TopNNode`. The pattern

```sql
SELECT * FROM (
  SELECT *, row_number() OVER (PARTITION BY ... ORDER BY ...) rn FROM wide_table
) WHERE rn <= N
```

is converted by `WindowFilterPushDown` into a `TopNRowNumberNode`, which the optimizer never visited — so these queries over wide tables got none of the late-materialization benefit.

## Motivation and Context

`row_number()`/`rank()`/`dense_rank()` ranking filters are an extremely common "top-N per group" shape, and over wide tables they suffer the same problem the optimizer already solves for `TopNNode`: every wide column is dragged through the ranking operator even though only N rows per partition survive.

This adds `visitTopNRowNumber`, applying the same `$row_id` rewrite to `TopNRowNumberNode`:
- the narrow key set is `partitionBy ∪ orderBy`;
- an inner `TopNRowNumber` selects the winning `$row_id`s over a narrow clone of the source;
- a `SemiJoin` restricts the wide scan to those `$row_id`s;
- the outer `TopNRowNumber` recomputes the ranking column over only the kept rows.

## Impact

- Behavior gated by the existing `optimize_top_n_using_row_id` session property (default `false`). No change unless enabled.
- Applies to `row_number()`, `rank()`, and `dense_rank()`, partitioned and unpartitioned, subject to the existing row-count threshold.

## Test Plan

- **Unit (plan shape):** `TestOptimizeTopNUsingRowId` — partitioned and unpartitioned `TopNRowNumber` rewrites plus negatives (property disabled, below threshold).
- **End-to-end (enabled vs disabled):** `TestLocalQueries#testOptimizeTopNRowNumberUsingRowId` covering `row_number`/`rank`/`dense_rank`, partitioned and unpartitioned, asserting identical results with the property ON vs OFF.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Extend the OptimizeTopNUsingRowId planner optimization to apply late materialization to TopNRowNumber plans produced for ranking functions.

Enhancements:
- Support applying the row-id-based TopN optimization to TopNRowNumberNode plans for row_number, rank, and dense_rank, including both partitioned and unpartitioned cases, guarded by the existing session properties.

Tests:
- Add planner tests covering TopNRowNumber rewrite behavior, including disabled mode, narrow-table scenarios, and unpartitioned queries.
- Add end-to-end local query tests validating identical results with the optimization enabled and disabled for row_number, rank, and dense_rank queries.