### PR TITLE
docs: Fix presto-flight-shim documentation download link

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/federation.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/federation.rst
@@ -15,7 +15,7 @@ information from the coordinator.
 Installing FlightShim
 ---------------------
 
-Download the Presto FlightShim tarball, :maven_download:`flight-shim`, and unpack it.
+Download the Presto FlightShim tarball, :maven_download:`flightshim`, and unpack it.
 The tarball will contain a single top-level directory,
 |presto_flight_shim_release|, which we will call the *installation* directory.
 


### PR DESCRIPTION
## Description
This fixes the download link for presto-flight-shim.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Correct the presto-flight-shim download link in the federation documentation page.