### PR TITLE
fix(security): Close allow-all gap during AccessControlManager startup (#28031)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -1107,31 +1107,283 @@ public class AccessControlManager
         }
     }
 
-    private static class InitializingSystemAccessControl
+    @VisibleForTesting
+    static class InitializingSystemAccessControl
             implements SystemAccessControl
     {
+        private static PrestoException notInitializedError()
+        {
+            return new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+        }
+
         @Override
         public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<String, String> preparedStatements, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
         {
-            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+            throw notInitializedError();
         }
 
         @Override
         public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
         {
-            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+            throw notInitializedError();
+        }
+
+        @Override
+        public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+        {
+            throw notInitializedError();
         }
 
         @Override
         public void checkCanSetSystemSessionProperty(Identity identity, AccessControlContext context, String propertyName)
         {
-            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+            throw notInitializedError();
         }
 
         @Override
         public void checkCanAccessCatalog(Identity identity, AccessControlContext context, String catalogName)
         {
-            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+            throw notInitializedError();
+        }
+
+        @Override
+        public Set<String> filterCatalogs(Identity identity, AccessControlContext context, Set<String> catalogs)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanAlterColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanRenameSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema, String newSchemaName)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanShowSchemas(Identity identity, AccessControlContext context, String catalogName)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public Set<String> filterSchemas(Identity identity, AccessControlContext context, String catalogName, Set<String> schemaNames)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanShowCreateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanSetTableProperties(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanRenameTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table, CatalogSchemaTableName newTable)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanShowTablesMetadata(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public Set<SchemaTableName> filterTables(Identity identity, AccessControlContext context, String catalogName, Set<SchemaTableName> tableNames)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanShowColumnsMetadata(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public List<ColumnMetadata> filterColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, List<ColumnMetadata> columns)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanAddColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanRenameColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanSelectFromColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> columns)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCallProcedure(Identity identity, AccessControlContext context, CatalogSchemaTableName procedure)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanInsertIntoTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDeleteFromTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanTruncateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanUpdateTableColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateView(Identity identity, AccessControlContext context, CatalogSchemaTableName view)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanRenameView(Identity identity, AccessControlContext context, CatalogSchemaTableName view, CatalogSchemaTableName newView)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropView(Identity identity, AccessControlContext context, CatalogSchemaTableName view)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateViewWithSelectFromColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> columns)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanSetCatalogSessionProperty(Identity identity, AccessControlContext context, String catalogName, String propertyName)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanGrantTablePrivilege(Identity identity, AccessControlContext context, Privilege privilege, CatalogSchemaTableName table, PrestoPrincipal grantee, boolean withGrantOption)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanRevokeTablePrivilege(Identity identity, AccessControlContext context, Privilege privilege, CatalogSchemaTableName table, PrestoPrincipal revokee, boolean grantOptionFor)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateBranch(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanCreateTag(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropBranch(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropTag(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanDropConstraint(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public void checkCanAddConstraint(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public List<ViewExpression> getRowFilters(Identity identity, AccessControlContext context, CatalogSchemaTableName tableName)
+        {
+            throw notInitializedError();
+        }
+
+        @Override
+        public Map<ColumnMetadata, ViewExpression> getColumnMasks(Identity identity, AccessControlContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+        {
+            throw notInitializedError();
         }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -67,6 +67,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_COLUMN_MASK;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyQueryIntegrityCheck;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -92,6 +93,12 @@ public class TestAccessControlManager
                 new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty(), Optional.empty(), Optional.empty()),
                 Optional.empty(),
                 "foo");
+    }
+
+    @Test
+    public void testInitializingSystemAccessControlEverythingImplemented()
+    {
+        assertAllMethodsOverridden(SystemAccessControl.class, AccessControlManager.InitializingSystemAccessControl.class);
     }
 
     @Test


### PR DESCRIPTION
## Description

Replace the 4-method `InitializingSystemAccessControl` sentinel in `AccessControlManager` with one that overrides every method on the `SystemAccessControl` SPI to throw `SERVER_STARTING_UP`. Previously only `checkQueryIntegrity`, `checkCanSetUser`, `checkCanSetSystemSessionProperty`, and `checkCanAccessCatalog` were overridden; the other ~42 methods inherited the no-op default implementations from the `SystemAccessControl` interface, which silently allowed access during the window between HTTP server start and `loadSystemAccessControl()` completion.

A `notInitialized()` private helper is extracted to avoid 46 copies of the same `throw new PrestoException(SERVER_STARTING_UP, ...)` boilerplate.

## Motivation and Context

The Presto coordinator's HTTP server (started by Airlift's `Bootstrap.initialize()` in `PrestoServer.java`) begins accepting requests before `loadSystemAccessControl()` runs and swaps the sentinel for the configured plugin. Because `InitializingSystemAccessControl` only overrode 4 of the SPI's 46 methods, any query that reached a data-access check (e.g. `checkCanSelectFromColumns`, `getRowFilters`, `getColumnMasks`, `filterColumns`) during this window inherited the empty default implementations and ran with no permission enforcement and no row/column filtering.

Most queries hit the four overridden methods early on the standard submit path via `checkCanSetUser`, so in practice the bypass affected query paths that skipped that early gate (cached identity, certain internal code paths). The bypass is nevertheless a real correctness hole for any deployment that uses a `SystemAccessControl` plugin for data authorization — the SPI guarantees that all methods are called against the configured plugin, and the startup sentinel breaks that guarantee for 42 of them.

This patch makes the startup gate uniform: every SPI method throws the same `SERVER_STARTING_UP` `PrestoException` until plugin loading completes, so the error surface during startup is consistent and there is no silent allow path.

## Impact

Behavior change for any code path that exercises an authorization check during the narrow startup window: previously some checks returned permissive no-op results; now all such checks throw `SERVER_STARTING_UP`. Operationally this just means "Presto server is still initializing" errors during startup instead of silently-allowed queries — strictly safer for any deployment using a `SystemAccessControl` plugin.

No public API change. The `InitializingSystemAccessControl` class is `private static` inside `AccessControlManager`, only visible to other code in this file.

## Release Notes

```
== NO RELEASE NOTE ==

```

Differential Revision: D109167538
