### PR TITLE
fix(plugin-iceberg): Mark synthesized metadata columns as hidden in getColumnMetadata 

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -675,12 +675,16 @@ public abstract class IcebergAbstractMetadata
     @Override
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
-        IcebergColumnHandle column = (IcebergColumnHandle) columnHandle;
+        return buildColumnMetadata((IcebergColumnHandle) columnHandle);
+    }
+
+    private static ColumnMetadata buildColumnMetadata(IcebergColumnHandle column)
+    {
         return ColumnMetadata.builder()
                 .setName(column.getName())
                 .setType(column.getType())
                 .setComment(column.getComment().orElse(null))
-                .setHidden(false)
+                .setHidden(column.getColumnType() == SYNTHESIZED)
                 .build();
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -225,6 +225,7 @@ import static com.facebook.presto.iceberg.IcebergTableType.EQUALITY_DELETES;
 import static com.facebook.presto.iceberg.IcebergUtil.MAX_FORMAT_VERSION_FOR_ROW_LEVEL_OPERATIONS;
 import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_DELETE;
 import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_ROW_LINEAGE;
+import static com.facebook.presto.iceberg.IcebergUtil.buildColumnMetadata;
 import static com.facebook.presto.iceberg.IcebergUtil.convertToIcebergLiteral;
 import static com.facebook.presto.iceberg.IcebergUtil.createDomainFromIcebergPartitionValue;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
@@ -676,16 +677,6 @@ public abstract class IcebergAbstractMetadata
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         return buildColumnMetadata((IcebergColumnHandle) columnHandle);
-    }
-
-    private static ColumnMetadata buildColumnMetadata(IcebergColumnHandle column)
-    {
-        return ColumnMetadata.builder()
-                .setName(column.getName())
-                .setType(column.getType())
-                .setComment(column.getComment().orElse(null))
-                .setHidden(column.getColumnType() == SYNTHESIZED)
-                .build();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -43,6 +43,7 @@ import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -141,6 +142,7 @@ import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VERSION_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VIEW_COMMENT;
@@ -341,6 +343,16 @@ public final class IcebergUtil
         if (formatVersion < minVersion) {
             throw new PrestoException(NOT_SUPPORTED, errorMessage);
         }
+    }
+
+    public static ColumnMetadata buildColumnMetadata(IcebergColumnHandle column)
+    {
+        return ColumnMetadata.builder()
+                .setName(column.getName())
+                .setType(column.getType())
+                .setComment(column.getComment().orElse(null))
+                .setHidden(column.getColumnType() == SYNTHESIZED)
+                .build();
     }
 
     public static List<IcebergColumnHandle> getPartitionKeyColumnHandles(IcebergTableHandle tableHandle, Table table, TypeManager typeManager)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -40,6 +39,7 @@ import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUE
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
+import static com.facebook.presto.iceberg.IcebergUtil.buildColumnMetadata;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static org.apache.iceberg.MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER;
 import static org.apache.iceberg.MetadataColumns.ROW_ID;
@@ -112,18 +112,6 @@ public class TestIcebergColumnHandle
         assertFalse(buildColumnMetadata(regularColumn).isHidden());
         assertFalse(buildColumnMetadata(ROW_ID_COLUMN_HANDLE).isHidden());
         assertFalse(buildColumnMetadata(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE).isHidden());
-    }
-
-    private static com.facebook.presto.spi.ColumnMetadata buildColumnMetadata(IcebergColumnHandle column)
-    {
-        try {
-            Method method = IcebergAbstractMetadata.class.getDeclaredMethod("buildColumnMetadata", IcebergColumnHandle.class);
-            method.setAccessible(true);
-            return (com.facebook.presto.spi.ColumnMetadata) method.invoke(null, column);
-        }
-        catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private void testRoundTrip(IcebergColumnHandle expected)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -32,7 +33,11 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.STRUCT;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
@@ -89,6 +94,36 @@ public class TestIcebergColumnHandle
         // Predicate pushdown exclusion is handled separately in getNonMetadataColumnConstraints().
         assertFalse(IcebergMetadataColumn.isMetadataColumnId(ROW_ID_COLUMN_HANDLE.getId()));
         assertFalse(IcebergMetadataColumn.isMetadataColumnId(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getId()));
+    }
+
+    @Test
+    public void testSynthesizedColumnHandlesAreHidden()
+    {
+        assertTrue(buildColumnMetadata(PATH_COLUMN_HANDLE).isHidden());
+        assertTrue(buildColumnMetadata(DATA_SEQUENCE_NUMBER_COLUMN_HANDLE).isHidden());
+        assertTrue(buildColumnMetadata(IS_DELETED_COLUMN_HANDLE).isHidden());
+        assertTrue(buildColumnMetadata(DELETE_FILE_PATH_COLUMN_HANDLE).isHidden());
+    }
+
+    @Test
+    public void testRegularColumnHandleIsNotHidden()
+    {
+        IcebergColumnHandle regularColumn = primitiveIcebergColumnHandle(1, "amount", BIGINT, Optional.empty());
+        assertFalse(buildColumnMetadata(regularColumn).isHidden());
+        assertFalse(buildColumnMetadata(ROW_ID_COLUMN_HANDLE).isHidden());
+        assertFalse(buildColumnMetadata(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE).isHidden());
+    }
+
+    private static com.facebook.presto.spi.ColumnMetadata buildColumnMetadata(IcebergColumnHandle column)
+    {
+        try {
+            Method method = IcebergAbstractMetadata.class.getDeclaredMethod("buildColumnMetadata", IcebergColumnHandle.class);
+            method.setAccessible(true);
+            return (com.facebook.presto.spi.ColumnMetadata) method.invoke(null, column);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void testRoundTrip(IcebergColumnHandle expected)


### PR DESCRIPTION
## Description
- Extract `getColumnMetadata` body into a package-private static helper `buildColumnMetadata` to enable unit testing
- Fix `setHidden` to derive from column type (`SYNTHESIZED → hidden`) instead of hardcoding `false`

## Motivation and Context
`IcebergAbstractMetadata.getColumnMetadata(ConnectorSession, ConnectorTableHandle, ColumnHandle)` — the `ConnectorMetadata` API used by Presto's analyzer when resolving column metadata — unconditionally returned `setHidden(false)` for all Iceberg column handles. This meant synthesized internal columns (`$path`, `$data_sequence_number`, `$is_deleted`, `$delete_file_path`) were incorrectly reported as visible, contrary to their intended behavior.                                                                                          

The intent was already expressed correctly elsewhere: `IcebergColumnHandle.getColumnMetadata(IcebergMetadataColumn)` (the private factory used to build static `*_COLUMN_METADATA` constants) has always set `setHidden(true)` for these columns. The `ConnectorMetadata` code path was simply missed. 

## Impact
Synthesized Iceberg metadata columns are now correctly reported as hidden through the `ConnectorMetadata` API. This affects column visibility in contexts such as `SHOW COLUMNS` and `information_schema.columns`, where these internal columns should not appear unless explicitly selected. `REGULAR` and `PARTITION_KEY` columns are unaffected.

## Test Plan
Added two unit tests to `TestIcebergColumnHandle`:

- `testSynthesizedColumnHandlesAreHidden`: asserts all four synthesized column handles (`PATH`, `DATA_SEQUENCE_NUMBER`, `IS_DELETED`, `DELETE_FILE_PATH`) produce `isHidden() == true` via `buildColumnMetadata`
- `testRegularColumnHandleIsNotHidden`: asserts a generic `primitiveIcebergColumnHandle`, `ROW_ID_COLUMN_HANDLE`, and `LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE` all produce `isHidden() == false`, covering every named non-synthesized special-case handle


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure Iceberg column metadata correctly marks synthesized metadata columns as hidden while keeping regular and partition-related columns visible.

Bug Fixes:
- Correct column metadata visibility so synthesized Iceberg metadata columns are exposed as hidden via the ConnectorMetadata API.

Enhancements:
- Extract column metadata construction into a reusable static helper to allow direct unit testing.

Tests:
- Add unit tests verifying synthesized Iceberg metadata columns are marked hidden and regular/special non-synthesized columns are not.