### PR TITLE
feat(plugin-iceberg): Add `commit-number-retries` connector config

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -390,6 +390,8 @@ Property Name                                           Description             
                                                         statistics. A value of 1 means a single record is equivalent
                                                         to 1 millisecond of time difference.
 
+``iceberg.commit-number-retries``                       Number of times to retry a commit before failing              ``4``                              Yes                 Yes
+
 ``iceberg.pushdown-filter-enabled``                     Experimental: Enable filter pushdown for Iceberg. This is     ``false``                          No                  Yes
                                                         only supported with Presto C++.
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.iceberg.util.StatisticsUtil.decodeMergeFlags;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
@@ -63,6 +64,7 @@ public class IcebergConfig
     private boolean deleteAsJoinRewriteEnabled = true;
     private int deleteAsJoinRewriteMaxDeleteColumns = 400;
     private int rowsForMetadataOptimizationThreshold = 1000;
+    private int commitNumberRetries = COMMIT_NUM_RETRIES_DEFAULT;
     private int metadataPreviousVersionsMax = METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
     private boolean metadataDeleteAfterCommit = METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
     private int metricsMaxInferredColumn = METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
@@ -416,6 +418,20 @@ public class IcebergConfig
     public IcebergConfig setSplitManagerThreads(int splitManagerThreads)
     {
         this.splitManagerThreads = splitManagerThreads;
+        return this;
+    }
+
+    @Min(0)
+    public int getCommitNumberRetries()
+    {
+        return commitNumberRetries;
+    }
+
+    @Config("iceberg.commit-number-retries")
+    @ConfigDescription("Number of times to retry a commit before failing")
+    public IcebergConfig setCommitNumberRetries(int commitNumberRetries)
+    {
+        this.commitNumberRetries = commitNumberRetries;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -177,7 +177,7 @@ public class IcebergTableProperties
                 .add(integerProperty(
                         TableProperties.COMMIT_NUM_RETRIES,
                         "Determines the number of attempts in case of concurrent upserts and deletes",
-                        TableProperties.COMMIT_NUM_RETRIES_DEFAULT,
+                        icebergConfig.getCommitNumberRetries(),
                         false))
                 .add(new PropertyMetadata<>(
                         TableProperties.DELETE_MODE,

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.spi.statistics.ColumnStatisticType.TOTAL_SIZE_
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
@@ -69,6 +70,7 @@ public class TestIcebergConfig
                 .setManifestCacheExpireDuration(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT)
                 .setManifestCacheMaxContentLength(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT)
                 .setSplitManagerThreads(Runtime.getRuntime().availableProcessors())
+                .setCommitNumberRetries(COMMIT_NUM_RETRIES_DEFAULT)
                 .setMetadataPreviousVersionsMax(METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT)
                 .setMetadataDeleteAfterCommit(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT)
                 .setMetricsMaxInferredColumn(METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT)
@@ -111,6 +113,7 @@ public class TestIcebergConfig
                 .put("iceberg.io.manifest.cache.max-content-length", "10485760")
                 .put("iceberg.io.manifest.cache.max-chunk-size", "1MB")
                 .put("iceberg.split-manager-threads", "42")
+                .put("iceberg.commit-number-retries", "10")
                 .put("iceberg.metadata-previous-versions-max", "1")
                 .put("iceberg.metadata-delete-after-commit", "true")
                 .put("iceberg.metrics-max-inferred-column", "16")
@@ -149,6 +152,7 @@ public class TestIcebergConfig
                 .setManifestCacheMaxContentLength(10485760)
                 .setManifestCacheMaxChunkSize(succinctDataSize(1, MEGABYTE))
                 .setSplitManagerThreads(42)
+                .setCommitNumberRetries(10)
                 .setMetadataPreviousVersionsMax(1)
                 .setMetadataDeleteAfterCommit(true)
                 .setMetricsMaxInferredColumn(16)


### PR DESCRIPTION
## Description

Add a connector-level configuration `iceberg.commit-number-retries` to specify the default number of commit retries for newly created Iceberg tables. Existing tables would not be affected.

## Motivation and Context

Provide a way to specify connector-level default value of commit retries for newly created Iceberg tables.

## Impact

Newly created Iceberg tables may inherit `commit.retry.num-retries` from the connector configuration when the property is not explicitly specified.

## Test Plan

 - Updated `TestIcebergConfig` accordingly

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add configuration property ``iceberg.commit-number-retries`` to specify the default number of commit retries for newly created tables.
```

## Summary by Sourcery

Add a connector-level configuration for default Iceberg commit retry count and wire it into table properties.

New Features:
- Introduce the `iceberg.commit-number-retries` connector configuration to control default commit retry attempts for new Iceberg tables.

Tests:
- Extend Iceberg configuration tests to cover the new commit retry configuration and its property mappings.