### PR TITLE
feat(connector): Add support for real datatype insert in oracle connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -180,13 +180,18 @@ Oracle to PrestoDB type mapping
 The connector maps Oracle types to the corresponding PrestoDB types:
 
 .. list-table:: Oracle to PrestoDB type mapping
-  :widths: 50, 50
   :header-rows: 1
 
   * - Oracle type
     - PrestoDB type
   * - ``BLOB``
     - ``VARBINARY``
+  * - ``BINARY_FLOAT``
+    - ``REAL``
+  * - ``REAL``
+    - ``REAL``
+  * - ``BINARY_DOUBLE``
+    - ``DOUBLE``
 
 Oracle Connector Limitations
 ----------------------------

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -284,6 +284,7 @@ public class OracleClient
             case OracleTypes.BINARY_DOUBLE:
                 return Optional.of(doubleReadMapping());
             case Types.REAL:
+            case OracleTypes.BINARY_FLOAT:
                 return Optional.of(realReadMapping());
             case Types.NUMERIC:
                 int precision = columnSize == 0 ? Decimals.MAX_PRECISION : columnSize;

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleTypes.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleTypes.java
@@ -35,6 +35,8 @@ import static com.facebook.presto.tests.datatype.DataType.stringDataType;
 import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestOracleTypes
         extends AbstractTestQueryFramework
@@ -124,5 +126,127 @@ public class TestOracleTypes
                 resultType,
                 value -> format("CAST('%s' AS %s)", value, resultType),
                 queryResult);
+    }
+
+    @Test
+    public void testRealInsert()
+    {
+        assertUpdate("create table test_real_type(datatype_real real)");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_real_type"));
+        try {
+            assertUpdate("insert into test_real_type(datatype_real) values (96.5)", 1);
+            assertQuery("SELECT datatype_real FROM test_real_type", "VALUES (96.5)");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_real_type");
+            assertFalse(getQueryRunner().tableExists(getSession(), "test_real_type"));
+        }
+    }
+
+    @Test
+    public void testRealCreateTableAsSelect()
+    {
+        assertUpdate("CREATE TABLE test_real_ctas AS SELECT REAL '42.5' as value", 1);
+
+        try {
+            assertQuery("SELECT * FROM test_real_ctas", "VALUES (42.5)");
+
+            // Verify the column type is REAL
+            assertQuery(
+                    "SELECT data_type FROM information_schema.columns " +
+                            "WHERE table_name = 'test_real_ctas' AND column_name = 'value'",
+                    "VALUES ('real')");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_real_ctas");
+        }
+    }
+
+    /**
+     * Test that REAL columns created in Oracle can be read by Presto.
+     * This verifies that the BINARY_FLOAT type mapping works correctly.
+     */
+    @Test
+    public void testReadOracleRealColumn()
+    {
+        // Create table directly in Oracle using BINARY_FLOAT
+        oracleServer.execute("CREATE TABLE test_binary_float (id NUMBER, value BINARY_FLOAT)");
+
+        try {
+            // Insert data directly in Oracle
+            oracleServer.execute("INSERT INTO test_binary_float VALUES (1, 1.5)");
+            oracleServer.execute("INSERT INTO test_binary_float VALUES (2, -2.25)");
+            oracleServer.execute("INSERT INTO test_binary_float VALUES (3, 0.5)");
+            oracleServer.execute("COMMIT");
+
+            // Verify Presto can read the BINARY_FLOAT column
+            assertQuery(
+                    "SELECT value FROM test_binary_float ORDER BY id",
+                    "VALUES (1.5), (-2.25), (0.5)");
+        }
+        finally {
+            oracleServer.execute("DROP TABLE test_binary_float");
+        }
+    }
+
+    @Test
+    public void testDoubleCreateTableAsSelect()
+    {
+        assertUpdate("CREATE TABLE test_double_ctas AS SELECT DOUBLE '42.5' as value", 1);
+
+        try {
+            assertQuery("SELECT * FROM test_double_ctas", "VALUES (42.5)");
+
+            // Verify the column type is DOUBLE
+            assertQuery(
+                    "SELECT data_type FROM information_schema.columns " +
+                            "WHERE table_name = 'test_double_ctas' AND column_name = 'value'",
+                    "VALUES ('double')");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_double_ctas");
+        }
+    }
+
+    @Test
+    public void testDoubleInsert()
+    {
+        assertUpdate("create table test_double_type(datatype_double double)");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_double_type"));
+        try {
+            assertUpdate("insert into test_double_type(datatype_double) values (96.5)", 1);
+            assertQuery("SELECT datatype_double FROM test_double_type", "VALUES (96.5)");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_double_type");
+            assertFalse(getQueryRunner().tableExists(getSession(), "test_double_type"));
+        }
+    }
+
+    /**
+     * Test that DOUBLE columns created in Oracle can be read by Presto.
+     * This verifies that the BINARY_DOUBLE type mapping works correctly.
+     */
+    @Test
+    public void testReadOracleDoubleColumn()
+    {
+        // Create table directly in Oracle using BINARY_DOUBLE
+        oracleServer.execute("CREATE TABLE test_binary_double (id NUMBER, value BINARY_DOUBLE)");
+
+        try {
+            // Insert data directly in Oracle
+            oracleServer.execute("INSERT INTO test_binary_double VALUES (1, 1.5)");
+            oracleServer.execute("INSERT INTO test_binary_double VALUES (2, -2.25)");
+            oracleServer.execute("INSERT INTO test_binary_double VALUES (3, 0.5)");
+            oracleServer.execute("COMMIT");
+
+            // Verify Presto can read the BINARY_DOUBLE column
+            assertQuery(
+                    "SELECT value FROM test_binary_double ORDER BY id",
+                    "VALUES (1.5), (-2.25), (0.5)");
+        }
+        finally {
+            oracleServer.execute("DROP TABLE test_binary_double");
+        }
     }
 }


### PR DESCRIPTION
## Description
Add support for `REAL` datatype insert in oracle connector.

## Motivation and Context

Resolves issue https://github.com/prestodb/presto/issues/28050

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

```
presto> create table oracle.tm_lh_user.table_real_389(datatype_real real);
CREATE TABLE

presto> show create table oracle.tm_lh_user.table_real_389;
                  Create Table
-------------------------------------------------
 CREATE TABLE oracle.tm_lh_user.table_real_389 (
    "datatype_real" real
 )
(1 row)


presto> describe oracle.tm_lh_user.table_real_389;
    Column     | Type | Extra | Comment | Precision | Scale | Length
---------------+------+-------+---------+-----------+-------+--------
 datatype_real | real |       |         |        24 | NULL  | NULL
(1 row)


presto> insert into oracle.tm_lh_user.table_real_389 values (96.602);
INSERT: 1 row


presto> select * from  oracle.tm_lh_user.table_real_389;
 datatype_real
---------------
        96.602
(1 row)
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Add support for REAL datatype insert
```



## Summary by Sourcery

Extend Oracle connector support for REAL type handling and add coverage for REAL inserts.

New Features:
- Support reading Oracle BINARY_FLOAT columns as Presto REAL type.

Tests:
- Add integration test verifying REAL column creation and insertion in the Oracle connector.

## Summary by Sourcery

Add support for Oracle BINARY_FLOAT columns to be handled as Presto REAL and validate REAL insert and CTAS flows in the Oracle connector.

New Features:
- Map Oracle BINARY_FLOAT columns to the Presto REAL type for reading.

Tests:
- Add integration tests covering REAL inserts, CTAS with REAL columns, and reading Oracle BINARY_FLOAT columns via the Oracle connector.