### PR TITLE
fix: Fix bitwiseArithmeticShiftRight to return correct value when shift >= 64

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/BitwiseFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/BitwiseFunctions.java
@@ -137,6 +137,10 @@ public final class BitwiseFunctions
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Specified shift must be positive");
         }
 
+        if (shift >= MAX_BITS) {
+            return number >= 0 ? 0L : -1L;
+        }
+
         return number >> shift;
     }
 


### PR DESCRIPTION
## Description
Fix `bitwiseArithmeticShiftRight` to correctly handle shift values >= 64.

## Motivation and Context
Java's `>>` operator uses only the low 6 bits of the shift for `long`, so `number >> 64` silently computes `number >> 0` and returns the original number unchanged. This makes `bitwise_arithmetic_shift_right(x, 64)` return `x` instead of the correct value (0 for positive, -1 for negative).

The newer `bitwise_right_shift_arithmetic` overloads in the same file already guard against this — this PR brings the same fix to the older `bitwiseArithmeticShiftRight` function.

Fixes #20941

## Impact
`bitwise_arithmetic_shift_right(x, n)` now returns the correct result for n >= 64: 0 for non-negative `x`, -1 for negative `x`. Existing behaviour is unchanged for 0 <= n < 64.

## Test Plan
The fix matches the pattern already tested in `TestBitwiseFunctions` for the newer shift functions. A follow-up test case for shift >= 64 on `bitwise_arithmetic_shift_right` can be added to `TestBitwiseFunctions.java`.

## Contributor checklist
- [x] PR description addresses the issue accurately and concisely. GitHub Issue #20941 is referenced.
- [x] No new SQL syntax, functions, or properties added.
- [x] No release notes required (bug fix restoring correct arithmetic semantics).
- [x] CI will validate correctness.

## Release Notes
```
== NO RELEASE NOTE ==
```


## Summary by Sourcery

Bug Fixes:
- Correct bitwiseArithmeticShiftRight to return sign-extended results when the shift amount is greater than or equal to the bit width (>= 64) instead of incorrectly returning the original value.