### PR TITLE
chore(ci): Fetch full history so base...head diff resolves

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Full history is required so codenotify can diff <base>...<head>;
+          # a shallow clone lacks the PR base commit and fails with exit 128.
+          fetch-depth: 0
           show-progress: false
           persist-credentials: false
       - uses: sourcegraph/codenotify@54e4320f0d93f162a371d8d9dc1fb11018199746 # v0.6.4


### PR DESCRIPTION
## Description
`error diffing 65c88f0bdd...b9b69b1198: git diff --name-only 65c88f0bdd...b9b69b1198 -> exit status 128`

  - 65c88f0bdd = PR base (feat(optimizer): Add AUTOMATIC rpc_streaming_mode...)
  - b9b69b1198 = feature branch tip

  I verified locally that both commits exist and 65c88f0bdd is a reachable ancestor of the head — the diff succeeds here. So the code/history is fine. The CI runner failed because actions/checkout@v6 defaults to a
  shallow clone (fetch-depth: 1); the sourcegraph/codenotify action then runs a three-dot diff base...head, which needs the base commit (and merge-base) present in the workspace. They weren't fetched → exit 128.

  This has nothing to do with the Cassandra Version refactor or the TestHost.java import ordering.

  Fix
    
  Added `fetch-depth: 0` to the checkout step in `codenotify.yml` so full history is available for the diff:
```
        - uses: actions/checkout@v6
          with:
            ref: ${{ github.event.pull_request.head.sha }}
            # Full history is required so codenotify can diff <base>...<head>;
            # a shallow clone lacks the PR base commit and fails with exit 128.
            fetch-depth: 0
            show-progress: false
            persist-credentials: false
```
## Motivation and Context
Avoids failures such as one experienced at [here](https://github.com/prestodb/presto/actions/runs/27881084871/job/82521226105?pr=27029).

## Impact
Allows codenotify to properly do the diff by pulling full history.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Update the codenotify GitHub Actions workflow to use actions/checkout with fetch-depth: 0 to avoid shallow-clone diff failures.