### PR TITLE
fix(docs): Resolve duplicate label warnings

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -79,27 +79,6 @@ When both ``scale_writers`` and ``redistribute_writes`` are set to ``true``,
 
 The corresponding configuration property is :ref:`admin/properties:\`\`scale-writers\`\``.
 
-``task_writer_count``
-^^^^^^^^^^^^^^^^^^^^^
-
-* **Type:** ``integer``
-* **Default value:** ``1``
-
-Default number of local parallel table writer threads per worker. It is required
-to be a power of two for a Java query engine.
-
-The corresponding configuration property is :ref:`admin/properties:\`\`task.writer-count\`\``.
-
-``task_partitioned_writer_count``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* **Type:** ``integer``
-* **Default value:** ``task_writer_count``
-
-Number of local parallel table writer threads per worker for partitioned writes. If not
-set, the number set by ``task_writer_count`` will be used. It is required to be a power
-of two for a Java query engine.
-
 ``single_node_execution_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -391,6 +370,16 @@ writing due to compression or other factors). Setting this too high may cause th
 to become overloaded due to excessive resource utilization.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`task.writer-count\`\``.
+
+``task_partitioned_writer_count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``task_writer_count``
+
+Number of local parallel table writer threads per worker for partitioned writes. If not
+set, the number set by ``task_writer_count`` will be used. It is required to be a power
+of two for a Java query engine.
 
 Optimizer Properties
 --------------------

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -399,9 +399,6 @@ Property Name                                                         Descriptio
 Metastore Cache Metrics
 -----------------------
 
-Overview
-^^^^^^^^
-
 The Hive connector uses in-memory caching to reduce load on the Hive metastore and improve query performance. 
 The connector maintains 14 distinct caches, each optimized for specific types of metadata. All caches expose 
 JMX metrics that provide visibility into cache performance, helping you monitor efficiency, tune cache 


### PR DESCRIPTION
## Description
The PR resolves minor duplicate label warnings for the following pages:
1. `Administration` / `Presto Session Properties`
```shell
./presto/presto-docs/src/main/sphinx/admin/properties-session.rst:328: WARNING: duplicate label admin/properties-session:``task_writer_count``, other instance in ./presto/presto-docs/src/main/sphinx/admin/properties-session.rst [autosectionlabel.admin/properties-session]
```
Deleted duplicated `task_writer_count` property.  Also `task_partitioned_writer_count` property moved from `General Properties` to `Task Properties` section closer to `task_writer_count`.

<img width="1356" height="718" alt="image" src="https://github.com/user-attachments/assets/de6635cb-d27b-41f9-8c4c-2d674d76f6b4" />


2. `Connectors` / `Hive Connector`
```shell
./presto/presto-docs/src/main/sphinx/connector/hive.rst:403: WARNING: duplicate label connector/hive:overview, other instance in ./presto/presto-docs/src/main/sphinx/connector/hive.rst [autosectionlabel.connector/hive] 
```
Deleted redundant `Overview` sub-header of `Metastore Cache Metrics` section.

<img width="1368" height="624" alt="image" src="https://github.com/user-attachments/assets/efd02133-8321-4d5f-ac57-5c16d2c68f49" />

## Motivation and Context
Reduce the number of warnings during the documentation build process.
The end goal to have zero warnings and enable zero warnings policy for documentation to prevent introducing new issues.

## Impact
_None_

## Test Plan
Build the documentation and check the pages are correct:
```shell
presto-docs/build

open presto-docs/target/html/admin/properties-session.rst
open presto-docs/target/html/connector/hive.html
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Resolve documentation build warnings by removing duplicate labels and redundant headings in admin session properties and Hive connector docs.

Documentation:
- Remove duplicated task_writer_count session property entry and relocate task_partitioned_writer_count closer to related task properties in the admin session properties documentation.
- Simplify the Hive connector metastore cache metrics section by removing a redundant Overview subheading to eliminate duplicate labels.