### PR TITLE
feat(optimizer): Add coordinator-mediated DPP planner support

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -94,4 +94,6 @@ public class RuntimeMetricName
     public static final String METASTORE_UPDATE_PARTITION_STATISTICS_TIME_NANOS = "metastoreUpdatePartitionStatisticsTimeNanos";
     public static final String METASTORE_UPDATE_TABLE_STATISTICS_TIME_NANOS = "metastoreUpdateTableStatisticsTimeNanos";
     public static final String CHECK_ACCESS_PERMISSIONS_TIME_NANOS = "checkAccessPermissionsTimeNanos";
+    public static final String DYNAMIC_FILTER_PLAN_CREATED_FAVORABLE_RATIO = "dynamicFilterPlanCreatedFavorableRatio";
+    public static final String DYNAMIC_FILTER_PLAN_SKIPPED_HIGH_CARDINALITY = "dynamicFilterPlanSkippedHighCardinality";
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.DistributedDynamicFilterStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
@@ -239,6 +240,12 @@ public final class SystemSessionProperties
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
     public static final String DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER = "dynamic_filtering_range_row_limit_per_driver";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_STRATEGY = "distributed_dynamic_filter_strategy";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_TIME = "distributed_dynamic_filter_max_wait_time";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_EXTENSIONS = "distributed_dynamic_filter_max_wait_extensions";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_MAX_SIZE = "distributed_dynamic_filter_max_size";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_CARDINALITY_RATIO_THRESHOLD = "distributed_dynamic_filter_cardinality_ratio_threshold";
+    public static final String DISTRIBUTED_DYNAMIC_FILTER_ON_REPLICATED_JOINS = "distributed_dynamic_filter_on_replicated_joins";
     public static final String FRAGMENT_RESULT_CACHING_ENABLED = "fragment_result_caching_enabled";
     public static final String INLINE_SQL_FUNCTIONS = "inline_sql_functions";
     public static final String REMOTE_FUNCTIONS_ENABLED = "remote_functions_enabled";
@@ -410,6 +417,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_ENFORCE_JOIN_BUILD_INPUT_PARTITION = "native_enforce_join_build_input_partition";
     public static final String NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED = "native_execution_scale_writer_threads_enabled";
     public static final String NATIVE_EXCHANGE_MATERIALIZATION_ENABLED = "native_exchange_materialization_enabled";
+    public static final String NATIVE_DYNAMIC_FILTER_PUSHDOWN_ENABLED = "native_dynamic_filter_pushdown_enabled";
     public static final String TRY_FUNCTION_CATCHABLE_ERRORS = "try_function_catchable_errors";
     public static final String PUSH_FILTER_THROUGH_SELECTING_AGGREGATION = "push_filter_through_selecting_aggregation";
     public static final String OPTIMIZE_ROW_IN_PREDICATE = "optimize_row_in_predicate";
@@ -1344,6 +1352,51 @@ public final class SystemSessionProperties
                         "Maximum number of build-side rows per driver up to which min and max values will be collected for dynamic filtering",
                         featuresConfig.getDynamicFilteringRangeRowLimitPerDriver(),
                         false),
+                new PropertyMetadata<>(
+                        DISTRIBUTED_DYNAMIC_FILTER_STRATEGY,
+                        format("When to add distributed dynamic filters to joins for split-level pruning. Value must be one of: %s",
+                                Stream.of(DistributedDynamicFilterStrategy.values())
+                                        .map(DistributedDynamicFilterStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        DistributedDynamicFilterStrategy.class,
+                        featuresConfig.getDistributedDynamicFilterStrategy(),
+                        true,
+                        value -> DistributedDynamicFilterStrategy.valueOf(((String) value).toUpperCase()),
+                        DistributedDynamicFilterStrategy::name),
+                new PropertyMetadata<>(
+                        DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_TIME,
+                        "Per-cycle maximum wait for a distributed dynamic filter before checking whether partition contributions are still arriving. Total wall = (1 + " + DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_EXTENSIONS + ") * this value.",
+                        VARCHAR,
+                        Duration.class,
+                        featuresConfig.getDistributedDynamicFilterMaxWaitTime(),
+                        true,
+                        value -> Duration.valueOf((String) value),
+                        Duration::toString),
+                integerProperty(
+                        DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_EXTENSIONS,
+                        "Maximum number of additional max-wait-time cycles to grant a partitioned dynamic filter when partition contributions are still arriving. Set to 0 to disable adaptive extension.",
+                        featuresConfig.getDistributedDynamicFilterMaxWaitExtensions(),
+                        true),
+                new PropertyMetadata<>(
+                        DISTRIBUTED_DYNAMIC_FILTER_MAX_SIZE,
+                        "Maximum size of coordinator-side merged dynamic filter before collapsing to min/max range",
+                        VARCHAR,
+                        DataSize.class,
+                        featuresConfig.getDistributedDynamicFilterMaxSize(),
+                        true,
+                        value -> DataSize.valueOf((String) value),
+                        DataSize::toString),
+                doubleProperty(
+                        DISTRIBUTED_DYNAMIC_FILTER_CARDINALITY_RATIO_THRESHOLD,
+                        "Maximum build/probe cardinality ratio for cost-based dynamic filter creation",
+                        featuresConfig.getDistributedDynamicFilterCardinalityRatioThreshold(),
+                        true),
+                booleanProperty(
+                        DISTRIBUTED_DYNAMIC_FILTER_ON_REPLICATED_JOINS,
+                        "Add distributed dynamic filters to REPLICATED (broadcast) joins. Disabled by default because Velox in-fragment pushdown already covers them",
+                        featuresConfig.isDistributedDynamicFilterOnReplicatedJoins(),
+                        true),
                 booleanProperty(
                         FRAGMENT_RESULT_CACHING_ENABLED,
                         "Enable fragment result caching and read/write leaf fragment result pages from/to cache when applicable",
@@ -2221,6 +2274,10 @@ public final class SystemSessionProperties
                         !featuresConfig.isNativeExecutionEnabled()),
                 booleanProperty(NATIVE_EXCHANGE_MATERIALIZATION_ENABLED,
                         "Native Execution only. Enable materialized exchange operators in Velox (MaterializedOutput/MaterializedExchange). When false, uses PartitionAndSerialize + ShuffleWrite.",
+                        true,
+                        false),
+                booleanProperty(NATIVE_DYNAMIC_FILTER_PUSHDOWN_ENABLED,
+                        "Native Execution only. Enable Velox built-in hash probe dynamic filter pushdown to upstream table scans",
                         true,
                         false),
                 stringProperty(
@@ -3221,6 +3278,54 @@ public final class SystemSessionProperties
     public static int getDynamicFilteringRangeRowLimitPerDriver(Session session)
     {
         return session.getSystemProperty(DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER, Integer.class);
+    }
+
+    public static DistributedDynamicFilterStrategy getDistributedDynamicFilterStrategy(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, DistributedDynamicFilterStrategy.class);
+    }
+
+    public static boolean isDistributedDynamicFilterEnabled(Session session)
+    {
+        boolean distributed = getDistributedDynamicFilterStrategy(session) != DistributedDynamicFilterStrategy.DISABLED;
+        if (distributed && isEnableDynamicFiltering(session)) {
+            throw new PrestoException(
+                    INVALID_SESSION_PROPERTY,
+                    "Cannot enable both 'enable_dynamic_filtering' and 'distributed_dynamic_filter_strategy'. " +
+                            "Use 'enable_dynamic_filtering' for local/within-fragment filtering or " +
+                            "'distributed_dynamic_filter_strategy' for coordinator-side split pruning, but not both.");
+        }
+        return distributed;
+    }
+
+    public static Duration getDistributedDynamicFilterMaxWaitTime(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_TIME, Duration.class);
+    }
+
+    public static int getDistributedDynamicFilterMaxWaitExtensions(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_MAX_WAIT_EXTENSIONS, Integer.class);
+    }
+
+    public static DataSize getDistributedDynamicFilterMaxSize(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_MAX_SIZE, DataSize.class);
+    }
+
+    public static double getDistributedDynamicFilterCardinalityRatioThreshold(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_CARDINALITY_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static boolean isDistributedDynamicFilterOnReplicatedJoins(Session session)
+    {
+        return session.getSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_ON_REPLICATED_JOINS, Boolean.class);
+    }
+
+    public static boolean isNativeDynamicFilterPushdownEnabled(Session session)
+    {
+        return session.getSystemProperty(NATIVE_DYNAMIC_FILTER_PUSHDOWN_ENABLED, Boolean.class);
     }
 
     public static boolean isFragmentResultCachingEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -189,6 +189,12 @@ public class FeaturesConfig
     private int dynamicFilteringMaxPerDriverRowCount = 100;
     private DataSize dynamicFilteringMaxPerDriverSize = new DataSize(10, KILOBYTE);
     private int dynamicFilteringRangeRowLimitPerDriver;
+    private DistributedDynamicFilterStrategy distributedDynamicFilterStrategy = DistributedDynamicFilterStrategy.DISABLED;
+    private Duration distributedDynamicFilterMaxWaitTime = new Duration(2, SECONDS);
+    private int distributedDynamicFilterMaxWaitExtensions = 2;
+    private DataSize distributedDynamicFilterMaxSize = new DataSize(1, MEGABYTE);
+    private double distributedDynamicFilterCardinalityRatioThreshold = 0.1;
+    private boolean distributedDynamicFilterOnReplicatedJoins;
 
     private boolean fragmentResultCachingEnabled;
 
@@ -478,6 +484,13 @@ public class FeaturesConfig
     }
 
     public enum ShardedJoinStrategy
+    {
+        DISABLED,
+        COST_BASED,
+        ALWAYS
+    }
+
+    public enum DistributedDynamicFilterStrategy
     {
         DISABLED,
         COST_BASED,
@@ -1635,6 +1648,86 @@ public class FeaturesConfig
     public FeaturesConfig setDynamicFilteringRangeRowLimitPerDriver(int dynamicFilteringRangeRowLimitPerDriver)
     {
         this.dynamicFilteringRangeRowLimitPerDriver = dynamicFilteringRangeRowLimitPerDriver;
+        return this;
+    }
+
+    public DistributedDynamicFilterStrategy getDistributedDynamicFilterStrategy()
+    {
+        return distributedDynamicFilterStrategy;
+    }
+
+    @Config("distributed-dynamic-filter.strategy")
+    @ConfigDescription("When to add distributed dynamic filters to joins for split-level pruning")
+    public FeaturesConfig setDistributedDynamicFilterStrategy(DistributedDynamicFilterStrategy distributedDynamicFilterStrategy)
+    {
+        this.distributedDynamicFilterStrategy = distributedDynamicFilterStrategy;
+        return this;
+    }
+
+    public Duration getDistributedDynamicFilterMaxWaitTime()
+    {
+        return distributedDynamicFilterMaxWaitTime;
+    }
+
+    @Config("distributed-dynamic-filter.max-wait-time")
+    public FeaturesConfig setDistributedDynamicFilterMaxWaitTime(Duration distributedDynamicFilterMaxWaitTime)
+    {
+        this.distributedDynamicFilterMaxWaitTime = distributedDynamicFilterMaxWaitTime;
+        return this;
+    }
+
+    @Min(0)
+    public int getDistributedDynamicFilterMaxWaitExtensions()
+    {
+        return distributedDynamicFilterMaxWaitExtensions;
+    }
+
+    @Config("distributed-dynamic-filter.max-wait-extensions")
+    @ConfigDescription("Maximum number of additional max-wait-time cycles to grant a partitioned dynamic filter when partition contributions are still arriving. Total wall = (1 + extensions) * max-wait-time. Set to 0 to disable adaptive extension.")
+    public FeaturesConfig setDistributedDynamicFilterMaxWaitExtensions(int distributedDynamicFilterMaxWaitExtensions)
+    {
+        this.distributedDynamicFilterMaxWaitExtensions = distributedDynamicFilterMaxWaitExtensions;
+        return this;
+    }
+
+    public DataSize getDistributedDynamicFilterMaxSize()
+    {
+        return distributedDynamicFilterMaxSize;
+    }
+
+    @Config("distributed-dynamic-filter.max-size")
+    @ConfigDescription("Maximum size of coordinator-side merged dynamic filter before collapsing to min/max range")
+    public FeaturesConfig setDistributedDynamicFilterMaxSize(DataSize distributedDynamicFilterMaxSize)
+    {
+        this.distributedDynamicFilterMaxSize = distributedDynamicFilterMaxSize;
+        return this;
+    }
+
+    @DecimalMin("0.0")
+    @DecimalMax("1.0")
+    public double getDistributedDynamicFilterCardinalityRatioThreshold()
+    {
+        return distributedDynamicFilterCardinalityRatioThreshold;
+    }
+
+    @Config("distributed-dynamic-filter.cardinality-ratio-threshold")
+    @ConfigDescription("Maximum build/probe cardinality ratio for cost-based dynamic filter creation")
+    public FeaturesConfig setDistributedDynamicFilterCardinalityRatioThreshold(double distributedDynamicFilterCardinalityRatioThreshold)
+    {
+        this.distributedDynamicFilterCardinalityRatioThreshold = distributedDynamicFilterCardinalityRatioThreshold;
+        return this;
+    }
+
+    public boolean isDistributedDynamicFilterOnReplicatedJoins()
+    {
+        return distributedDynamicFilterOnReplicatedJoins;
+    }
+
+    @Config("distributed-dynamic-filter.on-replicated-joins")
+    @ConfigDescription("Add distributed dynamic filters to REPLICATED (broadcast) joins. Disabled by default because Velox's in-fragment pushdown already covers them")
+    public FeaturesConfig setDistributedDynamicFilterOnReplicatedJoins(boolean distributedDynamicFilterOnReplicatedJoins)
+    {
+        this.distributedDynamicFilterOnReplicatedJoins = distributedDynamicFilterOnReplicatedJoins;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.AUTOMATIC;
 import static com.facebook.presto.sql.planner.iterative.ConfidenceBasedBroadcastUtil.confidenceBasedBroadcast;
 import static com.facebook.presto.sql.planner.iterative.ConfidenceBasedBroadcastUtil.treatLowConfidenceZeroEstimationsAsUnknown;
+import static com.facebook.presto.sql.planner.iterative.rule.DynamicFilterUtils.addApplicableDynamicFilters;
 import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.isBelowBroadcastLimit;
 import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.isSmallerThanThreshold;
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
@@ -102,12 +103,16 @@ public class DetermineJoinDistributionType
     public Result apply(JoinNode joinNode, Captures captures, Context context)
     {
         JoinDistributionType joinDistributionType = getJoinDistributionType(context.getSession());
+        JoinNode resultNode;
         if (joinDistributionType == AUTOMATIC) {
-            PlanNode resultNode = getCostBasedJoin(joinNode, context);
+            resultNode = (JoinNode) getCostBasedJoin(joinNode, context);
             statsSource = context.getStatsProvider().getStats(joinNode).getSourceInfo().getSourceInfoName();
-            return Result.ofPlanNode(resultNode);
         }
-        return Result.ofPlanNode(getSyntacticOrderJoin(joinNode, context, joinDistributionType));
+        else {
+            resultNode = getSyntacticOrderJoin(joinNode, context, joinDistributionType);
+        }
+        resultNode = addApplicableDynamicFilters(context.getSession(), resultNode, context.getStatsProvider(), context.getIdAllocator());
+        return Result.ofPlanNode(resultNode);
     }
 
     public static boolean isBelowMaxBroadcastSize(JoinNode joinNode, Context context)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -11,20 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.airlift.units.DataSize;
@@ -38,23 +24,34 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.statistics.HistoryBasedSourceInfo;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterStrategy;
 import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
 import static com.facebook.presto.SystemSessionProperties.getJoinMaxBroadcastTableSize;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterOnReplicatedJoins;
 import static com.facebook.presto.SystemSessionProperties.isSizeBasedJoinDistributionTypeEnabled;
 import static com.facebook.presto.SystemSessionProperties.isUseBroadcastJoinWhenBuildSizeSmallProbeSizeUnknownEnabled;
+import static com.facebook.presto.SystemSessionProperties.isVerboseRuntimeStatsEnabled;
 import static com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges.calculateJoinCostWithoutOutput;
 import static com.facebook.presto.spi.plan.SemiJoinNode.DistributionType.PARTITIONED;
 import static com.facebook.presto.spi.plan.SemiJoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.DistributedDynamicFilterStrategy.COST_BASED;
 import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.getSourceTablesSizeInBytes;
+import static com.facebook.presto.sql.planner.iterative.rule.DynamicFilterUtils.shouldCreateFilter;
 import static com.facebook.presto.sql.planner.plan.Patterns.semiJoin;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.Objects.requireNonNull;
 
@@ -102,18 +99,23 @@ public class DetermineSemiJoinDistributionType
     public Result apply(SemiJoinNode semiJoinNode, Captures captures, Context context)
     {
         JoinDistributionType joinDistributionType = getJoinDistributionType(context.getSession());
+        SemiJoinNode resultNode;
         switch (joinDistributionType) {
             case AUTOMATIC:
-                PlanNode resultNode = getCostBasedDistributionType(semiJoinNode, context);
+                resultNode = (SemiJoinNode) getCostBasedDistributionType(semiJoinNode, context);
                 statsSource = context.getStatsProvider().getStats(semiJoinNode).getSourceInfo().getSourceInfoName();
-                return Result.ofPlanNode(resultNode);
+                break;
             case PARTITIONED:
-                return Result.ofPlanNode(semiJoinNode.withDistributionType(PARTITIONED));
+                resultNode = semiJoinNode.withDistributionType(PARTITIONED);
+                break;
             case BROADCAST:
-                return Result.ofPlanNode(semiJoinNode.withDistributionType(REPLICATED));
+                resultNode = semiJoinNode.withDistributionType(REPLICATED);
+                break;
             default:
                 throw new IllegalArgumentException("Unknown join_distribution_type: " + joinDistributionType);
         }
+        resultNode = maybeAddDynamicFilters(resultNode, context);
+        return Result.ofPlanNode(resultNode);
     }
 
     private PlanNode getCostBasedDistributionType(SemiJoinNode node, Context context)
@@ -199,5 +201,45 @@ public class DetermineSemiJoinDistributionType
                 replicated,
                 estimatedSourceDistributedTaskCount);
         return new PlanNodeWithCost(cost.toPlanCost(), possibleJoinNode);
+    }
+
+    private static SemiJoinNode maybeAddDynamicFilters(SemiJoinNode node, Context context)
+    {
+        Session session = context.getSession();
+        if (!isDistributedDynamicFilterEnabled(session)) {
+            return node;
+        }
+        verify(node.getDynamicFilters().isEmpty(), "SemiJoinNode already has dynamic filters");
+        if (!isDistributedDynamicFilterOnReplicatedJoins(session) && node.getDistributionType().equals(Optional.of(REPLICATED))) {
+            return node;
+        }
+
+        boolean costBased = getDistributedDynamicFilterStrategy(session) == COST_BASED;
+        if (costBased && !shouldCreateFilter(
+                node.getFilteringSourceJoinVariable().getName(),
+                context.getStatsProvider().getStats(node.getFilteringSource()),
+                context.getStatsProvider().getStats(node.getSource()),
+                session,
+                isVerboseRuntimeStatsEnabled(session))) {
+            return node;
+        }
+
+        String filterId = context.getIdAllocator().getNextId().toString();
+        Map<String, VariableReferenceExpression> dynamicFilters = ImmutableMap.of(
+                filterId, node.getFilteringSourceJoinVariable());
+
+        return new SemiJoinNode(
+                node.getSourceLocation(),
+                node.getId(),
+                node.getStatsEquivalentPlanNode(),
+                node.getSource(),
+                node.getFilteringSource(),
+                node.getSourceJoinVariable(),
+                node.getFilteringSourceJoinVariable(),
+                node.getSemiJoinOutput(),
+                node.getSourceHashVariable(),
+                node.getFilteringSourceHashVariable(),
+                node.getDistributionType(),
+                dynamicFilters);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DynamicFilterUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DynamicFilterUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterCardinalityRatioThreshold;
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterStrategy;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterOnReplicatedJoins;
+import static com.facebook.presto.SystemSessionProperties.isVerboseRuntimeStatsEnabled;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PLAN_CREATED_FAVORABLE_RATIO;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PLAN_SKIPPED_HIGH_CARDINALITY;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+import static com.facebook.presto.spi.plan.JoinDistributionType.REPLICATED;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.DistributedDynamicFilterStrategy.COST_BASED;
+import static com.google.common.base.Verify.verify;
+import static java.lang.Double.isFinite;
+import static java.lang.String.format;
+
+public final class DynamicFilterUtils
+{
+    private DynamicFilterUtils() {}
+
+    /**
+     * If distributed DPP is enabled, adds a dynamic filter entry per equi-join
+     * clause to the given JoinNode. Returns the original node unchanged when DPP
+     * is disabled, the join type is unsupported, the join is REPLICATED and
+     * {@code distributed_dynamic_filter_on_replicated_joins} is false, or
+     * cost-based gating rejects all clauses.
+     */
+    public static JoinNode addApplicableDynamicFilters(Session session, JoinNode node, StatsProvider statsProvider, PlanNodeIdAllocator idAllocator)
+    {
+        if (!isDistributedDynamicFilterEnabled(session)) {
+            return node;
+        }
+        if (node.getType() != INNER && node.getType() != RIGHT) {
+            return node;
+        }
+        verify(node.getDynamicFilters().isEmpty(), "JoinNode already has dynamic filters");
+        if (node.getCriteria().isEmpty()) {
+            return node;
+        }
+        // Velox handles REPLICATED joins in-fragment; coordinator DPP only applies to PARTITIONED joins.
+        if (!isDistributedDynamicFilterOnReplicatedJoins(session) && node.getDistributionType().equals(Optional.of(REPLICATED))) {
+            return node;
+        }
+
+        boolean costBased = getDistributedDynamicFilterStrategy(session) == COST_BASED;
+        boolean extendedMetrics = isVerboseRuntimeStatsEnabled(session);
+        PlanNodeStatsEstimate buildStats = statsProvider.getStats(node.getRight());
+        PlanNodeStatsEstimate probeStats = statsProvider.getStats(node.getLeft());
+        Map<String, VariableReferenceExpression> dynamicFilters = new HashMap<>();
+        for (EquiJoinClause clause : node.getCriteria()) {
+            if (costBased && !shouldCreateFilter(clause.getLeft().getName(), buildStats, probeStats, session, extendedMetrics)) {
+                continue;
+            }
+            String filterId = idAllocator.getNextId().toString();
+            dynamicFilters.put(filterId, clause.getRight());
+        }
+
+        if (dynamicFilters.isEmpty()) {
+            return node;
+        }
+
+        return new JoinNode(
+                node.getSourceLocation(),
+                node.getId(),
+                node.getStatsEquivalentPlanNode(),
+                node.getType(),
+                node.getLeft(),
+                node.getRight(),
+                node.getCriteria(),
+                node.getOutputVariables(),
+                node.getFilter(),
+                node.getLeftHashVariable(),
+                node.getRightHashVariable(),
+                node.getDistributionType(),
+                dynamicFilters);
+    }
+
+    static boolean shouldCreateFilter(String columnName, PlanNodeStatsEstimate buildStats, PlanNodeStatsEstimate probeStats, Session session, boolean extendedMetrics)
+    {
+        double buildRowCount = buildStats.getOutputRowCount();
+        double probeRowCount = probeStats.getOutputRowCount();
+
+        if (!isFinite(buildRowCount) || !isFinite(probeRowCount)) {
+            return true;
+        }
+
+        double threshold = getDistributedDynamicFilterCardinalityRatioThreshold(session);
+        // Zero probe rows means the build can be fully pruned — the filter is maximally selective.
+        boolean create = probeRowCount == 0 || (buildRowCount / probeRowCount) < threshold;
+        if (extendedMetrics) {
+            String metricName = create ? DYNAMIC_FILTER_PLAN_CREATED_FAVORABLE_RATIO : DYNAMIC_FILTER_PLAN_SKIPPED_HIGH_CARDINALITY;
+            session.getRuntimeStats().addMetricValue(
+                    format("%s[%s]", metricName, columnName),
+                    NONE, 1);
+        }
+        return create;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -23,15 +23,18 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AbstractJoinNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.MergeJoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.plan.SpatialJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizerResult;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
@@ -43,8 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
 import static com.facebook.presto.expressions.DynamicFilters.extractDynamicFilters;
 import static com.facebook.presto.expressions.DynamicFilters.getPlaceholder;
 import static com.facebook.presto.expressions.DynamicFilters.removeNestedDynamicFilters;
@@ -52,6 +55,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -83,7 +87,7 @@ public class RemoveUnsupportedDynamicFilters
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector)
     {
-        Rewriter rewriter = new RemoveUnsupportedDynamicFilters.Rewriter();
+        Rewriter rewriter = new RemoveUnsupportedDynamicFilters.Rewriter(session);
         PlanWithConsumedDynamicFilters result = plan.accept(rewriter, ImmutableSet.of());
         return PlanOptimizerResult.optimizerResult(result.getNode(), rewriter.isPlanChanged());
     }
@@ -91,7 +95,13 @@ public class RemoveUnsupportedDynamicFilters
     private class Rewriter
             extends InternalPlanVisitor<PlanWithConsumedDynamicFilters, Set<String>>
     {
+        private final Session session;
         boolean planChanged;
+
+        Rewriter(Session session)
+        {
+            this.session = requireNonNull(session, "session is null");
+        }
 
         public boolean isPlanChanged()
         {
@@ -131,6 +141,7 @@ public class RemoveUnsupportedDynamicFilters
                         new JoinNode(
                                 node.getSourceLocation(),
                                 node.getId(),
+                                node.getStatsEquivalentPlanNode(),
                                 node.getType(),
                                 joinDynamicFilterResult.getProbe(),
                                 joinDynamicFilterResult.getBuild(),
@@ -180,9 +191,22 @@ public class RemoveUnsupportedDynamicFilters
 
             PlanWithConsumedDynamicFilters leftResult = node.getProbe().accept(this, allowedDynamicFilterIdsProbeSide);
             Set<String> consumedProbeSide = leftResult.getConsumedDynamicFilterIds();
-            Map<String, VariableReferenceExpression> dynamicFilters = node.getDynamicFilters().entrySet().stream()
-                    .filter(entry -> consumedProbeSide.contains(entry.getKey()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, VariableReferenceExpression> dynamicFilters;
+            if (isDistributedDynamicFilterEnabled(session)) {
+                // DPP applies filters at split level, not via probe-side FilterNodes — skip the consumption check.
+                // Exception: if the probe chain crosses a remote exchange, delivering the filter would deadlock.
+                if (hasRemoteExchangeInProbeChain(node.getProbe())) {
+                    dynamicFilters = ImmutableMap.of();
+                }
+                else {
+                    dynamicFilters = node.getDynamicFilters();
+                }
+            }
+            else {
+                dynamicFilters = node.getDynamicFilters().entrySet().stream()
+                        .filter(entry -> consumedProbeSide.contains(entry.getKey()))
+                        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
 
             PlanWithConsumedDynamicFilters rightResult = node.getBuild().accept(this, allowedDynamicFilterIds);
             Set<String> consumed = new HashSet<>(rightResult.getConsumedDynamicFilterIds());
@@ -251,6 +275,34 @@ public class RemoveUnsupportedDynamicFilters
             }
             return logicalRowExpressions.combineConjuncts(extractResult.getStaticConjuncts());
         }
+    }
+
+    // True when the probe subtree crosses a remote exchange — DPP filter delivery would deadlock.
+    private static boolean hasRemoteExchangeInProbeChain(PlanNode node)
+    {
+        if (node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isRemote()) {
+            return true;
+        }
+        // Descend into probe side of nested joins/semi-joins; stop at build sides to avoid
+        // false positives from the build branch which is not part of the probe chain.
+        if (node instanceof JoinNode) {
+            return hasRemoteExchangeInProbeChain(((JoinNode) node).getLeft());
+        }
+        if (node instanceof SemiJoinNode) {
+            return hasRemoteExchangeInProbeChain(((SemiJoinNode) node).getSource());
+        }
+        if (node instanceof SpatialJoinNode) {
+            return hasRemoteExchangeInProbeChain(((SpatialJoinNode) node).getLeft());
+        }
+        if (node instanceof MergeJoinNode) {
+            return hasRemoteExchangeInProbeChain(((MergeJoinNode) node).getLeft());
+        }
+        for (PlanNode source : node.getSources()) {
+            if (hasRemoteExchangeInProbeChain(source)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class JoinDynamicFilterResult

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -83,6 +83,7 @@ import static com.facebook.presto.sql.planner.VariablesExtractor.extractUnique;
 import static com.facebook.presto.sql.planner.iterative.ConfidenceBasedBroadcastUtil.confidenceBasedBroadcast;
 import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isBelowMaxBroadcastSize;
 import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.mustPartition;
+import static com.facebook.presto.sql.planner.iterative.rule.DynamicFilterUtils.addApplicableDynamicFilters;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerationResult.INFINITE_COST_RESULT;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerationResult.UNKNOWN_COST_RESULT;
 import static com.facebook.presto.sql.planner.optimizations.JoinNodeUtils.toRowExpression;
@@ -591,6 +592,9 @@ public class ReorderJoins
 
         private JoinEnumerationResult createJoinEnumerationResult(PlanNode planNode)
         {
+            if (planNode instanceof JoinNode) {
+                planNode = addApplicableDynamicFilters(session, (JoinNode) planNode, context.getStatsProvider(), idAllocator);
+            }
             return JoinEnumerationResult.createJoinEnumerationResult(Optional.of(planNode), costProvider.getCost(planNode));
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.difference;
@@ -95,12 +96,15 @@ public class DynamicFiltersChecker
                 Set<String> currentJoinDynamicFilters = node.getDynamicFilters().keySet();
                 Set<String> consumedProbeSide = node.getProbe().accept(this, context);
                 Set<String> unconsumedByProbeSide = difference(currentJoinDynamicFilters, consumedProbeSide);
-                verify(
-                        unconsumedByProbeSide.isEmpty(),
-                        "Dynamic filters %s present in join were not fully consumed by its probe side, currentJoinDynamicFilters is: %s, consumedProbeSide is: %s",
-                        unconsumedByProbeSide,
-                        currentJoinDynamicFilters,
-                        consumedProbeSide);
+                // DPP filters are applied at split level, not consumed by probe-side FilterNodes.
+                if (!isDistributedDynamicFilterEnabled(session) || node.getDynamicFilters().isEmpty()) {
+                    verify(
+                            unconsumedByProbeSide.isEmpty(),
+                            "Dynamic filters %s present in join were not fully consumed by its probe side, currentJoinDynamicFilters is: %s, consumedProbeSide is: %s",
+                            unconsumedByProbeSide,
+                            currentJoinDynamicFilters,
+                            consumedProbeSide);
+                }
 
                 Set<String> consumedBuildSide = node.getBuild().accept(this, context);
                 Set<String> unconsumedByBuildSide = intersection(currentJoinDynamicFilters, consumedBuildSide);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.DistributedDynamicFilterStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.LeftJoinArrayContainsToInnerJoinStrategy;
@@ -129,6 +130,12 @@ public class TestFeaturesConfig
                 .setDynamicFilteringMaxPerDriverRowCount(100)
                 .setDynamicFilteringMaxPerDriverSize(new DataSize(10, KILOBYTE))
                 .setDynamicFilteringRangeRowLimitPerDriver(0)
+                .setDistributedDynamicFilterStrategy(DistributedDynamicFilterStrategy.DISABLED)
+                .setDistributedDynamicFilterMaxWaitTime(new Duration(2, SECONDS))
+                .setDistributedDynamicFilterMaxWaitExtensions(2)
+                .setDistributedDynamicFilterMaxSize(new DataSize(1, MEGABYTE))
+                .setDistributedDynamicFilterCardinalityRatioThreshold(0.1)
+                .setDistributedDynamicFilterOnReplicatedJoins(false)
                 .setFragmentResultCachingEnabled(false)
                 .setEnableStatsCalculator(true)
                 .setEnableStatsCollectionForTemporaryTable(false)
@@ -570,6 +577,12 @@ public class TestFeaturesConfig
                 .put("use-connector-provided-serialization-codecs", "true")
                 .put("optimizer.remote-function-names-for-fixed-parallelism", "remote_.*")
                 .put("optimizer.remote-function-fixed-parallelism-task-count", "100")
+                .put("distributed-dynamic-filter.strategy", "COST_BASED")
+                .put("distributed-dynamic-filter.max-wait-time", "5s")
+                .put("distributed-dynamic-filter.max-wait-extensions", "3")
+                .put("distributed-dynamic-filter.max-size", "2MB")
+                .put("distributed-dynamic-filter.cardinality-ratio-threshold", "0.2")
+                .put("distributed-dynamic-filter.on-replicated-joins", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -584,6 +597,12 @@ public class TestFeaturesConfig
                 .setDynamicFilteringMaxPerDriverRowCount(256)
                 .setDynamicFilteringMaxPerDriverSize(new DataSize(64, KILOBYTE))
                 .setDynamicFilteringRangeRowLimitPerDriver(1000)
+                .setDistributedDynamicFilterStrategy(DistributedDynamicFilterStrategy.COST_BASED)
+                .setDistributedDynamicFilterMaxWaitTime(new Duration(5, SECONDS))
+                .setDistributedDynamicFilterMaxWaitExtensions(3)
+                .setDistributedDynamicFilterMaxSize(new DataSize(2, MEGABYTE))
+                .setDistributedDynamicFilterCardinalityRatioThreshold(0.2)
+                .setDistributedDynamicFilterOnReplicatedJoins(true)
                 .setFragmentResultCachingEnabled(true)
                 .setEnableStatsCalculator(false)
                 .setEnableStatsCollectionForTemporaryTable(true)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -21,6 +21,7 @@ import com.facebook.presto.cost.VariableStatsEstimate;
 import com.facebook.presto.spi.TestingColumnHandle;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -33,6 +34,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -43,6 +45,8 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.CONFIDENCE_BASED_BROADCAST_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_DYNAMIC_FILTER_CARDINALITY_RATIO_THRESHOLD;
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_DYNAMIC_FILTER_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_BROADCAST_MEMORY;
@@ -71,6 +75,7 @@ import static com.facebook.presto.sql.planner.iterative.rule.JoinSwappingUtils.g
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static java.lang.Double.NaN;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestDetermineJoinDistributionType
@@ -2005,6 +2010,167 @@ public class TestDetermineJoinDistributionType
                             return PlanNodeStatsEstimate.unknown();
                         }),
                 NaN);
+    }
+
+    @Test
+    public void testDynamicFilterAlwaysCreatesFilter()
+    {
+        // Force PARTITIONED; 0-row ValuesNodes trigger mustReplicate which skips DPP.
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), 1_000_000, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), 1_000_000, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertEquals(result.getDynamicFilters().size(), 1);
+        assertTrue(result.getDynamicFilters().values().iterator().next().getName().equals("B1"));
+    }
+
+    @Test
+    public void testDynamicFilterDisabledDoesNotModify()
+    {
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(p.variable("A1", BIGINT)),
+                                p.values(p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertTrue(result.getDynamicFilters().isEmpty());
+    }
+
+    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "JoinNode already has dynamic filters")
+    public void testDynamicFilterRejectsExistingDynamicFilters()
+    {
+        assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), 1_000_000, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), 1_000_000, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableMap.of("existing", p.variable("B1", BIGINT))))
+                .get();
+    }
+
+    @Test
+    public void testDynamicFilterSkipsLeftJoin()
+    {
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .on(p ->
+                        p.join(
+                                LEFT,
+                                p.values(p.variable("A1", BIGINT)),
+                                p.values(p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertTrue(result.getDynamicFilters().isEmpty());
+    }
+
+    @Test
+    public void testDynamicFilterCostBasedSkipsHighRatio()
+    {
+        int aRows = 1_000_000;
+        int bRows = 1_000_000;
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "COST_BASED")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "A1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "B1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertTrue(result.getDynamicFilters().isEmpty());
+    }
+
+    @Test
+    public void testDynamicFilterCostBasedCreatesForGoodRatio()
+    {
+        int aRows = 1_000_000;
+        int bRows = 100;
+        // Force PARTITIONED; small build side would otherwise get REPLICATED (which skips coordinator DPP).
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "COST_BASED")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "A1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "B1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertEquals(result.getDynamicFilters().size(), 1);
+    }
+
+    @Test
+    public void testDynamicFilterCostBasedRespectsCustomThreshold()
+    {
+        int aRows = 1_000_000;
+        int bRows = 800_000;
+        // Force PARTITIONED; REPLICATED bypasses coordinator DPP.
+        JoinNode result = (JoinNode) assertDetermineJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "COST_BASED")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_CARDINALITY_RATIO_THRESHOLD, "0.9")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "A1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "B1", BIGINT), VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
+                                ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                Optional.empty()))
+                .get();
+        assertEquals(result.getDynamicFilters().size(), 1);
     }
 
     private RuleAssert assertDetermineJoinDistributionType()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -11,20 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.common.type.Type;
@@ -33,6 +19,7 @@ import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.TaskCountEstimator;
 import com.facebook.presto.cost.VariableStatsEstimate;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
@@ -45,6 +32,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_DYNAMIC_FILTER_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -56,6 +44,8 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestDetermineSemiJoinDistributionType
@@ -366,6 +356,132 @@ public class TestDetermineSemiJoinDistributionType
                         Optional.of(REPLICATED),
                         values(ImmutableMap.of("A1", 0)),
                         filter("true", values(ImmutableMap.of("B1", 0)))));
+    }
+
+    @Test
+    public void testDynamicFilterAlwaysCreatesFilter()
+    {
+        int aRows = 10_000;
+        int bRows = 100;
+        VariableReferenceExpression a1 = new VariableReferenceExpression(Optional.empty(), "A1", BIGINT);
+        VariableReferenceExpression b1 = new VariableReferenceExpression(Optional.empty(), "B1", BIGINT);
+        SemiJoinNode result = (SemiJoinNode) assertDetermineSemiJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(a1, VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(b1, VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(new PlanNodeId("valuesA"), aRows, a1),
+                                p.values(new PlanNodeId("valuesB"), bRows, b1),
+                                a1,
+                                b1,
+                                p.variable("output"),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .get();
+        assertEquals(result.getDynamicFilters().size(), 1);
+        assertTrue(result.getDynamicFilters().values().iterator().next().getName().equals("B1"));
+    }
+
+    @Test
+    public void testDynamicFilterDisabledDoesNotModify()
+    {
+        int aRows = 10_000;
+        int bRows = 100;
+        VariableReferenceExpression a1 = new VariableReferenceExpression(Optional.empty(), "A1", BIGINT);
+        VariableReferenceExpression b1 = new VariableReferenceExpression(Optional.empty(), "B1", BIGINT);
+        SemiJoinNode result = (SemiJoinNode) assertDetermineSemiJoinDistributionType()
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(a1, VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(b1, VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(new PlanNodeId("valuesA"), aRows, a1),
+                                p.values(new PlanNodeId("valuesB"), bRows, b1),
+                                a1,
+                                b1,
+                                p.variable("output"),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .get();
+        assertTrue(result.getDynamicFilters().isEmpty());
+    }
+
+    @Test
+    public void testDynamicFilterCostBasedSkipsHighRatio()
+    {
+        int aRows = 1_000_000;
+        int bRows = 1_000_000;
+        VariableReferenceExpression a1 = new VariableReferenceExpression(Optional.empty(), "A1", BIGINT);
+        VariableReferenceExpression b1 = new VariableReferenceExpression(Optional.empty(), "B1", BIGINT);
+        SemiJoinNode result = (SemiJoinNode) assertDetermineSemiJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "COST_BASED")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(a1, VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(b1, VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(new PlanNodeId("valuesA"), aRows, a1),
+                                p.values(new PlanNodeId("valuesB"), bRows, b1),
+                                a1,
+                                b1,
+                                p.variable("output"),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .get();
+        assertTrue(result.getDynamicFilters().isEmpty());
+    }
+
+    @Test
+    public void testDynamicFilterCostBasedCreatesForGoodRatio()
+    {
+        int aRows = 1_000_000;
+        int bRows = 100;
+        VariableReferenceExpression a1 = new VariableReferenceExpression(Optional.empty(), "A1", BIGINT);
+        VariableReferenceExpression b1 = new VariableReferenceExpression(Optional.empty(), "B1", BIGINT);
+        SemiJoinNode result = (SemiJoinNode) assertDetermineSemiJoinDistributionType()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "COST_BASED")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addVariableStatistics(ImmutableMap.of(a1, VariableStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addVariableStatistics(ImmutableMap.of(b1, VariableStatsEstimate.unknown()))
+                        .build())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(new PlanNodeId("valuesA"), aRows, a1),
+                                p.values(new PlanNodeId("valuesB"), bRows, b1),
+                                a1,
+                                b1,
+                                p.variable("output"),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .get();
+        assertEquals(result.getDynamicFilters().size(), 1);
     }
 
     private RuleAssert assertDetermineSemiJoinDistributionType()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_DYNAMIC_FILTER_STRATEGY;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjuncts;
@@ -240,6 +241,46 @@ public class TestRemoveUnsupportedDynamicFilters
                                         tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
     }
 
+    @Test
+    public void testDppEnabledPreservesDynamicFilters()
+    {
+        PlanNode root = builder.join(
+                INNER,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new EquiJoinClause(ordersOrderKeyVariable, lineitemOrderKeyVariable)),
+                ImmutableList.of(ordersOrderKeyVariable),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("DF", lineitemOrderKeyVariable));
+
+        PlanNode planNode = removeUnsupportedDynamicFiltersWithSession(root, DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS");
+        assertTrue(planNode instanceof JoinNode);
+        JoinNode joinNode = (JoinNode) planNode;
+        assertEquals(joinNode.getDynamicFilters(), ImmutableMap.of("DF", lineitemOrderKeyVariable));
+    }
+
+    @Test
+    public void testDppDisabledRemovesUnconsumedFilter()
+    {
+        PlanNode root = builder.join(
+                INNER,
+                ordersTableScanNode,
+                lineitemTableScanNode,
+                ImmutableList.of(new EquiJoinClause(ordersOrderKeyVariable, lineitemOrderKeyVariable)),
+                ImmutableList.of(ordersOrderKeyVariable),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("DF", lineitemOrderKeyVariable));
+
+        PlanNode planNode = removeUnsupportedDynamicFilters(root);
+        assertTrue(planNode instanceof JoinNode);
+        JoinNode joinNode = (JoinNode) planNode;
+        assertTrue(joinNode.getDynamicFilters().isEmpty());
+    }
+
     PlanNode removeUnsupportedDynamicFilters(PlanNode root)
     {
         return getQueryRunner().inTransaction(session -> {
@@ -247,6 +288,21 @@ public class TestRemoveUnsupportedDynamicFilters
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
             PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
             new DynamicFiltersChecker().validate(rewrittenPlan, session, metadata, WarningCollector.NOOP);
+            return rewrittenPlan;
+        });
+    }
+
+    PlanNode removeUnsupportedDynamicFiltersWithSession(PlanNode root, String propertyKey, String propertyValue)
+    {
+        // Session.builder() cannot be called on a transactional session — build before entering.
+        com.facebook.presto.Session baseSession = getQueryRunner().getDefaultSession();
+        com.facebook.presto.Session sessionWithProp = com.facebook.presto.Session.builder(baseSession)
+                .setSystemProperty(propertyKey, propertyValue)
+                .build();
+        return getQueryRunner().inTransaction(sessionWithProp, transactionSession -> {
+            transactionSession.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(transactionSession, catalog));
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, transactionSession, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
+            new DynamicFiltersChecker().validate(rewrittenPlan, transactionSession, metadata, WarningCollector.NOOP);
             return rewrittenPlan;
         });
     }


### PR DESCRIPTION
## Description
Adds the planner half of coordinator-mediated dynamic partition pruning (DPP). When enabled, the optimizer attaches a dynamic filter to each equi-join clause on PARTITIONED INNER/RIGHT joins; the coordinator uses these filters to prune splits before workers execute them.

Three strategy modes: `DISABLED` (default — no behavior change), `COST_BASED` (filter created only when buildRows / probeRows < threshold), `ALWAYS`.

REPLICATED joins are skipped; Velox already handles broadcast joins in-fragment. Probe chains that cross a remote exchange are also skipped to prevent a coordinator deadlock.

All gated behind distributed_dynamic_filter_strategy=DISABLED. No existing plan shapes change.

## Motivation and Context
Part of a series upstreaming coordinator-mediated DPP. This PR covers session properties and planner filter creation. Coordinator collection and transport follow in subsequent PRs.

## Impact
None in the default configuration. Six new session properties are registered as hidden pending end-to-end wiring, I'll mark them as visible when the entire feature is complete.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce planner-side support for coordinator-mediated distributed dynamic partition pruning and its configuration.

New Features:
- Add distributed dynamic filter strategy, limits, and join handling settings to system and features configuration for coordinator-based split pruning.
- Attach dynamic filters to eligible inner, right, and semi joins based on join distribution type and optional cost-based row-count ratios, with safeguards for replicated joins and remote exchanges.
- Expose a native dynamic filter pushdown toggle for Velox-based execution and runtime metrics for dynamic filter planning decisions.

Enhancements:
- Adjust join and semijoin distribution rules and join reordering to integrate distributed dynamic filter creation without changing existing plans when disabled.
- Relax dynamic filter consumption checks and removal logic when distributed dynamic filters are enabled, while preventing deadlocks across remote exchanges.

Tests:
- Extend planner and optimizer tests to cover distributed dynamic filter creation, disabling, cost-based behavior, replicated join handling, and preservation/removal of filters under the new configuration.