### PR TITLE
feat: Coordinator dynamic filter collection and merge service

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -96,4 +96,43 @@ public class RuntimeMetricName
     public static final String CHECK_ACCESS_PERMISSIONS_TIME_NANOS = "checkAccessPermissionsTimeNanos";
     public static final String DYNAMIC_FILTER_PLAN_CREATED_FAVORABLE_RATIO = "dynamicFilterPlanCreatedFavorableRatio";
     public static final String DYNAMIC_FILTER_PLAN_SKIPPED_HIGH_CARDINALITY = "dynamicFilterPlanSkippedHighCardinality";
+
+    public static final String DYNAMIC_FILTER_SPLITS_PROCESSED = "dynamicFilterSplitsProcessed";
+    public static final String DYNAMIC_FILTER_WAIT_TIME_NANOS = "dynamicFilterWaitTimeNanos";
+    public static final String DYNAMIC_FILTER_COLLECTION_TIME_NANOS = "dynamicFilterCollectionTimeNanos";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED = "dynamicFilterPartitionsReceived";
+    public static final String DYNAMIC_FILTER_PUSHED_INTO_SCAN = "dynamicFilterPushedIntoScan";
+    public static final String DYNAMIC_FILTER_SPLITS_BEFORE_FILTER = "dynamicFilterSplitsBeforeFilter";
+    public static final String DYNAMIC_FILTER_CONSTRAINT_COLUMNS = "dynamicFilterConstraintColumns";
+    public static final String DYNAMIC_FILTER_EXPECTED_PARTITIONS = "dynamicFilterExpectedPartitions";
+    public static final String DYNAMIC_FILTER_FETCHERS_STARTED = "dynamicFilterFetchersStarted";
+    public static final String DYNAMIC_FILTER_SOURCE_DISTINCT_VALUES = "dynamicFilterSourceDistinctValues";
+    public static final String DYNAMIC_FILTER_SOURCE_FALLBACK_TO_MIN_MAX = "dynamicFilterSourceFallbackToMinMax";
+    public static final String DYNAMIC_FILTER_SOURCE_COLLECTION_TIME_NANOS = "dynamicFilterSourceCollectionTimeNanos";
+    public static final String DYNAMIC_FILTER_TIMED_OUT = "dynamicFilterTimedOut";
+    public static final String DYNAMIC_FILTER_DOMAIN_RANGE_COUNT = "dynamicFilterDomainRangeCount";
+    public static final String DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE = "dynamicFilterCoordinatorFallbackToRange";
+    public static final String DYNAMIC_FILTER_SHORT_CIRCUITED = "dynamicFilterShortCircuited";
+    public static final String DYNAMIC_FILTER_FETCHER_POLLS = "dynamicFilterFetcherPolls";
+    public static final String DYNAMIC_FILTER_FETCHER_STOPPED_BY_CLEANUP = "dynamicFilterFetcherStoppedByCleanup";
+    public static final String DYNAMIC_FILTER_FETCHER_FINAL_FETCH_COMPLETED = "dynamicFilterFetcherFinalFetchCompleted";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_FROM_TASK = "dynamicFilterPartitionsReceivedFromTask";
+    public static final String DYNAMIC_FILTER_OPERATOR_CALLBACK = "dynamicFilterOperatorCallback";
+    public static final String DYNAMIC_FILTER_FACTORY_CLOSED = "dynamicFilterFactoryClosed";
+    public static final String DYNAMIC_FILTER_FLUSH_FIRED = "dynamicFilterFlushFired";
+    public static final String DYNAMIC_FILTER_COMPLETED_ID_DELIVERED = "dynamicFilterCompletedIdDelivered";
+    // Push-to-worker metrics (extended metrics only)
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_COUNT = "dynamicFilterPushToWorkerCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_COUNT = "dynamicFilterPushToWorkerTaskCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_SUCCESS_COUNT = "dynamicFilterPushToWorkerSuccessCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_FAILURE_COUNT = "dynamicFilterPushToWorkerFailureCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_LATENCY_MS = "dynamicFilterPushToWorkerLatencyMs";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_HTTP_STATUS = "dynamicFilterPushToWorkerHttpStatus";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_NOT_FOUND_COUNT = "dynamicFilterPushToWorkerTaskNotFoundCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_THROTTLED_COUNT = "dynamicFilterPushToWorkerThrottledCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_RETRIED_COUNT = "dynamicFilterPushToWorkerRetriedCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_RETRY_GAVE_UP_COUNT = "dynamicFilterPushToWorkerRetryGaveUpCount";
+    // Column selectivity check metrics (extended metrics only)
+    public static final String DYNAMIC_FILTER_COLUMNS_SKIPPED = "dynamicFilterColumnsSkipped";
+    public static final String DYNAMIC_FILTER_COLUMNS_RELEVANT = "dynamicFilterColumnsRelevant";
 }

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -304,6 +304,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterResult
+{
+    private final Map<String, TupleDomain<String>> filters;
+    private final long version;
+    private final boolean operatorCompleted;
+    private final Set<String> completedFilterIds;
+
+    public DynamicFilterResult(Map<String, TupleDomain<String>> filters, long version, boolean operatorCompleted, Set<String> completedFilterIds)
+    {
+        this.filters = ImmutableMap.copyOf(requireNonNull(filters, "filters is null"));
+        this.version = version;
+        this.operatorCompleted = operatorCompleted;
+        this.completedFilterIds = ImmutableSet.copyOf(requireNonNull(completedFilterIds, "completedFilterIds is null"));
+    }
+
+    public Map<String, TupleDomain<String>> getFilters()
+    {
+        return filters;
+    }
+
+    public long getVersion()
+    {
+        return version;
+    }
+
+    public boolean isOperatorCompleted()
+    {
+        return operatorCompleted;
+    }
+
+    public Set<String> getCompletedFilterIds()
+    {
+        return completedFilterIds;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
@@ -22,6 +22,23 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Wire DTO returned by the coordinator's long-poll endpoint ({@code GET /v1/dynamicFilters}).
+ *
+ * <p>Each response carries:
+ * <ul>
+ *   <li>{@code filters} — the resolved {@link com.facebook.presto.common.predicate.TupleDomain}
+ *       per filter ID, keyed by filter ID string.</li>
+ *   <li>{@code version} — monotonically increasing version used by the fetcher to request
+ *       only filters newer than the last seen version.</li>
+ *   <li>{@code operatorCompleted} — true when the build-side operator has finished and no
+ *       further filter updates will arrive.</li>
+ *   <li>{@code completedFilterIds} — the subset of filter IDs that are fully resolved.</li>
+ * </ul>
+ *
+ * <p>Used by {@code DynamicFilterFetcher} (PR4 / #28044) and {@code DynamicFilterPusher}
+ * to carry resolved filters from workers to the coordinator and back to the probe side.
+ */
 public class DynamicFilterResult
 {
     private final Map<String, TupleDomain<String>> filters;

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class DomainRuntimeFilter
+        implements RuntimeFilter
+{
+    private final TupleDomain<String> domain;
+
+    public DomainRuntimeFilter(TupleDomain<String> domain)
+    {
+        this.domain = requireNonNull(domain, "domain is null");
+    }
+
+    @JsonValue
+    public TupleDomain<String> getDomain()
+    {
+        return domain;
+    }
+
+    @Override
+    public RuntimeFilter mergeWith(RuntimeFilter other)
+    {
+        if (!(other instanceof DomainRuntimeFilter)) {
+            throw new IllegalArgumentException(
+                    "Cannot merge a DomainRuntimeFilter with " + other.getClass().getSimpleName());
+        }
+        return new DomainRuntimeFilter(
+                TupleDomain.columnWiseUnion(domain, ((DomainRuntimeFilter) other).domain));
+    }
+
+    @Override
+    public TupleDomain<String> toTupleDomain(String column, Type type)
+    {
+        if (column.isEmpty() || domain.isAll() || domain.isNone() || !domain.getDomains().isPresent()) {
+            return domain;
+        }
+        Map<String, Domain> domains = domain.getDomains().get();
+        if (domains.size() != 1) {
+            return domain;
+        }
+        Domain single = domains.values().iterator().next();
+        return TupleDomain.withColumnDomains(ImmutableMap.of(column, single));
+    }
+
+    @Override
+    public boolean isAll()
+    {
+        return domain.isAll();
+    }
+
+    @Override
+    public boolean isNone()
+    {
+        return domain.isNone();
+    }
+
+    @Override
+    public long estimatedRetainedSizeInBytes()
+    {
+        if (domain.isNone() || domain.isAll() || !domain.getDomains().isPresent()) {
+            return 0;
+        }
+        long totalSize = 0;
+        for (Domain columnDomain : domain.getDomains().get().values()) {
+            if (!(columnDomain.getValues() instanceof SortedRangeSet)) {
+                continue;
+            }
+            for (Range range : columnDomain.getValues().getRanges().getOrderedRanges()) {
+                totalSize += range.getLow().getValueBlock().map(Block::getRetainedSizeInBytes).orElse(0L);
+                totalSize += range.getHigh().getValueBlock().map(Block::getRetainedSizeInBytes).orElse(0L);
+            }
+        }
+        return totalSize;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
@@ -24,8 +24,20 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A {@link RuntimeFilter} backed by a {@link TupleDomain}.
+ *
+ * <p>Each instance targets exactly one join column: the underlying domain is either
+ * {@code all()}, {@code none()}, or contains exactly one column entry keyed by the
+ * filter ID string. {@link #toTupleDomain(String, Type)} re-keys that single entry
+ * to the probe column name for use by the connector.
+ *
+ * <p>Wire form: serialized as a bare {@code TupleDomain} (no {@code @kind} field)
+ * for back-compat with older coordinators; deserialized by {@link RuntimeFilterDeserializer}.
+ */
 public class DomainRuntimeFilter
         implements RuntimeFilter
 {
@@ -56,13 +68,12 @@ public class DomainRuntimeFilter
     @Override
     public TupleDomain<String> toTupleDomain(String column, Type type)
     {
-        if (column.isEmpty() || domain.isAll() || domain.isNone() || !domain.getDomains().isPresent()) {
+        if (column.isEmpty() || domain.isAll() || domain.isNone()) {
             return domain;
         }
         Map<String, Domain> domains = domain.getDomains().get();
-        if (domains.size() != 1) {
-            return domain;
-        }
+        checkArgument(domains.size() == 1,
+                "Expected single-column domain but got %s columns: %s", domains.size(), domains.keySet());
         Domain single = domains.values().iterator().next();
         return TupleDomain.withColumnDomains(ImmutableMap.of(column, single));
     }
@@ -82,7 +93,7 @@ public class DomainRuntimeFilter
     @Override
     public long estimatedRetainedSizeInBytes()
     {
-        if (domain.isNone() || domain.isAll() || !domain.getDomains().isPresent()) {
+        if (domain.isNone() || domain.isAll()) {
             return 0;
         }
         long totalSize = 0;

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.ThreadSafe;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.Objects.requireNonNull;
+
+// Callers must call removeFiltersForQuery when queries complete.
+@ThreadSafe
+public class DynamicFilterService
+{
+    private final ConcurrentMap<QueryId, ConcurrentMap<String, JoinDynamicFilter>> filters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<QueryId, ConcurrentMap<PlanNodeId, Set<String>>> scanToFilterIds = new ConcurrentHashMap<>();
+    private final DynamicFilterStats stats;
+
+    public DynamicFilterService()
+    {
+        this(new DynamicFilterStats());
+    }
+
+    public DynamicFilterService(DynamicFilterStats stats)
+    {
+        this.stats = requireNonNull(stats, "stats is null");
+    }
+
+    public void registerFilter(QueryId queryId, String filterId, JoinDynamicFilter filter)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+        requireNonNull(filter, "filter is null");
+
+        boolean inserted = filters.computeIfAbsent(queryId, k -> new ConcurrentHashMap<>())
+                .putIfAbsent(filterId, filter) == null;
+        if (inserted) {
+            stats.getFilterRegistrations().update(1);
+        }
+    }
+
+    public Optional<JoinDynamicFilter> getFilter(QueryId queryId, String filterId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        if (queryFilters == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(queryFilters.get(filterId));
+    }
+
+    public void removeFiltersForQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        filters.remove(queryId);
+        scanToFilterIds.remove(queryId);
+    }
+
+    public void registerScanFilterMapping(QueryId queryId, PlanNodeId scanNodeId, Set<String> filterIds)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(scanNodeId, "scanNodeId is null");
+        requireNonNull(filterIds, "filterIds is null");
+
+        scanToFilterIds
+                .computeIfAbsent(queryId, k -> new ConcurrentHashMap<>())
+                .merge(scanNodeId, ImmutableSet.copyOf(filterIds), (existing, incoming) -> {
+                    Set<String> merged = new HashSet<>(existing);
+                    merged.addAll(incoming);
+                    return ImmutableSet.copyOf(merged);
+                });
+    }
+
+    public Set<String> getFilterIdsForScan(QueryId queryId, PlanNodeId scanNodeId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(scanNodeId, "scanNodeId is null");
+
+        ConcurrentMap<PlanNodeId, Set<String>> queryScanMappings = scanToFilterIds.get(queryId);
+        if (queryScanMappings == null) {
+            return ImmutableSet.of();
+        }
+        Set<String> filterIds = queryScanMappings.get(scanNodeId);
+        return filterIds != null ? filterIds : ImmutableSet.of();
+    }
+
+    public boolean hasFilter(QueryId queryId, String filterId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        return queryFilters != null && queryFilters.containsKey(filterId);
+    }
+
+    public Map<String, JoinDynamicFilter> getAllFiltersForQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        if (queryFilters == null) {
+            return ImmutableMap.of();
+        }
+        return ImmutableMap.copyOf(queryFilters);
+    }
+
+    public DynamicFilterStats getStats()
+    {
+        return stats;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
@@ -34,14 +34,14 @@ public class DynamicFilterService
 {
     private final ConcurrentMap<QueryId, ConcurrentMap<String, JoinDynamicFilter>> filters = new ConcurrentHashMap<>();
     private final ConcurrentMap<QueryId, ConcurrentMap<PlanNodeId, Set<String>>> scanToFilterIds = new ConcurrentHashMap<>();
-    private final DynamicFilterStats stats;
+    private final DynamicFilterServiceStats stats;
 
     public DynamicFilterService()
     {
-        this(new DynamicFilterStats());
+        this(new DynamicFilterServiceStats());
     }
 
-    public DynamicFilterService(DynamicFilterStats stats)
+    public DynamicFilterService(DynamicFilterServiceStats stats)
     {
         this.stats = requireNonNull(stats, "stats is null");
     }
@@ -126,7 +126,7 @@ public class DynamicFilterService
         return ImmutableMap.copyOf(queryFilters);
     }
 
-    public DynamicFilterStats getStats()
+    public DynamicFilterServiceStats getStats()
     {
         return stats;
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterServiceStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterServiceStats.java
@@ -17,7 +17,7 @@ import com.facebook.airlift.stats.CounterStat;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
-public class DynamicFilterStats
+public class DynamicFilterServiceStats
 {
     /**
      * Simple running average: tracks count and sum to expose a rolling mean.

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.stats.CounterStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import static com.facebook.presto.server.SimpleHttpResponseHandlerStats.IncrementalAverage;
+
+public class DynamicFilterStats
+{
+    private final CounterStat filterFetchSuccess = new CounterStat();
+    private final CounterStat filterFetchFailure = new CounterStat();
+    private final CounterStat filtersCollected = new CounterStat();
+    private final CounterStat filterRegistrations = new CounterStat();
+    private final CounterStat filterCollectionCompleted = new CounterStat();
+    private final CounterStat filterCollectionTimedOut = new CounterStat();
+    private final CounterStat filtersStored = new CounterStat();
+    private final CounterStat fetchersStarted = new CounterStat();
+    private final CounterStat filterFlushes = new CounterStat();
+    private final IncrementalAverage filterFetchRoundTripMillis = new IncrementalAverage();
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFetchSuccess()
+    {
+        return filterFetchSuccess;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFetchFailure()
+    {
+        return filterFetchFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFiltersCollected()
+    {
+        return filtersCollected;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterRegistrations()
+    {
+        return filterRegistrations;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterCollectionCompleted()
+    {
+        return filterCollectionCompleted;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterCollectionTimedOut()
+    {
+        return filterCollectionTimedOut;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFiltersStored()
+    {
+        return filtersStored;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchersStarted()
+    {
+        return fetchersStarted;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFlushes()
+    {
+        return filterFlushes;
+    }
+
+    @Managed
+    public double getFilterFetchRoundTripMillis()
+    {
+        return filterFetchRoundTripMillis.getAverage();
+    }
+
+    @Managed
+    public long getFilterFetchRoundTripCount()
+    {
+        return filterFetchRoundTripMillis.getCount();
+    }
+
+    public void recordFilterFetchRoundTripMillis(long millis)
+    {
+        filterFetchRoundTripMillis.add(millis);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
@@ -17,10 +17,34 @@ import com.facebook.airlift.stats.CounterStat;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
-import static com.facebook.presto.server.SimpleHttpResponseHandlerStats.IncrementalAverage;
-
 public class DynamicFilterStats
 {
+    /**
+     * Simple running average: tracks count and sum to expose a rolling mean.
+     * Inlined here to avoid a dependency on the {@code server} package.
+     */
+    static final class IncrementalAverage
+    {
+        private long count;
+        private double sum;
+
+        synchronized void add(long value)
+        {
+            count++;
+            sum += value;
+        }
+
+        synchronized double getAverage()
+        {
+            return count == 0 ? 0.0 : sum / count;
+        }
+
+        synchronized long getCount()
+        {
+            return count;
+        }
+    }
+
     private final CounterStat filterFetchSuccess = new CounterStat();
     private final CounterStat filterFetchFailure = new CounterStat();
     private final CounterStat filtersCollected = new CounterStat();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLLECTION_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_DOMAIN_RANGE_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_EXPECTED_PARTITIONS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PARTITIONS_RECEIVED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SHORT_CIRCUITED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_TIMED_OUT;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+import static com.facebook.presto.spi.connector.DynamicFilter.NOT_BLOCKED;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+// Does not implement DynamicFilter; the SPI-facing wrapper is TableScanDynamicFilter.
+@ThreadSafe
+public class JoinDynamicFilter
+{
+    // Injected by DynamicFilterService in PR4; shared daemon pool until then.
+    static final ScheduledExecutorService DEFAULT_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(daemonThreadsNamed("join-dynamic-filter-timeout-%s"));
+
+    private final ScheduledExecutorService timeoutScheduler;
+    private final String filterId;
+    private final String columnName;
+    private final Duration waitTimeout;
+    private final int maxWaitExtensions;
+    private final long maxSizeInBytes;
+    private final DynamicFilterStats stats;
+    private final RuntimeStats runtimeStats;
+    private final boolean extendedMetrics;
+
+    @GuardedBy("this")
+    private final List<RuntimeFilter> partitionsByFilterId = new ArrayList<>();
+    private final CompletableFuture<RuntimeFilter> constraintByFilterIdFuture;
+
+    private final AtomicBoolean timeoutStarted = new AtomicBoolean(false);
+
+    @GuardedBy("this")
+    private int expectedPartitions;
+
+    private volatile boolean fullyResolved;
+
+    @GuardedBy("this")
+    private RuntimeFilter mergedConstraint;
+
+    @GuardedBy("this")
+    private Domain probeColumnDomain;
+
+    @GuardedBy("this")
+    private long collectionStartNanos;
+    @GuardedBy("this")
+    private boolean collectionStarted;
+    @GuardedBy("this")
+    private boolean collectionTimeRecorded;
+    @GuardedBy("this")
+    private int extensionsUsed;
+    @GuardedBy("this")
+    private int lastTickPartitionCount;
+
+    public JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics)
+    {
+        this(filterId, columnName, waitTimeout, 0, maxSizeInBytes, stats, runtimeStats, extendedMetrics, DEFAULT_SCHEDULER);
+    }
+
+    public JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            int maxWaitExtensions,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics)
+    {
+        this(filterId, columnName, waitTimeout, maxWaitExtensions, maxSizeInBytes, stats, runtimeStats, extendedMetrics, DEFAULT_SCHEDULER);
+    }
+
+    // Package-private: for injection by DynamicFilterService (PR4) and tests.
+    JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            int maxWaitExtensions,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics,
+            ScheduledExecutorService timeoutScheduler)
+    {
+        this.filterId = requireNonNull(filterId, "filterId is null");
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.waitTimeout = requireNonNull(waitTimeout, "waitTimeout is null");
+        verify(maxWaitExtensions >= 0, "maxWaitExtensions must be non-negative");
+        this.maxWaitExtensions = maxWaitExtensions;
+        this.maxSizeInBytes = maxSizeInBytes;
+        this.expectedPartitions = Integer.MAX_VALUE;
+        this.stats = requireNonNull(stats, "stats is null");
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.extendedMetrics = extendedMetrics;
+        this.timeoutScheduler = requireNonNull(timeoutScheduler, "timeoutScheduler is null");
+
+        this.constraintByFilterIdFuture = new CompletableFuture<>();
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
+    }
+
+    public void setExpectedPartitions(int expectedPartitions)
+    {
+        RuntimeFilter resolved;
+        synchronized (this) {
+            verify(this.expectedPartitions == Integer.MAX_VALUE, "setExpectedPartitions already called");
+            verify(expectedPartitions > 0, "expectedPartitions must be positive");
+            this.expectedPartitions = expectedPartitions;
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_EXPECTED_PARTITIONS, NONE, expectedPartitions);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_EXPECTED_PARTITIONS, filterId), NONE, expectedPartitions);
+            }
+            resolved = tryCompleteResolution();
+        }
+        if (resolved != null) {
+            constraintByFilterIdFuture.complete(resolved);
+        }
+    }
+
+    // Must be called when wired to a split source, not at construction time.
+    public void startTimeout()
+    {
+        if (timeoutStarted.compareAndSet(false, true)) {
+            long timeoutMs = waitTimeout.toMillis();
+            if (timeoutMs > 0) {
+                // Baseline so pre-startTimeout contributions aren't credited as new progress on the first tick.
+                synchronized (this) {
+                    lastTickPartitionCount = partitionsByFilterId.size();
+                }
+                scheduleTick(timeoutMs);
+            }
+        }
+    }
+
+    public Duration getWaitTimeout()
+    {
+        return waitTimeout;
+    }
+
+    public String getFilterId()
+    {
+        return filterId;
+    }
+
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    public synchronized void setProbeColumnDomain(Domain domain)
+    {
+        this.probeColumnDomain = requireNonNull(domain, "domain is null");
+    }
+
+    public boolean isComplete()
+    {
+        return fullyResolved;
+    }
+
+    public void addPartitionByFilterId(TupleDomain<String> tupleDomain)
+    {
+        requireNonNull(tupleDomain, "tupleDomain is null");
+        tupleDomain.getDomains().ifPresent(domains ->
+                verify(domains.size() == 1, "Expected single-column filter domain but got %s columns", domains.size()));
+        addPartitionByFilterId(new DomainRuntimeFilter(tupleDomain));
+    }
+
+    public void addPartitionByFilterId(RuntimeFilter filter)
+    {
+        requireNonNull(filter, "filter is null");
+        RuntimeFilter resolved;
+        synchronized (this) {
+            if (!collectionStarted) {
+                collectionStartNanos = System.nanoTime();
+                collectionStarted = true;
+            }
+
+            partitionsByFilterId.add(filter);
+
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_PARTITIONS_RECEIVED, NONE, 1);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_PARTITIONS_RECEIVED, filterId), NONE, 1);
+            }
+
+            resolved = tryCompleteResolution();
+        }
+        if (resolved != null) {
+            constraintByFilterIdFuture.complete(resolved);
+        }
+    }
+
+    // Returns the resolved filter to complete outside the lock, or null if not yet ready.
+    @GuardedBy("this")
+    private RuntimeFilter tryCompleteResolution()
+    {
+        if (constraintByFilterIdFuture.isDone() || partitionsByFilterId.size() < expectedPartitions) {
+            return null;
+        }
+
+        RuntimeFilter union = partitionsByFilterId.get(0);
+        for (int i = 1; i < partitionsByFilterId.size(); i++) {
+            union = union.mergeWith(partitionsByFilterId.get(i));
+        }
+        mergedConstraint = collapseIfOversized(union);
+        maybeShortCircuit();
+        fullyResolved = true;
+        recordCollectionCompleted();
+        return mergedConstraint;
+    }
+
+    private RuntimeFilter collapseIfOversized(RuntimeFilter filter)
+    {
+        if (filter.estimatedRetainedSizeInBytes() <= maxSizeInBytes) {
+            return filter;
+        }
+        verify(filter instanceof DomainRuntimeFilter,
+                "Cannot collapse oversized %s; add collapse support before introducing new RuntimeFilter types",
+                filter.getClass().getSimpleName());
+        runtimeStats.addMetricValue(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, NONE, 1);
+        if (!filterId.isEmpty()) {
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, filterId), NONE, 1);
+        }
+        return new DomainRuntimeFilter(collapseToRange(((DomainRuntimeFilter) filter).getDomain()));
+    }
+
+    static TupleDomain<String> collapseToRange(TupleDomain<String> tupleDomain)
+    {
+        if (tupleDomain.isNone() || tupleDomain.isAll() || !tupleDomain.getDomains().isPresent()) {
+            return tupleDomain;
+        }
+        ImmutableMap.Builder<String, Domain> collapsed = ImmutableMap.builder();
+        for (Map.Entry<String, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
+            Domain domain = entry.getValue();
+            ValueSet values = domain.getValues();
+            if (values instanceof SortedRangeSet) {
+                SortedRangeSet sortedRangeSet = (SortedRangeSet) values;
+                if (sortedRangeSet.getRangeCount() > 1) {
+                    collapsed.put(entry.getKey(), Domain.create(ValueSet.ofRanges(sortedRangeSet.getSpan()), domain.isNullAllowed()));
+                    continue;
+                }
+            }
+            collapsed.put(entry.getKey(), domain);
+        }
+        return TupleDomain.withColumnDomains(collapsed.build());
+    }
+
+    private void maybeShortCircuit()
+    {
+        if (probeColumnDomain == null || !(mergedConstraint instanceof DomainRuntimeFilter)) {
+            return;
+        }
+        TupleDomain<String> tupleDomain = ((DomainRuntimeFilter) mergedConstraint).getDomain();
+        if (tupleDomain.isAll() || tupleDomain.isNone() || !tupleDomain.getDomains().isPresent()) {
+            return;
+        }
+        Map<String, Domain> domains = tupleDomain.getDomains().get();
+        if (domains.size() != 1) {
+            return;
+        }
+        Domain filterDomain = domains.values().iterator().next();
+        if (filterDomain.contains(probeColumnDomain)) {
+            mergedConstraint = new DomainRuntimeFilter(TupleDomain.all());
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_SHORT_CIRCUITED, NONE, 1);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_SHORT_CIRCUITED, filterId), NONE, 1);
+            }
+        }
+    }
+
+    private void recordCollectionCompleted()
+    {
+        stats.getFilterCollectionCompleted().update(1);
+        recordCollectionTime();
+        if (extendedMetrics && !filterId.isEmpty()) {
+            long rangeCount = (mergedConstraint instanceof DomainRuntimeFilter)
+                    ? computeRangeCount(((DomainRuntimeFilter) mergedConstraint).getDomain())
+                    : 0;
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_DOMAIN_RANGE_COUNT, filterId), NONE, rangeCount);
+        }
+    }
+
+    private synchronized void onTimeout()
+    {
+        if (!filterId.isEmpty()) {
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_TIMED_OUT, filterId), NONE, 1);
+        }
+        stats.getFilterCollectionTimedOut().update(1);
+        recordCollectionTime();
+    }
+
+    @GuardedBy("this")
+    private void recordCollectionTime()
+    {
+        if (collectionStarted && !collectionTimeRecorded) {
+            collectionTimeRecorded = true;
+            long elapsedNanos = System.nanoTime() - collectionStartNanos;
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_COLLECTION_TIME_NANOS, NANO, elapsedNanos);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_COLLECTION_TIME_NANOS, filterId), NANO, elapsedNanos);
+            }
+        }
+    }
+
+    static long computeRangeCount(TupleDomain<String> tupleDomain)
+    {
+        if (tupleDomain.isNone() || !tupleDomain.getDomains().isPresent()) {
+            return 0;
+        }
+        return tupleDomain.getDomains().get().values().stream()
+                .filter(domain -> domain.getValues() instanceof SortedRangeSet)
+                .mapToLong(domain -> domain.getValues().getRanges().getRangeCount())
+                .sum();
+    }
+
+    public CompletableFuture<?> isBlocked()
+    {
+        if (constraintByFilterIdFuture.isDone()) {
+            return NOT_BLOCKED;
+        }
+        return constraintByFilterIdFuture.thenApply(v -> null);
+    }
+
+    /** Returns all() until fully resolved. */
+    public synchronized TupleDomain<String> getCurrentConstraintByColumnName()
+    {
+        if (!fullyResolved || mergedConstraint == null) {
+            return TupleDomain.all();
+        }
+        Type type = probeColumnDomain != null ? probeColumnDomain.getType() : null;
+        return mergedConstraint.toTupleDomain(columnName, type);
+    }
+
+    /** Fires only on normal completion, not on timeout. */
+    public void onFullyResolved(BiConsumer<String, RuntimeFilter> callback)
+    {
+        constraintByFilterIdFuture.whenComplete((filter, throwable) -> {
+            if (fullyResolved && throwable == null) {
+                callback.accept(filterId, new DomainRuntimeFilter(getCurrentConstraintByColumnName()));
+            }
+        });
+    }
+
+    public synchronized boolean hasData()
+    {
+        return !partitionsByFilterId.isEmpty();
+    }
+
+    public static DynamicFilter createDisabled()
+    {
+        return DynamicFilter.EMPTY;
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return toStringHelper(this)
+                .add("filterId", filterId)
+                .add("columnName", columnName)
+                .add("waitTimeout", waitTimeout)
+                .add("expectedPartitions", expectedPartitions)
+                .add("receivedPartitions", partitionsByFilterId.size())
+                .add("complete", fullyResolved)
+                .toString();
+    }
+
+    private void scheduleTick(long timeoutMs)
+    {
+        timeoutScheduler.schedule(this::onTick, timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void onTick()
+    {
+        boolean reschedule;
+        synchronized (this) {
+            if (constraintByFilterIdFuture.isDone()) {
+                return;
+            }
+            int currentReceived = partitionsByFilterId.size();
+            boolean progress = currentReceived > lastTickPartitionCount;
+            lastTickPartitionCount = currentReceived;
+            if (progress && extensionsUsed < maxWaitExtensions) {
+                extensionsUsed++;
+                reschedule = true;
+            }
+            else {
+                // Finalize inside the monitor so a concurrent addPartitionByFilterId either
+                // resolves the filter first (and this tick observes isDone) or sees the
+                // future already completed and bails — partial state is never exposed.
+                constraintByFilterIdFuture.complete(new DomainRuntimeFilter(TupleDomain.all()));
+                onTimeout();
+                reschedule = false;
+            }
+        }
+        if (reschedule) {
+            scheduleTick(waitTimeout.toMillis());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
@@ -26,8 +26,6 @@ import com.google.errorprone.annotations.ThreadSafe;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -48,6 +46,7 @@ import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.spi.connector.DynamicFilter.NOT_BLOCKED;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -85,12 +84,15 @@ public class JoinDynamicFilter
     private final Duration waitTimeout;
     private final int maxWaitExtensions;
     private final long maxSizeInBytes;
-    private final DynamicFilterStats stats;
+    private final DynamicFilterServiceStats stats;
     private final RuntimeStats runtimeStats;
     private final boolean extendedMetrics;
 
+    // Partitions are merged incrementally on arrival; no list is retained.
     @GuardedBy("this")
-    private final List<RuntimeFilter> partitionsByFilterId = new ArrayList<>();
+    private RuntimeFilter runningUnion;
+    @GuardedBy("this")
+    private int partitionsReceived;
     private final CompletableFuture<RuntimeFilter> constraintByFilterIdFuture;
 
     private final AtomicBoolean timeoutStarted = new AtomicBoolean(false);
@@ -122,7 +124,7 @@ public class JoinDynamicFilter
             String columnName,
             Duration waitTimeout,
             long maxSizeInBytes,
-            DynamicFilterStats stats,
+            DynamicFilterServiceStats stats,
             RuntimeStats runtimeStats,
             boolean extendedMetrics)
     {
@@ -135,7 +137,7 @@ public class JoinDynamicFilter
             Duration waitTimeout,
             int maxWaitExtensions,
             long maxSizeInBytes,
-            DynamicFilterStats stats,
+            DynamicFilterServiceStats stats,
             RuntimeStats runtimeStats,
             boolean extendedMetrics)
     {
@@ -149,7 +151,7 @@ public class JoinDynamicFilter
             Duration waitTimeout,
             int maxWaitExtensions,
             long maxSizeInBytes,
-            DynamicFilterStats stats,
+            DynamicFilterServiceStats stats,
             RuntimeStats runtimeStats,
             boolean extendedMetrics,
             ScheduledExecutorService timeoutScheduler)
@@ -157,7 +159,7 @@ public class JoinDynamicFilter
         this.filterId = requireNonNull(filterId, "filterId is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.waitTimeout = requireNonNull(waitTimeout, "waitTimeout is null");
-        verify(maxWaitExtensions >= 0, "maxWaitExtensions must be non-negative");
+        checkArgument(maxWaitExtensions >= 0, "maxWaitExtensions must be non-negative");
         this.maxWaitExtensions = maxWaitExtensions;
         this.maxSizeInBytes = maxSizeInBytes;
         this.expectedPartitions = Integer.MAX_VALUE;
@@ -200,7 +202,7 @@ public class JoinDynamicFilter
             if (timeoutMs > 0) {
                 // Baseline so pre-startTimeout contributions aren't credited as new progress on the first tick.
                 synchronized (this) {
-                    lastTickPartitionCount = partitionsByFilterId.size();
+                    lastTickPartitionCount = partitionsReceived;
                 }
                 scheduleTick(timeoutMs);
             }
@@ -250,7 +252,9 @@ public class JoinDynamicFilter
                 collectionStarted = true;
             }
 
-            partitionsByFilterId.add(filter);
+            // Merge incrementally on arrival to avoid re-scanning the full list at completion.
+            runningUnion = (runningUnion == null) ? filter : runningUnion.mergeWith(filter);
+            partitionsReceived++;
 
             runtimeStats.addMetricValue(DYNAMIC_FILTER_PARTITIONS_RECEIVED, NONE, 1);
             if (!filterId.isEmpty()) {
@@ -268,15 +272,11 @@ public class JoinDynamicFilter
     @GuardedBy("this")
     private RuntimeFilter tryCompleteResolution()
     {
-        if (constraintByFilterIdFuture.isDone() || partitionsByFilterId.size() < expectedPartitions) {
+        if (constraintByFilterIdFuture.isDone() || partitionsReceived < expectedPartitions) {
             return null;
         }
 
-        RuntimeFilter union = partitionsByFilterId.get(0);
-        for (int i = 1; i < partitionsByFilterId.size(); i++) {
-            union = union.mergeWith(partitionsByFilterId.get(i));
-        }
-        mergedConstraint = collapseIfOversized(union);
+        mergedConstraint = collapseIfOversized(runningUnion);
         maybeShortCircuit();
         fullyResolved = true;
         recordCollectionCompleted();
@@ -401,7 +401,9 @@ public class JoinDynamicFilter
         if (!fullyResolved || mergedConstraint == null) {
             return TupleDomain.all();
         }
-        Type type = probeColumnDomain != null ? probeColumnDomain.getType() : null;
+        // type may be null when no probe-column domain has been set; implementations
+        // that need it (e.g. future BloomRuntimeFilter) should handle null gracefully.
+        @javax.annotation.Nullable Type type = probeColumnDomain != null ? probeColumnDomain.getType() : null;
         return mergedConstraint.toTupleDomain(columnName, type);
     }
 
@@ -417,7 +419,7 @@ public class JoinDynamicFilter
 
     public synchronized boolean hasData()
     {
-        return !partitionsByFilterId.isEmpty();
+        return partitionsReceived > 0;
     }
 
     public static DynamicFilter createDisabled()
@@ -433,7 +435,7 @@ public class JoinDynamicFilter
                 .add("columnName", columnName)
                 .add("waitTimeout", waitTimeout)
                 .add("expectedPartitions", expectedPartitions)
-                .add("receivedPartitions", partitionsByFilterId.size())
+                .add("receivedPartitions", partitionsReceived)
                 .add("complete", fullyResolved)
                 .toString();
     }
@@ -446,11 +448,12 @@ public class JoinDynamicFilter
     private void onTick()
     {
         boolean reschedule;
+        RuntimeFilter timedOut = null;
         synchronized (this) {
             if (constraintByFilterIdFuture.isDone()) {
                 return;
             }
-            int currentReceived = partitionsByFilterId.size();
+            int currentReceived = partitionsReceived;
             boolean progress = currentReceived > lastTickPartitionCount;
             lastTickPartitionCount = currentReceived;
             if (progress && extensionsUsed < maxWaitExtensions) {
@@ -458,13 +461,15 @@ public class JoinDynamicFilter
                 reschedule = true;
             }
             else {
-                // Finalize inside the monitor so a concurrent addPartitionByFilterId either
-                // resolves the filter first (and this tick observes isDone) or sees the
-                // future already completed and bails — partial state is never exposed.
-                constraintByFilterIdFuture.complete(new DomainRuntimeFilter(TupleDomain.all()));
+                timedOut = new DomainRuntimeFilter(TupleDomain.all());
                 onTimeout();
                 reschedule = false;
             }
+        }
+        // Complete the future outside the monitor, following the setExpectedPartitions pattern,
+        // so CompletableFuture callbacks cannot deadlock against the class monitor.
+        if (timedOut != null) {
+            constraintByFilterIdFuture.complete(timedOut);
         }
         if (reschedule) {
             scheduleTick(waitTimeout.toMillis());

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
@@ -22,9 +22,9 @@ import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.connector.DynamicFilter;
 import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.ThreadSafe;
 
 import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,26 @@ import static com.google.common.base.Verify.verify;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-// Does not implement DynamicFilter; the SPI-facing wrapper is TableScanDynamicFilter.
+/**
+ * Collects per-partition {@link RuntimeFilter} contributions from build-side tasks for a
+ * single join dynamic filter, merges them on completion, and exposes the result as a
+ * {@link TupleDomain} keyed by probe column name.
+ *
+ * <p>Each {@code JoinDynamicFilter} targets exactly one join column ({@code columnName})
+ * and one filter ID ({@code filterId}). It accumulates one {@link RuntimeFilter} per
+ * build partition via {@link #addPartitionByFilterId}. When all {@code expectedPartitions}
+ * have arrived, the contributions are union-merged and, if the result exceeds
+ * {@code maxSizeInBytes}, collapsed to a min/max range.
+ *
+ * <p>An adaptive timeout fires after {@code waitTimeout}; if new contributions arrived
+ * since the last tick, up to {@code maxWaitExtensions} additional cycles are granted.
+ * On expiry the future completes with {@code TupleDomain.all()} so the probe side
+ * can proceed without a filter.
+ *
+ * <p>This class does not implement {@link com.facebook.presto.spi.connector.DynamicFilter}
+ * directly. The SPI-facing wrapper is {@link TableScanDynamicFilter}, which intersects
+ * one or more {@code JoinDynamicFilter}s and exposes them to the connector split source.
+ */
 @ThreadSafe
 public class JoinDynamicFilter
 {
@@ -310,9 +329,9 @@ public class JoinDynamicFilter
             return;
         }
         Map<String, Domain> domains = tupleDomain.getDomains().get();
-        if (domains.size() != 1) {
-            return;
-        }
+        verify(domains.size() == 1,
+                "Expected single-column domain in maybeShortCircuit but got %s columns: %s",
+                domains.size(), domains.keySet());
         Domain filterDomain = domains.values().iterator().next();
         if (filterDomain.contains(probeColumnDomain)) {
             mergedConstraint = new DomainRuntimeFilter(TupleDomain.all());
@@ -391,7 +410,7 @@ public class JoinDynamicFilter
     {
         constraintByFilterIdFuture.whenComplete((filter, throwable) -> {
             if (fullyResolved && throwable == null) {
-                callback.accept(filterId, new DomainRuntimeFilter(getCurrentConstraintByColumnName()));
+                callback.accept(filterId, filter);
             }
         });
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+// Wire form: a bare TupleDomain (no @kind field) decodes to DomainRuntimeFilter for back-compat.
+@JsonDeserialize(using = RuntimeFilterDeserializer.class)
+public interface RuntimeFilter
+{
+    /** Throws if representations are incompatible. */
+    RuntimeFilter mergeWith(RuntimeFilter other);
+
+    TupleDomain<String> toTupleDomain(String column, Type type);
+
+    boolean isAll();
+
+    boolean isNone();
+
+    long estimatedRetainedSizeInBytes();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
@@ -17,13 +17,36 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-// Wire form: a bare TupleDomain (no @kind field) decodes to DomainRuntimeFilter for back-compat.
+/**
+ * Polymorphic carrier for a single-column dynamic filter contribution produced by one
+ * build-side partition.
+ *
+ * <p>Each implementation represents a filter over exactly one join column. The two
+ * current representations are:
+ * <ul>
+ *   <li>{@link DomainRuntimeFilter} — a {@link TupleDomain} of discrete values or ranges,
+ *       used for all current filter delivery.</li>
+ *   <li>Future: {@code BloomRuntimeFilter} — a Bloom filter for high-cardinality keys;
+ *       handled by {@link RuntimeFilterDeserializer} via {@code @kind: "bloom"}.</li>
+ * </ul>
+ *
+ * <p>Wire form: a bare {@code TupleDomain} JSON object (no {@code @kind} field) decodes
+ * to {@link DomainRuntimeFilter} for back-compat. An unknown {@code @kind} value causes
+ * deserialization to fail fast.
+ */
 @JsonDeserialize(using = RuntimeFilterDeserializer.class)
 public interface RuntimeFilter
 {
-    /** Throws if representations are incompatible. */
+    /** Union-merges this filter with {@code other}. Throws if representations are incompatible. */
     RuntimeFilter mergeWith(RuntimeFilter other);
 
+    /**
+     * Re-keys this filter's single column entry to {@code column} for use by the connector.
+     *
+     * @param column  the probe-side column name to use as the {@link TupleDomain} key
+     * @param type    the probe column's {@link Type}; may be used by implementations
+     *                that need type-specific conversion (e.g. coercion for Bloom filters)
+     */
     TupleDomain<String> toTupleDomain(String column, Type type);
 
     boolean isAll();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilterDeserializer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilterDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class RuntimeFilterDeserializer
+        extends JsonDeserializer<RuntimeFilter>
+{
+    private static final TypeReference<TupleDomain<String>> TUPLE_DOMAIN_TYPE = new TypeReference<TupleDomain<String>>() {};
+
+    @Override
+    public RuntimeFilter deserialize(JsonParser parser, DeserializationContext context)
+            throws IOException
+    {
+        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        JsonNode node = mapper.readTree(parser);
+        JsonNode kind = node.get("@kind");
+
+        if (kind != null && !"tupleDomain".equals(kind.asText())) {
+            throw new IOException("Unknown RuntimeFilter @kind: " + kind.asText());
+        }
+
+        JsonNode domainNode = (kind != null && node.has("domain")) ? node.get("domain") : node;
+        return new DomainRuntimeFilter(mapper.convertValue(domainNode, TUPLE_DOMAIN_TYPE));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableScanDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableScanDynamicFilter.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.joining;
+
+@ThreadSafe
+public class TableScanDynamicFilter
+        implements DynamicFilter
+{
+    private final List<JoinDynamicFilter> filters;
+    private final Map<String, ColumnHandle> columnNameToHandle;
+    private final Duration waitTimeout;
+    private volatile int taskCountHint;
+
+    public TableScanDynamicFilter(List<JoinDynamicFilter> filters, Map<String, ColumnHandle> columnNameToHandle)
+    {
+        requireNonNull(filters, "filters is null");
+        requireNonNull(columnNameToHandle, "columnNameToHandle is null");
+        verify(!filters.isEmpty(), "filters list cannot be empty");
+
+        this.filters = ImmutableList.copyOf(filters);
+        this.columnNameToHandle = ImmutableMap.copyOf(columnNameToHandle);
+
+        for (JoinDynamicFilter filter : this.filters) {
+            String columnName = filter.getColumnName();
+            verify(this.columnNameToHandle.containsKey(columnName),
+                    "Dynamic filter column '%s' not found in scan columns: %s",
+                    columnName, this.columnNameToHandle.keySet());
+        }
+
+        this.waitTimeout = filters.stream()
+                .map(JoinDynamicFilter::getWaitTimeout)
+                .min(Comparator.comparing(Duration::toMillis))
+                .orElse(new Duration(0, MILLISECONDS));
+    }
+
+    public List<JoinDynamicFilter> getFilters()
+    {
+        return filters;
+    }
+
+    public void setTaskCountHint(int taskCountHint)
+    {
+        this.taskCountHint = taskCountHint;
+    }
+
+    @Override
+    public int getTaskCountHint()
+    {
+        return taskCountHint;
+    }
+
+    @Override
+    public TupleDomain<ColumnHandle> getCurrentPredicate()
+    {
+        return filters.stream()
+                .map(JoinDynamicFilter::getCurrentConstraintByColumnName)
+                .map(this::translateToColumnHandle)
+                .reduce(TupleDomain::intersect)
+                .orElse(TupleDomain.all());
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return isBlocked(Optional.empty());
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        filters.forEach(JoinDynamicFilter::startTimeout);
+
+        List<CompletableFuture<?>> pendingFutures = getRelevantFilters(relevantColumns).stream()
+                .map(JoinDynamicFilter::isBlocked)
+                .filter(future -> !future.isDone())
+                .collect(toImmutableList());
+
+        if (pendingFutures.isEmpty()) {
+            return NOT_BLOCKED;
+        }
+
+        return CompletableFuture.anyOf(pendingFutures.toArray(new CompletableFuture[0]));
+    }
+
+    @Override
+    public Duration getWaitTimeout()
+    {
+        return waitTimeout;
+    }
+
+    @Override
+    public boolean isComplete()
+    {
+        return isComplete(Optional.empty());
+    }
+
+    @Override
+    public boolean isComplete(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        return getRelevantFilters(relevantColumns).stream()
+                .allMatch(JoinDynamicFilter::isComplete);
+    }
+
+    @Override
+    public boolean hasAnyComplete(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        List<JoinDynamicFilter> relevant = getRelevantFilters(relevantColumns);
+        return relevant.isEmpty() || relevant.stream().anyMatch(JoinDynamicFilter::isComplete);
+    }
+
+    @Override
+    public Set<ColumnHandle> getPendingFilterColumns()
+    {
+        return filters.stream()
+                .filter(f -> !f.isComplete())
+                .map(f -> columnNameToHandle.get(f.getColumnName()))
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    private List<JoinDynamicFilter> getRelevantFilters(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        if (!relevantColumns.isPresent()) {
+            return filters;
+        }
+
+        Set<ColumnHandle> columns = relevantColumns.get();
+        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        for (Map.Entry<String, ColumnHandle> entry : columnNameToHandle.entrySet()) {
+            if (columns.contains(entry.getValue())) {
+                builder.add(entry.getKey());
+            }
+        }
+        Set<String> relevantColumnNames = builder.build();
+
+        return filters.stream()
+                .filter(f -> relevantColumnNames.contains(f.getColumnName()))
+                .collect(toImmutableList());
+    }
+
+    public String getFilterId()
+    {
+        return filters.stream()
+                .map(JoinDynamicFilter::getFilterId)
+                .collect(joining(","));
+    }
+
+    private TupleDomain<ColumnHandle> translateToColumnHandle(TupleDomain<String> columnNameDomain)
+    {
+        return columnNameDomain.transform(columnNameToHandle::get);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("filterCount", filters.size())
+                .add("filterIds", getFilterId())
+                .add("columnNameToHandle", columnNameToHandle)
+                .add("waitTimeout", waitTimeout)
+                .add("complete", isComplete())
+                .toString();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestDynamicFilterService
+{
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+
+    private DynamicFilterService service;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        service = new DynamicFilterService();
+    }
+
+    @Test
+    public void testRegisterAndGet()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        String filterId = "filter_1";
+        JoinDynamicFilter filter = createTestFilter();
+
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertTrue(retrieved.isPresent());
+        assertEquals(retrieved.get(), filter);
+        assertEquals(service.getStats().getFilterRegistrations().getTotalCount(), 1);
+    }
+
+    @Test
+    public void testGetNonexistent()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+        String filterId = "nonexistent_filter";
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void testGetNonexistentFilter()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, "nonexistent_filter");
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void testHasFilter()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        String filterId = "filter_1";
+        JoinDynamicFilter filter = createTestFilter();
+
+        assertFalse(service.hasFilter(queryId, filterId));
+
+        service.registerFilter(queryId, filterId, filter);
+        assertTrue(service.hasFilter(queryId, filterId));
+
+        assertFalse(service.hasFilter(queryId, "other_filter"));
+    }
+
+    @Test
+    public void testRemoveFiltersForQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.hasFilter(queryId, "filter_2"));
+
+        service.removeFiltersForQuery(queryId);
+
+        assertFalse(service.hasFilter(queryId, "filter_1"));
+        assertFalse(service.hasFilter(queryId, "filter_2"));
+    }
+
+    @Test
+    public void testMultipleQueries()
+    {
+        QueryId queryId1 = QueryId.valueOf("test_query_1");
+        QueryId queryId2 = QueryId.valueOf("test_query_2");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId1, "filter_1", filter1);
+        service.registerFilter(queryId2, "filter_1", filter2);
+
+        java.util.Optional<JoinDynamicFilter> retrieved1 = service.getFilter(queryId1, "filter_1");
+        java.util.Optional<JoinDynamicFilter> retrieved2 = service.getFilter(queryId2, "filter_1");
+
+        assertTrue(retrieved1.isPresent());
+        assertTrue(retrieved2.isPresent());
+        assertEquals(retrieved1.get(), filter1);
+        assertEquals(retrieved2.get(), filter2);
+
+        service.removeFiltersForQuery(queryId1);
+        assertFalse(service.hasFilter(queryId1, "filter_1"));
+        assertTrue(service.hasFilter(queryId2, "filter_1"));
+    }
+
+    @Test
+    public void testMultipleFiltersPerQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+        JoinDynamicFilter filter3 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+        service.registerFilter(queryId, "filter_3", filter3);
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.hasFilter(queryId, "filter_2"));
+        assertTrue(service.hasFilter(queryId, "filter_3"));
+
+        assertEquals(service.getFilter(queryId, "filter_1").get(), filter1);
+        assertEquals(service.getFilter(queryId, "filter_2").get(), filter2);
+        assertEquals(service.getFilter(queryId, "filter_3").get(), filter3);
+        assertEquals(service.getStats().getFilterRegistrations().getTotalCount(), 3);
+    }
+
+    @Test
+    public void testGetAllFiltersForQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+
+        Map<String, JoinDynamicFilter> allFilters = service.getAllFiltersForQuery(queryId);
+        assertEquals(allFilters.size(), 2);
+        assertEquals(allFilters.get("filter_1"), filter1);
+        assertEquals(allFilters.get("filter_2"), filter2);
+    }
+
+    @Test
+    public void testGetAllFiltersForNonexistentQuery()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+
+        Map<String, JoinDynamicFilter> allFilters = service.getAllFiltersForQuery(queryId);
+        assertTrue(allFilters.isEmpty());
+    }
+
+    @Test
+    public void testFilterIdPreserved()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_filter_id");
+        String filterId = "549";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertTrue(retrieved.isPresent());
+        assertEquals(retrieved.get().getFilterId(), filterId);
+    }
+
+    @Test
+    public void testScanFilterMapping()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_scan_mapping");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+        Set<String> filterIds = ImmutableSet.of("filter_1", "filter_2");
+
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+
+        service.registerScanFilterMapping(queryId, scanNodeId, filterIds);
+
+        Set<String> retrieved = service.getFilterIdsForScan(queryId, scanNodeId);
+        assertEquals(retrieved, filterIds);
+    }
+
+    @Test
+    public void testScanFilterMappingMultipleScans()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_multi_scan");
+        PlanNodeId scan1 = new PlanNodeId("scan_1");
+        PlanNodeId scan2 = new PlanNodeId("scan_2");
+
+        service.registerScanFilterMapping(queryId, scan1, ImmutableSet.of("filter_1"));
+        service.registerScanFilterMapping(queryId, scan2, ImmutableSet.of("filter_2", "filter_3"));
+
+        assertEquals(service.getFilterIdsForScan(queryId, scan1), ImmutableSet.of("filter_1"));
+        assertEquals(service.getFilterIdsForScan(queryId, scan2), ImmutableSet.of("filter_2", "filter_3"));
+    }
+
+    @Test
+    public void testScanFilterMappingMergesOnDuplicateRegistration()
+    {
+        // Regression test: registerScanFilterMapping must merge filter IDs
+        // when called multiple times for the same scan (e.g., local filters
+        // from Step 1 and cross-fragment filters from Step 2).
+        QueryId queryId = QueryId.valueOf("test_query_merge");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_date"));
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_customer"));
+
+        assertEquals(service.getFilterIdsForScan(queryId, scanNodeId),
+                ImmutableSet.of("filter_date", "filter_customer"));
+    }
+
+    @Test
+    public void testScanFilterMappingNonexistent()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+    }
+
+    @Test
+    public void testRemoveFiltersAlsoClearsScanMappings()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_cleanup");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerFilter(queryId, "filter_1", createTestFilter());
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_1"));
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertEquals(service.getFilterIdsForScan(queryId, scanNodeId), ImmutableSet.of("filter_1"));
+
+        service.removeFiltersForQuery(queryId);
+        assertFalse(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+    }
+
+    @Test
+    public void testScanFilterMappingIsolationBetweenQueries()
+    {
+        QueryId query1 = QueryId.valueOf("test_query_1");
+        QueryId query2 = QueryId.valueOf("test_query_2");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerScanFilterMapping(query1, scanNodeId, ImmutableSet.of("filter_1"));
+        service.registerScanFilterMapping(query2, scanNodeId, ImmutableSet.of("filter_2"));
+
+        assertEquals(service.getFilterIdsForScan(query1, scanNodeId), ImmutableSet.of("filter_1"));
+        assertEquals(service.getFilterIdsForScan(query2, scanNodeId), ImmutableSet.of("filter_2"));
+
+        service.removeFiltersForQuery(query1);
+        assertTrue(service.getFilterIdsForScan(query1, scanNodeId).isEmpty());
+        assertEquals(service.getFilterIdsForScan(query2, scanNodeId), ImmutableSet.of("filter_2"));
+    }
+
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private JoinDynamicFilter createTestFilter()
+    {
+        return new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+
+    private JoinDynamicFilter createTestFilterWithId(String filterId)
+    {
+        return new JoinDynamicFilter(
+                filterId,
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
@@ -296,7 +296,7 @@ public class TestDynamicFilterService
                 "",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 new RuntimeStats(),
                 false);
     }
@@ -308,7 +308,7 @@ public class TestDynamicFilterService
                 "column_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 new RuntimeStats(),
                 false);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
@@ -1,0 +1,1013 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLLECTION_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_DOMAIN_RANGE_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PARTITIONS_RECEIVED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SHORT_CIRCUITED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_TIMED_OUT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestJoinDynamicFilter
+{
+    private static final String DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE = DYNAMIC_FILTER_COLLECTION_TIME_NANOS + "[%s]";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE = DYNAMIC_FILTER_PARTITIONS_RECEIVED + "[%s]";
+    private static final String DYNAMIC_FILTER_TIMED_OUT_TEMPLATE = DYNAMIC_FILTER_TIMED_OUT + "[%s]";
+    private static final String DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE = DYNAMIC_FILTER_DOMAIN_RANGE_COUNT + "[%s]";
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private static final TaskId TASK_0 = TaskId.valueOf("query.0.0.0.0");
+    private static final TaskId TASK_1 = TaskId.valueOf("query.0.0.1.0");
+    private static final TaskId TASK_2 = TaskId.valueOf("query.0.0.2.0");
+
+    @Test
+    public void testPerFilterMetrics()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+
+        assertTrue(filter.isComplete());
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_PARTITIONS_RECEIVED),
+                "Aggregate PARTITIONS_RECEIVED should be present");
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_PARTITIONS_RECEIVED).getSum(), 2);
+
+        String perFilterPartitions = format(DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterPartitions),
+                "Per-filter PARTITIONS_RECEIVED[549] should be present");
+        assertEquals(runtimeStats.getMetrics().get(perFilterPartitions).getSum(), 2);
+
+        String perFilterCollectionTime = format(DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterCollectionTime),
+                "Per-filter COLLECTION_TIME_NANOS[549] should be present");
+        assertTrue(runtimeStats.getMetrics().get(perFilterCollectionTime).getSum() > 0,
+                "Per-filter collection time should be positive");
+
+        String perFilterRangeCount = format(DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterRangeCount),
+                "Per-filter DOMAIN_RANGE_COUNT[549] should be present with extendedMetrics");
+        assertEquals(runtimeStats.getMetrics().get(perFilterRangeCount).getSum(), 2,
+                "Domain range count should be 2 for two single-value partitions");
+    }
+
+    @Test
+    public void testPeekFilterReturnsAllWhenNotResolved()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(3);
+
+        // No partitions received — should return all()
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // One partition finalized (partial w.r.t. expected) — should still return all()
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // Two partitions finalized (still partial) — should still return all()
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // All three partitions finalized — now returns actual constraint
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        assertTrue(filter.isComplete());
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(), "Fully resolved filter should return actual constraint, not all()");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+    }
+
+    @Test
+    public void testTimeoutDoesNotResolveFilter()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                new Duration(100, TimeUnit.MILLISECONDS),
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        filter.startTimeout();
+        Thread.sleep(300);
+
+        // Future is done (timeout) but filter is NOT fully resolved
+        assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data should not be exposed after timeout");
+    }
+
+    @Test
+    public void testNoPerFilterMetricsWithEmptyFilterId()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(filter.isComplete());
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_PARTITIONS_RECEIVED));
+
+        assertFalse(runtimeStats.getMetrics().keySet().stream().anyMatch(k -> k.contains("[")),
+                "No bracket-notation metrics should be present with empty filterId");
+    }
+
+    @Test
+    public void testGetFilterId()
+    {
+        JoinDynamicFilter defaultFilter = new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+        assertEquals(defaultFilter.getFilterId(), "");
+
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter namedFilter = new JoinDynamicFilter(
+                "549",
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        assertEquals(namedFilter.getFilterId(), "549");
+    }
+
+    @Test
+    public void testIsBlockedBeforeAndAfterResolution()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        CompletableFuture<?> blocked = filter.isBlocked();
+        assertFalse(blocked.isDone());
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertTrue(blocked.isDone());
+
+        assertEquals(filter.isBlocked(), DynamicFilter.NOT_BLOCKED);
+    }
+
+    @Test
+    public void testGetWaitTimeout()
+    {
+        Duration timeout = new Duration(5, TimeUnit.SECONDS);
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "",
+                "",
+                timeout,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+
+        assertEquals(filter.getWaitTimeout(), timeout);
+    }
+
+    @Test
+    public void testCreateDisabled()
+    {
+        assertEquals(JoinDynamicFilter.createDisabled(), DynamicFilter.EMPTY);
+    }
+
+    @Test
+    public void testTimeoutEmitsMetric()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        DynamicFilterStats stats = new DynamicFilterStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                new Duration(100, TimeUnit.MILLISECONDS),
+                DEFAULT_MAX_SIZE_BYTES,
+                stats,
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        filter.startTimeout();
+        Thread.sleep(300);
+
+        assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
+
+        String timeoutKey = format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(timeoutKey),
+                "Timeout metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(timeoutKey).getSum(), 1);
+
+        assertEquals(stats.getFilterCollectionTimedOut().getTotalCount(), 1);
+
+        String collectionTimeKey = format(DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(collectionTimeKey),
+                "Collection time should be emitted on timeout with extendedMetrics");
+        assertTrue(runtimeStats.getMetrics().get(collectionTimeKey).getSum() > 0,
+                "Collection time should be positive");
+    }
+
+    @Test
+    public void testNoTimeoutMetricOnSuccess()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(filter.isComplete());
+
+        String timeoutKey = format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549");
+        assertFalse(runtimeStats.getMetrics().containsKey(timeoutKey),
+                "Timeout metric should not be emitted on successful completion");
+    }
+
+    @Test
+    public void testDomainRangeCountForNone()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.none());
+
+        assertTrue(filter.isComplete());
+
+        String rangeCountKey = format(DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(rangeCountKey),
+                "Domain range count should be emitted for none()");
+        assertEquals(runtimeStats.getMetrics().get(rangeCountKey).getSum(), 0,
+                "Domain range count should be 0 for none() domain");
+    }
+
+    @Test
+    public void testComputeRangeCount()
+    {
+        assertEquals(JoinDynamicFilter.computeRangeCount(TupleDomain.none()), 0);
+        assertEquals(JoinDynamicFilter.computeRangeCount(TupleDomain.all()), 0);
+
+        TupleDomain<String> singleValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 10L)));
+        assertEquals(JoinDynamicFilter.computeRangeCount(singleValue), 1);
+
+        TupleDomain<String> multiValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L))));
+        assertEquals(JoinDynamicFilter.computeRangeCount(multiValue), 3);
+    }
+
+    @Test
+    public void testNoCollapseWhenUnderSizeLimit()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        // Default max size (1 MB) — small discrete-value filters should complete normally,
+        // not be collapsed to range.
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1_048_576L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 3);
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE),
+                "Fallback metric should not be emitted when under size limit");
+    }
+
+    @Test
+    public void testEstimateRetainedSizeInBytes()
+    {
+        assertEquals(new DomainRuntimeFilter(TupleDomain.none()).estimatedRetainedSizeInBytes(), 0);
+        assertEquals(new DomainRuntimeFilter(TupleDomain.all()).estimatedRetainedSizeInBytes(), 0);
+
+        // block storage for low + high markers
+        TupleDomain<String> singleValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 10L)));
+        assertTrue(new DomainRuntimeFilter(singleValue).estimatedRetainedSizeInBytes() > 0);
+
+        TupleDomain<String> multiValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L))));
+        assertTrue(new DomainRuntimeFilter(multiValue).estimatedRetainedSizeInBytes() >
+                new DomainRuntimeFilter(singleValue).estimatedRetainedSizeInBytes());
+    }
+
+    @Test
+    public void testNoCollapseWithDefaultSize()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        // 100 values still well under 1 MB — should not collapse
+        List<Long> values = new ArrayList<>();
+        for (long i = 0; i < 100; i++) {
+            values.add(i);
+        }
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, values))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 100);
+    }
+
+    @Test
+    public void testShortCircuitWhenBuildCoversProbe()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L, 4L, 5L)))));
+
+        assertTrue(filter.isComplete());
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Filter should short-circuit to all() when build covers probe");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED),
+                "Aggregate short-circuit metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_SHORT_CIRCUITED).getSum(), 1);
+    }
+
+    @Test
+    public void testShortCircuitEmitsPerFilterMetric()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+
+        String perFilterKey = format("%s[%s]", DYNAMIC_FILTER_SHORT_CIRCUITED, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterKey),
+                "Per-filter DYNAMIC_FILTER_SHORT_CIRCUITED[549] should be present");
+        assertEquals(runtimeStats.getMetrics().get(perFilterKey).getSum(), 1);
+    }
+
+    @Test
+    public void testNoShortCircuitWhenBuildDoesNotCoverProbe()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L, 4L, 5L)));
+        filter.setExpectedPartitions(1);
+
+        // build covers [1,2,3] but probe has [1,2,3,4,5] — cannot short-circuit
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(),
+                "Filter should NOT short-circuit when build does not cover probe");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED),
+                "Short-circuit metric should NOT be emitted when build does not cover probe");
+    }
+
+    @Test
+    public void testNoShortCircuitWithoutProbeColumnDomain()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(),
+                "Filter should NOT short-circuit without probeColumnDomain");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testShortCircuitViaSetExpectedPartitions()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L)));
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+        assertFalse(filter.isComplete());
+
+        filter.setExpectedPartitions(1);
+        assertTrue(filter.isComplete());
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Short-circuit should fire via setExpectedPartitions path");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testShortCircuitWithExactMatch()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        Domain probeDomain = Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L));
+        filter.setProbeColumnDomain(probeDomain);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Exact match of build and probe domains should short-circuit");
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testNoShortCircuitWhenBuildIsNone()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.none());
+
+        assertTrue(filter.isComplete());
+
+        // none() should NOT be short-circuited — it means the build was empty and
+        // we should prune everything
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertTrue(constraint.isNone(),
+                "none() constraint should be preserved (empty build prunes everything)");
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testSizeBasedCollapseToRange()
+    {
+        // With a tiny max-size, a multi-value domain must collapse to its [min, max]
+        // range when finalized. This exercises the post-Phase-2 completion path.
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L, // force range fallback
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete(),
+                "Range-fallback merge with finalized contributions must complete");
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1,
+                "Discrete values must collapse to a single range");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE).getSum(), 1);
+    }
+
+    @Test
+    public void testSizeBasedCollapseEmitsPerFilterMetric()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+
+        String perFilterKey = format("%s[%s]", DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterKey),
+                "Per-filter fallback-to-range metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(perFilterKey).getSum(), 1);
+    }
+
+    @Test
+    public void testSizeBasedCollapseInSetExpectedPartitions()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L)))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(30L, 40L)))));
+
+        filter.setExpectedPartitions(2);
+
+        assertTrue(filter.isComplete(),
+                "setExpectedPartitions should latch when all tasks already finalized");
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+    }
+
+    @Test
+    public void testCollapseToRange()
+    {
+        TupleDomain<String> multi = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 30L, 50L))));
+        TupleDomain<String> collapsed = JoinDynamicFilter.collapseToRange(multi);
+        Domain domain = collapsed.getDomains().get().get("col");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1);
+        assertTrue(domain.includesNullableValue(10L));
+        assertTrue(domain.includesNullableValue(30L));
+        assertTrue(domain.includesNullableValue(50L));
+        assertTrue(domain.includesNullableValue(40L), "Range collapse must span unseen values between min and max");
+
+        TupleDomain<String> single = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 7L)));
+        assertEquals(JoinDynamicFilter.collapseToRange(single), single);
+
+        assertEquals(JoinDynamicFilter.collapseToRange(TupleDomain.none()), TupleDomain.none());
+        assertEquals(JoinDynamicFilter.collapseToRange(TupleDomain.all()), TupleDomain.all());
+    }
+
+    @Test
+    public void testPartitionedJoinRequiresAllTasksFinalized()
+    {
+        // expectedPartitions=3: completion only when 3 distinct tasks have finalized.
+        // Modeling a HASH-distributed join with 3 build workers.
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertFalse(filter.isComplete(), "1 of 3 finalized — not complete");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        assertFalse(filter.isComplete(), "2 of 3 finalized — not complete");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        assertTrue(filter.isComplete(), "3 of 3 finalized — complete");
+
+        assertEquals(filter.getCurrentConstraintByColumnName(),
+                TupleDomain.withColumnDomains(ImmutableMap.of("col_a",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+    }
+
+    @Test
+    public void testRangeFallbackCompletesOnAllContributionsReceived()
+    {
+        // Q21 wrong-results regression: expectedPartitions=2 with both tasks
+        // contributing — the merge falls back to range. Final constraint is
+        // the union of both contributions, collapsed to a single [min,max] span.
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, 1L /* force range */,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+        assertFalse(filter.isComplete(), "1 of 2 received");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(50L, 60L, 70L)))));
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll());
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1);
+        assertTrue(domain.includesNullableValue(10L));
+        assertTrue(domain.includesNullableValue(70L));
+        assertTrue(domain.includesNullableValue(40L), "Range collapse spans 10-70");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+    }
+
+    @Test
+    public void testLateFinalizationAfterFutureCompleteIsNoOp()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.singleValue(INTEGER, 42L))));
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> resolvedConstraint = filter.getCurrentConstraintByColumnName();
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.singleValue(INTEGER, 100L))));
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), resolvedConstraint);
+    }
+
+    // BEGIN ADAPTIVE-WAIT TESTS
+    private static final Duration ADAPTIVE_CYCLE = new Duration(500, TimeUnit.MILLISECONDS);
+
+    /**
+     * Positive: contributions arrive across two cycles; the first cycle's tick sees
+     * progress (1 -> 2) and extends. The final contribution then resolves the filter
+     * via {@code addPartitionByFilterId} before the extension window expires.
+     */
+    @Test
+    public void testAdaptiveExtensionAllowsLateArrivalToResolve()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                2,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.startTimeout();
+
+        // Well before the first tick: add a second contribution so the tick observes
+        // progress (size went 1 -> 2 vs. baseline of 1) and extends.
+        Thread.sleep(150);
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+
+        // Wait for the first tick to fire and consume one extension, then deliver the
+        // third contribution. tryCompleteResolution on this add will resolve the filter
+        // synchronously since the extension is still in flight.
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis());
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+
+        assertTrue(filter.isComplete(), "Filter should resolve after late arrival within extension window");
+        assertFalse(runtimeStats.getMetrics().containsKey(format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549")),
+                "Filter resolved before timeout; no timed-out metric expected");
+    }
+
+    /**
+     * Negative: a contribution arrived before startTimeout, then no further progress.
+     * lastTickPartitionCount is baselined at startTimeout, so the first tick sees
+     * zero new progress and finalizes immediately without consuming any extension.
+     */
+    @Test
+    public void testNoProgressFinalizesAtFirstCycle()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                3,  // maxWaitExtensions — should NOT be consumed when no progress
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.startTimeout();
+
+        // Wait one cycle plus a buffer; with the startTimeout baseline in place the
+        // first tick observes zero progress and finalizes — no extension consumed.
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis() + 80);
+
+        assertFalse(filter.isComplete(), "Should not resolve without enough contributions");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data must not be exposed after timeout");
+        assertTrue(runtimeStats.getMetrics().containsKey(format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549")),
+                "Filter must be marked timed out");
+    }
+
+    /**
+     * Cap: contributions trickle in every cycle but never reach the expected count.
+     * The filter must finalize after exactly (1 + maxWaitExtensions) cycles.
+     */
+    @Test
+    public void testExtensionsCappedByMaxWaitExtensions()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                2,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(100);
+        filter.startTimeout();
+
+        // Trickle one contribution per cycle for more cycles than the cap permits.
+        // After (1 + 2) = 3 cycles the filter must finalize even though contributions
+        // are still arriving.
+        for (int i = 0; i < 6; i++) {
+            Thread.sleep(ADAPTIVE_CYCLE.toMillis() / 2);
+            filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                    ImmutableMap.of("549", Domain.singleValue(INTEGER, (long) i))));
+        }
+        Thread.sleep(50);
+
+        assertFalse(filter.isComplete(), "Cap should fire before expectedPartitions reached");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data must not be exposed after capped timeout");
+    }
+
+    /**
+     * Correctness: with adaptive extension enabled, the future is completed with
+     * all() on timeout and isComplete() / getCurrentConstraintByColumnName() preserve
+     * the 6c07185b guarantee (no partial constraint exposed).
+     */
+    @Test
+    public void testAdaptiveTimeoutPreservesAllOrNothingContract()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                3,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);  // extendedMetrics off — exercise the non-diagnostic path
+        filter.setExpectedPartitions(4);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        filter.startTimeout();
+
+        // No further contributions. After capped finalize, partial union (10, 20)
+        // must NOT leak to callers; getCurrentConstraintByColumnName stays all().
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis() * (1 + 3) + 80);
+
+        assertFalse(filter.isComplete(),
+                "Filter must remain incomplete after timeout despite partial contributions");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial union (10, 20) must not be exposed to connector");
+        assertTrue(filter.isBlocked().isDone(),
+                "Future must be completed so the connector unblocks");
+
+        // Even a super-late arrival after the future completed must not flip fullyResolved.
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 40L))));
+        assertFalse(filter.isComplete(),
+                "Late arrivals after timeout must not resolve the filter");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+    }
+    // END ADAPTIVE-WAIT TESTS
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
@@ -17,16 +17,24 @@ import com.facebook.airlift.units.Duration;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
-import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.spi.connector.DynamicFilter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLLECTION_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE;
@@ -43,15 +51,11 @@ import static org.testng.Assert.assertTrue;
 public class TestJoinDynamicFilter
 {
     private static final String DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE = DYNAMIC_FILTER_COLLECTION_TIME_NANOS + "[%s]";
-    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE = DYNAMIC_FILTER_PARTITIONS_RECEIVED + "[%s]";
+    private static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE = DYNAMIC_FILTER_PARTITIONS_RECEIVED + "[%s]";
     private static final String DYNAMIC_FILTER_TIMED_OUT_TEMPLATE = DYNAMIC_FILTER_TIMED_OUT + "[%s]";
     private static final String DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE = DYNAMIC_FILTER_DOMAIN_RANGE_COUNT + "[%s]";
     private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
     private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
-
-    private static final TaskId TASK_0 = TaskId.valueOf("query.0.0.0.0");
-    private static final TaskId TASK_1 = TaskId.valueOf("query.0.0.1.0");
-    private static final TaskId TASK_2 = TaskId.valueOf("query.0.0.2.0");
 
     @Test
     public void testPerFilterMetrics()
@@ -142,25 +146,27 @@ public class TestJoinDynamicFilter
 
     @Test
     public void testTimeoutDoesNotResolveFilter()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
+        ManualScheduler scheduler = new ManualScheduler();
 
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
                 new Duration(100, TimeUnit.MILLISECONDS),
+                0,
                 DEFAULT_MAX_SIZE_BYTES,
                 new DynamicFilterStats(),
                 runtimeStats,
-                false);
+                false,
+                scheduler);
         filter.setExpectedPartitions(2);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
 
         filter.startTimeout();
-        Thread.sleep(300);
+        scheduler.tick();
 
         // Future is done (timeout) but filter is NOT fully resolved
         assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
@@ -845,7 +851,6 @@ public class TestJoinDynamicFilter
     }
 
     // BEGIN ADAPTIVE-WAIT TESTS
-    private static final Duration ADAPTIVE_CYCLE = new Duration(500, TimeUnit.MILLISECONDS);
 
     /**
      * Positive: contributions arrive across two cycles; the first cycle's tick sees
@@ -854,34 +859,34 @@ public class TestJoinDynamicFilter
      */
     @Test
     public void testAdaptiveExtensionAllowsLateArrivalToResolve()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
+        ManualScheduler scheduler = new ManualScheduler();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
-                ADAPTIVE_CYCLE,
+                new Duration(500, TimeUnit.MILLISECONDS),
                 2,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
                 new DynamicFilterStats(),
                 runtimeStats,
-                true);
+                true,
+                scheduler);
         filter.setExpectedPartitions(3);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
         filter.startTimeout();
 
-        // Well before the first tick: add a second contribution so the tick observes
-        // progress (size went 1 -> 2 vs. baseline of 1) and extends.
-        Thread.sleep(150);
+        // Add a second contribution so the tick observes progress and extends.
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
 
-        // Wait for the first tick to fire and consume one extension, then deliver the
-        // third contribution. tryCompleteResolution on this add will resolve the filter
-        // synchronously since the extension is still in flight.
-        Thread.sleep(ADAPTIVE_CYCLE.toMillis());
+        // First tick — sees progress (1→2 vs. baseline 1), grants one extension.
+        scheduler.tick();
+        assertFalse(filter.isComplete(), "Should not be complete yet — extension granted");
+
+        // Third contribution arrives; tryCompleteResolution resolves synchronously.
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
 
@@ -897,27 +902,27 @@ public class TestJoinDynamicFilter
      */
     @Test
     public void testNoProgressFinalizesAtFirstCycle()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
+        ManualScheduler scheduler = new ManualScheduler();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
-                ADAPTIVE_CYCLE,
+                new Duration(500, TimeUnit.MILLISECONDS),
                 3,  // maxWaitExtensions — should NOT be consumed when no progress
                 DEFAULT_MAX_SIZE_BYTES,
                 new DynamicFilterStats(),
                 runtimeStats,
-                true);
+                true,
+                scheduler);
         filter.setExpectedPartitions(3);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
         filter.startTimeout();
 
-        // Wait one cycle plus a buffer; with the startTimeout baseline in place the
-        // first tick observes zero progress and finalizes — no extension consumed.
-        Thread.sleep(ADAPTIVE_CYCLE.toMillis() + 80);
+        // First tick observes zero new progress (baseline was set at startTimeout) — finalizes.
+        scheduler.tick();
 
         assertFalse(filter.isComplete(), "Should not resolve without enough contributions");
         assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
@@ -927,35 +932,33 @@ public class TestJoinDynamicFilter
     }
 
     /**
-     * Cap: contributions trickle in every cycle but never reach the expected count.
-     * The filter must finalize after exactly (1 + maxWaitExtensions) cycles.
+     * Cap: contributions trickle in every tick but never reach the expected count.
+     * The filter must finalize after exactly (1 + maxWaitExtensions) ticks.
      */
     @Test
     public void testExtensionsCappedByMaxWaitExtensions()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
+        ManualScheduler scheduler = new ManualScheduler();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
-                ADAPTIVE_CYCLE,
+                new Duration(500, TimeUnit.MILLISECONDS),
                 2,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
                 new DynamicFilterStats(),
                 runtimeStats,
-                true);
+                true,
+                scheduler);
         filter.setExpectedPartitions(100);
         filter.startTimeout();
 
-        // Trickle one contribution per cycle for more cycles than the cap permits.
-        // After (1 + 2) = 3 cycles the filter must finalize even though contributions
-        // are still arriving.
-        for (int i = 0; i < 6; i++) {
-            Thread.sleep(ADAPTIVE_CYCLE.toMillis() / 2);
+        // Trickle one contribution per tick; after (1 + 2) = 3 ticks the cap fires.
+        for (int i = 0; i < 3; i++) {
             filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                     ImmutableMap.of("549", Domain.singleValue(INTEGER, (long) i))));
+            scheduler.tick();
         }
-        Thread.sleep(50);
 
         assertFalse(filter.isComplete(), "Cap should fire before expectedPartitions reached");
         assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
@@ -965,22 +968,23 @@ public class TestJoinDynamicFilter
     /**
      * Correctness: with adaptive extension enabled, the future is completed with
      * all() on timeout and isComplete() / getCurrentConstraintByColumnName() preserve
-     * the 6c07185b guarantee (no partial constraint exposed).
+     * the all-or-nothing contract (no partial constraint exposed).
      */
     @Test
     public void testAdaptiveTimeoutPreservesAllOrNothingContract()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
+        ManualScheduler scheduler = new ManualScheduler();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
-                ADAPTIVE_CYCLE,
+                new Duration(500, TimeUnit.MILLISECONDS),
                 3,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
                 new DynamicFilterStats(),
                 runtimeStats,
-                false);  // extendedMetrics off — exercise the non-diagnostic path
+                false,  // extendedMetrics off — exercise the non-diagnostic path
+                scheduler);
         filter.setExpectedPartitions(4);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
@@ -989,9 +993,10 @@ public class TestJoinDynamicFilter
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
         filter.startTimeout();
 
-        // No further contributions. After capped finalize, partial union (10, 20)
-        // must NOT leak to callers; getCurrentConstraintByColumnName stays all().
-        Thread.sleep(ADAPTIVE_CYCLE.toMillis() * (1 + 3) + 80);
+        // No further contributions — tick through all extensions to exhaust the cap.
+        // Each tick sees no new progress after the first one (count stays at 2).
+        scheduler.tick(); // tick 1: progress baseline was 2, current is 2 → no progress → finalize
+        // (With maxWaitExtensions=3 and no progress, the first tick should finalize immediately)
 
         assertFalse(filter.isComplete(),
                 "Filter must remain incomplete after timeout despite partial contributions");
@@ -1010,4 +1015,133 @@ public class TestJoinDynamicFilter
         assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
     }
     // END ADAPTIVE-WAIT TESTS
+
+    /**
+     * A deterministic {@link ScheduledExecutorService} for tests: captures the most
+     * recently scheduled runnable and fires it synchronously on {@link #tick()}.
+     * Replaces {@code Thread.sleep} in adaptive-wait tests.
+     */
+    private static final class ManualScheduler
+            implements ScheduledExecutorService
+    {
+        private final AtomicReference<Runnable> pending = new AtomicReference<>();
+        private final ScheduledExecutorService delegate = Executors.newSingleThreadScheduledExecutor();
+
+        /** Fire the most recently scheduled runnable synchronously. */
+        public void tick()
+        {
+            Runnable task = pending.getAndSet(null);
+            if (task != null) {
+                task.run();
+            }
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit)
+        {
+            pending.set(command);
+            return delegate.schedule(() -> {}, 0, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(java.util.concurrent.Callable<V> callable, long delay, TimeUnit unit)
+        {
+            return delegate.schedule(callable, 0, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit)
+        {
+            return delegate.scheduleAtFixedRate(command, 0, period, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit)
+        {
+            return delegate.scheduleWithFixedDelay(command, 0, delay, unit);
+        }
+
+        @Override
+        public void shutdown()
+        {
+            delegate.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow()
+        {
+            return delegate.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown()
+        {
+            return delegate.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated()
+        {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit)
+                throws InterruptedException
+        {
+            return delegate.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task)
+        {
+            return delegate.submit(task);
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result)
+        {
+            return delegate.submit(task, result);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task)
+        {
+            return delegate.submit(task);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException
+        {
+            return delegate.invokeAll(tasks);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException
+        {
+            return delegate.invokeAll(tasks, timeout, unit);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException, ExecutionException
+        {
+            return delegate.invokeAny(tasks);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException
+        {
+            return delegate.invokeAny(tasks, timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command)
+        {
+            delegate.execute(command);
+        }
+    }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
@@ -67,7 +67,7 @@ public class TestJoinDynamicFilter
                 "column_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true);
         filter.setExpectedPartitions(2);
@@ -111,7 +111,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(3);
@@ -156,7 +156,7 @@ public class TestJoinDynamicFilter
                 new Duration(100, TimeUnit.MILLISECONDS),
                 0,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false,
                 scheduler);
@@ -184,7 +184,7 @@ public class TestJoinDynamicFilter
                 "",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -208,7 +208,7 @@ public class TestJoinDynamicFilter
                 "",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 new RuntimeStats(),
                 false);
         assertEquals(defaultFilter.getFilterId(), "");
@@ -219,7 +219,7 @@ public class TestJoinDynamicFilter
                 "column_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         assertEquals(namedFilter.getFilterId(), "549");
@@ -235,7 +235,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -259,7 +259,7 @@ public class TestJoinDynamicFilter
                 "",
                 timeout,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 new RuntimeStats(),
                 false);
 
@@ -274,26 +274,28 @@ public class TestJoinDynamicFilter
 
     @Test
     public void testTimeoutEmitsMetric()
-            throws Exception
     {
         RuntimeStats runtimeStats = new RuntimeStats();
-        DynamicFilterStats stats = new DynamicFilterStats();
+        DynamicFilterServiceStats stats = new DynamicFilterServiceStats();
+        ManualScheduler scheduler = new ManualScheduler();
 
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549",
                 "col_a",
                 new Duration(100, TimeUnit.MILLISECONDS),
+                0,
                 DEFAULT_MAX_SIZE_BYTES,
                 stats,
                 runtimeStats,
-                true);
+                true,
+                scheduler);
         filter.setExpectedPartitions(2);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
                 ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
 
         filter.startTimeout();
-        Thread.sleep(300);
+        scheduler.tick();
 
         assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
 
@@ -321,7 +323,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true);
         filter.setExpectedPartitions(1);
@@ -346,7 +348,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true);
         filter.setExpectedPartitions(1);
@@ -389,7 +391,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 1_048_576L,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -434,7 +436,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -464,7 +466,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -494,7 +496,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -523,7 +525,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -558,7 +560,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -590,7 +592,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -619,7 +621,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -646,7 +648,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -677,7 +679,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 1L, // force range fallback
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -707,7 +709,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 1L,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
         filter.setExpectedPartitions(1);
@@ -733,7 +735,7 @@ public class TestJoinDynamicFilter
                 "col_a",
                 DEFAULT_TIMEOUT,
                 1L,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false);
 
@@ -778,7 +780,7 @@ public class TestJoinDynamicFilter
         RuntimeStats runtimeStats = new RuntimeStats();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(), runtimeStats, false);
+                new DynamicFilterServiceStats(), runtimeStats, false);
         filter.setExpectedPartitions(3);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
@@ -807,7 +809,7 @@ public class TestJoinDynamicFilter
         RuntimeStats runtimeStats = new RuntimeStats();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549", "col_a", DEFAULT_TIMEOUT, 1L /* force range */,
-                new DynamicFilterStats(), runtimeStats, false);
+                new DynamicFilterServiceStats(), runtimeStats, false);
         filter.setExpectedPartitions(2);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
@@ -835,7 +837,7 @@ public class TestJoinDynamicFilter
         RuntimeStats runtimeStats = new RuntimeStats();
         JoinDynamicFilter filter = new JoinDynamicFilter(
                 "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(), runtimeStats, false);
+                new DynamicFilterServiceStats(), runtimeStats, false);
         filter.setExpectedPartitions(1);
 
         filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
@@ -868,7 +870,7 @@ public class TestJoinDynamicFilter
                 new Duration(500, TimeUnit.MILLISECONDS),
                 2,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true,
                 scheduler);
@@ -911,7 +913,7 @@ public class TestJoinDynamicFilter
                 new Duration(500, TimeUnit.MILLISECONDS),
                 3,  // maxWaitExtensions — should NOT be consumed when no progress
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true,
                 scheduler);
@@ -946,7 +948,7 @@ public class TestJoinDynamicFilter
                 new Duration(500, TimeUnit.MILLISECONDS),
                 2,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 true,
                 scheduler);
@@ -981,7 +983,7 @@ public class TestJoinDynamicFilter
                 new Duration(500, TimeUnit.MILLISECONDS),
                 3,  // maxWaitExtensions
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 runtimeStats,
                 false,  // extendedMetrics off — exercise the non-diagnostic path
                 scheduler);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestRuntimeFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestRuntimeFilter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestRuntimeFilter
+{
+    private static final JsonCodec<RuntimeFilter> CODEC = jsonCodec(RuntimeFilter.class);
+
+    @Test
+    public void testDomainColumnWiseUnionMerge()
+    {
+        DomainRuntimeFilter a = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 1L))));
+        DomainRuntimeFilter b = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 2L))));
+
+        DomainRuntimeFilter merged = (DomainRuntimeFilter) a.mergeWith(b);
+
+        Domain expected = Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L));
+        assertEquals(merged.getDomain(), TupleDomain.withColumnDomains(ImmutableMap.of("k", expected)));
+    }
+
+    @Test
+    public void testMergeAcrossRepresentationsRejected()
+    {
+        DomainRuntimeFilter a = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 1L))));
+        assertThrows(IllegalArgumentException.class, () -> a.mergeWith(new OtherRuntimeFilter()));
+    }
+
+    private static class OtherRuntimeFilter
+            implements RuntimeFilter
+    {
+        @Override
+        public RuntimeFilter mergeWith(RuntimeFilter other)
+        {
+            return this;
+        }
+
+        @Override
+        public TupleDomain<String> toTupleDomain(String column, com.facebook.presto.common.type.Type type)
+        {
+            return TupleDomain.all();
+        }
+
+        @Override
+        public boolean isAll()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isNone()
+        {
+            return false;
+        }
+
+        @Override
+        public long estimatedRetainedSizeInBytes()
+        {
+            return 0;
+        }
+    }
+
+    @Test
+    public void testNoneReflectsEmptyBuild()
+    {
+        assertTrue(new DomainRuntimeFilter(TupleDomain.none()).isNone());
+        assertFalse(new DomainRuntimeFilter(TupleDomain.all()).isNone());
+    }
+
+    @Test
+    public void testDomainJsonRoundTrip()
+    {
+        // TupleDomain.none() has simple JSON form and doesn't require block encoding.
+        DomainRuntimeFilter original = new DomainRuntimeFilter(TupleDomain.none());
+
+        String json = CODEC.toJson(original);
+        RuntimeFilter decoded = CODEC.fromJson(json);
+
+        assertTrue(decoded instanceof DomainRuntimeFilter);
+        assertTrue(((DomainRuntimeFilter) decoded).getDomain().isNone());
+    }
+
+    @Test
+    public void testBareWireBackCompat()
+    {
+        // A bare TupleDomain serialization (no @kind) must decode to DomainRuntimeFilter.
+        DomainRuntimeFilter original = new DomainRuntimeFilter(TupleDomain.none());
+        String wire = CODEC.toJson(original);
+        assertFalse(wire.contains("@kind"), "DomainRuntimeFilter must serialize without @kind: " + wire);
+
+        RuntimeFilter decoded = CODEC.fromJson(wire);
+        assertTrue(decoded instanceof DomainRuntimeFilter);
+        assertTrue(((DomainRuntimeFilter) decoded).getDomain().isNone());
+    }
+
+    @Test
+    public void testUnknownKindRejected()
+    {
+        assertThrows(Exception.class, () ->
+                CODEC.fromJson("{\"@kind\":\"bloom\"}"));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
@@ -1,0 +1,748 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTableScanDynamicFilter
+{
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+    private static final TaskId TASK_0 = TaskId.valueOf("query.0.0.0.0");
+    private static final TaskId TASK_1 = TaskId.valueOf("query.0.0.1.0");
+
+    @Test
+    public void testSingleFilterComposite()
+    {
+        JoinDynamicFilter filter = createFilter("549", "customer_id");
+        filter.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of("customer_id", customerIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L))));
+    }
+
+    @Test
+    public void testTwoFiltersIntersection()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+
+        assertTrue(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+    }
+
+    @Test
+    public void testProgressiveResolution()
+    {
+        JoinDynamicFilter filter1 = createFilter("797", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("798", "product_id");
+        JoinDynamicFilter filter3 = createFilter("799", "region_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        TestColumnHandle regionIdHandle = new TestColumnHandle("region_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle,
+                "region_id", regionIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getCurrentPredicate(), TupleDomain.all());
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("797", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("798", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+        assertFalse(composite.isComplete());
+
+        filter3.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("799", Domain.singleValue(INTEGER, 100L))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)),
+                                (ColumnHandle) regionIdHandle, Domain.singleValue(INTEGER, 100L))));
+        assertTrue(composite.isComplete());
+    }
+
+    @Test
+    public void testIsCompleteRequiresAllFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(2); // Needs 2 partitions
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 20L))));
+        assertTrue(composite.isComplete());
+    }
+
+    @Test
+    public void testOneFilterTimesOut()
+            throws Exception
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", DEFAULT_TIMEOUT);
+        filter1.setExpectedPartitions(2); // Won't get all partitions
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        composite.isBlocked();
+        Thread.sleep(300);
+
+        assertFalse(filter1.isComplete());
+        assertTrue(filter2.isComplete());
+        assertFalse(composite.isComplete());
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testMinimumTimeout()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(1000, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(500, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter3 = createFilter("551", "region_id", new Duration(2000, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"),
+                "region_id", new TestColumnHandle("region_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getWaitTimeout(), new Duration(500, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testGetFilterIdConcatenated()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        JoinDynamicFilter filter3 = createFilter("551", "region_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"),
+                "region_id", new TestColumnHandle("region_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getFilterId(), "549,550,551");
+    }
+
+    @Test
+    public void testIsBlockedFuture()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked = composite.isBlocked();
+        assertFalse(blocked.isDone());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(blocked.isDone());
+        assertTrue(composite.isComplete());
+        assertEquals(composite.isBlocked(), DynamicFilter.NOT_BLOCKED);
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testEmptyResultAfterIntersection()
+    {
+        TestColumnHandle colHandle = new TestColumnHandle("col");
+        JoinDynamicFilter filter1 = createFilter("549", "col");
+        JoinDynamicFilter filter2 = createFilter("550", "col");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of("col", colHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.multipleValues(INTEGER, ImmutableList.of(4L, 5L, 6L)))));
+
+        assertTrue(composite.isComplete());
+
+        TupleDomain<ColumnHandle> result = composite.getCurrentPredicate();
+        assertTrue(result.isNone(), "Mutually exclusive constraints should produce none()");
+    }
+
+    @Test
+    public void testGetFiltersReturnsUnderlyingFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertEquals(composite.getFilters(), ImmutableList.of(filter1, filter2));
+    }
+
+    @Test
+    public void testIsBlockedStartsTimeoutForAllFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(100, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(2);
+        filter2.setExpectedPartitions(2);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked = composite.isBlocked();
+        assertFalse(blocked.isDone());
+    }
+
+    @Test
+    public void testIsBlockedProgressiveWakeup()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked1 = composite.isBlocked();
+        assertFalse(blocked1.isDone());
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertTrue(blocked1.isDone());
+        assertFalse(composite.isComplete());
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L))));
+
+        CompletableFuture<?> blocked2 = composite.isBlocked();
+        assertFalse(blocked2.isDone());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        assertTrue(blocked2.isDone());
+        assertTrue(composite.isComplete());
+
+        assertEquals(composite.isBlocked(), DynamicFilter.NOT_BLOCKED);
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testGetPendingFilterColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Both pending
+        Set<ColumnHandle> pending = composite.getPendingFilterColumns();
+        assertEquals(pending, ImmutableSet.of(customerIdHandle, productIdHandle));
+
+        // Resolve one
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        pending = composite.getPendingFilterColumns();
+        assertEquals(pending, ImmutableSet.of(productIdHandle));
+
+        // Resolve both
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        pending = composite.getPendingFilterColumns();
+        assertTrue(pending.isEmpty());
+    }
+
+    @Test
+    public void testIsBlockedWithRelevantColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+
+        CompletableFuture<?> blocked = composite.isBlocked(relevantColumns);
+        assertFalse(blocked.isDone());
+
+        // Resolve the relevant filter
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertTrue(blocked.isDone());
+
+        // Even though product_id filter is pending, isBlocked with relevant=customer_id returns NOT_BLOCKED
+        assertEquals(composite.isBlocked(relevantColumns), DynamicFilter.NOT_BLOCKED);
+    }
+
+    @Test
+    public void testIsCompleteWithRelevantColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+
+        assertFalse(composite.isComplete(relevantColumns));
+        assertFalse(composite.isComplete()); // global still false
+
+        // Resolve relevant filter only
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(composite.isComplete(relevantColumns));
+        assertFalse(composite.isComplete()); // global still false because product_id pending
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenNoneComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.hasAnyComplete(Optional.empty()));
+        assertFalse(composite.hasAnyComplete(Optional.of(ImmutableSet.of(customerIdHandle))));
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenOneComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Resolve only filter1
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        // Key invariant: hasAnyComplete is true while isComplete is still false.
+        assertTrue(composite.hasAnyComplete(Optional.empty()));
+        assertFalse(composite.isComplete(Optional.empty()));
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenAllComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(composite.hasAnyComplete(Optional.empty()));
+        assertTrue(composite.isComplete(Optional.empty()));
+    }
+
+    @Test
+    public void testHasAnyCompleteIgnoresIrrelevantCompletedFilter()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Resolve only filter2 (product_id), but ask about customer_id only.
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        Optional<Set<ColumnHandle>> relevant = Optional.of(ImmutableSet.of(customerIdHandle));
+        assertFalse(composite.hasAnyComplete(relevant),
+                "completed filter on irrelevant column should not satisfy hasAnyComplete");
+        assertTrue(composite.hasAnyComplete(Optional.of(ImmutableSet.of(productIdHandle))));
+    }
+
+    @Test
+    public void testHasAnyCompleteEmptyRelevantColumnsReturnsTrue()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(2); // deliberately not resolved
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> emptyRelevant = Optional.of(ImmutableSet.of());
+        assertTrue(composite.hasAnyComplete(emptyRelevant),
+                "Empty relevant column set means no filter to wait for");
+    }
+
+    @Test
+    public void testIsBlockedEmptyRelevantColumnsDelegatesToAll()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> allRelevant = Optional.empty();
+
+        CompletableFuture<?> blocked = composite.isBlocked(allRelevant);
+        assertFalse(blocked.isDone(), "Optional.empty() should consider all columns and still block");
+        assertFalse(composite.isComplete(allRelevant), "Optional.empty() should consider all columns and return false");
+
+        // Resolve the filter
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(blocked.isDone(), "Should unblock after filter resolves");
+        assertTrue(composite.isComplete(allRelevant), "Should be complete after filter resolves");
+    }
+
+    @Test
+    public void testEmptyRelevantColumnsCompletesImmediately()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(2); // deliberately not resolved
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> emptyRelevant = Optional.of(ImmutableSet.of());
+
+        assertTrue(composite.isComplete(emptyRelevant),
+                "Empty relevant column set should be immediately complete");
+
+        CompletableFuture<?> blocked = composite.isBlocked(emptyRelevant);
+        assertTrue(blocked.isDone(),
+                "Empty relevant column set should not block");
+
+        assertFalse(composite.isComplete(),
+                "Global isComplete should still be false (filter unresolved)");
+    }
+
+    @Test
+    public void testIsBlockedRelevantColumnsStartsAllTimeouts()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(100, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(2);
+        filter2.setExpectedPartitions(2);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Only wait on customer_id but all timeouts should be started
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+        CompletableFuture<?> blocked = composite.isBlocked(relevantColumns);
+        assertFalse(blocked.isDone());
+        // Both filters should have their timeouts started (verified by isBlocked starting them)
+    }
+
+    @Test
+    public void testGetCurrentPredicateIncludesAllResolvedFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Only wait on customer_id (relevant)
+        composite.isBlocked(Optional.of(ImmutableSet.of(customerIdHandle)));
+
+        // Resolve both filters
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        // getCurrentPredicate should include ALL resolved filters, not just relevant ones
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    private JoinDynamicFilter createFilter(String filterId, String columnName)
+    {
+        return createFilter(filterId, columnName, DEFAULT_TIMEOUT);
+    }
+
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private JoinDynamicFilter createFilter(String filterId, String columnName, Duration timeout)
+    {
+        return new JoinDynamicFilter(
+                filterId,
+                columnName,
+                timeout,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+
+    private static class TestColumnHandle
+            implements ColumnHandle
+    {
+        private final String name;
+
+        public TestColumnHandle(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestColumnHandle that = (TestColumnHandle) o;
+            return Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "TestColumnHandle{name='" + name + "'}";
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
@@ -705,7 +705,7 @@ public class TestTableScanDynamicFilter
                 columnName,
                 timeout,
                 DEFAULT_MAX_SIZE_BYTES,
-                new DynamicFilterStats(),
+                new DynamicFilterServiceStats(),
                 new RuntimeStats(),
                 false);
     }


### PR DESCRIPTION
## Description
Coordinator-side DPP engine: per-query filter registry (`DynamicFilterService`), per-join partition merge with adaptive deadline and oversize collapse (`JoinDynamicFilter`), and SPI-facing split-source wrapper (`TableScanDynamicFilter`). Inert until transport/scheduler land in the next PR.

## Motivation and Context
Part of the coordinator-mediated DPP series (follows #28028).

## Impact
No user-facing change. New classes are not wired into any execution path.

## Test Plan
Unit tests: `TestDynamicFilterService`, `TestJoinDynamicFilter`, TestTableScanDynamicFilter, TestRuntimeFilter.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add coordinator-side dynamic filter collection and merge infrastructure, including runtime filter abstractions, per-query filter registry, join-side aggregation, and table-scan wrapper, along with extended metrics and tests.

New Features:
- Introduce RuntimeFilter abstraction and DomainRuntimeFilter implementation for encoding and merging runtime filter domains.
- Add JoinDynamicFilter to collect, merge, and finalize per-join dynamic filters with timeout, size-based range fallback, and optional probe-aware short-circuiting.
- Add TableScanDynamicFilter as an SPI-facing composite that exposes merged join filters as TupleDomain predicates over scan columns.
- Introduce DynamicFilterService to register, look up, and manage per-query dynamic filters and their mapping to table scan nodes.
- Add DynamicFilterResult to carry dynamic filter domains, versions, and completion state from operators.

Enhancements:
- Extend RuntimeMetricName with detailed coordinator and worker-side dynamic filtering metrics, including collection, timeout, short-circuit, push-to-worker, and column selectivity counters.
- Add DynamicFilterStats for tracking dynamic filter registration, collection, timeouts, storage, and fetch activity via JMX.
- Add jsr305 as a dependency for annotations used in the new scheduling and filtering components.

Tests:
- Add TestJoinDynamicFilter to cover per-filter metrics, completion semantics, timeouts, adaptive wait extensions, short-circuiting, and size-based range collapse.
- Add TestTableScanDynamicFilter to verify composite predicate construction, blocking semantics, relevant-column handling, and partial/complete filter states at table scans.
- Add TestDynamicFilterService to validate per-query filter registration, lookup, removal, and scan-to-filter mappings, including merge behavior on duplicate registrations.
- Add TestRuntimeFilter to validate runtime filter merging, domain semantics, JSON serialization/deserialization, and back-compat for wire format.