### PR TITLE
chore(plugin-iceberg): Split tests into multiple CI workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,7 @@ jobs:
           - :presto-spark-base -P presto-spark-tests-all-queries
           - :presto-spark-base -P presto-spark-tests-spill-queries
           - :presto-iceberg
+          - :presto-iceberg -P test-iceberg-others
           - :presto-clickhouse -P ci
     timeout-minutes: 80
     concurrency:

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -852,4 +852,52 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestIcebergSmoke*.java</include>
+                                <include>**/TestIcebergDistributed*.java</include>
+                                <include>**/TestIcebergHadoopCatalog*.java</include>
+                                <include>**/TestIcebergHiveCatalog*.java</include>
+                                <include>**/TestIcebergNessie*.java</include>
+                                <include>**/TestIcebergRestCatalog*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-iceberg-others</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestIcebergSmoke*.java</exclude>
+                                <exclude>**/TestIcebergDistributed*.java</exclude>
+                                <exclude>**/TestIcebergHadoopCatalog*.java</exclude>
+                                <exclude>**/TestIcebergHiveCatalog*.java</exclude>
+                                <exclude>**/TestIcebergNessie*.java</exclude>
+                                <exclude>**/TestIcebergRestCatalog*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Description

Currently, as the number of test cases continues to grow, the CI test workflow for presto-iceberg frequently times out (at 80 minutes).

This PR splits the Iceberg CI tests into multiple workflows. It separates the test classes related to `IcebergDistributedTestBase`, `IcebergDistributedSmokeTestBase`, and `TestIcebergDistributedQueries` from all other tests into two distinct CI workflows, thereby resolving this issue.

## Motivation and Context

Avoid frequent timeouts in Iceberg CI tests. Closes #28029.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Split presto-iceberg tests into separate Maven profiles and update CI to run them in distinct workflows for better isolation and parallelization.

Build:
- Introduce Maven profiles in presto-iceberg to separate smoke/distributed/catalog/materialized view tests from the remaining tests using Surefire includes/excludes.

CI:
- Update GitHub Actions test workflow to run presto-iceberg tests both with the default profile and with the test-iceberg-others profile.

## Summary by Sourcery

Split presto-iceberg tests into separate Maven profiles and run them in distinct CI workflow steps to reduce test timeouts and improve parallelization.

Build:
- Introduce Maven Surefire profiles in presto-iceberg to separate smoke/distributed/catalog tests from the remaining tests via includes/excludes.

CI:
- Update the GitHub Actions tests workflow to run presto-iceberg both with the default profile and with the test-iceberg-others profile as separate jobs.