### PR TITLE
feat(ci): Publish portable multi-arch presto-native images

### DIFF
--- a/.github/actions/registry-login/action.yml
+++ b/.github/actions/registry-login/action.yml
@@ -1,0 +1,39 @@
+name: Registry login
+description: Log in to docker.io or ghcr.io based on the REGISTRY input.
+
+inputs:
+  registry:
+    description: Registry host. Must be 'docker.io' or 'ghcr.io'.
+    required: true
+  dockerhub_username:
+    required: false
+  dockerhub_token:
+    required: false
+  ghcr_username:
+    description: Defaults to github.actor when empty.
+    required: false
+  ghcr_token:
+    description: Defaults to the auto GITHUB_TOKEN when empty.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Docker Hub
+      if: inputs.registry == 'docker.io'
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      with:
+        username: ${{ inputs.dockerhub_username }}
+        password: ${{ inputs.dockerhub_token }}
+
+    - name: Login to GHCR
+      if: inputs.registry == 'ghcr.io'
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      with:
+        registry: ghcr.io
+        # GHCR packages are namespaced under the account that owns them.
+        # The auto GITHUB_TOKEN (default) can only write to this repo
+        # owner's namespace; override ghcr_token (and ghcr_username) to
+        # publish elsewhere.
+        username: ${{ inputs.ghcr_username || github.actor }}
+        password: ${{ inputs.ghcr_token || github.token }}

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -373,8 +373,11 @@ jobs:
     needs: publish-release-tag
     if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true'
     runs-on: ubuntu-latest
-    permissions: {}
-    timeout-minutes: 5
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    outputs:
+      COMMIT_SHA: ${{ steps.sha.outputs.commit_sha }}
     steps:
       - name: Validate REGISTRY
         run: |
@@ -382,6 +385,19 @@ jobs:
             echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'docker.io' or 'ghcr.io'."
             exit 1
           fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
+      - name: Get dependency commit sha
+        id: sha
+        working-directory: presto-native-execution
+        run: |
+          make submodules
+          echo "commit_sha=$(git rev-parse --short HEAD)" >> "${GITHUB_OUTPUT}"
 
   publish-native-dependency-image:
     needs: [publish-release-tag, validate-native-release]
@@ -394,8 +410,6 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
-    outputs:
-      COMMIT_SHA: ${{ steps.set-commit-sha.outputs.commit_sha }}
     permissions:
       contents: read
       packages: write
@@ -416,14 +430,6 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
-      - name: Initialize Prestissimo submodules
-        id: set-commit-sha
-        run: |
-          df -h
-          cd presto-native-execution && make submodules
-          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-          echo "commit_sha=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
-
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
         uses: ./.github/actions/registry-login
@@ -437,8 +443,14 @@ jobs:
       - name: Set dependency image tag
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
         run: |
-          echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+          echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${COMMIT_SHA}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+
+      - name: Initialize Prestissimo submodules
+        run: |
+          df -h
+          cd presto-native-execution && make submodules
 
       - name: Build Dependency Image
         working-directory: presto-native-execution
@@ -463,7 +475,7 @@ jobs:
           docker images
 
   publish-native-dependency-image-manifest:
-    needs: publish-native-dependency-image
+    needs: [publish-native-dependency-image, validate-native-release]
     if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true' && github.event.inputs.dependency_image == ''
     runs-on: ubuntu-latest
     environment: release
@@ -486,7 +498,7 @@ jobs:
         env:
           TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-          COMMIT_SHA: ${{ needs.publish-native-dependency-image.outputs.COMMIT_SHA }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
         run: |
           DEP_TARGET=${REGISTRY}/${ORG_NAME}/presto-native-dependency
           tags=(--tag ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA})
@@ -544,16 +556,11 @@ jobs:
           ghcr_username: ${{ vars.GHCR_USERNAME }}
           ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Initialize Prestissimo submodules
-        run: |
-          df -h
-          cd presto-native-execution && make submodules
-          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-
       - name: Set dependency image tag
         env:
           DEPENDENCY_IMAGE: ${{ github.event.inputs.dependency_image }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
         run: |
           if [[ -n "${DEPENDENCY_IMAGE}" ]]; then
             echo "DEPENDENCY_IMAGE=${DEPENDENCY_IMAGE}" >> ${GITHUB_ENV}

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -385,7 +385,7 @@ jobs:
       contents: read
     timeout-minutes: 10
     outputs:
-      COMMIT_SHA: ${{ steps.sha.outputs.commit_sha }}
+      commit_sha: ${{ steps.sha.outputs.commit_sha }}
     steps:
       - name: Validate REGISTRY
         run: |
@@ -460,7 +460,7 @@ jobs:
       - name: Set dependency image tag
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.commit_sha }}
           ARCH: ${{ matrix.arch }}
         run: |
           echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${COMMIT_SHA}-${ARCH}" >> ${GITHUB_ENV}
@@ -531,7 +531,7 @@ jobs:
         env:
           TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.commit_sha }}
         run: |
           DEP_TARGET=${REGISTRY}/${ORG_NAME}/presto-native-dependency
           tags=(--tag ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA})
@@ -601,7 +601,7 @@ jobs:
         env:
           DEPENDENCY_IMAGE: ${{ github.event.inputs.dependency_image }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
-          COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
+          COMMIT_SHA: ${{ needs.validate-native-release.outputs.commit_sha }}
           ARCH: ${{ matrix.arch }}
         run: |
           if [[ -n "${DEPENDENCY_IMAGE}" ]]; then

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -461,8 +461,9 @@ jobs:
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${COMMIT_SHA}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+          echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${COMMIT_SHA}-${ARCH}" >> ${GITHUB_ENV}
 
       - name: Initialize Prestissimo submodules
         run: |
@@ -601,11 +602,12 @@ jobs:
           DEPENDENCY_IMAGE: ${{ github.event.inputs.dependency_image }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           COMMIT_SHA: ${{ needs.validate-native-release.outputs.COMMIT_SHA }}
+          ARCH: ${{ matrix.arch }}
         run: |
           if [[ -n "${DEPENDENCY_IMAGE}" ]]; then
             echo "DEPENDENCY_IMAGE=${DEPENDENCY_IMAGE}" >> ${GITHUB_ENV}
           else
-            echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+            echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${COMMIT_SHA}-${ARCH}" >> ${GITHUB_ENV}
           fi
 
       - name: Pull Dependency Image
@@ -634,16 +636,20 @@ jobs:
         working-directory: presto-native-execution
         env:
           ORG_NAME: ${{ env.ORG_NAME }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          docker tag presto/prestissimo-runtime:centos9 ${REGISTRY}/${ORG_NAME}/${{ env.IMAGE_NAME }}:${RELEASE_TAG}-${{ matrix.arch }}
+          docker tag presto/prestissimo-runtime:centos9 ${REGISTRY}/${ORG_NAME}/${IMAGE_NAME}:${RELEASE_TAG}-${ARCH}
 
       - name: Push image
         env:
           ORG_NAME: ${{ env.ORG_NAME }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          docker push ${REGISTRY}/${ORG_NAME}/${{ env.IMAGE_NAME }}:${RELEASE_TAG}-${{ matrix.arch }}
+          docker push ${REGISTRY}/${ORG_NAME}/${IMAGE_NAME}:${RELEASE_TAG}-${ARCH}
 
   publish-native-image-manifest:
     needs: publish-native-image

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -329,21 +329,14 @@ jobs:
             exit 1
           fi
 
-      - name: Login to docker.io
-        if: ${{ env.REGISTRY == 'docker.io' }}
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - name: Registry login
+        uses: ./.github/actions/registry-login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to ghcr.io
-        if: ${{ env.REGISTRY == 'ghcr.io' }}
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_username: ${{ vars.GHCR_USERNAME }}
+          ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Set up qemu
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -431,21 +424,15 @@ jobs:
           echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
           echo "commit_sha=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
 
-      - name: Login to Docker Hub
-        if: env.REGISTRY == 'docker.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - name: Registry login
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: ./.github/actions/registry-login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: env.REGISTRY == 'ghcr.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_username: ${{ vars.GHCR_USERNAME }}
+          ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Set dependency image tag
         env:
@@ -485,21 +472,15 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Login to Docker Hub
-        if: env.REGISTRY == 'docker.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - name: Registry login
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: ./.github/actions/registry-login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: env.REGISTRY == 'ghcr.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_username: ${{ vars.GHCR_USERNAME }}
+          ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Create multi-arch dep manifest
         env:
@@ -554,21 +535,14 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - name: Login to docker.io
-        if: ${{ env.REGISTRY == 'docker.io' }}
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - name: Registry login
+        uses: ./.github/actions/registry-login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to ghcr.io
-        if: ${{ env.REGISTRY == 'ghcr.io' }}
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_username: ${{ vars.GHCR_USERNAME }}
+          ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Initialize Prestissimo submodules
         run: |
@@ -634,21 +608,15 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Login to Docker Hub
-        if: env.REGISTRY == 'docker.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - name: Registry login
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: ./.github/actions/registry-login
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: env.REGISTRY == 'ghcr.io'
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_username: ${{ vars.GHCR_USERNAME }}
+          ghcr_token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Create multi-arch runtime manifest
         env:

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -329,8 +329,16 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout workflow actions
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions/registry-login
+          path: workflow-actions
+          persist-credentials: false
+
       - name: Registry login
-        uses: ./.github/actions/registry-login
+        uses: ./workflow-actions/.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -430,9 +438,18 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
+      - name: Checkout workflow actions
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions/registry-login
+          path: workflow-actions
+          persist-credentials: false
+
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
-        uses: ./.github/actions/registry-login
+        uses: ./workflow-actions/.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -490,9 +507,18 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
+      - name: Checkout workflow actions
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions/registry-login
+          path: workflow-actions
+          persist-credentials: false
+
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
-        uses: ./.github/actions/registry-login
+        uses: ./workflow-actions/.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -553,8 +579,16 @@ jobs:
           submodules: true
           persist-credentials: false
 
+      - name: Checkout workflow actions
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions/registry-login
+          path: workflow-actions
+          persist-credentials: false
+
       - name: Registry login
-        uses: ./.github/actions/registry-login
+        uses: ./workflow-actions/.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -627,9 +661,18 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
+      - name: Checkout workflow actions
+        if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions/registry-login
+          path: workflow-actions
+          persist-credentials: false
+
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
-        uses: ./.github/actions/registry-login
+        uses: ./workflow-actions/.github/actions/registry-login
         with:
           registry: ${{ env.REGISTRY }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -53,8 +53,13 @@ env:
   JAVA_VERSION: ${{ vars.JAVA_VERSION || '17' }}
   JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
   MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
-  IMAGE_REPO: ${{ github.repository }}
-  ORG_NAME: ${{ github.repository_owner }}
+  # GHCR packages are namespaced under the account that owns them. The auto
+  # GITHUB_TOKEN (the GHCR login default) can only write to this repo owner's
+  # namespace. To publish to a different org, set BOTH: ORG_NAME (vars override
+  # below) to that org AND a GHCR_TOKEN secret whose account is a member of it
+  # (with GHCR_USERNAME var = that account's login). Overriding ORG_NAME alone
+  # rewrites the tag but leaves a token that can't write there -> GHCR denies.
+  ORG_NAME: ${{ vars.ORG_NAME || github.repository_owner }}
   IMAGE_NAME: presto-native
   REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
@@ -336,11 +341,9 @@ jobs:
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set image prefix
-        run: echo "IMAGE_PREFIX=${REGISTRY}/" >> $GITHUB_ENV
+          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up qemu
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -370,8 +373,8 @@ jobs:
             PRESTO_VERSION=${{ env.RELEASE_TAG }}
             JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
           tags: |
-            ${{ env.IMAGE_PREFIX }}${{ env.IMAGE_REPO }}:${{ env.RELEASE_TAG }}
-            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}{1}:latest', env.IMAGE_PREFIX, env.IMAGE_REPO) || '' }}
+            ${{ env.REGISTRY }}/${{ env.ORG_NAME }}/presto:${{ env.RELEASE_TAG }}
+            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}/{1}/presto:latest', env.REGISTRY, env.ORG_NAME) || '' }}
 
   validate-native-release:
     needs: publish-release-tag
@@ -440,14 +443,15 @@ jobs:
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set dependency image tag
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          echo "DEPENDENCY_IMAGE=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+          echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
 
       - name: Build Dependency Image
         working-directory: presto-native-execution
@@ -493,8 +497,9 @@ jobs:
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch dep manifest
         env:
@@ -502,7 +507,7 @@ jobs:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           COMMIT_SHA: ${{ needs.publish-native-dependency-image.outputs.COMMIT_SHA }}
         run: |
-          DEP_TARGET=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency
+          DEP_TARGET=${REGISTRY}/${ORG_NAME}/presto-native-dependency
           tags=(--tag ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA})
           [[ "${TAG_IMAGE_AS_LATEST}" == "true" ]] && tags+=(--tag ${DEP_TARGET}:latest)
           docker buildx imagetools create "${tags[@]}" \
@@ -561,8 +566,9 @@ jobs:
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Initialize Prestissimo submodules
         run: |
@@ -578,7 +584,7 @@ jobs:
           if [[ -n "${DEPENDENCY_IMAGE}" ]]; then
             echo "DEPENDENCY_IMAGE=${DEPENDENCY_IMAGE}" >> ${GITHUB_ENV}
           else
-            echo "DEPENDENCY_IMAGE=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+            echo "DEPENDENCY_IMAGE=${REGISTRY}/${ORG_NAME}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
           fi
 
       - name: Pull Dependency Image
@@ -640,8 +646,9 @@ jobs:
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # See ORG_NAME note; defaults to the repo-owner-scoped GITHUB_TOKEN.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch runtime manifest
         env:

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -484,6 +484,12 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
         uses: ./.github/actions/registry-login
@@ -615,6 +621,12 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
       - name: Registry login
         if: env.REGISTRY == 'docker.io' || env.REGISTRY == 'ghcr.io'
         uses: ./.github/actions/registry-login

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -475,7 +475,7 @@ jobs:
         env:
           # Build with the "common" target (-march=armv8-a+crc+crypto) for
           # broad ARM CPU compatibility rather than tuning to the local host.
-          # Our GitHub runner runs on AWS Graviton, so Velox's default target
+          # GitHub's arm64 runners run on AWS Graviton, so Velox's default target
           # "local" emits -mcpu=neoverse-n2, which SIGILLs on Apple Silicon
           # and other non-Neoverse cores. Small perf trade-off. See
           # docker-compose.yml.

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -373,10 +373,159 @@ jobs:
             ${{ env.IMAGE_PREFIX }}${{ env.IMAGE_REPO }}:${{ env.RELEASE_TAG }}
             ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}{1}:latest', env.IMAGE_PREFIX, env.IMAGE_REPO) || '' }}
 
-  publish-native-image:
+  validate-native-release:
     needs: publish-release-tag
     if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
+    steps:
+      - name: Validate REGISTRY
+        run: |
+          if [[ "${REGISTRY}" != "docker.io" && "${REGISTRY}" != "ghcr.io" ]]; then
+            echo "::error::Unsupported REGISTRY '${REGISTRY}'. Must be 'docker.io' or 'ghcr.io'."
+            exit 1
+          fi
+
+  publish-native-dependency-image:
+    needs: [publish-release-tag, validate-native-release]
+    if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true' && github.event.inputs.dependency_image == ''
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      COMMIT_SHA: ${{ steps.set-commit-sha.outputs.commit_sha }}
+    permissions:
+      contents: read
+      packages: write
+    environment: release
+    timeout-minutes: 300
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
+      - name: Initialize Prestissimo submodules
+        id: set-commit-sha
+        run: |
+          df -h
+          cd presto-native-execution && make submodules
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
+          echo "commit_sha=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
+
+      - name: Login to Docker Hub
+        if: env.REGISTRY == 'docker.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: env.REGISTRY == 'ghcr.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set dependency image tag
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          echo "DEPENDENCY_IMAGE=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
+
+      - name: Build Dependency Image
+        working-directory: presto-native-execution
+        env:
+          # Build with the "common" target (-march=armv8-a+crc+crypto) for
+          # broad ARM CPU compatibility rather than tuning to the local host.
+          # Our GitHub runner runs on AWS Graviton, so Velox's default target
+          # "local" emits -mcpu=neoverse-n2, which SIGILLs on Apple Silicon
+          # and other non-Neoverse cores. Small perf trade-off. See
+          # docker-compose.yml.
+          ARM_BUILD_TARGET: common
+        run: |
+          df -h
+          if docker pull ${{ env.DEPENDENCY_IMAGE }}; then
+            echo "Using dependency image ${{ env.DEPENDENCY_IMAGE }}"
+          else
+            echo "Building new dependency image"
+            docker compose build centos-native-dependency
+            docker tag presto/prestissimo-dependency:centos9 ${{ env.DEPENDENCY_IMAGE }}
+            docker push ${{ env.DEPENDENCY_IMAGE }}
+          fi
+          docker images
+
+  publish-native-dependency-image-manifest:
+    needs: publish-native-dependency-image
+    if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true' && github.event.inputs.dependency_image == ''
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 15
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        if: env.REGISTRY == 'docker.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: env.REGISTRY == 'ghcr.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch dep manifest
+        env:
+          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          COMMIT_SHA: ${{ needs.publish-native-dependency-image.outputs.COMMIT_SHA }}
+        run: |
+          DEP_TARGET=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency
+          tags=(--tag ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA})
+          [[ "${TAG_IMAGE_AS_LATEST}" == "true" ]] && tags+=(--tag ${DEP_TARGET}:latest)
+          docker buildx imagetools create "${tags[@]}" \
+            ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA}-amd64 \
+            ${DEP_TARGET}:${RELEASE_TAG}-${COMMIT_SHA}-arm64
+
+  publish-native-image:
+    needs: [publish-native-dependency-image, validate-native-release]
+    # always() bypasses the skip that otherwise propagates when
+    # publish-native-dependency-image is skipped (i.e. when a caller supplies
+    # the dependency_image input); !failure() && !cancelled() still prevent
+    # running when the dependency build or validate-native-release actually
+    # failed or was cancelled. validate-native-release is a direct need so that
+    # a bad REGISTRY is seen as a failure here, not just an upstream skip.
+    if: always() && (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true'
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -400,13 +549,6 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - name: Validate REGISTRY
-        run: |
-          if [[ "$REGISTRY" != "docker.io" && "$REGISTRY" != "ghcr.io" ]]; then
-            echo "::error::Unsupported REGISTRY '$REGISTRY'. Must be 'docker.io' or 'ghcr.io'."
-            exit 1
-          fi
-
       - name: Login to docker.io
         if: ${{ env.REGISTRY == 'docker.io' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
@@ -422,50 +564,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set image prefix
-        run: echo "IMAGE_PREFIX=${REGISTRY}/" >> $GITHUB_ENV
-
       - name: Initialize Prestissimo submodules
         run: |
           df -h
           cd presto-native-execution && make submodules
-          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
 
       - name: Set dependency image tag
         env:
           DEPENDENCY_IMAGE: ${{ github.event.inputs.dependency_image }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          if [[ -n "$DEPENDENCY_IMAGE" ]]; then
-            echo "DEPENDENCY_IMAGE=$DEPENDENCY_IMAGE" >> $GITHUB_ENV
+          if [[ -n "${DEPENDENCY_IMAGE}" ]]; then
+            echo "DEPENDENCY_IMAGE=${DEPENDENCY_IMAGE}" >> ${GITHUB_ENV}
           else
-            echo "DEPENDENCY_IMAGE=${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}" >> $GITHUB_ENV
+            echo "DEPENDENCY_IMAGE=${REGISTRY}/${{ github.repository_owner }}/presto-native-dependency:${RELEASE_TAG}-${{ env.COMMIT_SHA }}-${{ matrix.arch }}" >> ${GITHUB_ENV}
           fi
 
-      - name: Build Dependency Image
-        working-directory: presto-native-execution
-        env:
-          PUBLISH_NATIVE_IMAGE: ${{ github.event.inputs.publish_native_image }}
-          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+      - name: Pull Dependency Image
         run: |
-          df -h
-          if docker pull ${{ env.DEPENDENCY_IMAGE }}; then
-            echo "Using dependency image ${{ env.DEPENDENCY_IMAGE }}"
-            docker tag ${{ env.DEPENDENCY_IMAGE }} presto/prestissimo-dependency:centos9
-          else
-            echo "Building new depedency image"
-            docker compose build centos-native-dependency
-            if [[ "$PUBLISH_NATIVE_IMAGE" == "true" ]]; then
-              docker tag presto/prestissimo-dependency:centos9 ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
-              docker push ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
-
-              if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-                docker tag presto/prestissimo-dependency:centos9 ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:latest
-                docker push ${IMAGE_PREFIX}${{ github.repository_owner }}/presto-native-dependency:latest
-              fi
-            fi
-          fi
+          docker pull ${{ env.DEPENDENCY_IMAGE }}
+          docker tag ${{ env.DEPENDENCY_IMAGE }} presto/prestissimo-dependency:centos9
           docker images
 
       - name: Build Runtime Image
@@ -487,26 +606,55 @@ jobs:
       - name: Add release tag
         working-directory: presto-native-execution
         env:
-          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
           ORG_NAME: ${{ env.ORG_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          docker tag presto/prestissimo-runtime:centos9 ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
-          if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag presto/prestissimo-runtime:centos9 ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
-          fi
+          docker tag presto/prestissimo-runtime:centos9 ${REGISTRY}/${ORG_NAME}/${{ env.IMAGE_NAME }}:${RELEASE_TAG}-${{ matrix.arch }}
 
       - name: Push image
+        env:
+          ORG_NAME: ${{ env.ORG_NAME }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          docker push ${REGISTRY}/${ORG_NAME}/${{ env.IMAGE_NAME }}:${RELEASE_TAG}-${{ matrix.arch }}
+
+  publish-native-image-manifest:
+    needs: publish-native-image
+    if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 15
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        if: env.REGISTRY == 'docker.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: env.REGISTRY == 'ghcr.io'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch runtime manifest
         env:
           TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
           ORG_NAME: ${{ env.ORG_NAME }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          docker push ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
-          if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
-            docker push ${IMAGE_PREFIX}$ORG_NAME/${{ env.IMAGE_NAME }}:latest
-          fi
+          TARGET=${REGISTRY}/${ORG_NAME}/${{ env.IMAGE_NAME }}
+          tags=(--tag ${TARGET}:${RELEASE_TAG})
+          [[ "${TAG_IMAGE_AS_LATEST}" == "true" ]] && tags+=(--tag ${TARGET}:latest)
+          docker buildx imagetools create "${tags[@]}" \
+            ${TARGET}:${RELEASE_TAG}-amd64 \
+            ${TARGET}:${RELEASE_TAG}-arm64
 
   publish-docs:
     needs: publish-maven-artifacts

--- a/presto-docs/src/main/sphinx/presto_cpp/installation.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/installation.rst
@@ -226,6 +226,10 @@ Create a ``docker-compose.yml`` file in the ``~/presto-lab`` directory to orches
 
    **arm64 only:** The pre-built ``presto-native`` image is built with ``-march=armv8-a+crc+crypto`` for broad compatibility (AWS Graviton, Apple M1, and newer). It is suitable for getting started, but leaves CPU-specific optimisations on the table. For production use, build a custom image with ``-march=native``.
 
+.. note::
+
+   To track the latest unreleased changes, use the nightly builds instead of the release images: set the coordinator image to ``public.ecr.aws/oss-presto/presto:latest`` and the worker images to ``public.ecr.aws/oss-presto/presto-native:latest``. The nightly coordinator image (``presto``) is multi-arch, but the nightly worker image (``presto-native``) is published for ``linux/amd64`` only, so on an arm64 host (e.g. Apple Silicon, AWS Graviton) add ``platform: linux/amd64`` to the native worker services (``worker-1``, ``worker-2``) to run them under emulation.
+
 
 Start the Cluster and Verify
 ----------------------------

--- a/presto-docs/src/main/sphinx/presto_cpp/installation.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/installation.rst
@@ -189,8 +189,7 @@ Create a ``docker-compose.yml`` file in the ``~/presto-lab`` directory to orches
    # docker-compose.yml
    services:
      coordinator:
-       image: public.ecr.aws/oss-presto/presto:latest
-       platform: linux/amd64
+       image: prestodb/presto:latest
        container_name: presto-coordinator
        hostname: coordinator
        ports:
@@ -200,8 +199,7 @@ Create a ``docker-compose.yml`` file in the ``~/presto-lab`` directory to orches
        restart: unless-stopped
 
      worker-1:
-       image: public.ecr.aws/oss-presto/presto-native:latest
-       platform: linux/amd64
+       image: prestodb/presto-native:latest
        container_name: prestissimo-worker-1
        hostname: worker-1
        depends_on:
@@ -211,8 +209,7 @@ Create a ``docker-compose.yml`` file in the ``~/presto-lab`` directory to orches
        restart: unless-stopped
 
      worker-2:
-       image: public.ecr.aws/oss-presto/presto-native:latest
-       platform: linux/amd64
+       image: prestodb/presto-native:latest
        container_name: prestissimo-worker-2
        hostname: worker-2
        depends_on:
@@ -223,8 +220,12 @@ Create a ``docker-compose.yml`` file in the ``~/presto-lab`` directory to orches
 
 * The coordinator service uses the standard Java Presto image (presto:latest).
 * The worker-1 and worker-2 services use the Prestissimo (C++ Native) image (presto-native:latest).
-* The setting ``platform: linux/amd64`` is essential for users running on Apple Silicon Macs.
 * The ``volumes`` section mounts your local configuration directories (``./coordinator/etc``, ``./worker-1/etc``) into the container's expected path (``/opt/presto-server/etc``).
+
+.. warning::
+
+   **arm64 only:** The pre-built ``presto-native`` image is built with ``-march=armv8-a+crc+crypto`` for broad compatibility (AWS Graviton, Apple M1, and newer). It is suitable for getting started, but leaves CPU-specific optimisations on the table. For production use, build a custom image with ``-march=native``.
+
 
 Start the Cluster and Verify
 ----------------------------

--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -42,6 +42,14 @@ services:
     #   podman compose build centos-native-dependency
     image: presto/prestissimo-dependency:centos9
     build:
+      args:
+        # Forward ARM_BUILD_TARGET to the build so callers can override
+        # Velox's default ("local"), which uses MIDR_EL1-based CPU detection.
+        # On AWS Graviton runners that default emits -mcpu=neoverse-n2, which
+        # SIGILLs on Apple Silicon and other non-Neoverse ARMv8 CPUs. CI sets
+        # this to "common" for portable -march=armv8-a+crc+crypto flags;
+        # empty default preserves upstream behavior for local-dev builds.
+        - ARM_BUILD_TARGET=${ARM_BUILD_TARGET:-}
       context: .
       dockerfile: scripts/dockerfiles/centos-dependency.dockerfile
 


### PR DESCRIPTION
Description
-----------

Publish multi-arch (amd64 + arm64) Presto-native Docker images from the release workflow. The single amd64-only `publish-native-image` job is replaced with a per-arch matrix pipeline: `publish-native-dependency-image` and `publish-native-image` build/push per-arch (`-amd64`/`-arm64`) tags, and `publish-native-dependency-image-manifest` / `publish-native-image-manifest` merge them back into the original single-arch tag names (and `latest`) via `docker buildx imagetools create`.

Motivation and Context
----------------------

The release workflow currently publishes only amd64 `presto-native` and `presto-native-dependency` images, so users on ARM hosts (e.g., Apple Silicon) must rely on emulation or build their own images. Publishing multi-arch images lets consumers `docker pull` the native image and resolve the correct architecture from the OCI manifest list on both x86 and ARM.

The arm64 build sets `ARM_BUILD_TARGET=common` so it emits the portable `-march=armv8-a+crc+crypto` baseline instead of Velox's MIDR-detected `-mcpu=neoverse-n2` (the GitHub runner is AWS Graviton); the latter would SIGILL on Apple Silicon and other non-Neoverse ARMv8 cores that lack SVE. The `ARM_BUILD_TARGET` build arg is forwarded to the dependency image build via `docker-compose.yml`, defaulting to empty to preserve upstream behavior for local-dev builds.

This builds on #28010 (configurable container registry), reusing the `REGISTRY` variable and `docker.io`/`ghcr.io` login conventions established there.

Configurable publish target and credentials
--------------------------------------------

In addition to the `REGISTRY` variable from #28010, the release workflow now exposes the image **namespace** and **GHCR credentials** as configurable repo/org settings, so a release can be retargeted to a different org without editing the workflow. All three published images (`presto`, `presto-native-dependency`, `presto-native`) now build their reference from a single `ORG_NAME` knob: `${REGISTRY}/${ORG_NAME}/<image>:<tag>`.

| Setting | Kind | Default | Purpose |
|---|---|---|---|
| `REGISTRY` | variable | `docker.io` | registry host (`docker.io` or `ghcr.io`) |
| `ORG_NAME` | variable | `github.repository_owner` | image namespace (org/user) |
| `GHCR_USERNAME` | variable | `github.actor` | `docker login` username for ghcr.io |
| `GHCR_TOKEN` | secret | auto `GITHUB_TOKEN` | push credential for ghcr.io |

With nothing configured, behavior is unchanged: images publish to the repo owner's namespace (`prestodb`) using the auto `GITHUB_TOKEN`, via the same paths as before.

To publish to a different org (e.g. a staging or mirror namespace), set the namespace **and** matching GHCR credentials together. GHCR packages are namespaced under the account that owns them, and the auto `GITHUB_TOKEN` can only write to the repo owner's namespace:

1. Set `ORG_NAME` (variable) to the target org.
2. Set `GHCR_TOKEN` (secret) to a PAT whose account is a member of that org with `package:write` permission, and `GHCR_USERNAME` (variable) to that account's login.

Overriding `ORG_NAME` alone rewrites the image tag but leaves a token that cannot write to the new namespace, so GHCR rejects the push.

Docker Hub credentials (`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`) are unchanged; since that account can push to any org it belongs to, overriding `ORG_NAME` alone is sufficient when `REGISTRY=docker.io`.

Impact
------

### User-facing changes

* `presto-native` and `presto-native-dependency` release images are now published as multi-arch (amd64 + arm64) OCI manifest lists. Existing amd64 pulls resolve unchanged via the manifest list.
* The `dependency_image` workflow input is preserved: when a caller supplies a pre-built dependency image, the per-arch dependency build is skipped and the runtime images are still built and published using the provided image.

### Compatibility

Backward compatible. amd64 tags resolve as before through the manifest list. Existing workflow inputs (`publish_native_image`, `dependency_image`, `tag_image_as_latest`) behave as before; `tag_image_as_latest` now tags the merged multi-arch manifest.

Test Plan
---------

Validated by publishing images from a fork to GHCR via a manual `workflow_dispatch` run: [run](https://github.com/y-scope/presto/actions/runs/28262917250/job/83743491562)

This PR's native images published successfully as multi-arch (amd64 + arm64):
* [presto-native-dependency](https://github.com/y-scope/presto/pkgs/container/presto-native-dependency/976873820?tag=0.299-a8149422)
* [presto-native](https://github.com/y-scope/presto/pkgs/container/presto-native/976962300?tag=0.299)

The same release run also published the Java image (its multi-arch support is from the fork's separate CI changes, not this PR):
* [presto](https://github.com/y-scope/presto/pkgs/container/presto/976772111?tag=0.299)

The job DAG and skip/failure propagation were additionally traced by hand across the normal, `dependency_image`-supplied, bad-`REGISTRY`, and dependency-build-failure scenarios to confirm the runtime job runs when it should and halts otherwise.

Contributor checklist
---------------------

* [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
* [x] PR description addresses the issue accurately and concisely. If this change is non-trivial, a GitHub Issue is referenced.
* [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
* [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
* [x] Adequate tests were added if applicable.
* [x] CI passed.
* [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

Release Notes
-------------

```
== RELEASE NOTES ==

General Changes
* Add multi-arch (amd64 + arm64) support for presto-native and presto-native-dependency release Docker images, with the arm64 build using a portable -march=armv8-a+crc+crypto baseline for broad ARM CPU compatibility.
```