### PR TITLE
perf: Add extra && qualified overloads to RequestBuilder (#28053)

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -219,31 +219,62 @@ class RequestBuilder {
  public:
   RequestBuilder() {}
 
-  RequestBuilder& jwtOptions(JwtOptions options) {
+  RequestBuilder& jwtOptions(JwtOptions options) & {
     jwtOptions_ = std::move(options);
     return *this;
   }
 
-  RequestBuilder& method(proxygen::HTTPMethod method) {
+  RequestBuilder&& jwtOptions(JwtOptions options) && {
+    jwtOptions_ = std::move(options);
+    return std::move(*this);
+  }
+
+  RequestBuilder& method(proxygen::HTTPMethod method) & {
     headers_.setMethod(method);
     return *this;
   }
 
-  RequestBuilder& url(const std::string& url) {
+  RequestBuilder&& method(proxygen::HTTPMethod method) && {
+    headers_.setMethod(method);
+    return std::move(*this);
+  }
+
+  RequestBuilder& url(const std::string& url) & {
     headers_.setURL(url);
     return *this;
   }
 
+  RequestBuilder&& url(const std::string& url) && {
+    headers_.setURL(url);
+    return std::move(*this);
+  }
+
   RequestBuilder& header(
       proxygen::HTTPHeaderCode code,
-      const std::string& value) {
+      const std::string& value) & {
     headers_.getHeaders().set(code, value);
     return *this;
   }
 
-  RequestBuilder& header(const std::string& header, const std::string& value) {
+  RequestBuilder&& header(
+      proxygen::HTTPHeaderCode code,
+      const std::string& value) && {
+    headers_.getHeaders().set(code, value);
+    return std::move(*this);
+  }
+
+  RequestBuilder& header(
+      const std::string& header,
+      const std::string& value) & {
     headers_.getHeaders().set(header, value);
     return *this;
+  }
+
+  RequestBuilder&& header(
+      const std::string& header,
+      const std::string& value) && {
+    headers_.getHeaders().set(header, value);
+    return std::move(*this);
   }
 
   folly::SemiFuture<std::unique_ptr<HttpResponse>>


### PR DESCRIPTION
Summary:

This showed up in internal performance profiles. This is an AI generated optimization, but human reviewed:

Optimized `RequestBuilder` in `HttpClient.h` to avoid unnecessary copy construction when chaining builder methods on temporary (rvalue) objects.

**Problem:** The builder methods (`jwtOptions`, `method`, `url`, `header`) returned `RequestBuilder&` (lvalue reference). When chaining on a temporary (e.g., `auto rb = RequestBuilder().method(...).url(...);`), the final result was an lvalue reference, forcing the implicit copy constructor to be invoked.

**Fix:** Added `&&`-qualified (rvalue ref-qualified) overloads of all builder methods. When called on an rvalue `RequestBuilder`, these overloads return `RequestBuilder&&`, enabling move construction instead of copy construction at call sites like `PrestoExchangeSource::doRequest`. The existing `&`-qualified overloads continue to work identically for lvalue usage. This eliminates the copy of both `JwtOptions` and `proxygen::HTTPMessage` members in the common temporary-chaining pattern.

```
== NO RELEASE NOTE ==
```

Differential Revision: D107396503


