### PR TITLE
fix(ci): Fix broken doc-only PR detection in GH Actions workflows

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
+              - '!(presto-docs{,/**})'
 
   arrowflight-java-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
 
   hive-tests:
     permissions:

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
 
   jdbc-connector-tests:
     permissions:

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   kudu:
     permissions:
       contents: read

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -25,8 +25,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
               - 'presto-docs/pom.xml'
 
   dependency-check:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
+              - '!(presto-docs{,/**})'
 
   prestocpp-linux-build-for-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
+              - '!(presto-docs{,/**})'
 
   prestocpp-linux-build-gpu-engine:
     runs-on: ubuntu-22.04

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   product-tests-basic-environment:
     strategy:
       fail-fast: false

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   product-tests-specific-environment1:
     strategy:
       fail-fast: false

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   singlestore-dockerized-tests:
     strategy:
       fail-fast: false

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   spark-integration:
     strategy:
       fail-fast: false

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
   test-other-modules:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,11 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          # Use a single extglob negation pattern instead of multiple negation
+          # list items. See https://github.com/prestodb/presto/pull/28052 for details.
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           filters: |
             codechange:
-              - '!presto-docs/**'
-              - '!presto-native-execution/presto_cpp/**'
+              - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'
               - 'presto-ui/**'
   web-ui-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
The codechange filter used negation-only YAML list items:
  - '!presto-docs/**'
  - '!presto-native-execution/presto_cpp/**'

dorny/paths-filter(v4.0.1) evaluates patterns with OR semantics (some()). Each item is an independent picomatch matcher. A file under presto-docs/ fails the first pattern but satisfies the second (it is not under presto_cpp/), so some() returns true and codechange is always true — CI jobs never skip for doc-only PRs.

This worked with dorny/paths-filter@v2 which used `micromatch`, applying negations as a set. The breakage was introduced in PR #25556 which upgraded to a pinned v3.0.2 hash (picomatch), and PR #27879 which added the second negation item across remaining workflows.

Fix by replacing multi-item negation lists with a single picomatch extglob negation pattern evaluated atomically:
  - '!(presto-docs{,/**}|presto-native-execution/presto_cpp{,/**})'

The {,/**} brace expansion is required as picomatch's extglob engine does not match deeply nested paths with /** alone inside !(...).

## Motivation and Context
Fix the broken doc-only detection

## Impact
Reduce unnecessary CI jobs for doc-only PRs

## Test Plan
Manually verified with local code, but still need to confirm the fix after this change is merged.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Update dorny/paths-filter patterns across multiple workflows to use a single extglob negation for docs and prestocpp paths, restoring accurate code-change detection.