### PR TITLE
feat(security): Enable GitHub OAuth2 support

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
@@ -34,6 +34,8 @@ import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 public class WebUiResource
 {
     public static final String UI_ENDPOINT = "/";
+    public static final String LOGOUT_PATH = "/logout";
+    public static final String LOGOUT_HTML_PATH = "/ui/oauth2/logout.html";
 
     @GET
     public Response redirectIndexHtml(
@@ -56,7 +58,7 @@ public class WebUiResource
     }
 
     @GET
-    @Path("/logout")
+    @Path(LOGOUT_PATH)
     public Response logout(
             @HeaderParam(X_FORWARDED_PROTO) String proto,
             @Context UriInfo uriInfo)
@@ -65,7 +67,7 @@ public class WebUiResource
             proto = uriInfo.getRequestUri().getScheme();
         }
         return Response
-                .temporaryRedirect(uriInfo.getBaseUriBuilder().scheme(proto).path("/ui/logout.html").build())
+                .temporaryRedirect(uriInfo.getBaseUriBuilder().scheme(proto).path(LOGOUT_HTML_PATH).build())
                 .cookie(OAuthWebUiCookie.delete())
                 .build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.server.WebUiResource.LOGOUT_PATH;
 import static com.facebook.presto.server.WebUiResource.UI_ENDPOINT;
 import static com.facebook.presto.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
 import static com.facebook.presto.server.security.oauth2.OAuth2TokenExchangeResource.TOKEN_ENDPOINT;
@@ -256,7 +257,7 @@ public class AuthenticationFilter
     private boolean isWebUiRequest(HttpServletRequest request)
     {
         String pathInfo = request.getPathInfo();
-        return pathInfo == null || pathInfo.equals(UI_ENDPOINT) || pathInfo.startsWith("/ui");
+        return pathInfo == null || pathInfo.equals(UI_ENDPOINT) || pathInfo.startsWith("/ui") || pathInfo.equals(LOGOUT_PATH);
     }
 
     public static class ModifiedHttpServletRequest

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/NimbusAirliftHttpClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/NimbusAirliftHttpClient.java
@@ -24,6 +24,7 @@ import com.nimbusds.jose.util.Resource;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriBuilder;
 
 import javax.inject.Inject;
@@ -35,7 +36,9 @@ import java.net.URL;
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static com.google.common.net.HttpHeaders.ACCEPT;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.DELETE;
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
@@ -91,6 +94,11 @@ public class NimbusAirliftHttpClient
 
         ImmutableMultimap.Builder<String, String> headers = ImmutableMultimap.builder();
         httpRequest.getHeaderMap().forEach(headers::putAll);
+        if (!httpRequest.getHeaderMap().containsKey(ACCEPT)) {
+            headers.put(ACCEPT, MediaType.APPLICATION_JSON);
+        }
+        // Some OAuth providers (for example, GitHub) require a User-Agent header to be present.
+        headers.put(USER_AGENT, "Presto");
         request.addHeaders(headers.build());
 
         if (method.equals(POST) || method.equals(PUT)) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/NimbusOAuth2Client.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/NimbusOAuth2Client.java
@@ -102,6 +102,7 @@ public class NimbusOAuth2Client
     private final String principalField;
     private final Set<String> accessTokenAudiences;
     private final Duration maxClockSkew;
+    private final Duration challengeTimeout;
     private final NimbusHttpClient httpClient;
     private final OAuth2ServerConfigProvider serverConfigurationProvider;
     private volatile boolean loaded;
@@ -128,6 +129,7 @@ public class NimbusOAuth2Client
         scope = Scope.parse(oauthConfig.getScopes());
         principalField = oauthConfig.getPrincipalField();
         maxClockSkew = oauthConfig.getMaxClockSkew();
+        challengeTimeout = oauthConfig.getChallengeTimeout();
 
         accessTokenAudiences = new HashSet<>(oauthConfig.getAdditionalAudiences());
         accessTokenAudiences.add(clientId.getValue());
@@ -275,7 +277,7 @@ public class NimbusOAuth2Client
 
             return new Response(
                     accessToken.getValue(),
-                    determineExpiration(getExpiration(accessToken), claims.getExpirationTime()),
+                    determineExpiration(getExpiration(accessToken), claims.getExpirationTime(), challengeTimeout),
                     buildRefreshToken(refreshToken, existingRefreshToken),
                     claims.getClaims());
         }
@@ -640,7 +642,13 @@ public class NimbusOAuth2Client
         }
     }
 
-    private static Instant determineExpiration(Optional<Instant> validUntil, Date expiration)
+    static Instant determineExpiration(Optional<Instant> validUntil, Date expiration)
+            throws ChallengeFailedException
+    {
+        return determineExpiration(validUntil, expiration, null);
+    }
+
+    static Instant determineExpiration(Optional<Instant> validUntil, Date expiration, Duration fallback)
             throws ChallengeFailedException
     {
         if (validUntil.isPresent()) {
@@ -653,6 +661,10 @@ public class NimbusOAuth2Client
 
         if (expiration != null) {
             return expiration.toInstant();
+        }
+
+        if (fallback != null) {
+            return Instant.now().plusMillis(fallback.toMillis());
         }
 
         throw new ChallengeFailedException("no valid expiration date");

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2WebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2WebUiAuthenticationManager.java
@@ -32,6 +32,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
+import static com.facebook.presto.server.WebUiResource.LOGOUT_HTML_PATH;
+import static com.facebook.presto.server.WebUiResource.LOGOUT_PATH;
 import static com.facebook.presto.server.security.AuthenticationFilter.withPrincipal;
 import static com.facebook.presto.server.security.oauth2.OAuth2Authenticator.extractTokenFromCookie;
 import static com.facebook.presto.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
@@ -61,6 +63,10 @@ public class OAuth2WebUiAuthenticationManager
     public void handleRequest(HttpServletRequest request, HttpServletResponse response, FilterChain nextFilter)
             throws IOException, ServletException
     {
+        if (LOGOUT_PATH.equals(request.getPathInfo()) || LOGOUT_HTML_PATH.equals(request.getPathInfo())) {
+            nextFilter.doFilter(request, response);
+            return;
+        }
         try {
             Principal principal = this.oAuth2Authenticator.authenticate(request);
             nextFilter.doFilter(withPrincipal(request, principal), response);

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
@@ -31,6 +31,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -275,6 +276,31 @@ public abstract class BaseOAuth2AuthenticationFilterTest
         assertThat(oauth2Cookie).isNotEmpty();
         assertOAuth2Cookie(oauth2Cookie.get());
         assertUICallWithCookie(oauth2Cookie.get().getValue());
+    }
+
+    @DataProvider
+    public Object[][] logoutPaths()
+    {
+        return new Object[][] {{"/logout"}, {"/ui/oauth2/logout.html"}};
+    }
+
+    @Test(dataProvider = "logoutPaths")
+    public void testLogoutDoesNotRedirectToIdp(String path)
+            throws IOException
+    {
+        try (Response response = httpClient
+                .newCall(new Request.Builder()
+                        .url(proxyURI.resolve(path).toString())
+                        .get()
+                        .build())
+                .execute()) {
+            String location = response.header(LOCATION);
+            if (location != null) {
+                assertThat(location)
+                        .as("'%s' must not redirect to the IdP authorization endpoint", path)
+                        .doesNotContain("/oauth2/auth");
+            }
+        }
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestNimbusOAuth2ClientUserInfoParser.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestNimbusOAuth2ClientUserInfoParser.java
@@ -14,11 +14,19 @@
 package com.facebook.presto.server.security.oauth2;
 
 import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.http.client.testing.TestingResponse;
 import com.facebook.airlift.units.Duration;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
+import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.UserInfoSuccessResponse;
 import net.minidev.json.JSONArray;
@@ -26,8 +34,13 @@ import net.minidev.json.JSONObject;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static com.facebook.airlift.http.client.HttpStatus.OK;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -372,6 +385,101 @@ public class TestNimbusOAuth2ClientUserInfoParser
         response.setContentType("application/json");
         return response;
     }
-}
+    /**
+     * Verifies that NimbusAirliftHttpClient injects Accept: application/json and
+     * User-Agent: Presto on every outbound request without dropping existing headers
+     * (for example, the Authorization: Bearer header set by the Nimbus SDK).
+     */
+    @Test
+    public void testAcceptAndUserAgentHeadersAreAlwaysInjected()
+    {
+        AtomicReference<Request> captured = new AtomicReference<>();
 
-// Made with Bob
+        ListMultimap<String, String> responseHeaders = ArrayListMultimap.create();
+        responseHeaders.put("Content-Type", "application/json");
+        HttpClient httpClient = new TestingHttpClient(request -> {
+            captured.set(request);
+            return new TestingResponse(OK, responseHeaders, "{}".getBytes());
+        });
+        NimbusAirliftHttpClient nimbusClient = new NimbusAirliftHttpClient(httpClient);
+
+        nimbusClient.execute(
+                new UserInfoRequest(URI.create("https://idp.example.com/userinfo"), new BearerAccessToken("opaque_token")),
+                httpResponse -> null);
+
+        Request sent = captured.get();
+        assertThat(sent.getHeader("Authorization")).isNotNull();
+        assertThat(sent.getHeader(HttpHeaders.ACCEPT)).isEqualTo(MediaType.JSON_UTF_8.withoutParameters().toString());
+        assertThat(sent.getHeader(HttpHeaders.USER_AGENT)).isEqualTo("Presto");
+    }
+
+    /**
+     * When an opaque access token carries no 'exp' claim and the token endpoint reports
+     * no lifetime, determineExpiration falls back to challengeTimeout so the session
+     * still gets a valid expiry instead of throwing ChallengeFailedException.
+     */
+    @Test
+    public void testDetermineExpirationFallsBackToChallengeTimeoutForOpaqueTokens()
+            throws ChallengeFailedException
+    {
+        Duration challengeTimeout = new Duration(15, TimeUnit.MINUTES);
+        Instant before = Instant.now();
+
+        Instant result = NimbusOAuth2Client.determineExpiration(
+                Optional.empty(),
+                null,
+                challengeTimeout);
+
+        Instant after = Instant.now();
+
+        // Result should be ~now + 15 minutes (allow 2 s of wall-clock drift in CI)
+        assertThat(result)
+                .isAfterOrEqualTo(before.plusSeconds(14 * 60 + 58))
+                .isBeforeOrEqualTo(after.plusSeconds(15 * 60 + 2));
+    }
+
+    /**
+     * When the claims set carries an 'exp' Date but validUntil is absent (e.g. some
+     * providers return exp in the UserInfo body), exp is used directly instead of
+     * the fallback.
+     */
+    @Test
+    public void testDetermineExpirationPrefersExpClaimOverFallback()
+            throws ChallengeFailedException
+    {
+        // Use Date.from() for both construction and expected value so nanoseconds are stripped consistently
+        Instant expected = Date.from(Instant.now().plusSeconds(300)).toInstant();
+        Duration fallback = new Duration(15, TimeUnit.MINUTES);
+
+        assertThat(NimbusOAuth2Client.determineExpiration(Optional.empty(), Date.from(expected), fallback))
+                .isEqualTo(expected);
+    }
+
+    /**
+     * When both validUntil and expiration are present, the earlier of the two wins
+     * (regression guard — existing behaviour must not change).
+     */
+    @Test
+    public void testDetermineExpirationChoosesEarlierOfValidUntilAndExp()
+            throws ChallengeFailedException
+    {
+        // Use Date round-trip to strip sub-millisecond precision, matching what determineExpiration returns
+        Instant soon = Date.from(Instant.now().plusSeconds(30)).toInstant();
+        Instant later = Date.from(Instant.now().plusSeconds(120)).toInstant();
+
+        assertThat(NimbusOAuth2Client.determineExpiration(Optional.of(soon), Date.from(later))).isEqualTo(soon);
+        assertThat(NimbusOAuth2Client.determineExpiration(Optional.of(later), Date.from(soon))).isEqualTo(soon);
+    }
+
+    /**
+     * Without a fallback (two-arg overload), absent validUntil and absent exp must still
+     * throw ChallengeFailedException (regression guard).
+     */
+    @Test
+    public void testDetermineExpirationThrowsWhenBothAbsentAndNoFallback()
+    {
+        assertThatThrownBy(() -> NimbusOAuth2Client.determineExpiration(Optional.empty(), null))
+                .isInstanceOf(ChallengeFailedException.class)
+                .hasMessageContaining("no valid expiration date");
+    }
+}

--- a/presto-ui/src/static/assets/presto.css
+++ b/presto-ui/src/static/assets/presto.css
@@ -44,6 +44,10 @@ h3 {
     color: #dadada;
 }
 
+h4 {
+    color: #dadada;
+}
+
 h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
     color: #888;
 }


### PR DESCRIPTION
## Description
- Add Accept and User-Agent headers in NimbusAirliftHttpClient for GitHub OAuth2 API compatibility
- Fall back to challengeTimeout for token expiration when provider omits 'exp' claim (for example: GitHub opaque tokens)
- Fix OAuth2 logout by bypassing authentication on logout endpoints
- Specify light color for the `<h4>` to make the texts more visible

## Motivation and Context
Fixes: #28021
Also, make the `/logout` work properly

## Impact
Both the Presto console and CLI can use GH OAuth as the IdP for user login

## Test Plan
Manually verify the GH integration

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable more robust OAuth2 support including GitHub OAuth and fix logout behavior for the Presto web UI.

New Features:
- Add default Accept and User-Agent headers to outbound OAuth2 HTTP requests for compatibility with GitHub OAuth APIs.
- Allow OAuth2 token expiration to fall back to the configured challenge timeout when no exp claim or token lifetime is provided by the IdP.

Bug Fixes:
- Ensure web UI logout endpoints bypass OAuth2 authentication and redirect to the internal logout page instead of the IdP.
- Maintain existing behavior where missing expiration without a fallback still fails with an error.

Enhancements:
- Adjust web UI heading styles to improve h4 text visibility on dark backgrounds.

Tests:
- Add tests covering injected HTTP headers for Nimbus OAuth2 client requests, token expiration fallback logic, and correct logout redirect behavior.