### PR TITLE
fix(native): register Presto cuDF functions

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -86,6 +86,7 @@
 #ifdef PRESTO_ENABLE_CUDF
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #endif
 
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
@@ -190,6 +191,8 @@ void registerVeloxCudf() {
         systemConfig->values());
     if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
       velox::cudf_velox::registerCudf();
+      velox::cudf_velox::registerPrestoFunctions(
+          velox::cudf_velox::CudfConfig::getInstance().functionNamePrefix);
       PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
     }
   }


### PR DESCRIPTION
## Summary
- Register Velox cuDF Presto-specific functions when cuDF is enabled in Presto native.
- Keep the Presto-specific cuDF registration next to the existing `registerCudf()` call in the cuDF initialization path.
- Reuse `CudfConfig::functionNamePrefix` so these registrations honor the configured Presto function namespace.

## Motivation
Velox separates the common cuDF function registration from Presto-specific cuDF functions. Presto native currently initializes cuDF with `velox::cudf_velox::registerCudf()`, but it does not call `velox::cudf_velox::registerPrestoFunctions()`. As a result, Presto-specific cuDF functions are not registered when cuDF is enabled.

This wires the Presto-specific registration into the existing Presto native cuDF initialization path. The change is guarded by `PRESTO_ENABLE_CUDF`, so non-cuDF builds are unaffected.
