### PR TITLE
feat(plugin-iceberg): Support ALTER COLUMN SET/DROP NOT NULL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/Joe-Abraham/velox.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,127 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Full build with tests
+./mvnw clean install
+
+# Build skipping tests (faster iteration)
+./mvnw clean install -DskipTests
+
+# Build skipping the UI (saves time when not touching frontend)
+./mvnw clean install -DskipTests -DskipUI
+
+# Build a single module
+./mvnw clean install -pl presto-iceberg -DskipTests
+
+# Build a module and its dependencies
+./mvnw clean install -pl presto-iceberg -am -DskipTests
+```
+
+## Running Tests
+
+Presto uses TestNG (not JUnit). Tests run in parallel (`methods` mode) with a 4GB JVM.
+
+```bash
+# Run all tests in a module
+./mvnw test -pl presto-iceberg
+
+# Run a specific test class
+./mvnw test -pl presto-iceberg -Dtest=TestIcebergMetadataListing
+
+# Run a specific test method
+./mvnw test -pl presto-iceberg -Dtest=TestIcebergMetadataListing#testListTables
+
+# Run tests matching a pattern
+./mvnw test -pl presto-main -Dtest="TestSql*"
+```
+
+**TestNG-specific patterns:**
+- Test classes use `@Test` annotations; lifecycle uses `@BeforeMethod`/`@AfterMethod`
+- TestNG does NOT create a new object per test method — reinitialize mutable state in `@BeforeMethod` and annotate with `@Test(singleThreaded = true)` if the class uses instance fields
+- Avoid `Thread.sleep` and random values in tests — tests must be reproducible
+
+## Running the Server (IntelliJ)
+
+Main class: `com.facebook.presto.server.PrestoServer`
+Working directory: `presto-main/`
+VM options:
+```
+-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+ExplicitGCInvokesConcurrent -Xmx2G
+-Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties
+-Djdk.attach.allowAttachSelf=true
+```
+Also add `--add-opens` flags listed in README.md for Java 17 reflective access.
+
+## Architecture Overview
+
+Presto is a distributed SQL query engine with a coordinator + worker model. The Java codebase handles planning, optimization, and coordination; the C++ native execution layer (`presto-native-execution`, using Velox) handles physical evaluation in performance-critical deployments.
+
+**Core query pipeline** (follow code in this order):
+1. `presto-parser` — ANTLR 4 grammar, produces AST
+2. `presto-analyzer` — semantic analysis, type checking, resolves references
+3. `presto-main` — query planning, optimization (cost-based optimizer), scheduling, and coordinator logic; this is the largest module
+4. `presto-spi` — plugin/connector interface (start here when adding a new connector)
+
+**Key modules:**
+- `presto-spi` — the plugin SPI; defines `Connector`, `ConnectorMetadata`, `ConnectorSplitManager`, `ConnectorPageSource`, `Type`, and `Plugin` interfaces
+- `presto-main` — core engine: `QueryManager`, `SqlQueryExecution`, optimizer rules, `LocalExecutionPlanner`
+- `presto-common` — shared utilities, `Page`/`Block` data structures (columnar format used at runtime)
+- `presto-expressions` — row expression evaluation
+- `presto-bytecode` — JVM bytecode generation for compiled expressions
+- `presto-orc` / `presto-parquet` — file format readers
+- `presto-hive` / `presto-iceberg` / `presto-delta` — table format connectors (built on `presto-hive-metastore`, `presto-hdfs-core`)
+- `presto-native-execution` — C++ Prestissimo worker (Velox-based); separate build system
+
+**Plugin model:** Connectors and other extensions are loaded via Java ServiceLoader. Each plugin JAR implements `Plugin` and is listed in `plugin.bundles` in `presto-main/etc/config.properties`. The SPI is the stable interface — never depend on `presto-main` internals from a connector.
+
+**Data flow:** Queries arrive at the coordinator → parsed → analyzed → planned into a distributed plan → split into stages → tasks distributed to workers → workers execute operators over `Page` objects (columnar blocks) → results stream back.
+
+## Code Style
+
+Max line width: **180 characters** (IntelliJ "Reformat code" does not enforce this — adjust manually).
+
+**Java conventions:**
+- `requireNonNull(param, "param is null")` in every constructor
+- Use `ImmutableList`/`ImmutableMap`/`ImmutableSet` (Guava); collect with `toImmutableList()` not `Collectors.toList()`
+- Static-import constants and factory methods (`toImmutableList`, `NANOSECONDS`, `format`, etc.)
+- `Optional` for nullable public method parameters — but not in performance-critical tight loops
+- Fields before methods; members ordered public → protected → package-private → private; within each level, static final → final → normal
+- Javadoc on all interface methods; `//` inline comments only for non-obvious implementation details
+- Alphabetize: sections in docs, methods, variables
+
+**Multi-line function declarations** (when > 180 chars): put each parameter on its own line, first parameter NOT on the same line as the method name:
+```java
+public Foo(
+        ParamType param1,
+        ParamType param2)
+{
+    ...
+}
+```
+
+## Commit and PR Standards
+
+All commits use [Conventional Commits](https://www.conventionalcommits.org/). The PR title becomes the squashed commit message.
+
+**Format:** `<type>[(scope)]: <description>`
+
+**Types:** `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `misc`
+
+**Scopes:** `parser`, `analyzer`, `planner`, `spi`, `scheduler`, `connector`, `resource`, `security`, `function`, `type`, `expression`, `operator`, `client`, `server`, `native`, `testing`, `docs`, `build` — or any connector/plugin name prefixed with `plugin-` (e.g., `plugin-iceberg`, `plugin-hive`).
+
+**Description rules:** Start with capital letter, imperative mood ("Add" not "Added"), no trailing period, 50–72 characters preferred.
+
+**Breaking changes:** Append `!` after type/scope and include `BREAKING CHANGE:` footer in the body.
+
+**Examples:**
+```
+feat(plugin-iceberg): Support ALTER COLUMN SET NOT NULL
+fix: Resolve memory leak in query executor
+feat!: Remove deprecated configuration options
+```
+
+All PRs are squashed to a single commit on merge ("Squash and merge"). Reference issues at the end of the body: `Resolves: #1234`.

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1736,49 +1736,102 @@ frequently used together in query predicates.
 SQL Support
 -----------
 
-======================================== ============= ============ ============================================================================
-SQL Operation                            Presto Java   Presto C++   Comments
-======================================== ============= ============ ============================================================================
-``CREATE SCHEMA``                        Yes           Yes
+.. list-table::
+   :widths: 30 15 15 40
+   :header-rows: 1
 
-``CREATE TABLE``                         Yes           Yes
-
-``CREATE VIEW``                          Yes           Yes
-
-``INSERT INTO``                          Yes           No
-
-``CREATE TABLE AS SELECT``               Yes           No
-
-``SELECT``                               Yes           Yes          Read is supported in Presto C++ including those with positional delete files.
-
-``ALTER TABLE``                              Yes           Yes
-
-``ALTER TABLE ADD COLUMN DEFAULT``           Yes           Yes
-
-``ALTER TABLE ALTER COLUMN SET DEFAULT``     Yes           Yes
-
-``ALTER VIEW``                               Yes           Yes
-
-``TRUNCATE``                             Yes           Yes
-
-``DELETE``                               Yes           No
-
-``DROP TABLE``                           Yes           Yes
-
-``DROP VIEW``                            Yes           Yes
-
-``DROP SCHEMA``                          Yes           Yes
-
-``SHOW CREATE TABLE``                    Yes           Yes
-
-``SHOW COLUMNS``                         Yes           Yes
-
-``DESCRIBE``                             Yes           Yes
-
-``UPDATE``                               Yes           No
-
-``MERGE``                                Yes           No
-======================================== ============= ============ ============================================================================
+   * - SQL Operation
+     - Presto Java
+     - Presto C++
+     - Comments
+   * - ``CREATE SCHEMA``
+     - Yes
+     - Yes
+     -
+   * - ``CREATE TABLE``
+     - Yes
+     - Yes
+     -
+   * - ``CREATE VIEW``
+     - Yes
+     - Yes
+     -
+   * - ``INSERT INTO``
+     - Yes
+     - No
+     -
+   * - ``CREATE TABLE AS SELECT``
+     - Yes
+     - No
+     -
+   * - ``SELECT``
+     - Yes
+     - Yes
+     - Read is supported in Presto C++, including queries involving positional delete files.
+   * - ``ALTER TABLE``
+     - Yes
+     - Yes
+     -
+   * - ``ALTER TABLE ADD COLUMN DEFAULT``
+     - Yes
+     - Yes
+     -
+   * - ``ALTER TABLE ALTER COLUMN SET DEFAULT``
+     - Yes
+     - Yes
+     -
+   * - ``ALTER TABLE ALTER COLUMN SET NOT NULL``
+     - Yes
+     - Yes
+     -
+   * - ``ALTER TABLE ALTER COLUMN DROP NOT NULL``
+     - Yes
+     - Yes
+     -
+   * - ``ALTER VIEW``
+     - Yes
+     - Yes
+     -
+   * - ``TRUNCATE``
+     - Yes
+     - Yes
+     -
+   * - ``DELETE``
+     - Yes
+     - No
+     -
+   * - ``DROP TABLE``
+     - Yes
+     - Yes
+     -
+   * - ``DROP VIEW``
+     - Yes
+     - Yes
+     -
+   * - ``DROP SCHEMA``
+     - Yes
+     - Yes
+     -
+   * - ``SHOW CREATE TABLE``
+     - Yes
+     - Yes
+     -
+   * - ``SHOW COLUMNS``
+     - Yes
+     - Yes
+     -
+   * - ``DESCRIBE``
+     - Yes
+     - Yes
+     -
+   * - ``UPDATE``
+     - Yes
+     - No
+     -
+   * - ``MERGE``
+     - Yes
+     - No
+     -
 
 The Iceberg connector supports querying and manipulating Iceberg tables and schemas
 (databases). Here are some examples of the SQL operations supported by Presto:
@@ -2121,6 +2174,46 @@ value automatically.
 
 This feature requires Iceberg Format Version 3. Attempting to use ``ALTER COLUMN SET DEFAULT`` on
 a table with format version 2 or lower will result in an error.
+
+ALTER COLUMN SET NOT NULL
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Iceberg connector supports adding a ``NOT NULL`` constraint on an existing column
+via ``ALTER COLUMN``.
+
+.. code-block:: sql
+
+    ALTER TABLE iceberg.web.page_views ALTER COLUMN user_id SET NOT NULL;
+
+**Important:** ``SET NOT NULL`` is a metadata-only operation in Iceberg. It updates the column's
+required/optional flag in the schema without rewriting data files. This means:
+
+* The operation succeeds even if existing rows contain ``NULL`` values for that column.
+* Existing rows with ``NULL`` values remain readable after the constraint is set.
+* ``NOT NULL`` is enforced only on subsequent writes.
+
+This behavior follows Iceberg's schema evolution model and is consistent with how Iceberg
+handles the ``required`` field flag internally.
+
+ALTER COLUMN DROP NOT NULL
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Iceberg connector supports removing a ``NOT NULL`` constraint from an existing column
+via ``ALTER COLUMN``.
+
+.. code-block:: sql
+
+    ALTER TABLE iceberg.web.page_views ALTER COLUMN user_id DROP NOT NULL;
+
+**Important:** ``DROP NOT NULL`` is a metadata-only operation in Iceberg. It relaxes the column's
+required/optional flag in the schema without rewriting data files. This means:
+
+* The operation succeeds immediately, regardless of the amount of existing data.
+* Dropping ``NOT NULL`` on a column that is already nullable is idempotent and does not change the schema.
+* After the constraint is dropped, ``NULL`` values are accepted for that column on subsequent writes.
+
+This behavior follows Iceberg's schema evolution model and is consistent with how Iceberg
+handles the ``required`` field flag internally.
 
 ALTER VIEW
 ^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -77,6 +77,8 @@ import com.facebook.presto.spi.connector.ConnectorTableVersion.VersionOperator;
 import com.facebook.presto.spi.connector.ConnectorTableVersion.VersionType;
 import com.facebook.presto.spi.connector.EmptyConnectorCommitHandle;
 import com.facebook.presto.spi.connector.RowChangeParadigm;
+import com.facebook.presto.spi.constraints.NotNullConstraint;
+import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.procedure.BaseProcedure;
@@ -132,6 +134,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
@@ -335,6 +338,8 @@ public abstract class IcebergAbstractMetadata
     protected static final String PRESTO_MATERIALIZED_VIEW_USE_TIMESTAMP_BASED_STALENESS = "presto.materialized_view.use_timestamp_based_staleness";
 
     protected static final int CURRENT_MATERIALIZED_VIEW_FORMAT_VERSION = 1;
+    // Balances retry coverage against latency; each retry adds one full Iceberg commit round-trip.
+    private static final int MAX_COMMIT_RETRIES = 5;
 
     protected final TypeManager typeManager;
     protected final ProcedureRegistry procedureRegistry;
@@ -992,7 +997,6 @@ public abstract class IcebergAbstractMetadata
                         .setExtraInfo(partitionFields.containsKey(column.name()) ?
                                 columnExtraInfo(partitionFields.get(column.name())) :
                                 null)
-                        .setNullable(column.isOptional())
                         .build())
                 .collect(toImmutableList());
     }
@@ -2796,6 +2800,93 @@ public abstract class IcebergAbstractMetadata
         }
         catch (RuntimeException e) {
             throw new PrestoException(ICEBERG_INCOMPATIBLE_COLUMN_TYPE, "Failed to set column type: " + firstNonNull(e.getMessage(), e), e);
+        }
+    }
+
+    @Override
+    public void dropConstraint(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> constraintName, Optional<String> columnName)
+    {
+        if (!columnName.isPresent()) {
+            throw new PrestoException(NOT_SUPPORTED, "Iceberg does not support named constraints; only NOT NULL constraints identified by column are supported");
+        }
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        verify(handle.getIcebergTableName().getTableType() == DATA, "only the data table can have constraints dropped");
+        validateNoBranchSpecified(handle, "ALTER COLUMN DROP NOT NULL");
+        String column = columnName.get();
+        // Reject Presto-virtual synthesized columns ($path, $data_sequence_number, etc.) that have
+        // no corresponding entry in the Iceberg schema and cannot have NOT NULL dropped.
+        IcebergColumnHandle targetHandle = (IcebergColumnHandle) getColumnHandles(session, tableHandle).get(column);
+        if (targetHandle != null && targetHandle.getColumnType() == SYNTHESIZED) {
+            throw new PrestoException(NOT_SUPPORTED, "Cannot add/drop NOT NULL on hidden column: " + column);
+        }
+        // Intentionally bypasses the transaction cache (getRawIcebergTable instead of getIcebergTable)
+        // so that refresh() between retries fetches a current version number. Iceberg's UpdateSchema
+        // does not retry CommitFailedException internally, so we do it here.
+        Table icebergTable = getRawIcebergTable(session, handle.getSchemaTableName());
+        try {
+            for (int attempt = 0; ; attempt++) {
+                try {
+                    // Relaxing required -> optional is always a compatible change.
+                    icebergTable.updateSchema().makeColumnOptional(column).commit();
+                    break;
+                }
+                catch (CommitFailedException e) {
+                    if (attempt >= MAX_COMMIT_RETRIES) {
+                        throw e;
+                    }
+                    icebergTable.refresh();
+                }
+            }
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(COLUMN_NOT_FOUND, format("Cannot drop NOT NULL: column '%s' does not exist in Iceberg schema", column), e);
+        }
+        catch (RuntimeException e) {
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, format("Failed to drop NOT NULL on column '%s': %s", column, firstNonNull(e.getMessage(), e)), e);
+        }
+    }
+
+    @Override
+    public void addConstraint(ConnectorSession session, ConnectorTableHandle tableHandle, TableConstraint<String> constraint)
+    {
+        if (!(constraint instanceof NotNullConstraint)) {
+            throw new PrestoException(NOT_SUPPORTED, format("Unsupported constraint type %s; Iceberg only supports NOT NULL constraints", constraint.getClass().getSimpleName()));
+        }
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        verify(handle.getIcebergTableName().getTableType() == DATA, "only the data table can have constraints added");
+        validateNoBranchSpecified(handle, "ALTER COLUMN SET NOT NULL");
+        verify(constraint.getColumns().size() == 1, "NotNullConstraint must apply to exactly one column");
+        String columnName = constraint.getColumns().iterator().next();
+        // Reject Presto-virtual synthesized columns ($path, $data_sequence_number, etc.) that have
+        // no corresponding entry in the Iceberg schema and cannot be made required.
+        IcebergColumnHandle targetHandle = (IcebergColumnHandle) getColumnHandles(session, tableHandle).get(columnName);
+        if (targetHandle != null && targetHandle.getColumnType() == SYNTHESIZED) {
+            throw new PrestoException(NOT_SUPPORTED, "Cannot add/drop NOT NULL on hidden column: " + columnName);
+        }
+        // Intentionally bypasses the transaction cache (getRawIcebergTable instead of getIcebergTable)
+        // so that refresh() between retries fetches a current version number. Iceberg's UpdateSchema
+        // does not retry CommitFailedException internally, so we do it here.
+        Table icebergTable = getRawIcebergTable(session, handle.getSchemaTableName());
+        try {
+            for (int attempt = 0; ; attempt++) {
+                try {
+                    // allowIncompatibleChanges is required: optional -> required is an incompatible change.
+                    icebergTable.updateSchema().allowIncompatibleChanges().requireColumn(columnName).commit();
+                    break;
+                }
+                catch (CommitFailedException e) {
+                    if (attempt >= MAX_COMMIT_RETRIES) {
+                        throw e;
+                    }
+                    icebergTable.refresh();
+                }
+            }
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(COLUMN_NOT_FOUND, format("Cannot set NOT NULL: column '%s' does not exist in Iceberg schema", columnName), e);
+        }
+        catch (RuntimeException e) {
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, format("Failed to set NOT NULL on column '%s': %s", columnName, firstNonNull(e.getMessage(), e)), e);
         }
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.ALTER_COLUMN;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.REPEATABLE_READ;
@@ -117,7 +118,7 @@ public class IcebergConnector
     @Override
     public Set<ConnectorCapabilities> getCapabilities()
     {
-        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT, ALTER_COLUMN);
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -51,10 +51,17 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
@@ -94,6 +101,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public abstract class IcebergDistributedSmokeTestBase
         extends AbstractTestIntegrationSmokeTest
@@ -1415,6 +1423,354 @@ public abstract class IcebergDistributedSmokeTestBase
                 dropTable(session, tableName);
             }
         });
+    }
+
+    @Test
+    public void testAlterColumnNotNull()
+    {
+        String tableName = "test_alter_column_not_null_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT, c3 VARCHAR, c4 BIGINT)", tableName));
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinitionNotNull("c2", "bigint"),
+                            columnDefinition("c3", "varchar"),
+                            columnDefinition("c4", "bigint")),
+                    null, null);
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c4 SET NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinitionNotNull("c2", "bigint"),
+                            columnDefinition("c3", "varchar"),
+                            columnDefinitionNotNull("c4", "bigint")),
+                    null, null);
+
+            // explicit NULL in c4
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (1, 2, 'a', NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c4");
+            // explicit NULL in c2
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (1, NULL, 'a', 4)", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+            // omitting a NOT NULL column also produces an implicit NULL violation
+            assertQueryFails(
+                    format("INSERT INTO %s (c1, c2, c3) VALUES (1, 2, 'a')", tableName),
+                    "NULL value not allowed for NOT NULL column: c4");
+            assertUpdate(format("INSERT INTO %s VALUES (1, 2, 'a', 4)", tableName), 1);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testSetNotNullWithExistingNullData()
+    {
+        // Iceberg's requireColumn is a metadata-only operation: it succeeds even when existing rows
+        // contain nulls. NOT NULL is enforced only on subsequent writes.
+        String tableName = "test_set_not_null_existing_nulls_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT)", tableName));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL)", tableName), 1);
+
+            // SET NOT NULL succeeds despite existing null data (Iceberg schema evolution)
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName));
+
+            // Existing null row is still readable
+            assertQuery(format("SELECT c1, c2 FROM %s", tableName), "VALUES (1, NULL)");
+
+            // Future inserts with NULL are rejected
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+            assertUpdate(format("INSERT INTO %s VALUES (2, 3)", tableName), 1);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAlterColumnNotNullNegative()
+    {
+        String tableName = "test_alter_column_not_null_negative_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT NOT NULL)", tableName));
+
+            // Non-existent column
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN nonexistent SET NOT NULL", tableName),
+                    ".*Column 'nonexistent' does not exist");
+
+            // SET NOT NULL on a column that is already NOT NULL (idempotent — schema unchanged)
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinitionNotNull("c2", "bigint")),
+                    null, null);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDropNotNull()
+    {
+        String tableName = "test_drop_not_null_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT NOT NULL, c3 VARCHAR NOT NULL)", tableName));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 2, 'a')", tableName), 1);
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL, 'b')", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinition("c2", "bigint"),
+                            columnDefinitionNotNull("c3", "varchar")),
+                    null, null);
+
+            // c2 no longer rejects NULL, c3 still does
+            assertUpdate(format("INSERT INTO %s VALUES (2, NULL, 'b')", tableName), 1);
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (3, 4, NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c3");
+            assertQuery(format("SELECT c1, c2, c3 FROM %s", tableName), "VALUES (1, 2, 'a'), (2, NULL, 'b')");
+
+            // DROP NOT NULL on a column that is already nullable is idempotent - schema unchanged
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinition("c2", "bigint"),
+                            columnDefinitionNotNull("c3", "varchar")),
+                    null, null);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDropNotNullNegative()
+    {
+        String tableName = "test_drop_not_null_negative_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT NOT NULL)", tableName));
+
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN nonexistent DROP NOT NULL", tableName),
+                    ".*Column 'nonexistent' does not exist");
+
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN \"$path\" DROP NOT NULL", tableName),
+                    ".*Cannot add/drop NOT NULL on hidden column.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDropNotNullOnBranch()
+    {
+        String tableName = "test_drop_not_null_branch_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT NOT NULL, c2 BIGINT)", tableName));
+            assertUpdate(format("ALTER TABLE %s CREATE BRANCH 'br1'", tableName));
+
+            assertQueryFails(
+                    format("ALTER TABLE \"%s.branch_br1\" ALTER COLUMN c1 DROP NOT NULL", tableName),
+                    ".*ALTER COLUMN DROP NOT NULL is not supported on branch-specific tables.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testSetNotNullIfExistsOnNonExistentTable()
+    {
+        String tableName = "test_set_not_null_nonexistent_" + randomTableSuffix();
+        assertUpdate(format("ALTER TABLE IF EXISTS %s ALTER COLUMN c1 SET NOT NULL", tableName));
+    }
+
+    @Test
+    public void testSetNotNullOnHiddenColumn()
+    {
+        String tableName = "test_set_not_null_hidden_col_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT)", tableName));
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN \"$path\" SET NOT NULL", tableName),
+                    ".*Cannot add/drop NOT NULL on hidden column.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testSetNotNullOnInternalColumns()
+    {
+        // _row_id and _last_updated_sequence_number are Iceberg metadata columns exposed in
+        // getColumnHandles but absent from the user table schema. requireColumn() in Iceberg
+        // rejects them, so SET NOT NULL must fail even though they are not flagged as hidden.
+        String tableName = "test_set_not_null_internal_cols_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT)", tableName));
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN \"_row_id\" SET NOT NULL", tableName),
+                    ".*Cannot set NOT NULL: column '_row_id' does not exist in Iceberg schema.*");
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN \"_last_updated_sequence_number\" SET NOT NULL", tableName),
+                    ".*Cannot set NOT NULL: column '_last_updated_sequence_number' does not exist in Iceberg schema.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAlterColumnNotNullOnBranch()
+    {
+        String tableName = "test_alter_column_not_null_branch_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT)", tableName));
+            assertUpdate(format("ALTER TABLE %s CREATE BRANCH 'br1'", tableName));
+
+            assertQueryFails(
+                    format("ALTER TABLE \"%s.branch_br1\" ALTER COLUMN c1 SET NOT NULL", tableName),
+                    ".*ALTER COLUMN SET NOT NULL is not supported on branch-specific tables.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testSetNotNullOnStructColumn()
+    {
+        // SET NOT NULL applies to the top-level struct column, not its nested fields.
+        String tableName = "test_set_not_null_struct_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id BIGINT, payload ROW(x BIGINT, y VARCHAR))", tableName));
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN payload SET NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("id", "bigint"),
+                            columnDefinitionNotNull("payload", "ROW(\"x\" bigint,\"y\" varchar)")),
+                    null, null);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testSetNotNullOnNestedStructField()
+    {
+        String tableName = "test_set_not_null_nested_struct_" + randomTableSuffix();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id BIGINT, payload ROW(x BIGINT, y VARCHAR))", tableName));
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN \"payload.x\" SET NOT NULL", tableName),
+                    ".*Column 'payload\\.x' does not exist.*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAlterColumnNotNullOnPartitionColumn()
+    {
+        String tableName = "test_alter_not_null_partition_col_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id BIGINT, region VARCHAR) WITH (partitioning = ARRAY['region'])", tableName));
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN region SET NOT NULL", tableName));
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("id", "bigint"),
+                            columnDefinitionNotNull("region", "varchar")),
+                    null, null);
+
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'us-east')", tableName), 1);
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: region");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testConcurrentSetNotNull()
+            throws Exception
+    {
+        // Five identical SET NOT NULL statements submitted concurrently. The query runner may
+        // serialize them internally, but the test verifies idempotency: every attempt must
+        // succeed regardless of ordering, and the column must be required in the final schema.
+        String tableName = "test_concurrent_set_not_null_" + randomTableSuffix();
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT)", tableName));
+
+            int threadCount = 5;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(() ->
+                        assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName))));
+            }
+            executor.shutdown();
+            for (Future<?> future : futures) {
+                try {
+                    future.get(60, TimeUnit.SECONDS);
+                }
+                catch (TimeoutException e) {
+                    executor.shutdownNow();
+                    fail("Timed out waiting for concurrent SET NOT NULL to finish");
+                }
+                catch (ExecutionException e) {
+                    executor.shutdownNow();
+                    throw new AssertionError(e.getCause());
+                }
+            }
+
+            validateShowCreateTable(catalog, schema, tableName,
+                    ImmutableList.of(
+                            columnDefinition("c1", "bigint"),
+                            columnDefinitionNotNull("c2", "bigint")),
+                    null, null);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
     }
 
     @Test
@@ -2840,6 +3196,11 @@ public abstract class IcebergDistributedSmokeTestBase
     protected ColumnDefinition columnDefinition(String name, String type)
     {
         return new ColumnDefinition(new Identifier(name, true), type, true, ImmutableList.of(), Optional.empty());
+    }
+
+    protected ColumnDefinition columnDefinitionNotNull(String name, String type)
+    {
+        return new ColumnDefinition(new Identifier(name, true), type, false, ImmutableList.of(), Optional.empty());
     }
 
     private void validateShowCreateTableInner(String catalog, String schema, String table,

--- a/presto-native-execution/presto_cpp/main/common/Exception.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Exception.cpp
@@ -163,7 +163,10 @@ protocol::ExecutionFailureInfo VeloxToPrestoExceptionTranslator::translate(
   error.errorLocation.columnNumber = 1;
   error.type = e.exceptionName();
   std::stringstream msg;
-  msg << e.failingExpression() << " " << e.message();
+  if (!e.failingExpression().empty()) {
+    msg << e.failingExpression() << " ";
+  }
+  msg << e.message();
   if (!e.context().empty()) {
     msg << " " << e.context();
   }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1566,6 +1566,34 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 
+namespace {
+// Translates notNullColumnVariables (source variable names) to the
+// corresponding target column names so the TableWriter can enforce them.
+std::vector<std::string> toNotNullColumnNames(
+    const protocol::List<protocol::VariableReferenceExpression>&
+        notNullColumnVariables,
+    const protocol::List<protocol::VariableReferenceExpression>& columns,
+    const protocol::List<protocol::String>& columnNames) {
+  std::vector<std::string> notNullColumnNames;
+  if (notNullColumnVariables.empty()) {
+    return notNullColumnNames;
+  }
+
+  std::unordered_set<std::string> notNullVarNames;
+  notNullVarNames.reserve(notNullColumnVariables.size());
+  for (const auto& var : notNullColumnVariables) {
+    notNullVarNames.insert(var.name);
+  }
+  notNullColumnNames.reserve(notNullColumnVariables.size());
+  for (size_t i = 0; i < columns.size(); ++i) {
+    if (notNullVarNames.count(columns[i].name) > 0) {
+      notNullColumnNames.push_back(columnNames[i]);
+    }
+  }
+  return notNullColumnNames;
+}
+} // namespace
+
 std::shared_ptr<const core::TableWriteNode>
 VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::TableWriterNode>& node,
@@ -1619,6 +1647,7 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       sourceVeloxPlan,
       tableWriteInfo,
       taskId);
+
   return std::make_shared<core::TableWriteNode>(
       node->id,
       toRowType(node->columns, typeParser_),
@@ -1628,7 +1657,9 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->partitioningScheme != nullptr,
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan);
+      sourceVeloxPlan,
+      toNotNullColumnNames(
+          node->notNullColumnVariables, node->columns, node->columnNames));
 }
 
 std::shared_ptr<const core::TableWriteNode>
@@ -1683,7 +1714,9 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->partitioningScheme != nullptr,
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan);
+      sourceVeloxPlan,
+      toNotNullColumnNames(
+          node->notNullColumnVariables, node->columns, node->columnNames));
 }
 
 std::shared_ptr<const core::TableWriteNode>
@@ -1758,7 +1791,8 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       true, // delete only supported on partitioned tables
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan);
+      sourceVeloxPlan,
+      std::nullopt);
 }
 
 std::shared_ptr<const core::TableWriteMergeNode>
@@ -2036,7 +2070,8 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       /*hasPartitioningScheme=*/true,
       outputType,
       getCommitStrategy(),
-      renamedSource);
+      renamedSource,
+      std::nullopt);
 
   // 5. Alias TableWriteNode's Velox-mandated output names
   //    (rows/fragments/commitcontext) to whatever MergeWriterNode.outputs

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1629,7 +1629,10 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   }
 
   auto insertTableHandle = std::make_shared<core::InsertTableHandle>(
-      connectorId, connectorInsertHandle);
+      connectorId,
+      connectorInsertHandle,
+      toNotNullColumnNames(
+          node->notNullColumnVariables, node->columns, node->columnNames));
 
   const auto outputType = toRowType(
       generateOutputVariables(
@@ -1657,9 +1660,7 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->partitioningScheme != nullptr,
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan,
-      toNotNullColumnNames(
-          node->notNullColumnVariables, node->columns, node->columnNames));
+      sourceVeloxPlan);
 }
 
 std::shared_ptr<const core::TableWriteNode>
@@ -1693,7 +1694,10 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   }
 
   auto insertTableHandle = std::make_shared<core::InsertTableHandle>(
-      connectorId, connectorInsertHandle);
+      connectorId,
+      connectorInsertHandle,
+      toNotNullColumnNames(
+          node->notNullColumnVariables, node->columns, node->columnNames));
 
   const auto outputType = toRowType(
       generateOutputVariables(
@@ -1714,9 +1718,7 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->partitioningScheme != nullptr,
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan,
-      toNotNullColumnNames(
-          node->notNullColumnVariables, node->columns, node->columnNames));
+      sourceVeloxPlan);
 }
 
 std::shared_ptr<const core::TableWriteNode>
@@ -1791,8 +1793,7 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       true, // delete only supported on partitioned tables
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan,
-      std::nullopt);
+      sourceVeloxPlan);
 }
 
 std::shared_ptr<const core::TableWriteMergeNode>
@@ -2070,8 +2071,7 @@ velox::core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       /*hasPartitioningScheme=*/true,
       outputType,
       getCommitStrategy(),
-      renamedSource,
-      std::nullopt);
+      renamedSource);
 
   // 5. Alias TableWriteNode's Velox-mandated output names
   //    (rows/fragments/commitcontext) to whatever MergeWriterNode.outputs

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1324,6 +1324,65 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testAlterColumnSetAndDropNotNull()
+    {
+        String tableName = generateRandomTableName();
+        QueryRunner javaQueryRunner = (QueryRunner) getExpectedQueryRunner();
+        try {
+            // CREATE TABLE and ALTER TABLE are metadata-only operations executed against the native
+            // coordinator; the native and java coordinators share the same file-based metastore, so the
+            // resulting schema (including the NOT NULL constraints added/dropped below) is visible to both.
+            getQueryRunner().execute(format(
+                    "CREATE TABLE %s (" +
+                            "c1 BIGINT, " +
+                            "c2 DOUBLE, " +
+                            "c3 VARCHAR, " +
+                            "c4 BIGINT) " +
+                            "WITH (format = 'PARQUET')",
+                    tableName));
+
+            // NULLs are initially allowed: inserts must succeed on both engines.
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), 1);
+            assertUpdateExpected(getSession(), format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), 1);
+            assertUpdate(format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), 1);
+            assertUpdateExpected(getSession(), format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), 1);
+
+            getQueryRunner().execute(format(
+                    "ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL",
+                    tableName));
+            getQueryRunner().execute(format(
+                    "ALTER TABLE %s ALTER COLUMN c4 SET NOT NULL",
+                    tableName));
+
+            // NULLs should now be rejected on both the native and java engines.
+            assertQueryFails(javaQueryRunner, format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), "NULL value not allowed for NOT NULL column: c2");
+            assertQueryFails(format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), "NULL value not allowed for NOT NULL column: c2");
+            assertQueryFails(javaQueryRunner, format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), "NULL value not allowed for NOT NULL column: c4");
+            assertQueryFails(format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), "NULL value not allowed for NOT NULL column: c4");
+
+            // Columns that were never marked NOT NULL remain nullable on both engines.
+            assertUpdate(format("INSERT INTO %s VALUES (NULL, 2.3, NULL, 4)", tableName), 1);
+            assertUpdateExpected(getSession(), format("INSERT INTO %s VALUES (NULL, 2.3, NULL, 4)", tableName), 1);
+
+            // Drop NOT NULL on c2.
+            getQueryRunner().execute(format(
+                    "ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL",
+                    tableName));
+
+            // c2 accepts NULL again on both engines.
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), 1);
+            assertUpdateExpected(getSession(), format("INSERT INTO %s VALUES (1, NULL, 'abc', 4)", tableName), 1);
+
+            // c4 should still reject NULL on both engines.
+            assertQueryFails(javaQueryRunner, format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), "NULL value not allowed for NOT NULL column: c4");
+            assertQueryFails(format("INSERT INTO %s VALUES (1, 2.3, 'abc', NULL)", tableName), "NULL value not allowed for NOT NULL column: c4");
+        }
+        finally {
+            dropTableIfExists(tableName);
+        }
+    }
+
+    @Test
     public void testUnnest()
     {
         assertQuery("SELECT orderkey, quantity FROM orders_ex CROSS JOIN UNNEST (quantities) as t(quantity)");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -156,10 +156,13 @@ public class PrestoNativeQueryRunnerUtils
                         .put("native-execution-enabled", "true")
                         .put("http-server.http.port", "8081")
                         .build());
-                // The property "hive.allow-drop-table" needs to be set to true because security is always "legacy" in NativeQueryRunner.
+                // The properties "hive.allow-drop-table", "hive.allow-add-constraint" and "hive.allow-drop-constraint"
+                // need to be set to true because security is always "legacy" in NativeQueryRunner.
                 this.hiveProperties.putAll(ImmutableMap.<String, String>builder()
                         .putAll(getNativeWorkerHiveProperties())
                         .put("hive.allow-drop-table", "true")
+                        .put("hive.allow-add-constraint", "true")
+                        .put("hive.allow-drop-constraint", "true")
                         .build());
                 this.security = "legacy";
                 this.useExternalWorkerLauncher = true;

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
@@ -230,4 +230,48 @@ public abstract class AbstractTestSchemaEvolution
             assertUpdate(format("DROP TABLE IF EXISTS %s", table));
         }
     }
+
+    // A NOT NULL constraint added via ALTER COLUMN is enforced by the engine's
+    // generic TableWriter NOT NULL check (connector-agnostic: the same mechanism
+    // Hive tables use), independent of Iceberg's own field-id schema evolution
+    // exercised by the tests above. The constraint applies only to writes that
+    // happen after it is added; it does not rewrite existing data files.
+    @Test
+    public void testAlterColumnSetNotNull()
+    {
+        String table = "schema_evolution_set_not_null";
+        try {
+            assertUpdate(format("CREATE TABLE %s (a INTEGER, b VARCHAR) WITH (format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, '1001')", table), 1);
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN b SET NOT NULL", table));
+
+            assertQueryFails(format("INSERT INTO %s VALUES (2, NULL)", table), "NULL value not allowed for NOT NULL column: b");
+            assertUpdate(format("INSERT INTO %s VALUES (2, '1002')", table), 1);
+            assertQuery(format("SELECT a, b FROM %s ORDER BY a", table), "VALUES (1, '1001'), (2, '1002')");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Dropping a NOT NULL constraint must allow subsequent writes with NULL for
+    // that column, while leaving previously-written (non-null) data unaffected.
+    @Test
+    public void testAlterColumnDropNotNull()
+    {
+        String table = "schema_evolution_drop_not_null";
+        try {
+            assertUpdate(format("CREATE TABLE %s (a INTEGER, b VARCHAR NOT NULL) WITH (format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, '1001')", table), 1);
+            assertQueryFails(format("INSERT INTO %s VALUES (2, NULL)", table), "NULL value not allowed for NOT NULL column: b");
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN b DROP NOT NULL", table));
+            assertUpdate(format("INSERT INTO %s VALUES (2, NULL)", table), 1);
+            assertQuery(format("SELECT a, b FROM %s ORDER BY a", table), "VALUES (1, '1001'), (2, NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
 }

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -284,6 +284,13 @@
             <version>${dep.parquet.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${dep.assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergAlterColumnNotNull.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergAlterColumnNotNull.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests.iceberg;
+
+import com.facebook.presto.iceberg.CatalogType;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+
+public class TestIcebergAlterColumnNotNull
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCatalogType(CatalogType.HADOOP)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testAlterColumnSetAndDropNotNull()
+    {
+        String tableName = "alter_column_set_and_drop_not_null_" + randomTableSuffix();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT, c3 VARCHAR, c4 BIGINT)", tableName));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 2, 'a', 4)", tableName), 1);
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName));
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c4 SET NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'NO'), ('c3', 'YES'), ('c4', 'NO')");
+
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL, 'b', 5)", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, 3, 'b', NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c4");
+
+            assertUpdate(format("INSERT INTO %s VALUES (2, 3, 'b', 5)", tableName), 1);
+            assertUpdate(format("INSERT INTO %s VALUES (NULL, 6, NULL, 7)", tableName), 1);
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'YES'), ('c3', 'YES'), ('c4', 'NO')");
+
+            assertUpdate(format("INSERT INTO %s VALUES (3, NULL, 'c', 8)", tableName), 1);
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (3, 9, 'c', NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c4");
+
+            assertQuery(format("SELECT count(*) FROM %s", tableName), "VALUES 4");
+
+            // DROP NOT NULL on a column that is already nullable is idempotent - schema unchanged.
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'YES'), ('c3', 'YES'), ('c4', 'NO')");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testSetNotNullWithExistingNullData()
+    {
+        // Iceberg SET NOT NULL is metadata-only: existing rows with NULLs remain readable.
+        String tableName = "alter_not_null_existing_nulls_" + randomTableSuffix();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT)", tableName));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL)", tableName), 1);
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 SET NOT NULL", tableName));
+
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'NO')");
+
+            assertQuery(format("SELECT c1, c2 FROM %s", tableName), "VALUES (1, NULL)");
+
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+
+            assertUpdate(format("INSERT INTO %s VALUES (2, 3)", tableName), 1);
+            assertQuery(format("SELECT count(*) FROM %s", tableName), "VALUES 2");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testSetNotNullOnStructColumn()
+    {
+        // SET NOT NULL applies to the top-level struct column, not its nested fields.
+        String tableName = "alter_column_not_null_struct_" + randomTableSuffix();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id BIGINT, payload ROW(x BIGINT, y VARCHAR))", tableName));
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN payload SET NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('id', 'YES'), ('payload', 'NO')");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testDropNotNullOnColumnDefinedAtCreateTime()
+    {
+        String tableName = "alter_column_drop_not_null_create_time_" + randomTableSuffix();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (c1 BIGINT, c2 BIGINT NOT NULL, c3 VARCHAR)", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'NO'), ('c3', 'YES')");
+
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (1, NULL, 'a')", tableName),
+                    "NULL value not allowed for NOT NULL column: c2");
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN c2 DROP NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('c1', 'YES'), ('c2', 'YES'), ('c3', 'YES')");
+
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL, 'a')", tableName), 1);
+            assertUpdate(format("INSERT INTO %s VALUES (2, 3, 'b')", tableName), 1);
+            assertUpdate(format("INSERT INTO %s VALUES (3, NULL, NULL)", tableName), 1);
+
+            assertQuery(format("SELECT c1, c2, c3 FROM %s ORDER BY c1", tableName),
+                    "VALUES (1, NULL, 'a'), (2, 3, 'b'), (3, NULL, NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    public void testAlterColumnNotNullOnPartitionColumn()
+    {
+        String tableName = "alter_column_not_null_partition_" + randomTableSuffix();
+        String schema = getSession().getSchema().get();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id BIGINT, region VARCHAR) WITH (partitioning = ARRAY['region'])", tableName));
+
+            assertUpdate(format("ALTER TABLE %s ALTER COLUMN region SET NOT NULL", tableName));
+            assertQuery(
+                    format("SELECT column_name, is_nullable FROM information_schema.columns WHERE table_name = '%s' AND table_schema = '%s' ORDER BY ordinal_position", tableName, schema),
+                    "VALUES ('id', 'YES'), ('region', 'NO')");
+
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'us-east')", tableName), 1);
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (2, NULL)", tableName),
+                    "NULL value not allowed for NOT NULL column: region");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds support for `ALTER TABLE ... ALTER COLUMN <column> SET NOT NULL` and `ALTER TABLE ... ALTER COLUMN <column> DROP NOT NULL` in the Iceberg connector.

Depends on #28450, which lands first. That commit is no longer part of this branch; this branch is rebased on top of it and carries the Iceberg connector change only. The `presto-native-tests` coverage below needs #28450 to be in `master` to pass.

`IcebergAbstractMetadata`:

* Implements the existing `ConnectorMetadata.addConstraint`/`dropConstraint` SPI hooks on top of Iceberg's `UpdateSchema`, mirroring the Hive connector's implementation of the same hooks. Both directions share a single `updateColumnNullability` helper: `SET NOT NULL` maps to `requireColumn()` (which needs `allowIncompatibleChanges()`, since optional -> required is an incompatible change in Iceberg), and `DROP NOT NULL` maps to `makeColumnOptional()`.
* Declares the `ALTER_COLUMN` connector capability so `AlterColumnNotNullTask` routes the statement to the connector. That capability is consumed only by `AlterColumnNotNullTask`, so no other behavior changes as a result.
* Loads the table with the transaction-scoped `getIcebergTable`, so the schema update is staged on the surrounding Presto transaction and committed with it — the same shape as `addColumn`, `dropColumn`, `renameColumn`, `setColumnDefault` and `setColumnType` in this class. A `ROLLBACK` discards the change, and later statements in the same transaction plan against the new schema.
* Rejects unsupported inputs: named constraints (`DROP CONSTRAINT <name>`), non-`NotNullConstraint` constraint types, branch-specific tables, metadata columns, and columns absent from the Iceberg schema. Iceberg's reserved `_`-prefixed columns (`_row_id`, `_last_updated_sequence_number`) are exposed as non-hidden `REGULAR` handles and so reach the connector, which rejects them via the new `IcebergMetadataColumn.isSynthesizedColumnName` alongside `MetadataColumns.isMetadataColumn`; Presto's synthesized `$`-prefixed columns are already rejected upstream by `AlterColumnNotNullTask`.

Documentation:

* Documents both operations and their metadata-only semantics in the Iceberg connector docs, including an explicit warning that `SET NOT NULL` applies an Iceberg-incompatible schema change without validating existing data.
* Widens the Iceberg SQL Support table. The previous fixed-width table had misaligned columns on the `ALTER TABLE ADD COLUMN DEFAULT` and `ALTER TABLE ALTER COLUMN SET DEFAULT` rows, which rendered incorrectly.

## Motivation and Context

Part of #28156.

`NOT NULL` could only be set at table creation time in the Iceberg connector. There was no way to add or remove the constraint on an existing column, even though Iceberg's schema evolution supports both directions and the `addConstraint`/`dropConstraint` SPI already existed and was already implemented by the Hive connector. `DROP NOT NULL` in particular failed with `This connector does not support dropping table constraints`, so a column made `NOT NULL` at `CREATE TABLE` time could never be relaxed — the table had to be recreated.

This covers items 1 and 3 of the desired behavior in #28156 (Iceberg `SET`/`DROP NOT NULL`, plus dual-runner native coverage for Iceberg). Item 2, native-worker enforcement of `NOT NULL` on writes, is a separate connector-agnostic fix reviewed on its own in **#28450** and merging first, so it is no longer carried here. The `presto-native-tests` coverage added in this PR exercises that enforcement for Iceberg and depends on it, and the `Presto C++` column of the Iceberg SQL support table reflects it.

## Impact

New SQL support in the Iceberg connector: `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL` and `ALTER TABLE ... ALTER COLUMN ... DROP NOT NULL`. Nothing that worked before changes behavior.

Semantics worth calling out for `SET NOT NULL`: it is a metadata-only operation. It updates the column's required/optional flag without rewriting data files, so it succeeds even when existing rows contain `NULL` values for that column, those rows remain readable, and the constraint is enforced only on subsequent writes. Iceberg classifies optional -> required as an *incompatible* schema change, so a table can end up advertising a `required` field while its data files still contain `NULL` values, which other engines (Spark, Trino) may optimize on. This is called out as a warning in the Iceberg connector docs. `DROP NOT NULL` is the compatible direction and is always safe.

Both statements are transactional in the same way the connector's other column DDL is: staged on the Presto transaction, discarded by `ROLLBACK`, and surfacing a commit conflict when the transaction commits.

No new configuration or session properties. No new dependencies. No SPI changes.

## Test Plan

`IcebergDistributedSmokeTestBase` (runs for every catalog type - Hadoop, Hive, Nessie, REST, S3):

* `testAlterColumnNotNull` - set `NOT NULL` on multiple columns, verify `SHOW CREATE TABLE`, verify explicit `NULL`, implicit `NULL` from an omitted column, and a valid insert.
* `testDropNotNull` - drop on one column while another stays constrained, verify both write paths, verify readback and idempotency.
* `testAlterColumnNotNullNegative` - both directions where applicable: nonexistent column, nested struct field path, `DROP CONSTRAINT <name>`, and idempotent re-application leaving the schema unchanged.
* `testAlterColumnNotNullDoesNotTamperWithMetadataColumns` - every column exposed on top of the table's own schema is rejected in both directions, with the schema byte-identical afterwards: hidden `$path` and friends (stopped by the engine), non-hidden `_row_id` / `_last_updated_sequence_number` (rejected by the connector), and synthesized names with no column handle at all. Also asserts a real column named `partition_data` stays alterable and enforced, since that name collides with a synthesized one but is not `$`-prefixed.
* `testAlterColumnNotNullInTransaction` - the change is visible to later statements in the same transaction, `ROLLBACK` discards it, and a `DROP NOT NULL` committed alongside an `INSERT` in one transaction takes effect together.
* `testAlterColumnNotNullOnBranch` - both directions rejected on branch-specific tables.
* `testSetNotNullIfExistsOnNonExistentTable` - `ALTER TABLE IF EXISTS` is a no-op.

`TestIcebergV3`:

* `testAlterColumnNotNullDoesNotTamperWithRowLineage` - on a format-version-3 table, both directions on `_row_id` / `_last_updated_sequence_number` are rejected with the Iceberg schema and the row lineage values unchanged, and altering a real column leaves lineage intact.

`presto-native-tests`, `TestIcebergAlterColumnNotNull` (native worker vs. Java engine dual runner; requires #28450 to be merged):

* `testAlterColumnSetAndDropNotNull` - set on two columns, `information_schema.columns` reflects it, `NULL` writes rejected, valid writes accepted, then drop and verify the reverse, including idempotent drop.
* `testSetNotNullWithExistingNullData` - metadata-only semantics: succeeds with pre-existing `NULL` rows, those rows stay readable, later `NULL` writes are rejected.
* `testDropNotNullOnColumnDefinedAtCreateTime` - relaxes a constraint declared at `CREATE TABLE` time and verifies `NULL` writes then succeed.
* `testSetNotNullOnStructColumn` - applies to the top-level struct column.
* `testAlterColumnNotNullOnPartitionColumn` - works on an identity-partitioned column and is enforced on write.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for ``ALTER TABLE ... ALTER COLUMN ... SET NOT NULL`` and ``ALTER TABLE ... ALTER COLUMN ... DROP NOT NULL``. ``SET NOT NULL`` is a metadata-only operation in Iceberg, so it succeeds even when existing rows contain ``NULL`` values and the constraint is enforced only on subsequent writes. See :doc:`/connector/iceberg`.

Documentation Changes
* Fix misaligned columns in the Iceberg connector SQL support table. See :doc:`/connector/iceberg`.
```

## Summary by Sourcery

Enable transactional Iceberg column nullability changes and enforce the resulting NOT NULL constraints across Java and native writes.

New Features:
- Add Iceberg connector support for ALTER TABLE ... ALTER COLUMN ... SET NOT NULL and DROP NOT NULL, including transactional schema evolution and validation of unsupported columns and table variants.
- Propagate NOT NULL column metadata to native table writes so Velox enforces constraints for inserts and CTAS-related writer plans.

Bug Fixes:
- Prevent native table-writer planning from silently losing NOT NULL enforcement when source variables map to target columns, including shared-variable projections.

Enhancements:
- Reject metadata, synthesized, named, nested-field, and branch-specific constraint alterations while preserving Iceberg row-lineage metadata.

Documentation:
- Document Iceberg SET/DROP NOT NULL semantics and warnings, and correct alignment in the Iceberg SQL support table.

Tests:
- Add Java and native coverage for nullability changes, transactional behavior, existing NULL data, metadata and row-lineage protection, partition and struct columns, native write enforcement, and invalid inputs.