### PR TITLE
refactor: Widen OutputMatcher constructor to accept Collection instead of List

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Collection;
 import java.util.List;
 
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
@@ -34,7 +35,7 @@ public class OutputMatcher
 {
     private final List<String> aliases;
 
-    OutputMatcher(List<String> aliases)
+    OutputMatcher(Collection<String> aliases)
     {
         this.aliases = ImmutableList.copyOf(requireNonNull(aliases, "aliases is null"));
     }


### PR DESCRIPTION
## Description
Widen `OutputMatcher` constructor parameter from `List<String>` to `Collection<String>`.

## Motivation and Context
The constructor body immediately passes the argument to `ImmutableList.copyOf()`, which accepts any `Collection` — not just `List`. Narrowing the parameter to `List` forces callers to convert (e.g. `Set`, `Deque`) unnecessarily. This is a backwards-compatible widening: `List` is a subtype of `Collection`, so all existing callers continue to work unchanged.

Fixes #22756

## Impact
No runtime behaviour change. The field type remains `List<String>` (backed by `ImmutableList`). Only the constructor signature is widened.

## Test Plan
Existing unit tests cover `OutputMatcher` via the plan matcher framework. No new test needed — this is a pure API widening with no logic change.

## Contributor checklist
- [x] PR description addresses the issue accurately and concisely.
- [x] No new properties, SQL syntax, functions, or other functionality added.
- [x] No release notes required (test-only / internal API change).
- [x] CI will validate no breaking changes.

## Release Notes
```
== NO RELEASE NOTE ==
```


## Summary by Sourcery

Enhancements:
- Relax the OutputMatcher constructor parameter from List<String> to Collection<String> to support non-list collections in tests.