### PR TITLE
fix: Return HTTP 401 instead of 500 when password exceeds bcrypt limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticator.java
@@ -69,7 +69,10 @@ public class PasswordAuthenticator
             throw needAuthentication(e.getMessage());
         }
         catch (IllegalArgumentException e) {
-            throw needAuthentication(e.getMessage());
+            // IllegalArgumentException is thrown by some authenticators (e.g. bcrypt-backed ones)
+            // when the password exceeds implementation limits (e.g. >72 bytes for bcrypt).
+            // Treat this as an authentication failure rather than a server error.
+            throw needAuthentication("Invalid credentials");
         }
         catch (RuntimeException e) {
             throw new RuntimeException("Authentication error", e);

--- a/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticator.java
@@ -68,6 +68,9 @@ public class PasswordAuthenticator
         catch (AccessDeniedException e) {
             throw needAuthentication(e.getMessage());
         }
+        catch (IllegalArgumentException e) {
+            throw needAuthentication(e.getMessage());
+        }
         catch (RuntimeException e) {
             throw new RuntimeException("Authentication error", e);
         }


### PR DESCRIPTION
## Description
Add a `catch (IllegalArgumentException e)` block in `PasswordAuthenticator` so that oversized passwords return HTTP 401 instead of HTTP 500.

## Motivation and Context
bcrypt silently truncates passwords at ~72 bytes in most implementations, but some libraries throw `IllegalArgumentException` when the input exceeds this limit. This uncaught exception bubbles up through the generic `catch (RuntimeException e)` handler and becomes an unhandled server error (HTTP 500), leaking implementation details and giving clients a misleading response.

The correct behaviour is HTTP 401 — the same as any other authentication failure.

Fixes #25679

## Impact
Passwords longer than ~72 bytes now return HTTP 401 with a `WWW-Authenticate` challenge instead of HTTP 500. No change for valid-length passwords.

## Test Plan
Can be tested by configuring a `PasswordAuthenticatorManager` backed by bcrypt and submitting a password > 72 bytes. The response should change from 500 to 401.

## Contributor checklist
- [x] PR description addresses the issue accurately and concisely. GitHub Issue #25679 is referenced.
- [x] No new SQL syntax, functions, or properties added.
- [x] No release notes required (bug fix; external behaviour is correct 401 vs incorrect 500).
- [x] CI will validate correctness.

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Return HTTP 401 with a WWW-Authenticate challenge instead of HTTP 500 when password hashing throws IllegalArgumentException for oversized passwords.