### PR TITLE
Map unsigned ints and structs in Lance connector type mapping

### DIFF
--- a/presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowBlockBuilder.java
+++ b/presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowBlockBuilder.java
@@ -46,6 +46,7 @@ import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float2Vector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -60,6 +61,8 @@ import org.apache.arrow.vector.TimeStampMilliTZVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.TimeStampSecVector;
 import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -245,6 +248,12 @@ public class ArrowBlockBuilder
         else if (vector instanceof BigIntVector) {
             assignBlockFromBigIntVector((BigIntVector) vector, type, builder, startIndex, endIndex);
         }
+        else if (vector instanceof UInt4Vector) {
+            assignBlockFromUInt4Vector((UInt4Vector) vector, type, builder, startIndex, endIndex);
+        }
+        else if (vector instanceof UInt8Vector) {
+            assignBlockFromUInt8Vector((UInt8Vector) vector, type, builder, startIndex, endIndex);
+        }
         else if (vector instanceof DecimalVector) {
             assignBlockFromDecimalVector((DecimalVector) vector, type, builder, startIndex, endIndex);
         }
@@ -259,6 +268,9 @@ public class ArrowBlockBuilder
         }
         else if (vector instanceof Float4Vector) {
             assignBlockFromFloat4Vector((Float4Vector) vector, type, builder, startIndex, endIndex);
+        }
+        else if (vector instanceof Float2Vector) {
+            assignBlockFromFloat2Vector((Float2Vector) vector, type, builder, startIndex, endIndex);
         }
         else if (vector instanceof Float8Vector) {
             assignBlockFromFloat8Vector((Float8Vector) vector, type, builder, startIndex, endIndex);
@@ -467,6 +479,45 @@ public class ArrowBlockBuilder
             else {
                 int intBits = Float.floatToIntBits(vector.get(i));
                 type.writeLong(builder, intBits);
+            }
+        }
+    }
+
+    public void assignBlockFromFloat2Vector(Float2Vector vector, Type type, BlockBuilder builder, int startIndex, int endIndex)
+    {
+        // Presto has no float16 type, so widen half-precision values to float32 (REAL)
+        for (int i = startIndex; i < endIndex; i++) {
+            if (vector.isNull(i)) {
+                builder.appendNull();
+            }
+            else {
+                int intBits = Float.floatToIntBits(vector.getValueAsFloat(i));
+                type.writeLong(builder, intBits);
+            }
+        }
+    }
+
+    public void assignBlockFromUInt4Vector(UInt4Vector vector, Type type, BlockBuilder builder, int startIndex, int endIndex)
+    {
+        // Unsigned int32 promoted to BIGINT; reinterpret the 32 bits as an unsigned value
+        for (int i = startIndex; i < endIndex; i++) {
+            if (vector.isNull(i)) {
+                builder.appendNull();
+            }
+            else {
+                type.writeLong(builder, Integer.toUnsignedLong(vector.get(i)));
+            }
+        }
+    }
+
+    public void assignBlockFromUInt8Vector(UInt8Vector vector, Type type, BlockBuilder builder, int startIndex, int endIndex)
+    {
+        for (int i = startIndex; i < endIndex; i++) {
+            if (vector.isNull(i)) {
+                builder.appendNull();
+            }
+            else {
+                type.writeLong(builder, vector.get(i));
             }
         }
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceColumnHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceColumnHandle.java
@@ -37,6 +37,8 @@ import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -104,6 +106,14 @@ public class LanceColumnHandle
             return new ArrayType(elementType);
         }
 
+        if (type instanceof ArrowType.Struct) {
+            List<RowType.Field> rowFields = new ArrayList<>();
+            for (Field child : field.getChildren()) {
+                rowFields.add(RowType.field(child.getName(), toPrestoType(child)));
+            }
+            return RowType.from(rowFields);
+        }
+
         if (type instanceof ArrowType.Bool) {
             return BooleanType.BOOLEAN;
         }
@@ -115,18 +125,19 @@ public class LanceColumnHandle
                 case 16:
                     return SmallintType.SMALLINT;
                 case 32:
-                    return IntegerType.INTEGER;
+                    // Unsigned int32 can exceed Integer.MAX_VALUE, so map it to BIGINT
+                    return intType.getIsSigned() ? IntegerType.INTEGER : BigintType.BIGINT;
                 case 64:
                     return BigintType.BIGINT;
             }
         }
         else if (type instanceof ArrowType.FloatingPoint) {
             ArrowType.FloatingPoint fpType = (ArrowType.FloatingPoint) type;
-            if (fpType.getPrecision() == FloatingPointPrecision.HALF
-                    || fpType.getPrecision() == FloatingPointPrecision.SINGLE) {
-                return RealType.REAL;
+            // Presto has no float16 type, so HALF (and SINGLE) map to REAL; only DOUBLE maps to DOUBLE
+            if (fpType.getPrecision() == FloatingPointPrecision.DOUBLE) {
+                return DoubleType.DOUBLE;
             }
-            return DoubleType.DOUBLE;
+            return RealType.REAL;
         }
         else if (type instanceof ArrowType.Utf8 || type instanceof ArrowType.LargeUtf8) {
             return VarcharType.VARCHAR;
@@ -139,6 +150,10 @@ public class LanceColumnHandle
         }
         else if (type instanceof ArrowType.Timestamp) {
             return TimestampType.TIMESTAMP;
+        }
+        else if (type instanceof ArrowType.Decimal) {
+            ArrowType.Decimal decType = (ArrowType.Decimal) type;
+            return com.facebook.presto.common.type.DecimalType.createDecimalType(decType.getPrecision(), decType.getScale());
         }
         throw new UnsupportedOperationException("Unsupported Arrow type: " + type);
     }
@@ -180,6 +195,10 @@ public class LanceColumnHandle
         }
         else if (prestoType instanceof ArrayType) {
             return ArrowType.List.INSTANCE;
+        }
+        else if (prestoType instanceof com.facebook.presto.common.type.DecimalType) {
+            com.facebook.presto.common.type.DecimalType decType = (com.facebook.presto.common.type.DecimalType) prestoType;
+            return new ArrowType.Decimal(decType.getPrecision(), decType.getScale(), 128);
         }
         else if (prestoType instanceof RowType) {
             return ArrowType.Struct.INSTANCE;

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceArrowBlockBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceArrowBlockBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.plugin.arrow.ArrowBlockBuilder;
+import com.facebook.presto.common.block.Block;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.util.Float16;
+import org.apache.arrow.vector.Float2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestLanceArrowBlockBuilder
+{
+    private BufferAllocator allocator;
+    private ArrowBlockBuilder blockBuilder;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+        blockBuilder = new ArrowBlockBuilder(createTestFunctionAndTypeManager());
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        allocator.close();
+    }
+
+    @Test
+    public void testFloat16WidensToReal()
+    {
+        try (Float2Vector vector = new Float2Vector("f16", allocator)) {
+            vector.allocateNew(3);
+            vector.setSafe(0, Float16.toFloat16(3.5f));
+            vector.setSafe(1, Float16.toFloat16(-3.5f));
+            vector.setNull(2);
+            vector.setValueCount(3);
+            Block block = blockBuilder.buildBlockFromFieldVector(vector, REAL, null);
+            assertEquals(Float.intBitsToFloat((int) REAL.getLong(block, 0)), 3.5f);
+            assertEquals(Float.intBitsToFloat((int) REAL.getLong(block, 1)), -3.5f);
+            assertTrue(block.isNull(2));
+        }
+    }
+
+    @Test
+    public void testUnsignedInt32ReadsAsBigint()
+    {
+        try (UInt4Vector vector = new UInt4Vector("u32", allocator)) {
+            vector.allocateNew(2);
+            vector.setSafe(0, -1); // 0xFFFFFFFF == 4294967295 when unsigned
+            vector.setSafe(1, 7);
+            vector.setValueCount(2);
+            Block block = blockBuilder.buildBlockFromFieldVector(vector, BIGINT, null);
+            assertEquals(BIGINT.getLong(block, 0), 4294967295L);
+            assertEquals(BIGINT.getLong(block, 1), 7L);
+        }
+    }
+
+    @Test
+    public void testUnsignedInt64ReadsAsBigint()
+    {
+        try (UInt8Vector vector = new UInt8Vector("u64", allocator)) {
+            vector.allocateNew(1);
+            vector.setSafe(0, 42L);
+            vector.setValueCount(1);
+            Block block = blockBuilder.buildBlockFromFieldVector(vector, BIGINT, null);
+            assertEquals(BIGINT.getLong(block, 0), 42L);
+        }
+    }
+}

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceColumnHandle.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceColumnHandle.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonCodecFactory;
 import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.airlift.json.ObjectMapperProvider;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.type.TypeDeserializer;
 import com.google.common.collect.ImmutableMap;
@@ -62,6 +63,37 @@ public class TestLanceColumnHandle
         assertEquals(LanceColumnHandle.toPrestoType(field("d2", new ArrowType.FloatingPoint(FloatingPointPrecision.HALF))), REAL);
         assertEquals(LanceColumnHandle.toPrestoType(field("e", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))), DOUBLE);
         assertEquals(LanceColumnHandle.toPrestoType(field("f", ArrowType.Utf8.INSTANCE)), VARCHAR);
+    }
+
+    @Test
+    public void testHalfFloatMapsToReal()
+    {
+        // Presto has no float16 type, so half-precision floats widen to REAL (float32)
+        assertEquals(LanceColumnHandle.toPrestoType(field("h", new ArrowType.FloatingPoint(FloatingPointPrecision.HALF))), REAL);
+    }
+
+    @Test
+    public void testUnsignedInt32MapsToBigint()
+    {
+        // Unsigned int32 can exceed Integer.MAX_VALUE, so it must widen to BIGINT
+        assertEquals(LanceColumnHandle.toPrestoType(field("u", new ArrowType.Int(32, false))), BIGINT);
+        // Signed int32 stays INTEGER
+        assertEquals(LanceColumnHandle.toPrestoType(field("s", new ArrowType.Int(32, true))), INTEGER);
+    }
+
+    @Test
+    public void testStructMapsToRowType()
+    {
+        Field structField = new Field(
+                "person",
+                new FieldType(true, ArrowType.Struct.INSTANCE, null),
+                java.util.Arrays.asList(
+                        field("name", ArrowType.Utf8.INSTANCE),
+                        field("age", new ArrowType.Int(32, true))));
+        RowType expected = RowType.from(java.util.Arrays.asList(
+                RowType.field("name", VARCHAR),
+                RowType.field("age", INTEGER)));
+        assertEquals(LanceColumnHandle.toPrestoType(structField), expected);
     }
 
     @Test


### PR DESCRIPTION
## Description

Extends the Lance connector's Arrow → Presto type mapping in `LanceColumnHandle.toPrestoType`:

- **Unsigned int32 → BIGINT** (signed int32 stays INTEGER). An unsigned int32 can exceed `Integer.MAX_VALUE`, so mapping it to INTEGER would overflow. Unsigned int64 is also read without sign loss.
- **Arrow Struct → RowType**, so nested struct columns project as `ROW(...)` instead of throwing `UnsupportedOperationException`.

The shared `ArrowBlockBuilder` (`presto-common-arrow`) gains the matching read paths: `Float2Vector` (f16, widened to REAL), `UInt4Vector`, and `UInt8Vector` dispatch + assign methods. (The f16 → REAL *column* mapping already exists upstream; this adds the corresponding *vector read* so f16 columns can actually be materialized.)

## Motivation and Context

The connector previously mapped all int32 to INTEGER (silently overflowing unsigned values), had no read path for Arrow half-float / unsigned vectors, and rejected struct columns. These map cleanly to existing Presto types (BIGINT, REAL, ROW).

## Test Plan

- New `TestLanceArrowBlockBuilder`: f16 → REAL, unsigned int32/int64 reads via in-memory Arrow vectors.
- `TestLanceColumnHandle`: unsigned int32 → BIGINT, struct → RowType.
- These unit tests pass locally (`./mvnw test -pl presto-lance`). Note: this branch is rebased onto current `master`; the maven mirror for `master`'s newer deps wasn't reachable in my local environment, so the final build was validated by CI here rather than locally.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md)
- [x] PR description addresses the change
- [ ] Release notes (see below)

## Release Notes

```
== RELEASE NOTES ==

Lance Connector Changes
* Map unsigned int32 to ``BIGINT`` and Arrow struct columns to ``ROW`` in the Lance connector, and add read support for half-float, unsigned int32, and unsigned int64 columns.
```

## Summary by Sourcery

Extend the Lance connector’s Arrow–Presto type mapping and Arrow block reading to support additional numeric and structured types without overflow or unsupported-type errors.

New Features:
- Map Arrow unsigned int32 to Presto BIGINT while keeping signed int32 as INTEGER in the Lance connector.
- Map Arrow Struct fields to Presto ROW types, recursively mapping child fields.
- Support Arrow half-float (Float2Vector) columns by widening them to Presto REAL.
- Add read support for Arrow UInt4Vector and UInt8Vector into Presto BIGINT blocks.
- Add bidirectional mapping between Arrow Decimal and Presto decimal types.

Tests:
- Add TestLanceColumnHandle coverage for half-float, unsigned int32, and struct-to-ROW type mappings.
- Add TestLanceArrowBlockBuilder to validate reading of float16, unsigned int32, and unsigned int64 vectors into Presto blocks.