### PR TITLE
fix(analyzer): Fix error message and access control ordering in AlterColumnNotNullTask

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/AlterColumnNotNullTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/AlterColumnNotNullTask.java
@@ -69,7 +69,7 @@ public class AlterColumnNotNullTask
         Optional<MaterializedViewDefinition> optionalMaterializedView = metadata.getMetadataResolver(session).getMaterializedView(tableName);
         if (optionalMaterializedView.isPresent()) {
             if (!statement.isTableExists()) {
-                throw new SemanticException(NOT_SUPPORTED, statement, "'%s' is a materialized view, and rename column is not supported", tableName);
+                throw new SemanticException(NOT_SUPPORTED, statement, "'%s' is a materialized view, and ALTER COLUMN SET/DROP NOT NULL is not supported", tableName);
             }
             return immediateFuture(null);
         }
@@ -81,10 +81,10 @@ public class AlterColumnNotNullTask
             throw new SemanticException(NOT_SUPPORTED, statement, "Catalog %s does not support ALTER COLUMN with NOT NULL", connectorId.getCatalogName());
         }
 
+        accessControl.checkCanAddConstraints(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName);
+
         TableHandle tableHandle = tableHandleOptional.get();
         String column = metadata.normalizeIdentifier(session, tableName.getCatalogName(), statement.getColumn().getValue());
-
-        accessControl.checkCanAddConstraints(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName);
 
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
         ColumnHandle columnHandle = columnHandles.get(column);


### PR DESCRIPTION
## Description
- Correct copy-paste error where the materialized view error message said "rename column is not supported" instead of "ALTER COLUMN SET/DROP NOT NULL is not supported"
- Move checkCanAddConstraints call before metadata lookups to fail fast on unauthorized requests, consistent with AddConstraintTask

## Motivation and Context

AlterColumnNotNullTask contained a copy-paste error where the error message thrown for materialized view targets said "rename column is not supported" instead of "ALTER COLUMN SET/DROP NOT NULL is not supported". Additionally, the access control check (checkCanAddConstraints) was placed after resolving the TableHandle and normalizing the column identifier, meaning unnecessary metadata work was done before checking authorization. This aligns the task with the convention established by AddConstraintTask.

## Impact

No public API or behavioral change. The error message seen by users targeting a materialized view with ALTER COLUMN SET/DROP NOT NULL is now accurate. The access control check ordering change has no observable effect on authorized requests; unauthorized requests now fail slightly earlier (before metadata lookups).

## Test Plan

- Ran existing TestHiveIntegrationSmokeTest#testAlterColumnNotNull to confirm no regression.
- Manually verified the corrected error message by running ALTER COLUMN SET NOT NULL against a materialized view and confirming the exception text matches the new wording.
- Confirmed the access control check is still exercised on the unauthorized path by running with a restricted access control policy and verifying an AccessDeniedException is thrown before any column metadata is fetched.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Clarify ALTER COLUMN NOT NULL behavior on materialized views and align access control ordering with other tasks.

Bug Fixes:
- Fix incorrect error message for ALTER COLUMN SET/DROP NOT NULL on materialized views in AlterColumnNotNullTask.

Enhancements:
- Perform access control checks for ALTER COLUMN NOT NULL before metadata resolution to fail fast on unauthorized requests.