### PR TITLE
fix(plugin-hive): Add Azure filesystem impl registration for ABFSS and WASB/S schemes

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/azure/HiveAzureConfigurationInitializer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/azure/HiveAzureConfigurationInitializer.java
@@ -16,7 +16,11 @@ package com.facebook.presto.hive.azure;
 import com.facebook.airlift.log.Logger;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
+import org.apache.hadoop.fs.azurebfs.Abfs;
+import org.apache.hadoop.fs.azurebfs.Abfss;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+import org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem;
 
 import java.util.Optional;
 
@@ -46,6 +50,11 @@ public class HiveAzureConfigurationInitializer
     private static final String WASB_ACCOUNT_KEY_PROPERTY_FORMAT = "fs.azure.account.key.%s" + BLOB_ENDPOINT_SUFFIX;
 
     private static final String ABFS_IMPL_PROPERTY = "fs.abfs.impl";
+    private static final String ABFSS_IMPL_PROPERTY = "fs.abfss.impl";
+    private static final String WASB_IMPL_PROPERTY = "fs.wasb.impl";
+    private static final String WASBS_IMPL_PROPERTY = "fs.wasbs.impl";
+    private static final String ABFS_ABSTRACT_IMPL_PROPERTY = "fs.AbstractFileSystem.abfs.impl";
+    private static final String ABFSS_ABSTRACT_IMPL_PROPERTY = "fs.AbstractFileSystem.abfss.impl";
     private static final String OAUTH_AUTH_TYPE = "OAuth";
     private static final String ABFS_OAUTH_PROVIDER = "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider";
 
@@ -97,21 +106,27 @@ public class HiveAzureConfigurationInitializer
     {
         if (wasbAccessKey.isPresent() && wasbStorageAccount.isPresent()) {
             config.set(format(WASB_ACCOUNT_KEY_PROPERTY_FORMAT, wasbStorageAccount.get()), wasbAccessKey.get());
+            config.set(WASB_IMPL_PROPERTY, NativeAzureFileSystem.class.getName());
+            config.set(WASBS_IMPL_PROPERTY, NativeAzureFileSystem.Secure.class.getName());
         }
 
         if (abfsStorageAccount.isPresent()) {
             String dfsEndpoint = abfsStorageAccount.get() + DFS_ENDPOINT_SUFFIX;
 
+            // Register ABFS/ABFSS filesystem implementations. These are required for URI scheme resolution and
+            // must be set whenever ABFS storage is configured
+            config.set(ABFS_IMPL_PROPERTY, AzureBlobFileSystem.class.getName());
+            config.set(ABFSS_IMPL_PROPERTY, SecureAzureBlobFileSystem.class.getName());
+            config.set(ABFS_ABSTRACT_IMPL_PROPERTY, Abfs.class.getName());
+            config.set(ABFSS_ABSTRACT_IMPL_PROPERTY, Abfss.class.getName());
+
             if (abfsAccessKey.isPresent()) {
                 config.set(accountProperty(FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME, dfsEndpoint), abfsAccessKey.get());
-                if (config.get(ABFS_IMPL_PROPERTY) == null) {
-                    config.set(ABFS_IMPL_PROPERTY, AzureBlobFileSystem.class.getName());
-                }
             }
 
             if (abfsOAuthClientEndpoint.isPresent() && abfsOAuthClientId.isPresent() && abfsOAuthClientSecret.isPresent()) {
                 config.set(accountProperty(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, dfsEndpoint), OAUTH_AUTH_TYPE);
-                config.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME, ABFS_OAUTH_PROVIDER);
+                config.set(accountProperty(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME, dfsEndpoint), ABFS_OAUTH_PROVIDER);
                 config.set(accountProperty(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT, dfsEndpoint), abfsOAuthClientEndpoint.get());
                 config.set(accountProperty(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID, dfsEndpoint), abfsOAuthClientId.get());
                 config.set(accountProperty(FS_AZURE_ACCOUNT_OAUTH_CLIENT_SECRET, dfsEndpoint), abfsOAuthClientSecret.get());


### PR DESCRIPTION
## Description

**Problem :** 

When querying Iceberg tables stored on Azure Data Lake Storage Gen2 (abfss://), the following error occurs:

`org.apache.iceberg.exceptions.RuntimeIOException: Failed to get file system for path: abfss://contenedoretablasexternas@stgactdemoigsaenz.dfs.core.windows.net/datoscatalogo/metadatos/__unitystorage/catalogs/4163d293-495c-4a22-bb0b-4a6fade419e0/tables/8d4a853b-758c-406d-9955-24e84ccc7d4e/metadata/snap-791700452297062007-1-8e186dd4-f6b2-45a3-a955-77afee73039b.avro
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:57)
	at org.apache.iceberg.hadoop.HadoopInputFile.fromLocation(HadoopInputFile.java:56)
	at org.apache.iceberg.hadoop.HadoopFileIO.newInputFile(HadoopFileIO.java:87)
	at org.apache.iceberg.BaseSnapshot.cacheManifests(BaseSnapshot.java:185)
	at org.apache.iceberg.BaseSnapshot.allManifests(BaseSnapshot.java:203)
	at com.facebook.presto.iceberg.IcebergUtil.lambda$getPartitionKeyColumnHandles$1(IcebergUtil.java:324)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.facebook.presto.iceberg.IcebergUtil.getPartitionKeyColumnHandles(IcebergUtil.java:324)
	at com.facebook.presto.iceberg.IcebergAbstractMetadata.getTableLayoutForConstraint(IcebergAbstractMetadata.java:450)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.getTableLayoutForConstraint(ClassLoaderSafeConnectorMetadata.java:106)
	at com.facebook.presto.metadata.MetadataManager.getLayout(MetadataManager.java:479)
	at com.facebook.presto.metadata.StatsRecordingMetadataManager.getLayout(StatsRecordingMetadataManager.java:1322)
	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutWithoutPredicate.apply(PickTableLayout.java:213)
	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutWithoutPredicate.apply(PickTableLayout.java:180)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:238)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:190)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:152)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:282)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:154)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:139)
	at com.facebook.presto.sql.Optimizer.validateAndOptimizePlan(Optimizer.java:114)
	at com.facebook.presto.execution.SqlQueryExecution.lambda$doCreateLogicalPlanAndOptimize$6(SqlQueryExecution.java:603)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.doCreateLogicalPlanAndOptimize(SqlQueryExecution.java:601)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.createLogicalPlanAndOptimize(SqlQueryExecution.java:572)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:500)
	at com.facebook.presto.$gen.Presto_0_298_SNAPSHOT_3daf639__0_298_SNAPSHOT____20260618_142057_1.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:326)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:217)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.apache.hadoop.fs.UnsupportedFileSystemException: No FileSystem for scheme "abfss"
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3902)
	at org.apache.hadoop.fs.PrestoFileSystemCache.createFileSystem(PrestoFileSystemCache.java:149)
	at org.apache.hadoop.fs.PrestoFileSystemCache.getInternal(PrestoFileSystemCache.java:94)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:62)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:612)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:55)
	... 32 more`
	
Same error has occurred for wasb and wasbs schemes when querying via iceberg.

`[java.util.concurrent.ExecutionException: org.apache.iceberg.exceptions.RuntimeIOException: Failed to get file system for path: wasbs://adlsgen1e2e@adlsqagen1.blob.core.windows.net
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:592)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:551)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:111)
	at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:247)
	at com.google.common.cache.LocalCache$Segment.getAndRecordStats(LocalCache.java:2346)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2314)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2190)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2080)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4012)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4920)
	at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getCatalog(IcebergNativeCatalogFactory.java:88)
	at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getNamespaces(IcebergNativeCatalogFactory.java:105)
	at com.facebook.presto.iceberg.IcebergNativeMetadata.listSchemaNames(IcebergNativeMetadata.java:197)
	at com.facebook.presto.spi.connector.ConnectorMetadata.schemaExists(ConnectorMetadata.java:86)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.schemaExists(ClassLoaderSafeConnectorMetadata.java:210)
	at com.facebook.presto.metadata.MetadataManager$1.lambda$schemaExists$0(MetadataManager.java:1702)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1002)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at com.facebook.presto.metadata.MetadataManager$1.schemaExists(MetadataManager.java:1702)
	at com.facebook.presto.execution.CreateSchemaTask.execute(CreateSchemaTask.java:64)
	at com.facebook.presto.execution.CreateSchemaTask.execute(CreateSchemaTask.java:39)
	at com.facebook.presto.execution.DDLDefinitionExecution.executeTask(DDLDefinitionExecution.java:66)
	at com.facebook.presto.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:217)
	at com.facebook.presto.$gen.Presto_null__testversion____20260629_132950_1.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:326)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:217)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.apache.iceberg.exceptions.RuntimeIOException: Failed to get file system for path: wasbs://adlsgen1e2e@adlsqagen1.blob.core.windows.net
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:57)
	at org.apache.iceberg.hadoop.HadoopCatalog.initialize(HadoopCatalog.java:112)
	at org.apache.iceberg.CatalogUtil.loadCatalog(CatalogUtil.java:280)
	at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.lambda$getCatalog$0(IcebergNativeCatalogFactory.java:88)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4925)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3571)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2313)
	... 32 more
Caused by: org.apache.hadoop.fs.UnsupportedFileSystemException: No FileSystem for scheme "wasbs"
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3902)
	at org.apache.hadoop.fs.PrestoFileSystemCache.createFileSystem(PrestoFileSystemCache.java:149)
	at org.apache.hadoop.fs.PrestoFileSystemCache.getInternal(PrestoFileSystemCache.java:94)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:62)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:612)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:55)
	... 38 more`

**Root Cause :**

The Iceberg connector creates its Hadoop Configuration via IcebergNativeCatalogFactory.getHadoopConfiguration() using new Configuration(false), which loads only 37 minimal properties and does NOT load core-default.xml or any other resource files.

The Hive connector (and Delta/Hudi which reuse Hive infrastructure via HiveAzureModule + HiveCommonModule) uses HdfsEnvironment which creates new Configuration(), loading core-default.xml with 927 properties including fs.abfss.impl = SecureAzureBlobFileSystem. So abfss:// works for Hive/Delta/Hudi without any explicit registration.

**Fix :** 

Add Hadoop filesystem registration for Azure Data Lake Storage (ADLS) by configuring the following properties in `HiveAzureConfigurationInitializer.updateConfiguration()` when ABFS storage account credentials are provided:

- `fs.abfss.impl`=`org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem`
- `fs.AbstractFileSystem.abfs.impl`=`org.apache.hadoop.fs.azurebfs.Abfs`
- `fs.AbstractFileSystem.abfss.impl`=`org.apache.hadoop.fs.azurebfs.Abfss`

Add Hadoop filesystem registration for WASB/S by configuring the following properties in `HiveAzureConfigurationInitializer.updateConfiguration()`
- `fs.wasb.impl`=`org.apache.hadoop.fs.azure.NativeAzureFileSystem`
- `fs.wasbs.impl`=`org.apache.hadoop.fs.azure.NativeAzureFileSystem$Secure`

## Impact
ADLS now explicitly registers the Hadoop filesystem implementations for `abfs://`, `abfss://`, `wasb://` and `wasbs://` storage locations

## Test Plan
Tested in local with real adls instance.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add Azure filesystem impl registration for ABFSS and WASB/S schemes

```

## Summary by Sourcery

Ensure the Hive Azure configuration correctly registers Hadoop filesystem implementations for ABFS/ABFSS and scopes the ABFS OAuth token provider configuration per storage account.

Enhancements:
- Register Hadoop filesystem implementations for abfs:// and abfss:// schemes when ABFS credentials are configured.
- Scope the ABFS OAuth token provider configuration to the specific ADLS storage account instead of using a global setting.