### PR TITLE
feat(iceberg): Consume dynamic filter for split/partition pruning

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -96,4 +96,43 @@ public class RuntimeMetricName
     public static final String CHECK_ACCESS_PERMISSIONS_TIME_NANOS = "checkAccessPermissionsTimeNanos";
     public static final String DYNAMIC_FILTER_PLAN_CREATED_FAVORABLE_RATIO = "dynamicFilterPlanCreatedFavorableRatio";
     public static final String DYNAMIC_FILTER_PLAN_SKIPPED_HIGH_CARDINALITY = "dynamicFilterPlanSkippedHighCardinality";
+
+    public static final String DYNAMIC_FILTER_SPLITS_PROCESSED = "dynamicFilterSplitsProcessed";
+    public static final String DYNAMIC_FILTER_WAIT_TIME_NANOS = "dynamicFilterWaitTimeNanos";
+    public static final String DYNAMIC_FILTER_COLLECTION_TIME_NANOS = "dynamicFilterCollectionTimeNanos";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED = "dynamicFilterPartitionsReceived";
+    public static final String DYNAMIC_FILTER_PUSHED_INTO_SCAN = "dynamicFilterPushedIntoScan";
+    public static final String DYNAMIC_FILTER_SPLITS_BEFORE_FILTER = "dynamicFilterSplitsBeforeFilter";
+    public static final String DYNAMIC_FILTER_CONSTRAINT_COLUMNS = "dynamicFilterConstraintColumns";
+    public static final String DYNAMIC_FILTER_EXPECTED_PARTITIONS = "dynamicFilterExpectedPartitions";
+    public static final String DYNAMIC_FILTER_FETCHERS_STARTED = "dynamicFilterFetchersStarted";
+    public static final String DYNAMIC_FILTER_SOURCE_DISTINCT_VALUES = "dynamicFilterSourceDistinctValues";
+    public static final String DYNAMIC_FILTER_SOURCE_FALLBACK_TO_MIN_MAX = "dynamicFilterSourceFallbackToMinMax";
+    public static final String DYNAMIC_FILTER_SOURCE_COLLECTION_TIME_NANOS = "dynamicFilterSourceCollectionTimeNanos";
+    public static final String DYNAMIC_FILTER_TIMED_OUT = "dynamicFilterTimedOut";
+    public static final String DYNAMIC_FILTER_DOMAIN_RANGE_COUNT = "dynamicFilterDomainRangeCount";
+    public static final String DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE = "dynamicFilterCoordinatorFallbackToRange";
+    public static final String DYNAMIC_FILTER_SHORT_CIRCUITED = "dynamicFilterShortCircuited";
+    public static final String DYNAMIC_FILTER_FETCHER_POLLS = "dynamicFilterFetcherPolls";
+    public static final String DYNAMIC_FILTER_FETCHER_STOPPED_BY_CLEANUP = "dynamicFilterFetcherStoppedByCleanup";
+    public static final String DYNAMIC_FILTER_FETCHER_FINAL_FETCH_COMPLETED = "dynamicFilterFetcherFinalFetchCompleted";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_FROM_TASK = "dynamicFilterPartitionsReceivedFromTask";
+    public static final String DYNAMIC_FILTER_OPERATOR_CALLBACK = "dynamicFilterOperatorCallback";
+    public static final String DYNAMIC_FILTER_FACTORY_CLOSED = "dynamicFilterFactoryClosed";
+    public static final String DYNAMIC_FILTER_FLUSH_FIRED = "dynamicFilterFlushFired";
+    public static final String DYNAMIC_FILTER_COMPLETED_ID_DELIVERED = "dynamicFilterCompletedIdDelivered";
+    // Push-to-worker metrics (extended metrics only)
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_COUNT = "dynamicFilterPushToWorkerCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_COUNT = "dynamicFilterPushToWorkerTaskCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_SUCCESS_COUNT = "dynamicFilterPushToWorkerSuccessCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_FAILURE_COUNT = "dynamicFilterPushToWorkerFailureCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_LATENCY_MS = "dynamicFilterPushToWorkerLatencyMs";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_HTTP_STATUS = "dynamicFilterPushToWorkerHttpStatus";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_NOT_FOUND_COUNT = "dynamicFilterPushToWorkerTaskNotFoundCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_THROTTLED_COUNT = "dynamicFilterPushToWorkerThrottledCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_RETRIED_COUNT = "dynamicFilterPushToWorkerRetriedCount";
+    public static final String DYNAMIC_FILTER_PUSH_TO_WORKER_RETRY_GAVE_UP_COUNT = "dynamicFilterPushToWorkerRetryGaveUpCount";
+    // Column selectivity check metrics (extended metrics only)
+    public static final String DYNAMIC_FILTER_COLUMNS_SKIPPED = "dynamicFilterColumnsSkipped";
+    public static final String DYNAMIC_FILTER_COLUMNS_RELEVANT = "dynamicFilterColumnsRelevant";
 }

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -448,6 +448,33 @@ Property Name                                           Description             
                                                         ``256MB``, ``1GB``). Supported units are: ``B`` (bytes),
                                                         ``kB`` (kilobytes), ``MB`` (megabytes), ``GB`` (gigabytes),
                                                         ``TB`` (terabytes), ``PB`` (petabytes).
+
+``iceberg.dynamic-filter-extended-metrics``             When set to ``true``, the Iceberg split source emits        ``false``                          Yes                 Yes
+                                                        additional runtime metrics for dynamic filter diagnostics,
+                                                        such as constraint column counts, partition evaluator
+                                                        outcomes, and wait-time histograms. Intended for
+                                                        troubleshooting and benchmarking, not production use.
+                                                        Overridable per session with the
+                                                        ``dynamic_filter_extended_metrics`` session property.
+
+``iceberg.dynamic-filter-warmup-enabled``               When ``true``, the split source dispatches a warmup batch  ``true``                           Yes                 Yes
+                                                        of splits (up to the budget set by
+                                                        ``iceberg.dynamic-filter-warmup-weight-per-task``) before
+                                                        pausing to wait for the coordinator-collected dynamic
+                                                        filter. When the filter arrives, the source performs a
+                                                        filtered re-scan using Iceberg manifest pruning and
+                                                        deduplicates warmup splits. Set to ``false`` to wait for
+                                                        the filter before enumerating any splits.
+                                                        Overridable per session with the
+                                                        ``dynamic_filter_warmup_enabled`` session property.
+
+``iceberg.dynamic-filter-warmup-weight-per-task``       Split weight per coordinator task to dispatch during the   ``Number of available processors`` Yes                 Yes
+                                                        warmup phase. The total warmup budget is this value
+                                                        multiplied by the task count hint. Set to ``0`` to
+                                                        disable the warmup budget (dispatch all splits
+                                                        immediately before pausing).
+                                                        Overridable per session with the
+                                                        ``dynamic_filter_warmup_weight_per_task`` session property.
 ======================================================= ============================================================= ================================== =================== =============================================
 
 Table Properties
@@ -696,6 +723,27 @@ Session properties set behavior changes for queries executed within the given se
        ``aggregate_push_down_enabled``
      - Overrides the behavior of the connector property
        ``iceberg.aggregate-push-down-enabled`` in the current session.
+     - Yes
+     - Yes
+   * - .. _iceberg-sess-dynamic-filter-extended-metrics:
+
+       ``dynamic_filter_extended_metrics``
+     - Overrides the behavior of the connector property
+       ``iceberg.dynamic-filter-extended-metrics`` in the current session.
+     - Yes
+     - Yes
+   * - .. _iceberg-sess-dynamic-filter-warmup-enabled:
+
+       ``dynamic_filter_warmup_enabled``
+     - Overrides the behavior of the connector property
+       ``iceberg.dynamic-filter-warmup-enabled`` in the current session.
+     - Yes
+     - Yes
+   * - .. _iceberg-sess-dynamic-filter-warmup-weight-per-task:
+
+       ``dynamic_filter_warmup_weight_per_task``
+     - Overrides the behavior of the connector property
+       ``iceberg.dynamic-filter-warmup-weight-per-task`` in the current session.
      - Yes
      - Yes
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -170,6 +170,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HiveUtil.PRESTO_QUERY_ID;
+import static com.facebook.presto.hive.MetadataUtils.createPredicate;
 import static com.facebook.presto.hive.MetadataUtils.getCombinedRemainingPredicate;
 import static com.facebook.presto.hive.MetadataUtils.getDiscretePredicates;
 import static com.facebook.presto.hive.MetadataUtils.getPredicate;
@@ -526,10 +527,14 @@ public abstract class IcebergAbstractMetadata
         Optional<? extends Iterable<HivePartition>> partitions = icebergTableLayoutHandle.getPartitions();
         Optional<DiscretePredicates> discretePredicates = partitions.flatMap(parts -> getDiscretePredicates(partitionColumns, parts));
         if (!isPushdownFilterEnabled(session)) {
+            TupleDomain<ColumnHandle> predicate = partitions
+                    .map(parts ->
+                            icebergTableLayoutHandle.getPartitionColumnPredicate().intersect(createPredicate(partitionColumns, ImmutableList.copyOf(parts))))
+                    .orElse(TupleDomain.none());
             return new ConnectorTableLayout(
                     icebergTableLayoutHandle,
                     Optional.empty(),
-                    partitions.isPresent() ? icebergTableLayoutHandle.getPartitionColumnPredicate() : TupleDomain.none(),
+                    predicate,
                     Optional.empty(),
                     Optional.empty(),
                     discretePredicates,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -85,6 +85,9 @@ public class IcebergConfig
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
     private boolean aggregatePushDownEnabled = true;
     private DataSize targetMaxFileSize = succinctDataSize(1, GIGABYTE);
+    private boolean dynamicFilterExtendedMetrics;
+    private boolean dynamicFilterWarmupEnabled = true;
+    private double dynamicFilterWarmupWeightPerTask = Runtime.getRuntime().availableProcessors();
 
     @NotNull
     public FileFormat getFileFormat()
@@ -592,6 +595,48 @@ public class IcebergConfig
             throw new IllegalArgumentException("iceberg.target-max-file-size must be at least 1 byte");
         }
         this.targetMaxFileSize = targetMaxFileSize;
+        return this;
+    }
+
+    public boolean isDynamicFilterExtendedMetrics()
+    {
+        return dynamicFilterExtendedMetrics;
+    }
+
+    @Config("iceberg.dynamic-filter-extended-metrics")
+    @ConfigDescription("Emit extended metrics for dynamic filter diagnostics in Iceberg split sources")
+    public IcebergConfig setDynamicFilterExtendedMetrics(boolean dynamicFilterExtendedMetrics)
+    {
+        this.dynamicFilterExtendedMetrics = dynamicFilterExtendedMetrics;
+        return this;
+    }
+
+    public boolean isDynamicFilterWarmupEnabled()
+    {
+        return dynamicFilterWarmupEnabled;
+    }
+
+    @Config("iceberg.dynamic-filter-warmup-enabled")
+    @ConfigDescription("When enabled, dispatch a warmup batch of splits proportional to task count before pausing " +
+            "for the dynamic filter. When the filter resolves, a filtered re-scan with manifest-level pruning begins.")
+    public IcebergConfig setDynamicFilterWarmupEnabled(boolean dynamicFilterWarmupEnabled)
+    {
+        this.dynamicFilterWarmupEnabled = dynamicFilterWarmupEnabled;
+        return this;
+    }
+
+    @DecimalMin("0")
+    public double getDynamicFilterWarmupWeightPerTask()
+    {
+        return dynamicFilterWarmupWeightPerTask;
+    }
+
+    @Config("iceberg.dynamic-filter-warmup-weight-per-task")
+    @ConfigDescription("Split weight per task to dispatch during warmup before pausing for the dynamic filter. " +
+            "Multiplied by task count to compute total warmup budget. 0 disables warmup budget (full eager dispatch).")
+    public IcebergConfig setDynamicFilterWarmupWeightPerTask(double dynamicFilterWarmupWeightPerTask)
+    {
+        this.dynamicFilterWarmupWeightPerTask = dynamicFilterWarmupWeightPerTask;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -79,6 +79,9 @@ public final class IcebergSessionProperties
     public static final String MATERIALIZED_VIEW_DEFAULT_MAX_SNAPSHOTS_PER_REFRESH = "materialized_view_default_max_snapshots_per_refresh";
     public static final String AGGREGATE_PUSH_DOWN_ENABLED = "aggregate_push_down_enabled";
     public static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
+    private static final String DYNAMIC_FILTER_EXTENDED_METRICS = "dynamic_filter_extended_metrics";
+    private static final String DYNAMIC_FILTER_WARMUP_ENABLED = "dynamic_filter_warmup_enabled";
+    private static final String DYNAMIC_FILTER_WARMUP_WEIGHT_PER_TASK = "dynamic_filter_warmup_weight_per_task";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -288,7 +291,23 @@ public final class IcebergSessionProperties
                             }
                             return dataSize;
                         },
-                        DataSize::toString));
+                        DataSize::toString))
+                .add(booleanProperty(
+                        DYNAMIC_FILTER_EXTENDED_METRICS,
+                        "Emit extended metrics for dynamic filter diagnostics in Iceberg split sources",
+                        icebergConfig.isDynamicFilterExtendedMetrics(),
+                        false))
+                .add(booleanProperty(
+                        DYNAMIC_FILTER_WARMUP_ENABLED,
+                        "When enabled, dispatch a warmup batch of splits before pausing for the dynamic filter",
+                        icebergConfig.isDynamicFilterWarmupEnabled(),
+                        false))
+                .add(doubleProperty(
+                        DYNAMIC_FILTER_WARMUP_WEIGHT_PER_TASK,
+                        "Split weight per task to dispatch during warmup before pausing for the dynamic filter. " +
+                                "Multiplied by task count to compute total warmup budget. 0 disables warmup budget (full eager dispatch).",
+                        icebergConfig.getDynamicFilterWarmupWeightPerTask(),
+                        false));
 
         nessieConfig.ifPresent((config) -> propertiesBuilder
                 .add(stringProperty(
@@ -470,5 +489,20 @@ public final class IcebergSessionProperties
     public static DataSize getTargetMaxFileSize(ConnectorSession session)
     {
         return session.getProperty(TARGET_MAX_FILE_SIZE, DataSize.class);
+    }
+
+    public static boolean isDynamicFilterExtendedMetrics(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTER_EXTENDED_METRICS, Boolean.class);
+    }
+
+    public static boolean isDynamicFilterWarmupEnabled(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTER_WARMUP_ENABLED, Boolean.class);
+    }
+
+    public static double getDynamicFilterWarmupWeightPerTask(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTER_WARMUP_WEIGHT_PER_TASK, Double.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.google.common.collect.ImmutableList;
 import jakarta.inject.Inject;
 import org.apache.iceberg.DeleteFile;
@@ -75,6 +76,17 @@ public class IcebergSplitManager
             ConnectorSession session,
             ConnectorTableLayoutHandle layout,
             SplitSchedulingContext splitSchedulingContext)
+    {
+        return getSplits(transaction, session, layout, splitSchedulingContext, DynamicFilter.EMPTY);
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext,
+            DynamicFilter dynamicFilter)
     {
         IcebergTableLayoutHandle layoutHandle = (IcebergTableLayoutHandle) layout;
 
@@ -133,7 +145,8 @@ public class IcebergSplitManager
                     .orElseGet(() -> new IcebergSplitSource(
                             session,
                             tableScan,
-                            metadataColumnConstraints));
+                            metadataColumnConstraints,
+                            dynamicFilter));
         }
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -13,37 +13,69 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.iceberg.delete.DeleteFile;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closer;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
+import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLUMNS_RELEVANT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLUMNS_SKIPPED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_CONSTRAINT_COLUMNS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSHED_INTO_SCAN;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SPLITS_BEFORE_FILTER;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SPLITS_PROCESSED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_WAIT_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getAffinitySchedulingFileSectionSize;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.FileFormat.fromIcebergFileFormat;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getDynamicFilterWarmupWeightPerTask;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isDynamicFilterExtendedMetrics;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isDynamicFilterWarmupEnabled;
 import static com.facebook.presto.iceberg.IcebergUtil.buildLastUpdatedSequenceNumberEvaluator;
 import static com.facebook.presto.iceberg.IcebergUtil.getDataSequenceNumber;
 import static com.facebook.presto.iceberg.IcebergUtil.getFirstRowId;
@@ -60,6 +92,51 @@ import static org.apache.iceberg.util.TableScanUtil.splitFiles;
 public class IcebergSplitSource
         implements ConnectorSplitSource
 {
+    private static final ConnectorSplitBatch EMPTY_BATCH_NOT_FINISHED =
+            new ConnectorSplitBatch(ImmutableList.of(), false);
+
+    private enum State
+    {
+        WAITING_FOR_FILTER,
+        WARMUP_SCANNING,
+        WARMUP_PAUSED,
+        SCANNING_FILTERED
+    }
+
+    /**
+     * Key for deduplicating warmup splits during filtered re-scan.
+     */
+    private static final class SplitKey
+    {
+        private final String path;
+        private final long start;
+
+        SplitKey(String path, long start)
+        {
+            this.path = requireNonNull(path, "path is null");
+            this.start = start;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SplitKey splitKey = (SplitKey) o;
+            return start == splitKey.start && path.equals(splitKey.path);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(path, start);
+        }
+    }
+
     private CloseableIterator<FileScanTask> fileScanTaskIterator;
 
     private final Closer closer = Closer.create();
@@ -79,12 +156,101 @@ public class IcebergSplitSource
     // without help. See `toIcebergSplit()` for the override logic.
     private final FileFormat tableWriteFormat;
 
+    private final DynamicFilter dynamicFilter;
+    private final TableScan tableScan;
+    private final Schema tableSchema;
+    private final boolean warmupEnabled;
+    private State state;
+
+    private final RuntimeStats runtimeStats;
+    private final boolean dynamicFilterActive;
+    private final boolean extendedMetrics;
+    private long splitsExamined;
+    private long filterWaitStartNanos;
+    private boolean filterWaitTimeEmitted;
+    private boolean dynamicFilterApplied;
+    private boolean closed;
+
+    private final Optional<Set<ColumnHandle>> relevantFilterColumns;
+
+    private Expression filterExpression;
+    private InclusiveMetricsEvaluator metricsEvaluator;
+    private Map<Integer, Evaluator> partitionEvaluatorCache;
+    private boolean inlineFilterActive;
+    // Tracks the last predicate pushed into the scan; per-batch narrowing only re-applies
+    // when a strictly newer predicate arrives.
+    private TupleDomain<ColumnHandle> lastAppliedPredicate = TupleDomain.all();
+
+    private OptionalInt warmupMaxWeight;
+    private final double warmupWeightPerTask;
+    private Set<SplitKey> dispatchedSplitKeys;
+    private long warmupWeightDispatched;
+    private long warmupPauseStartNanos;
+
+    private long splitsBeforeFilter;
+    private long splitsFilteredInline;
+    private long warmupSplitsDispatched;
+    private long reScanDedupSkipped;
+    private long reScanSplitsProduced;
+    private boolean reScanTriggered;
+
     public IcebergSplitSource(
             ConnectorSession session,
             TableScan tableScan,
-            TupleDomain<IcebergColumnHandle> metadataColumnConstraints)
+            TupleDomain<IcebergColumnHandle> metadataColumnConstraints,
+            DynamicFilter dynamicFilter)
     {
-        this(session, getTargetSplitSize(session, tableScan).toBytes(), tableScan.planFiles(), metadataColumnConstraints, parseTableWriteFormat(tableScan));
+        requireNonNull(session, "session is null");
+        this.metadataColumnConstraints = requireNonNull(metadataColumnConstraints, "metadataColumnConstraints is null");
+        this.lineageEvaluator = buildLastUpdatedSequenceNumberEvaluator(metadataColumnConstraints);
+        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
+        this.tableScan = requireNonNull(tableScan, "tableScan is null");
+        this.tableSchema = tableScan.table().schema();
+        this.tableWriteFormat = parseTableWriteFormat(tableScan);
+        this.targetSplitSize = getTargetSplitSize(session, tableScan).toBytes();
+        this.minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
+        this.nodeSelectionStrategy = getNodeSelectionStrategy(session);
+        this.affinitySchedulingFileSectionSize = getAffinitySchedulingFileSectionSize(session).toBytes();
+
+        this.runtimeStats = session.getRuntimeStats();
+        this.dynamicFilterActive = dynamicFilter.getWaitTimeout().toMillis() > 0;
+        this.extendedMetrics = isDynamicFilterExtendedMetrics(session);
+        this.warmupEnabled = isDynamicFilterWarmupEnabled(session);
+        this.warmupWeightPerTask = getDynamicFilterWarmupWeightPerTask(session);
+
+        if (dynamicFilterActive && !dynamicFilter.isComplete()) {
+            Set<ColumnHandle> relevant = computeRelevantFilterColumns(
+                    dynamicFilter.getPendingFilterColumns());
+            this.relevantFilterColumns = Optional.of(relevant);
+        }
+        else {
+            this.relevantFilterColumns = Optional.empty();
+        }
+
+        // taskCountHint is 0 at construction; defer warmup budget computation to first getNextBatch().
+        this.warmupMaxWeight = OptionalInt.empty();
+
+        if (dynamicFilter.isComplete()) {
+            dynamicFilterApplied = true;
+            initializeScanWithDynamicFilter(dynamicFilter.getCurrentPredicate());
+            state = State.SCANNING_FILTERED;
+        }
+        else if (relevantFilterColumns.isPresent() && relevantFilterColumns.get().isEmpty()) {
+            initializeScan();
+            state = State.SCANNING_FILTERED;
+        }
+        else if (warmupEnabled && warmupWeightPerTask > 0) {
+            initializeScan();
+            this.dispatchedSplitKeys = new HashSet<>();
+            filterWaitStartNanos = System.nanoTime();
+            dynamicFilter.isBlocked(relevantFilterColumns);
+            state = State.WARMUP_SCANNING;
+        }
+        else {
+            filterWaitStartNanos = System.nanoTime();
+            dynamicFilter.isBlocked(relevantFilterColumns);
+            state = State.WAITING_FOR_FILTER;
+        }
     }
 
     public IcebergSplitSource(
@@ -106,16 +272,27 @@ public class IcebergSplitSource
         requireNonNull(session, "session is null");
         this.metadataColumnConstraints = requireNonNull(metadataColumnConstraints, "metadataColumnConstraints is null");
         this.lineageEvaluator = buildLastUpdatedSequenceNumberEvaluator(metadataColumnConstraints);
+        this.dynamicFilter = DynamicFilter.EMPTY;
+        this.tableScan = null;
+        this.tableSchema = null;
         this.targetSplitSize = targetSplitSize;
         this.minimumAssignedSplitWeight = getMinimumAssignedSplitWeight(session);
         this.nodeSelectionStrategy = getNodeSelectionStrategy(session);
         this.affinitySchedulingFileSectionSize = getAffinitySchedulingFileSectionSize(session).toBytes();
         this.tableWriteFormat = tableWriteFormat;
+        this.runtimeStats = session.getRuntimeStats();
+        this.dynamicFilterActive = false;
+        this.extendedMetrics = false;
+        this.warmupEnabled = false;
+        this.warmupWeightPerTask = 0;
+        this.relevantFilterColumns = Optional.empty();
+        this.warmupMaxWeight = OptionalInt.of(0);
         this.fileScanTaskIterator = closer.register(
                 splitFiles(
                         closer.register(fileScanTasks),
                         targetSplitSize)
                         .iterator());
+        this.state = State.SCANNING_FILTERED;
     }
 
     // Reads the table's `write.format.default` property (e.g. "NIMBLE",
@@ -141,38 +318,438 @@ public class IcebergSplitSource
     @Override
     public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
     {
-        // TODO: move this to a background thread
+        if (state == State.WAITING_FOR_FILTER) {
+            if (shouldExitWaiting()) {
+                transitionFromBlocking();
+            }
+            else {
+                // Return a not-yet-completed future so that BufferingSplitSource
+                // does not recursively chain on an already-completed empty batch.
+                CompletableFuture<?> blocked = dynamicFilter.isBlocked(relevantFilterColumns);
+                if (!blocked.isDone()) {
+                    return blocked.thenApply(ignored -> {
+                        if (closed) {
+                            return EMPTY_BATCH_NOT_FINISHED;
+                        }
+                        if (shouldExitWaiting()) {
+                            transitionFromBlocking();
+                        }
+                        return state == State.SCANNING_FILTERED ? enumerateSplitBatch(maxSize) : EMPTY_BATCH_NOT_FINISHED;
+                    });
+                }
+                transitionFromBlocking();
+            }
+        }
+        else if (state == State.WARMUP_SCANNING) {
+            if (!warmupMaxWeight.isPresent() && warmupEnabled && warmupWeightPerTask > 0) {
+                int taskCountHint = dynamicFilter.getTaskCountHint();
+                if (taskCountHint > 0) {
+                    int maxWeight = (int) Math.round(warmupWeightPerTask * SplitWeight.rawValueForStandardSplitCount(taskCountHint));
+                    this.warmupMaxWeight = OptionalInt.of(maxWeight);
+                }
+            }
+
+            if (shouldExitWaiting()) {
+                transitionToFilteredReScan();
+            }
+            else if (warmupMaxWeight.isPresent() && warmupWeightDispatched >= warmupMaxWeight.getAsInt()) {
+                warmupPauseStartNanos = System.nanoTime();
+                state = State.WARMUP_PAUSED;
+                return handleWarmupPaused(maxSize);
+            }
+        }
+        else if (state == State.WARMUP_PAUSED) {
+            return handleWarmupPaused(maxSize);
+        }
+        // Re-check predicate each batch; filters arriving after the warmup transition narrow inline.
+        if (state == State.SCANNING_FILTERED) {
+            TupleDomain<ColumnHandle> currentPredicate = dynamicFilter.getCurrentPredicate();
+            if (!currentPredicate.equals(lastAppliedPredicate)) {
+                activateInlineFilter(currentPredicate);
+            }
+        }
+        return completedFuture(enumerateSplitBatch(maxSize));
+    }
+
+    private CompletableFuture<ConnectorSplitBatch> handleWarmupPaused(int maxSize)
+    {
+        if (shouldExitWaiting()) {
+            transitionToFilteredReScan();
+            return completedFuture(enumerateSplitBatch(maxSize));
+        }
+
+        CompletableFuture<?> blocked = dynamicFilter.isBlocked(relevantFilterColumns);
+        if (!blocked.isDone()) {
+            return blocked.thenApply(ignored -> {
+                if (closed) {
+                    return EMPTY_BATCH_NOT_FINISHED;
+                }
+                if (shouldExitWaiting()) {
+                    transitionToFilteredReScan();
+                }
+                return state == State.SCANNING_FILTERED ? enumerateSplitBatch(maxSize) : EMPTY_BATCH_NOT_FINISHED;
+            });
+        }
+        transitionToFilteredReScan();
+        return completedFuture(enumerateSplitBatch(maxSize));
+    }
+
+    private void transitionFromBlocking()
+    {
+        recordFilterWaitTime();
+        dynamicFilterApplied = dynamicFilter.isComplete(relevantFilterColumns)
+                || dynamicFilter.hasAnyComplete(relevantFilterColumns);
+        state = State.SCANNING_FILTERED;
+        initializeScanWithDynamicFilter(dynamicFilter.getCurrentPredicate());
+    }
+
+    private void transitionToFilteredReScan()
+    {
+        recordFilterWaitTime();
+        if (warmupPauseStartNanos > 0 && extendedMetrics) {
+            long pauseNanos = System.nanoTime() - warmupPauseStartNanos;
+            runtimeStats.addMetricValue("dynamicFilterWarmupPauseNanos", NANO, pauseNanos);
+        }
+        dynamicFilterApplied = dynamicFilter.isComplete(relevantFilterColumns)
+                || dynamicFilter.hasAnyComplete(relevantFilterColumns);
+        state = State.SCANNING_FILTERED;
+
+        TupleDomain<ColumnHandle> currentPredicate = dynamicFilter.getCurrentPredicate();
+        if (!currentPredicate.isAll()) {
+            reScanTriggered = true;
+            closeCurrentIterator();
+            initializeScanWithDynamicFilter(currentPredicate);
+        }
+        else {
+            activateInlineFilter(currentPredicate);
+            dispatchedSplitKeys = null;
+        }
+    }
+
+    private void activateInlineFilter(TupleDomain<ColumnHandle> dynamicFilterConstraint)
+    {
+        if (dynamicFilterConstraint.isAll()) {
+            return;
+        }
+
+        TupleDomain<IcebergColumnHandle> icebergConstraint = dynamicFilterConstraint
+                .transform(columnHandle -> columnHandle instanceof IcebergColumnHandle ? (IcebergColumnHandle) columnHandle : null);
+
+        if (extendedMetrics) {
+            if (icebergConstraint.isNone()) {
+                runtimeStats.addMetricValue("dynamicFilterIcebergConstraintIsNone", NONE, 1);
+            }
+            if (icebergConstraint.isAll()) {
+                runtimeStats.addMetricValue("dynamicFilterIcebergConstraintIsAll", NONE, 1);
+            }
+            recordDomainDetails(icebergConstraint);
+        }
+
+        Expression dfExpression = toIcebergExpression(icebergConstraint);
+
+        if (extendedMetrics) {
+            runtimeStats.addMetricValue("dynamicFilterExpressionOp", NONE, dfExpression.op().ordinal());
+        }
+
+        this.filterExpression = dfExpression;
+        this.metricsEvaluator = new InclusiveMetricsEvaluator(tableSchema, dfExpression);
+        this.partitionEvaluatorCache = new HashMap<>();
+        this.inlineFilterActive = true;
+        this.lastAppliedPredicate = dynamicFilterConstraint;
+    }
+
+    private boolean taskMatchesFilter(FileScanTask task)
+    {
+        if (task.spec().isPartitioned()) {
+            Evaluator partEval = partitionEvaluatorCache.computeIfAbsent(
+                    task.spec().specId(),
+                    specId -> {
+                        Expression projected = Projections.inclusive(task.spec()).project(filterExpression);
+                        return new Evaluator(task.spec().partitionType(), projected);
+                    });
+            if (!partEval.eval(task.file().partition())) {
+                return false;
+            }
+        }
+        return metricsEvaluator.eval(task.file());
+    }
+
+    private boolean hasExceededFilterWaitTime()
+    {
+        return filterWaitStartNanos > 0
+                && Duration.nanosSince(filterWaitStartNanos).compareTo(dynamicFilter.getWaitTimeout()) >= 0;
+    }
+
+    /**
+     * Whether the WAITING_FOR_FILTER / WARMUP_* state should exit and start producing
+     * splits. Exits when (a) all relevant filters are complete, (b) at least one is
+     * complete *and* contributes a useful (non-{@code all()}) constraint, or (c) the
+     * wait timeout has elapsed.
+     *
+     * <p>The condition is asymmetric on purpose: a single filter resolving to
+     * {@code all()} (e.g., a short-circuit) does not unblock the gate by itself —
+     * we want to wait for siblings that may carry actual pruning constraints.
+     * If every filter ends up trivial, {@code isComplete} eventually fires and the
+     * gate exits anyway.
+     */
+    private boolean shouldExitWaiting()
+    {
+        if (hasExceededFilterWaitTime()) {
+            return true;
+        }
+        if (dynamicFilter.isComplete(relevantFilterColumns)) {
+            return true;
+        }
+        return dynamicFilter.hasAnyComplete(relevantFilterColumns)
+                && !dynamicFilter.getCurrentPredicate().isAll();
+    }
+
+    private void recordFilterWaitTime()
+    {
+        if (filterWaitStartNanos != 0) {
+            long filterWaitNanos = System.nanoTime() - filterWaitStartNanos;
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_WAIT_TIME_NANOS, NANO, filterWaitNanos);
+            filterWaitStartNanos = 0;
+            filterWaitTimeEmitted = true;
+        }
+    }
+
+    private void initializeScan()
+    {
+        this.fileScanTaskIterator = closer.register(
+                splitFiles(
+                        closer.register(tableScan.planFiles()),
+                        targetSplitSize)
+                        .iterator());
+    }
+
+    private void initializeScanWithDynamicFilter(TupleDomain<ColumnHandle> dynamicFilterConstraint)
+    {
+        TableScan filteredScan = this.tableScan;
+        if (!dynamicFilterConstraint.isAll()) {
+            if (extendedMetrics && dynamicFilterConstraint.isNone()) {
+                runtimeStats.addMetricValue("dynamicFilterConstraintIsNone", NONE, 1);
+            }
+
+            TupleDomain<IcebergColumnHandle> icebergConstraint = dynamicFilterConstraint
+                    .transform(columnHandle -> columnHandle instanceof IcebergColumnHandle ? (IcebergColumnHandle) columnHandle : null);
+
+            if (extendedMetrics) {
+                if (icebergConstraint.isNone()) {
+                    runtimeStats.addMetricValue("dynamicFilterIcebergConstraintIsNone", NONE, 1);
+                }
+                if (icebergConstraint.isAll()) {
+                    runtimeStats.addMetricValue("dynamicFilterIcebergConstraintIsAll", NONE, 1);
+                }
+                recordDomainDetails(icebergConstraint);
+            }
+
+            Expression dfExpression = toIcebergExpression(icebergConstraint);
+
+            if (extendedMetrics) {
+                runtimeStats.addMetricValue("dynamicFilterExpressionOp", NONE, dfExpression.op().ordinal());
+            }
+            filteredScan = filteredScan.filter(dfExpression);
+            this.lastAppliedPredicate = dynamicFilterConstraint;
+        }
+        this.fileScanTaskIterator = closer.register(
+                splitFiles(
+                        closer.register(filteredScan.planFiles()),
+                        targetSplitSize)
+                        .iterator());
+    }
+
+    private void closeCurrentIterator()
+    {
+        // Closer owns the lifecycle; null out so enumerateSplitBatch stops reading before re-scan.
+        fileScanTaskIterator = null;
+    }
+
+    /**
+     * Determines which pending dynamic filter columns are relevant for this table.
+     * All columns with pending dynamic filters are considered relevant because
+     * Iceberg's InclusiveMetricsEvaluator can prune data files using file-level
+     * column statistics (min/max bounds) for any column, not just partition or
+     * sort columns.
+     */
+    private Set<ColumnHandle> computeRelevantFilterColumns(
+            Set<ColumnHandle> pendingFilterColumns)
+    {
+        if (pendingFilterColumns.isEmpty()) {
+            return ImmutableSet.of();
+        }
+
+        Set<ColumnHandle> result = ImmutableSet.copyOf(pendingFilterColumns);
+
+        if (extendedMetrics) {
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_COLUMNS_RELEVANT, NONE, result.size());
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_COLUMNS_SKIPPED, NONE, 0);
+        }
+
+        return result;
+    }
+
+    private void recordDomainDetails(TupleDomain<IcebergColumnHandle> constraint)
+    {
+        constraint.getDomains().ifPresent(domains -> {
+            for (Map.Entry<IcebergColumnHandle, Domain> entry : domains.entrySet()) {
+                String colName = entry.getKey().getName();
+                Type prestoType = entry.getKey().getType();
+                Domain domain = entry.getValue();
+
+                if (domain.isNone()) {
+                    runtimeStats.addMetricValue("dynamicFilterDomainIsNone[" + colName + "]", NONE, 1);
+                    continue;
+                }
+                if (domain.isAll()) {
+                    runtimeStats.addMetricValue("dynamicFilterDomainIsAll[" + colName + "]", NONE, 1);
+                    continue;
+                }
+
+                long rangeCount = domain.getValues().getRanges().getRangeCount();
+                runtimeStats.addMetricValue("dynamicFilterConnectorRangeCount[" + colName + "]", NONE, rangeCount);
+
+                runtimeStats.addMetricValue("dynamicFilterDomainPrestoTypeId[" + colName + "]", NONE, prestoType.getTypeSignature().hashCode());
+
+                if (domain.getValues() instanceof SortedRangeSet) {
+                    List<Range> ranges = ((SortedRangeSet) domain.getValues()).getOrderedRanges();
+                    if (!ranges.isEmpty()) {
+                        Range first = ranges.get(0);
+                        Range last = ranges.get(ranges.size() - 1);
+                        if (first.getLow().getValueBlock().isPresent() && first.getLow().getValue() instanceof Number) {
+                            runtimeStats.addMetricValue("dynamicFilterDomainMin[" + colName + "]", NONE,
+                                    ((Number) first.getLow().getValue()).longValue());
+                        }
+                        if (last.getHigh().getValueBlock().isPresent() && last.getHigh().getValue() instanceof Number) {
+                            runtimeStats.addMetricValue("dynamicFilterDomainMax[" + colName + "]", NONE,
+                                    ((Number) last.getHigh().getValue()).longValue());
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    private ConnectorSplitBatch enumerateSplitBatch(int maxSize)
+    {
         List<ConnectorSplit> splits = new ArrayList<>();
         Iterator<FileScanTask> iterator = limit(fileScanTaskIterator, maxSize);
         while (iterator.hasNext()) {
             FileScanTask task = iterator.next();
+            splitsExamined++;
+
+            if (inlineFilterActive && !taskMatchesFilter(task)) {
+                splitsFilteredInline++;
+                continue;
+            }
+
             IcebergSplit icebergSplit = (IcebergSplit) toIcebergSplit(task);
-            if (metadataColumnsMatchPredicates(
-                    metadataColumnConstraints,
-                    icebergSplit.getPath(),
-                    icebergSplit.getDataSequenceNumber(),
-                    task.file(),
-                    lineageEvaluator)) {
+
+            if (dispatchedSplitKeys != null && state == State.SCANNING_FILTERED) {
+                SplitKey key = new SplitKey(icebergSplit.getPath(), icebergSplit.getStart());
+                if (dispatchedSplitKeys.remove(key)) {
+                    reScanDedupSkipped++;
+                    continue;
+                }
+                reScanSplitsProduced++;
+                if (dispatchedSplitKeys.isEmpty()) {
+                    dispatchedSplitKeys = null;
+                }
+            }
+
+            if (state == State.WARMUP_SCANNING) {
+                warmupSplitsDispatched++;
+                warmupWeightDispatched += icebergSplit.getSplitWeight().getRawValue();
+                dispatchedSplitKeys.add(new SplitKey(icebergSplit.getPath(), icebergSplit.getStart()));
+                splitsBeforeFilter++;
+            }
+
+            if (metadataColumnsMatchPredicates(metadataColumnConstraints, icebergSplit.getPath(), icebergSplit.getDataSequenceNumber(), task.file(), lineageEvaluator)) {
                 splits.add(icebergSplit);
             }
+
+            // Check warmup budget after adding the split (don't break mid-batch for partial weight)
+            if (state == State.WARMUP_SCANNING && warmupMaxWeight.isPresent() && warmupWeightDispatched >= warmupMaxWeight.getAsInt()) {
+                break;
+            }
         }
-        return completedFuture(new ConnectorSplitBatch(splits, isFinished()));
+        return new ConnectorSplitBatch(splits, isFinished());
     }
 
     @Override
     public boolean isFinished()
     {
-        return !fileScanTaskIterator.hasNext();
+        return state == State.SCANNING_FILTERED
+                && fileScanTaskIterator != null
+                && !fileScanTaskIterator.hasNext();
     }
 
     @Override
     public void close()
     {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        if (dynamicFilterActive) {
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_SPLITS_PROCESSED, NONE,
+                    splitsExamined - splitsFilteredInline - reScanDedupSkipped);
+
+            // Small-table scans may finish in a single batch before later-arriving filters
+            // are seen by the per-batch narrowing loop; catch up here for accurate metrics.
+            if (state == State.SCANNING_FILTERED) {
+                TupleDomain<ColumnHandle> finalPredicate = dynamicFilter.getCurrentPredicate();
+                if (!finalPredicate.isAll() && !finalPredicate.equals(lastAppliedPredicate)) {
+                    lastAppliedPredicate = finalPredicate;
+                }
+            }
+
+            // Emit once at close so per-batch activateInlineFilter calls don't double-count.
+            if (!lastAppliedPredicate.isAll()) {
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSHED_INTO_SCAN, NONE, 1);
+                lastAppliedPredicate.getDomains().ifPresent(domains ->
+                        runtimeStats.addMetricValue(DYNAMIC_FILTER_CONSTRAINT_COLUMNS, NONE, domains.size()));
+            }
+
+            long effectiveSplitsBeforeFilter;
+            if (!relevantFilterColumns.isPresent() || relevantFilterColumns.get().isEmpty()) {
+                effectiveSplitsBeforeFilter = 0;
+            }
+            else if (!dynamicFilterApplied) {
+                effectiveSplitsBeforeFilter = splitsExamined;
+            }
+            else {
+                effectiveSplitsBeforeFilter = splitsBeforeFilter;
+            }
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_SPLITS_BEFORE_FILTER, NONE, effectiveSplitsBeforeFilter);
+
+            if (extendedMetrics) {
+                runtimeStats.addMetricValue("dynamicFilterSplitsFilteredInline", NONE, splitsFilteredInline);
+                runtimeStats.addMetricValue("dynamicFilterWarmupSplitsDispatched", NONE, warmupSplitsDispatched);
+                runtimeStats.addMetricValue("dynamicFilterWarmupWeightDispatched", NONE, warmupWeightDispatched);
+                runtimeStats.addMetricValue("dynamicFilterReScanTriggered", NONE, reScanTriggered ? 1 : 0);
+                runtimeStats.addMetricValue("dynamicFilterReScanDedupSkipped", NONE, reScanDedupSkipped);
+                runtimeStats.addMetricValue("dynamicFilterReScanSplitsProduced", NONE, reScanSplitsProduced);
+            }
+        }
+
+        if (dynamicFilterActive) {
+            if (filterWaitStartNanos != 0) {
+                recordFilterWaitTime();
+            }
+            else if (!filterWaitTimeEmitted) {
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_WAIT_TIME_NANOS, NANO, 0);
+            }
+        }
+
         try {
             closer.close();
             // TODO: remove this after org.apache.iceberg.io.CloseableIterator'withClose
             //  correct release resources holds by iterator.
-            fileScanTaskIterator = CloseableIterator.empty();
+            if (fileScanTaskIterator != null) {
+                fileScanTaskIterator = CloseableIterator.empty();
+            }
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -82,7 +82,10 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(100)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0)
                 .setAggregatePushDownEnabled(true)
-                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE)));
+                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE))
+                .setDynamicFilterExtendedMetrics(false)
+                .setDynamicFilterWarmupEnabled(true)
+                .setDynamicFilterWarmupWeightPerTask(Runtime.getRuntime().availableProcessors()));
     }
 
     @Test
@@ -125,6 +128,9 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-view-default-max-snapshots-per-refresh", "10")
                 .put("iceberg.aggregate-push-down-enabled", "false")
                 .put("iceberg.target-max-file-size", "512MB")
+                .put("iceberg.dynamic-filter-extended-metrics", "true")
+                .put("iceberg.dynamic-filter-warmup-enabled", "false")
+                .put("iceberg.dynamic-filter-warmup-weight-per-task", "2.0")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -163,7 +169,10 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(2000)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10)
                 .setAggregatePushDownEnabled(false)
-                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE));
+                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE))
+                .setDynamicFilterExtendedMetrics(true)
+                .setDynamicFilterWarmupEnabled(false)
+                .setDynamicFilterWarmupWeightPerTask(2.0);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergPartitionPredicate.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergPartitionPredicate.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.hive.HivePartitionKey;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
+import static com.facebook.presto.iceberg.IcebergUtil.deserializeIcebergValue;
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergPartitionPredicate
+{
+    private static final int YEAR_COLUMN_ID = 1;
+    private static final int MONTH_COLUMN_ID = 2;
+
+    @Test
+    public void testFilterConstraintIsAll()
+    {
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")));
+
+        assertTrue(partitionMatchesPredicate(TupleDomain.all(), partitionKeys));
+    }
+
+    @Test
+    public void testFilterConstraintIsNone()
+    {
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")));
+
+        assertFalse(partitionMatchesPredicate(TupleDomain.none(), partitionKeys));
+    }
+
+    @Test
+    public void testEmptyPartitionKeys()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(yearColumn, Domain.singleValue(INTEGER, 2024L)));
+
+        assertTrue(partitionMatchesPredicate(filterConstraint, ImmutableMap.of()));
+    }
+
+    @Test
+    public void testPartitionValueMatchesDomain()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(yearColumn, Domain.singleValue(INTEGER, 2024L)));
+
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")));
+
+        assertTrue(partitionMatchesPredicate(filterConstraint, partitionKeys));
+    }
+
+    @Test
+    public void testPartitionValueNotInDomain()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(yearColumn, Domain.multipleValues(INTEGER, ImmutableList.of(2023L, 2025L))));
+
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")));
+
+        assertFalse(partitionMatchesPredicate(filterConstraint, partitionKeys));
+    }
+
+    @Test
+    public void testNullPartitionValueWithNullAllowed()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(yearColumn, Domain.onlyNull(INTEGER)));
+
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.empty()));
+
+        assertTrue(partitionMatchesPredicate(filterConstraint, partitionKeys));
+    }
+
+    @Test
+    public void testNullPartitionValueWithNullNotAllowed()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(yearColumn, Domain.singleValue(INTEGER, 2024L)));
+
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.empty()));
+
+        assertFalse(partitionMatchesPredicate(filterConstraint, partitionKeys));
+    }
+
+    @Test
+    public void testNonPartitionColumnInFilter()
+    {
+        IcebergColumnHandle nonPartitionColumn = primitiveIcebergColumnHandle(99, "non_partition_col", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(nonPartitionColumn, Domain.singleValue(INTEGER, 2024L)));
+
+        Map<Integer, HivePartitionKey> partitionKeys = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2020")));
+
+        assertTrue(partitionMatchesPredicate(filterConstraint, partitionKeys));
+    }
+
+    @Test
+    public void testMultiplePartitionColumns()
+    {
+        IcebergColumnHandle yearColumn = primitiveIcebergColumnHandle(YEAR_COLUMN_ID, "year", INTEGER, Optional.empty());
+        IcebergColumnHandle monthColumn = primitiveIcebergColumnHandle(MONTH_COLUMN_ID, "month", INTEGER, Optional.empty());
+
+        TupleDomain<IcebergColumnHandle> filterConstraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        yearColumn, Domain.singleValue(INTEGER, 2024L),
+                        monthColumn, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 6L, 12L))));
+
+        Map<Integer, HivePartitionKey> matchingPartition = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")),
+                MONTH_COLUMN_ID, new HivePartitionKey("month", Optional.of("6")));
+        assertTrue(partitionMatchesPredicate(filterConstraint, matchingPartition));
+
+        Map<Integer, HivePartitionKey> nonMatchingPartition = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2024")),
+                MONTH_COLUMN_ID, new HivePartitionKey("month", Optional.of("3")));
+        assertFalse(partitionMatchesPredicate(filterConstraint, nonMatchingPartition));
+
+        Map<Integer, HivePartitionKey> wrongYearPartition = ImmutableMap.of(
+                YEAR_COLUMN_ID, new HivePartitionKey("year", Optional.of("2023")),
+                MONTH_COLUMN_ID, new HivePartitionKey("month", Optional.of("6")));
+        assertFalse(partitionMatchesPredicate(filterConstraint, wrongYearPartition));
+    }
+
+    @Test
+    public void testPartitionMatchesDynamicFilterWithYearTransform()
+    {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "order_date", Types.DateType.get()),
+                Types.NestedField.optional(2, "amount", Types.DoubleType.get()));
+
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .year("order_date")
+                .build();
+
+        // year transform value = 54 (2024 - 1970)
+        DataFile dataFile2024 = DataFiles.builder(spec)
+                .withPath("/data/order_date_year=2024/file1.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_year=54")
+                .build();
+
+        DataFile dataFile2023 = DataFiles.builder(spec)
+                .withPath("/data/order_date_year=2023/file2.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_year=53")
+                .build();
+
+        String schemaString = SchemaParser.toJson(schema);
+        String specString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals = ResidualEvaluator.of(spec, alwaysTrue(), false);
+
+        FileScanTask task2024 = new BaseFileScanTask(dataFile2024, new DeleteFile[0], schemaString, specString, residuals);
+        FileScanTask task2023 = new BaseFileScanTask(dataFile2023, new DeleteFile[0], schemaString, specString, residuals);
+
+        // 2024-01-01 = 19723, 2024-12-31 = 20088 (days since epoch)
+        IcebergColumnHandle orderDateColumn = primitiveIcebergColumnHandle(1, "order_date", DATE, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterFor2024 = TupleDomain.withColumnDomains(
+                ImmutableMap.of(orderDateColumn, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.range(DATE, 19723L, true, 20088L, true)),
+                        false)));
+
+        assertTrue(partitionMatchesDynamicFilter(filterFor2024, task2024),
+                "Year 2024 partition should match filter for dates in 2024");
+
+        assertFalse(partitionMatchesDynamicFilter(filterFor2024, task2023),
+                "Year 2023 partition should not match filter for dates in 2024");
+    }
+
+    @Test
+    public void testPartitionMatchesDynamicFilterWithMonthTransform()
+    {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "order_date", Types.DateType.get()),
+                Types.NestedField.optional(2, "amount", Types.DoubleType.get()));
+
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .month("order_date")
+                .build();
+
+        // Month transform: months since epoch (2024-06 = 653, 2024-01 = 648)
+        DataFile dataFileJun2024 = DataFiles.builder(spec)
+                .withPath("/data/order_date_month=2024-06/file1.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_month=653")
+                .build();
+
+        DataFile dataFileJan2024 = DataFiles.builder(spec)
+                .withPath("/data/order_date_month=2024-01/file2.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_month=648")
+                .build();
+
+        String schemaString = SchemaParser.toJson(schema);
+        String specString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals = ResidualEvaluator.of(spec, alwaysTrue(), false);
+
+        FileScanTask taskJun = new BaseFileScanTask(dataFileJun2024, new DeleteFile[0], schemaString, specString, residuals);
+        FileScanTask taskJan = new BaseFileScanTask(dataFileJan2024, new DeleteFile[0], schemaString, specString, residuals);
+
+        // 2024-06-01 = 19875, 2024-06-30 = 19904 (days since epoch)
+        IcebergColumnHandle orderDateColumn = primitiveIcebergColumnHandle(1, "order_date", DATE, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterForJun2024 = TupleDomain.withColumnDomains(
+                ImmutableMap.of(orderDateColumn, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.range(DATE, 19875L, true, 19904L, true)),
+                        false)));
+
+        assertTrue(partitionMatchesDynamicFilter(filterForJun2024, taskJun),
+                "June 2024 partition should match filter for June 2024 dates");
+
+        assertFalse(partitionMatchesDynamicFilter(filterForJun2024, taskJan),
+                "January 2024 partition should not match filter for June 2024 dates");
+    }
+
+    @Test
+    public void testPartitionMatchesDynamicFilterWithIdentityTransform()
+    {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "customer_id", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "amount", Types.DoubleType.get()));
+
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .identity("customer_id")
+                .build();
+
+        DataFile dataFileCustomer1 = DataFiles.builder(spec)
+                .withPath("/data/customer_id=1/file1.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("customer_id=1")
+                .build();
+
+        DataFile dataFileCustomer2 = DataFiles.builder(spec)
+                .withPath("/data/customer_id=2/file2.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("customer_id=2")
+                .build();
+
+        String schemaString = SchemaParser.toJson(schema);
+        String specString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals = ResidualEvaluator.of(spec, alwaysTrue(), false);
+
+        FileScanTask task1 = new BaseFileScanTask(dataFileCustomer1, new DeleteFile[0], schemaString, specString, residuals);
+        FileScanTask task2 = new BaseFileScanTask(dataFileCustomer2, new DeleteFile[0], schemaString, specString, residuals);
+
+        IcebergColumnHandle customerIdColumn = primitiveIcebergColumnHandle(1, "customer_id", INTEGER, Optional.empty());
+        TupleDomain<IcebergColumnHandle> filterForCustomer1 = TupleDomain.withColumnDomains(
+                ImmutableMap.of(customerIdColumn, Domain.singleValue(INTEGER, 1L)));
+
+        assertTrue(partitionMatchesDynamicFilter(filterForCustomer1, task1),
+                "customer_id=1 partition should match filter for customer_id=1");
+
+        assertFalse(partitionMatchesDynamicFilter(filterForCustomer1, task2),
+                "customer_id=2 partition should not match filter for customer_id=1");
+    }
+
+    @Test
+    public void testPartitionMatchesDynamicFilterAllConstraint()
+    {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "order_date", Types.DateType.get()));
+
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .year("order_date")
+                .build();
+
+        DataFile dataFile = DataFiles.builder(spec)
+                .withPath("/data/file.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_year=54")
+                .build();
+
+        String schemaString = SchemaParser.toJson(schema);
+        String specString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals = ResidualEvaluator.of(spec, alwaysTrue(), false);
+        FileScanTask task = new BaseFileScanTask(dataFile, new DeleteFile[0], schemaString, specString, residuals);
+
+        assertTrue(partitionMatchesDynamicFilter(TupleDomain.<IcebergColumnHandle>all(), task));
+    }
+
+    @Test
+    public void testPartitionMatchesDynamicFilterNoneConstraint()
+    {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "order_date", Types.DateType.get()));
+
+        PartitionSpec spec = PartitionSpec.builderFor(schema)
+                .year("order_date")
+                .build();
+
+        DataFile dataFile = DataFiles.builder(spec)
+                .withPath("/data/file.parquet")
+                .withFileSizeInBytes(1024)
+                .withRecordCount(100)
+                .withPartitionPath("order_date_year=54")
+                .build();
+
+        String schemaString = SchemaParser.toJson(schema);
+        String specString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals = ResidualEvaluator.of(spec, alwaysTrue(), false);
+        FileScanTask task = new BaseFileScanTask(dataFile, new DeleteFile[0], schemaString, specString, residuals);
+
+        assertFalse(partitionMatchesDynamicFilter(TupleDomain.<IcebergColumnHandle>none(), task));
+    }
+
+    private static boolean partitionMatchesPredicate(
+            TupleDomain<IcebergColumnHandle> filterConstraint,
+            Map<Integer, HivePartitionKey> partitionKeys)
+    {
+        if (filterConstraint.isAll()) {
+            return true;
+        }
+        if (filterConstraint.isNone()) {
+            return false;
+        }
+        if (partitionKeys.isEmpty()) {
+            return true;
+        }
+        if (!filterConstraint.getDomains().isPresent()) {
+            return true;
+        }
+
+        for (Map.Entry<IcebergColumnHandle, Domain> entry : filterConstraint.getDomains().get().entrySet()) {
+            IcebergColumnHandle columnHandle = entry.getKey();
+            Domain domain = entry.getValue();
+            int columnId = columnHandle.getId();
+
+            HivePartitionKey partitionKey = partitionKeys.get(columnId);
+            if (partitionKey == null) {
+                continue;
+            }
+
+            Optional<String> valueOpt = partitionKey.getValue();
+            if (!valueOpt.isPresent()) {
+                if (!domain.isNullAllowed()) {
+                    return false;
+                }
+            }
+            else {
+                Object convertedValue = convertPartitionValue(columnHandle.getType(), valueOpt.get());
+                if (convertedValue == null) {
+                    continue;
+                }
+                if (!domain.includesNullableValue(convertedValue)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean partitionMatchesDynamicFilter(
+            TupleDomain<IcebergColumnHandle> filterConstraint,
+            FileScanTask task)
+    {
+        if (filterConstraint.isAll()) {
+            return true;
+        }
+        if (filterConstraint.isNone()) {
+            return false;
+        }
+        if (!task.spec().isPartitioned()) {
+            return true;
+        }
+
+        Expression icebergExpression = ExpressionConverter.toIcebergExpression(filterConstraint);
+        Expression projected = Projections.inclusive(task.spec()).project(icebergExpression);
+        return new Evaluator(task.spec().partitionType(), projected).eval(task.file().partition());
+    }
+
+    private static Object convertPartitionValue(Type type, String valueString)
+    {
+        if (valueString == null) {
+            return null;
+        }
+        try {
+            return deserializeIcebergValue(type, valueString, "dynamic_filter");
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -304,6 +304,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -244,6 +244,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DynamicFilterResult.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterResult
+{
+    private final Map<String, TupleDomain<String>> filters;
+    private final long version;
+    private final boolean operatorCompleted;
+    private final Set<String> completedFilterIds;
+
+    public DynamicFilterResult(Map<String, TupleDomain<String>> filters, long version, boolean operatorCompleted, Set<String> completedFilterIds)
+    {
+        this.filters = ImmutableMap.copyOf(requireNonNull(filters, "filters is null"));
+        this.version = version;
+        this.operatorCompleted = operatorCompleted;
+        this.completedFilterIds = ImmutableSet.copyOf(requireNonNull(completedFilterIds, "completedFilterIds is null"));
+    }
+
+    public Map<String, TupleDomain<String>> getFilters()
+    {
+        return filters;
+    }
+
+    public long getVersion()
+    {
+        return version;
+    }
+
+    public boolean isOperatorCompleted()
+    {
+        return operatorCompleted;
+    }
+
+    public Set<String> getCompletedFilterIds()
+    {
+        return completedFilterIds;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.RuntimeFilter;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -78,4 +79,6 @@ public interface RemoteTask
     int getUnacknowledgedPartitionedSplitCount();
 
     PlanFragment getPlanFragment();
+
+    default void pushDynamicFilter(PlanNodeId scanNodeId, String filterId, RuntimeFilter constraint) {}
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -25,6 +25,7 @@ import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
 import com.facebook.presto.execution.scheduler.ExecutionPolicy;
 import com.facebook.presto.execution.scheduler.SectionExecutionFactory;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
@@ -130,6 +131,7 @@ public class SqlQueryExecution
     private final ExecutorService queryExecutor;
     private final ScheduledExecutorService timeoutThreadExecutor;
     private final SectionExecutionFactory sectionExecutionFactory;
+    private final DynamicFilterService dynamicFilterService;
     private final InternalNodeManager internalNodeManager;
 
     private final AtomicReference<SqlQuerySchedulerInterface> queryScheduler = new AtomicReference<>();
@@ -168,6 +170,7 @@ public class SqlQueryExecution
             ExecutorService queryExecutor,
             ScheduledExecutorService timeoutThreadExecutor,
             SectionExecutionFactory sectionExecutionFactory,
+            DynamicFilterService dynamicFilterService,
             ExecutorService eagerPlanValidationExecutor,
             InternalNodeManager internalNodeManager,
             ExecutionPolicy executionPolicy,
@@ -194,6 +197,7 @@ public class SqlQueryExecution
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
             this.timeoutThreadExecutor = requireNonNull(timeoutThreadExecutor, "timeoutThreadExecutor is null");
             this.sectionExecutionFactory = requireNonNull(sectionExecutionFactory, "sectionExecutionFactory is null");
+            this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
             this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
             this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
@@ -245,6 +249,7 @@ public class SqlQueryExecution
                 if (scheduler != null) {
                     scheduler.abort();
                 }
+                dynamicFilterService.removeFiltersForQuery(stateMachine.getQueryId());
             });
 
             this.remoteTaskFactory = new TrackingRemoteTaskFactory(requireNonNull(remoteTaskFactory, "remoteTaskFactory is null"), stateMachine);
@@ -686,7 +691,7 @@ public class SqlQueryExecution
                     .withNoMoreBufferIds();
         }
 
-        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector(), metadata);
+        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector(), dynamicFilterService, metadata);
         // build the stage execution objects (this doesn't schedule execution)
         SqlQuerySchedulerInterface scheduler = SqlQueryScheduler.createSqlQueryScheduler(
                 locationFactory,
@@ -932,6 +937,7 @@ public class SqlQueryExecution
         private final ScheduledExecutorService timeoutThreadExecutor;
         private final ExecutorService queryExecutor;
         private final SectionExecutionFactory sectionExecutionFactory;
+        private final DynamicFilterService dynamicFilterService;
         private final ExecutorService eagerPlanValidationExecutor;
         private final InternalNodeManager internalNodeManager;
         private final Map<String, ExecutionPolicy> executionPolicies;
@@ -954,6 +960,7 @@ public class SqlQueryExecution
                 @ForQueryExecution ExecutorService queryExecutor,
                 @ForTimeoutThread ScheduledExecutorService timeoutThreadExecutor,
                 SectionExecutionFactory sectionExecutionFactory,
+                DynamicFilterService dynamicFilterService,
                 @ForEagerPlanValidation ExecutorService eagerPlanValidationExecutor,
                 InternalNodeManager internalNodeManager,
                 Map<String, ExecutionPolicy> executionPolicies,
@@ -976,6 +983,7 @@ public class SqlQueryExecution
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
             this.timeoutThreadExecutor = requireNonNull(timeoutThreadExecutor, "timeoutThreadExecutor is null");
             this.sectionExecutionFactory = requireNonNull(sectionExecutionFactory, "sectionExecutionFactory is null");
+            this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
             this.eagerPlanValidationExecutor = requireNonNull(eagerPlanValidationExecutor, "eagerPlanValidationExecutor is null");
             this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
@@ -1021,6 +1029,7 @@ public class SqlQueryExecution
                     queryExecutor,
                     timeoutThreadExecutor,
                     sectionExecutionFactory,
+                    dynamicFilterService,
                     eagerPlanValidationExecutor,
                     internalNodeManager,
                     executionPolicy,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -55,6 +55,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -140,6 +141,7 @@ public final class SqlStageExecution
     private final AtomicReference<OutputBuffers> outputBuffers = new AtomicReference<>();
 
     private final ListenerManager<Set<Lifespan>> completedLifespansChangeListeners = new ListenerManager<>();
+    private final List<Consumer<RemoteTask>> taskCreatedListeners = new CopyOnWriteArrayList<>();
 
     @GuardedBy("this")
     private Optional<StageTaskRecoveryCallback> stageTaskRecoveryCallback = Optional.empty();
@@ -449,6 +451,14 @@ public final class SqlStageExecution
                 .collect(toImmutableList());
     }
 
+    public synchronized void addTaskCreatedListener(Consumer<RemoteTask> listener)
+    {
+        taskCreatedListeners.add(listener);
+        for (RemoteTask task : getAllTasks()) {
+            listener.accept(task);
+        }
+    }
+
     // We only support removeRemoteSource for single task stage because stages with many tasks introduce coordinator to worker HTTP requests in bursty manner.
     // See https://github.com/prestodb/presto/pull/11065 for a similar issue.
     public void removeRemoteSourceIfSingleTaskStage(TaskId remoteSourceTaskId)
@@ -548,6 +558,10 @@ public final class SqlStageExecution
 
         task.addStateChangeListener(new StageTaskListener(taskId));
         task.addFinalTaskInfoListener(this::updateFinalTaskInfo);
+
+        for (Consumer<RemoteTask> listener : taskCreatedListeners) {
+            listener.accept(task);
+        }
 
         if (!stateMachine.getState().isDone()) {
             task.start();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.LazyOutputBuffer;
@@ -37,6 +38,7 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -45,9 +47,12 @@ import org.joda.time.DateTime;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -79,6 +84,8 @@ public class SqlTask
 
     private final AtomicLong lastHeartbeat = new AtomicLong(System.currentTimeMillis());
     private final AtomicLong nextTaskInfoVersion = new AtomicLong(TaskStatus.STARTING_VERSION);
+    private final ConcurrentMap<String, TupleDomain<String>> dynamicFilters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> dynamicFilterVersions = new ConcurrentHashMap<>();
 
     private final AtomicReference<TaskHolder> taskHolderReference = new AtomicReference<>(new TaskHolder());
     private final AtomicBoolean needsPlan = new AtomicBoolean(true);
@@ -513,6 +520,20 @@ public class SqlTask
     {
         taskStateMachine.abort();
         return getTaskInfo();
+    }
+
+    public Map<String, TupleDomain<String>> getDynamicFiltersSince(long sinceVersion)
+    {
+        ImmutableMap.Builder<String, TupleDomain<String>> result = ImmutableMap.builder();
+        for (Map.Entry<String, Long> entry : dynamicFilterVersions.entrySet()) {
+            if (entry.getValue() > sinceVersion) {
+                TupleDomain<String> filter = dynamicFilters.get(entry.getKey());
+                if (filter != null) {
+                    result.put(entry.getKey(), filter);
+                }
+            }
+        }
+        return result.build();
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -23,6 +23,7 @@ import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.BufferResult;
@@ -476,6 +477,13 @@ public class SqlTaskManager
         requireNonNull(remoteSourceTaskId, "remoteSourceTaskId is null");
 
         tasks.getUnchecked(taskId).removeRemoteSource(remoteSourceTaskId);
+    }
+
+    @Override
+    public Map<String, TupleDomain<String>> getDynamicFiltersSince(TaskId taskId, long sinceVersion)
+    {
+        requireNonNull(taskId, "taskId is null");
+        return tasks.getUnchecked(taskId).getDynamicFiltersSince(sinceVersion);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBufferInfo;
@@ -25,6 +26,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface TaskManager
@@ -150,4 +152,9 @@ public interface TaskManager
      * from {@code remoteSourceTaskId} will be ignored.
      */
     void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId);
+
+    /**
+     * Returns dynamic filter data stored by the task since the given version.
+     */
+    Map<String, TupleDomain<String>> getDynamicFiltersSince(TaskId taskId, long sinceVersion);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DomainRuntimeFilter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class DomainRuntimeFilter
+        implements RuntimeFilter
+{
+    private final TupleDomain<String> domain;
+
+    public DomainRuntimeFilter(TupleDomain<String> domain)
+    {
+        this.domain = requireNonNull(domain, "domain is null");
+    }
+
+    @JsonValue
+    public TupleDomain<String> getDomain()
+    {
+        return domain;
+    }
+
+    @Override
+    public RuntimeFilter mergeWith(RuntimeFilter other)
+    {
+        if (!(other instanceof DomainRuntimeFilter)) {
+            throw new IllegalArgumentException(
+                    "Cannot merge a DomainRuntimeFilter with " + other.getClass().getSimpleName());
+        }
+        return new DomainRuntimeFilter(
+                TupleDomain.columnWiseUnion(domain, ((DomainRuntimeFilter) other).domain));
+    }
+
+    @Override
+    public TupleDomain<String> toTupleDomain(String column, Type type)
+    {
+        if (column.isEmpty() || domain.isAll() || domain.isNone() || !domain.getDomains().isPresent()) {
+            return domain;
+        }
+        Map<String, Domain> domains = domain.getDomains().get();
+        if (domains.size() != 1) {
+            return domain;
+        }
+        Domain single = domains.values().iterator().next();
+        return TupleDomain.withColumnDomains(ImmutableMap.of(column, single));
+    }
+
+    @Override
+    public boolean isAll()
+    {
+        return domain.isAll();
+    }
+
+    @Override
+    public boolean isNone()
+    {
+        return domain.isNone();
+    }
+
+    @Override
+    public long estimatedRetainedSizeInBytes()
+    {
+        if (domain.isNone() || domain.isAll() || !domain.getDomains().isPresent()) {
+            return 0;
+        }
+        long totalSize = 0;
+        for (Domain columnDomain : domain.getDomains().get().values()) {
+            if (!(columnDomain.getValues() instanceof SortedRangeSet)) {
+                continue;
+            }
+            for (Range range : columnDomain.getValues().getRanges().getOrderedRanges()) {
+                totalSize += range.getLow().getValueBlock().map(Block::getRetainedSizeInBytes).orElse(0L);
+                totalSize += range.getHigh().getValueBlock().map(Block::getRetainedSizeInBytes).orElse(0L);
+            }
+        }
+        return totalSize;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterPusher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterPusher.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.SqlStageExecution;
+import com.facebook.presto.spi.plan.PlanNodeId;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_COUNT;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+
+/**
+ * Pushes coordinator-collected dynamic filters to probe-side C++ workers
+ * for row-group and row-level filtering within Velox.
+ *
+ * <p>Fire-and-forget: push failures do not affect query correctness (workers
+ * that don't support the endpoint return 404, which is silently ignored).
+ * Early splits still benefit from Phase 1 split pruning.
+ */
+public class DynamicFilterPusher
+{
+    private static final Logger log = Logger.get(DynamicFilterPusher.class);
+
+    private final ConcurrentMap<String, ResolvedFilter> resolvedFilters = new ConcurrentHashMap<>();
+    private final RuntimeStats runtimeStats;
+    private final boolean extendedMetrics;
+    private final ConcurrentMap<String, Boolean> pushedTaskIds = new ConcurrentHashMap<>();
+
+    public DynamicFilterPusher(RuntimeStats runtimeStats, boolean extendedMetrics)
+    {
+        this.runtimeStats = runtimeStats;
+        this.extendedMetrics = extendedMetrics;
+    }
+
+    /**
+     * Registers a callback on the given {@link JoinDynamicFilter} so that when
+     * the filter is fully resolved, its constraint is pushed to all tasks in
+     * the probe-side {@link SqlStageExecution}.
+     *
+     * <p>Also registers a task-created listener so tasks created after filter
+     * completion receive the push too.
+     */
+    public void startPushing(
+            String filterId,
+            PlanNodeId scanNodeId,
+            JoinDynamicFilter joinFilter,
+            SqlStageExecution probeStageExecution)
+    {
+        String resolvedKey = filterId + ":" + scanNodeId;
+
+        joinFilter.onFullyResolved((resolvedFilterId, resolvedFilter) -> {
+            if (resolvedFilter.isAll()) {
+                return;
+            }
+            resolvedFilters.put(resolvedKey, new ResolvedFilter(scanNodeId, resolvedFilter));
+            for (RemoteTask task : probeStageExecution.getAllTasks()) {
+                pushToTask(task, scanNodeId, resolvedFilterId, resolvedFilter);
+            }
+        });
+
+        probeStageExecution.addTaskCreatedListener(task -> {
+            ResolvedFilter resolved = resolvedFilters.get(resolvedKey);
+            if (resolved != null) {
+                pushToTask(task, resolved.scanNodeId, filterId, resolved.constraint);
+            }
+        });
+    }
+
+    private void pushToTask(RemoteTask task, PlanNodeId scanNodeId, String filterId, RuntimeFilter constraint)
+    {
+        try {
+            task.pushDynamicFilter(scanNodeId, filterId, constraint);
+            if (extendedMetrics) {
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_COUNT, NONE, 1);
+                if (pushedTaskIds.putIfAbsent(task.getTaskId().toString(), Boolean.TRUE) == null) {
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_COUNT, NONE, 1);
+                }
+            }
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to push dynamic filter %s to task %s (fire-and-forget)", filterId, task.getTaskId());
+        }
+    }
+
+    private static class ResolvedFilter
+    {
+        final PlanNodeId scanNodeId;
+        final RuntimeFilter constraint;
+
+        ResolvedFilter(PlanNodeId scanNodeId, RuntimeFilter constraint)
+        {
+            this.scanNodeId = scanNodeId;
+            this.constraint = constraint;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterService.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.ThreadSafe;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.Objects.requireNonNull;
+
+// Callers must call removeFiltersForQuery when queries complete.
+@ThreadSafe
+public class DynamicFilterService
+{
+    private final ConcurrentMap<QueryId, ConcurrentMap<String, JoinDynamicFilter>> filters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<QueryId, ConcurrentMap<PlanNodeId, Set<String>>> scanToFilterIds = new ConcurrentHashMap<>();
+    private final DynamicFilterStats stats;
+
+    public DynamicFilterService()
+    {
+        this(new DynamicFilterStats());
+    }
+
+    public DynamicFilterService(DynamicFilterStats stats)
+    {
+        this.stats = requireNonNull(stats, "stats is null");
+    }
+
+    public void registerFilter(QueryId queryId, String filterId, JoinDynamicFilter filter)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+        requireNonNull(filter, "filter is null");
+
+        boolean inserted = filters.computeIfAbsent(queryId, k -> new ConcurrentHashMap<>())
+                .putIfAbsent(filterId, filter) == null;
+        if (inserted) {
+            stats.getFilterRegistrations().update(1);
+        }
+    }
+
+    public Optional<JoinDynamicFilter> getFilter(QueryId queryId, String filterId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        if (queryFilters == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(queryFilters.get(filterId));
+    }
+
+    public void removeFiltersForQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        filters.remove(queryId);
+        scanToFilterIds.remove(queryId);
+    }
+
+    public void registerScanFilterMapping(QueryId queryId, PlanNodeId scanNodeId, Set<String> filterIds)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(scanNodeId, "scanNodeId is null");
+        requireNonNull(filterIds, "filterIds is null");
+
+        scanToFilterIds
+                .computeIfAbsent(queryId, k -> new ConcurrentHashMap<>())
+                .merge(scanNodeId, ImmutableSet.copyOf(filterIds), (existing, incoming) -> {
+                    Set<String> merged = new HashSet<>(existing);
+                    merged.addAll(incoming);
+                    return ImmutableSet.copyOf(merged);
+                });
+    }
+
+    public Set<String> getFilterIdsForScan(QueryId queryId, PlanNodeId scanNodeId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(scanNodeId, "scanNodeId is null");
+
+        ConcurrentMap<PlanNodeId, Set<String>> queryScanMappings = scanToFilterIds.get(queryId);
+        if (queryScanMappings == null) {
+            return ImmutableSet.of();
+        }
+        Set<String> filterIds = queryScanMappings.get(scanNodeId);
+        return filterIds != null ? filterIds : ImmutableSet.of();
+    }
+
+    public boolean hasFilter(QueryId queryId, String filterId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(filterId, "filterId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        return queryFilters != null && queryFilters.containsKey(filterId);
+    }
+
+    public Map<String, JoinDynamicFilter> getAllFiltersForQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+
+        ConcurrentMap<String, JoinDynamicFilter> queryFilters = filters.get(queryId);
+        if (queryFilters == null) {
+            return ImmutableMap.of();
+        }
+        return ImmutableMap.copyOf(queryFilters);
+    }
+
+    public DynamicFilterStats getStats()
+    {
+        return stats;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/DynamicFilterStats.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.stats.CounterStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import static com.facebook.presto.server.SimpleHttpResponseHandlerStats.IncrementalAverage;
+
+public class DynamicFilterStats
+{
+    private final CounterStat filterFetchSuccess = new CounterStat();
+    private final CounterStat filterFetchFailure = new CounterStat();
+    private final CounterStat filtersCollected = new CounterStat();
+    private final CounterStat filterRegistrations = new CounterStat();
+    private final CounterStat filterCollectionCompleted = new CounterStat();
+    private final CounterStat filterCollectionTimedOut = new CounterStat();
+    private final CounterStat filtersStored = new CounterStat();
+    private final CounterStat fetchersStarted = new CounterStat();
+    private final CounterStat filterFlushes = new CounterStat();
+    private final IncrementalAverage filterFetchRoundTripMillis = new IncrementalAverage();
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFetchSuccess()
+    {
+        return filterFetchSuccess;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFetchFailure()
+    {
+        return filterFetchFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFiltersCollected()
+    {
+        return filtersCollected;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterRegistrations()
+    {
+        return filterRegistrations;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterCollectionCompleted()
+    {
+        return filterCollectionCompleted;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterCollectionTimedOut()
+    {
+        return filterCollectionTimedOut;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFiltersStored()
+    {
+        return filtersStored;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFetchersStarted()
+    {
+        return fetchersStarted;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFilterFlushes()
+    {
+        return filterFlushes;
+    }
+
+    @Managed
+    public double getFilterFetchRoundTripMillis()
+    {
+        return filterFetchRoundTripMillis.getAverage();
+    }
+
+    @Managed
+    public long getFilterFetchRoundTripCount()
+    {
+        return filterFetchRoundTripMillis.getCount();
+    }
+
+    public void recordFilterFetchRoundTripMillis(long millis)
+    {
+        filterFetchRoundTripMillis.add(millis);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/JoinDynamicFilter.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLLECTION_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_DOMAIN_RANGE_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_EXPECTED_PARTITIONS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PARTITIONS_RECEIVED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SHORT_CIRCUITED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_TIMED_OUT;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+import static com.facebook.presto.spi.connector.DynamicFilter.NOT_BLOCKED;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+// Does not implement DynamicFilter; the SPI-facing wrapper is TableScanDynamicFilter.
+@ThreadSafe
+public class JoinDynamicFilter
+{
+    // Injected by DynamicFilterService in PR4; shared daemon pool until then.
+    static final ScheduledExecutorService DEFAULT_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(daemonThreadsNamed("join-dynamic-filter-timeout-%s"));
+
+    private final ScheduledExecutorService timeoutScheduler;
+    private final String filterId;
+    private final String columnName;
+    private final Duration waitTimeout;
+    private final int maxWaitExtensions;
+    private final long maxSizeInBytes;
+    private final DynamicFilterStats stats;
+    private final RuntimeStats runtimeStats;
+    private final boolean extendedMetrics;
+
+    @GuardedBy("this")
+    private final List<RuntimeFilter> partitionsByFilterId = new ArrayList<>();
+    private final CompletableFuture<RuntimeFilter> constraintByFilterIdFuture;
+
+    private final AtomicBoolean timeoutStarted = new AtomicBoolean(false);
+
+    @GuardedBy("this")
+    private int expectedPartitions;
+
+    private volatile boolean fullyResolved;
+
+    @GuardedBy("this")
+    private RuntimeFilter mergedConstraint;
+
+    @GuardedBy("this")
+    private Domain probeColumnDomain;
+
+    @GuardedBy("this")
+    private long collectionStartNanos;
+    @GuardedBy("this")
+    private boolean collectionStarted;
+    @GuardedBy("this")
+    private boolean collectionTimeRecorded;
+    @GuardedBy("this")
+    private int extensionsUsed;
+    @GuardedBy("this")
+    private int lastTickPartitionCount;
+
+    public JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics)
+    {
+        this(filterId, columnName, waitTimeout, 0, maxSizeInBytes, stats, runtimeStats, extendedMetrics, DEFAULT_SCHEDULER);
+    }
+
+    public JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            int maxWaitExtensions,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics)
+    {
+        this(filterId, columnName, waitTimeout, maxWaitExtensions, maxSizeInBytes, stats, runtimeStats, extendedMetrics, DEFAULT_SCHEDULER);
+    }
+
+    // Package-private: for injection by DynamicFilterService (PR4) and tests.
+    JoinDynamicFilter(
+            String filterId,
+            String columnName,
+            Duration waitTimeout,
+            int maxWaitExtensions,
+            long maxSizeInBytes,
+            DynamicFilterStats stats,
+            RuntimeStats runtimeStats,
+            boolean extendedMetrics,
+            ScheduledExecutorService timeoutScheduler)
+    {
+        this.filterId = requireNonNull(filterId, "filterId is null");
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.waitTimeout = requireNonNull(waitTimeout, "waitTimeout is null");
+        verify(maxWaitExtensions >= 0, "maxWaitExtensions must be non-negative");
+        this.maxWaitExtensions = maxWaitExtensions;
+        this.maxSizeInBytes = maxSizeInBytes;
+        this.expectedPartitions = Integer.MAX_VALUE;
+        this.stats = requireNonNull(stats, "stats is null");
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.extendedMetrics = extendedMetrics;
+        this.timeoutScheduler = requireNonNull(timeoutScheduler, "timeoutScheduler is null");
+
+        this.constraintByFilterIdFuture = new CompletableFuture<>();
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
+    }
+
+    public void setExpectedPartitions(int expectedPartitions)
+    {
+        RuntimeFilter resolved;
+        synchronized (this) {
+            verify(this.expectedPartitions == Integer.MAX_VALUE, "setExpectedPartitions already called");
+            verify(expectedPartitions > 0, "expectedPartitions must be positive");
+            this.expectedPartitions = expectedPartitions;
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_EXPECTED_PARTITIONS, NONE, expectedPartitions);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_EXPECTED_PARTITIONS, filterId), NONE, expectedPartitions);
+            }
+            resolved = tryCompleteResolution();
+        }
+        if (resolved != null) {
+            constraintByFilterIdFuture.complete(resolved);
+        }
+    }
+
+    // Must be called when wired to a split source, not at construction time.
+    public void startTimeout()
+    {
+        if (timeoutStarted.compareAndSet(false, true)) {
+            long timeoutMs = waitTimeout.toMillis();
+            if (timeoutMs > 0) {
+                // Baseline so pre-startTimeout contributions aren't credited as new progress on the first tick.
+                synchronized (this) {
+                    lastTickPartitionCount = partitionsByFilterId.size();
+                }
+                scheduleTick(timeoutMs);
+            }
+        }
+    }
+
+    public Duration getWaitTimeout()
+    {
+        return waitTimeout;
+    }
+
+    public String getFilterId()
+    {
+        return filterId;
+    }
+
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    public synchronized void setProbeColumnDomain(Domain domain)
+    {
+        this.probeColumnDomain = requireNonNull(domain, "domain is null");
+    }
+
+    public boolean isComplete()
+    {
+        return fullyResolved;
+    }
+
+    public void addPartitionByFilterId(TupleDomain<String> tupleDomain)
+    {
+        requireNonNull(tupleDomain, "tupleDomain is null");
+        tupleDomain.getDomains().ifPresent(domains ->
+                verify(domains.size() == 1, "Expected single-column filter domain but got %s columns", domains.size()));
+        addPartitionByFilterId(new DomainRuntimeFilter(tupleDomain));
+    }
+
+    public void addPartitionByFilterId(RuntimeFilter filter)
+    {
+        requireNonNull(filter, "filter is null");
+        RuntimeFilter resolved;
+        synchronized (this) {
+            if (!collectionStarted) {
+                collectionStartNanos = System.nanoTime();
+                collectionStarted = true;
+            }
+
+            partitionsByFilterId.add(filter);
+
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_PARTITIONS_RECEIVED, NONE, 1);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_PARTITIONS_RECEIVED, filterId), NONE, 1);
+            }
+
+            resolved = tryCompleteResolution();
+        }
+        if (resolved != null) {
+            constraintByFilterIdFuture.complete(resolved);
+        }
+    }
+
+    // Returns the resolved filter to complete outside the lock, or null if not yet ready.
+    @GuardedBy("this")
+    private RuntimeFilter tryCompleteResolution()
+    {
+        if (constraintByFilterIdFuture.isDone() || partitionsByFilterId.size() < expectedPartitions) {
+            return null;
+        }
+
+        RuntimeFilter union = partitionsByFilterId.get(0);
+        for (int i = 1; i < partitionsByFilterId.size(); i++) {
+            union = union.mergeWith(partitionsByFilterId.get(i));
+        }
+        mergedConstraint = collapseIfOversized(union);
+        maybeShortCircuit();
+        fullyResolved = true;
+        recordCollectionCompleted();
+        return mergedConstraint;
+    }
+
+    private RuntimeFilter collapseIfOversized(RuntimeFilter filter)
+    {
+        if (filter.estimatedRetainedSizeInBytes() <= maxSizeInBytes) {
+            return filter;
+        }
+        verify(filter instanceof DomainRuntimeFilter,
+                "Cannot collapse oversized %s; add collapse support before introducing new RuntimeFilter types",
+                filter.getClass().getSimpleName());
+        runtimeStats.addMetricValue(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, NONE, 1);
+        if (!filterId.isEmpty()) {
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, filterId), NONE, 1);
+        }
+        return new DomainRuntimeFilter(collapseToRange(((DomainRuntimeFilter) filter).getDomain()));
+    }
+
+    static TupleDomain<String> collapseToRange(TupleDomain<String> tupleDomain)
+    {
+        if (tupleDomain.isNone() || tupleDomain.isAll() || !tupleDomain.getDomains().isPresent()) {
+            return tupleDomain;
+        }
+        ImmutableMap.Builder<String, Domain> collapsed = ImmutableMap.builder();
+        for (Map.Entry<String, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
+            Domain domain = entry.getValue();
+            ValueSet values = domain.getValues();
+            if (values instanceof SortedRangeSet) {
+                SortedRangeSet sortedRangeSet = (SortedRangeSet) values;
+                if (sortedRangeSet.getRangeCount() > 1) {
+                    collapsed.put(entry.getKey(), Domain.create(ValueSet.ofRanges(sortedRangeSet.getSpan()), domain.isNullAllowed()));
+                    continue;
+                }
+            }
+            collapsed.put(entry.getKey(), domain);
+        }
+        return TupleDomain.withColumnDomains(collapsed.build());
+    }
+
+    private void maybeShortCircuit()
+    {
+        if (probeColumnDomain == null || !(mergedConstraint instanceof DomainRuntimeFilter)) {
+            return;
+        }
+        TupleDomain<String> tupleDomain = ((DomainRuntimeFilter) mergedConstraint).getDomain();
+        if (tupleDomain.isAll() || tupleDomain.isNone() || !tupleDomain.getDomains().isPresent()) {
+            return;
+        }
+        Map<String, Domain> domains = tupleDomain.getDomains().get();
+        if (domains.size() != 1) {
+            return;
+        }
+        Domain filterDomain = domains.values().iterator().next();
+        if (filterDomain.contains(probeColumnDomain)) {
+            mergedConstraint = new DomainRuntimeFilter(TupleDomain.all());
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_SHORT_CIRCUITED, NONE, 1);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_SHORT_CIRCUITED, filterId), NONE, 1);
+            }
+        }
+    }
+
+    private void recordCollectionCompleted()
+    {
+        stats.getFilterCollectionCompleted().update(1);
+        recordCollectionTime();
+        if (extendedMetrics && !filterId.isEmpty()) {
+            long rangeCount = (mergedConstraint instanceof DomainRuntimeFilter)
+                    ? computeRangeCount(((DomainRuntimeFilter) mergedConstraint).getDomain())
+                    : 0;
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_DOMAIN_RANGE_COUNT, filterId), NONE, rangeCount);
+        }
+    }
+
+    private synchronized void onTimeout()
+    {
+        if (!filterId.isEmpty()) {
+            runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_TIMED_OUT, filterId), NONE, 1);
+        }
+        stats.getFilterCollectionTimedOut().update(1);
+        recordCollectionTime();
+    }
+
+    @GuardedBy("this")
+    private void recordCollectionTime()
+    {
+        if (collectionStarted && !collectionTimeRecorded) {
+            collectionTimeRecorded = true;
+            long elapsedNanos = System.nanoTime() - collectionStartNanos;
+            runtimeStats.addMetricValue(DYNAMIC_FILTER_COLLECTION_TIME_NANOS, NANO, elapsedNanos);
+            if (!filterId.isEmpty()) {
+                runtimeStats.addMetricValue(format("%s[%s]", DYNAMIC_FILTER_COLLECTION_TIME_NANOS, filterId), NANO, elapsedNanos);
+            }
+        }
+    }
+
+    static long computeRangeCount(TupleDomain<String> tupleDomain)
+    {
+        if (tupleDomain.isNone() || !tupleDomain.getDomains().isPresent()) {
+            return 0;
+        }
+        return tupleDomain.getDomains().get().values().stream()
+                .filter(domain -> domain.getValues() instanceof SortedRangeSet)
+                .mapToLong(domain -> domain.getValues().getRanges().getRangeCount())
+                .sum();
+    }
+
+    public CompletableFuture<?> isBlocked()
+    {
+        if (constraintByFilterIdFuture.isDone()) {
+            return NOT_BLOCKED;
+        }
+        return constraintByFilterIdFuture.thenApply(v -> null);
+    }
+
+    /** Returns all() until fully resolved. */
+    public synchronized TupleDomain<String> getCurrentConstraintByColumnName()
+    {
+        if (!fullyResolved || mergedConstraint == null) {
+            return TupleDomain.all();
+        }
+        Type type = probeColumnDomain != null ? probeColumnDomain.getType() : null;
+        return mergedConstraint.toTupleDomain(columnName, type);
+    }
+
+    /** Fires only on normal completion, not on timeout. */
+    public void onFullyResolved(BiConsumer<String, RuntimeFilter> callback)
+    {
+        constraintByFilterIdFuture.whenComplete((filter, throwable) -> {
+            if (fullyResolved && throwable == null) {
+                callback.accept(filterId, new DomainRuntimeFilter(getCurrentConstraintByColumnName()));
+            }
+        });
+    }
+
+    public synchronized boolean hasData()
+    {
+        return !partitionsByFilterId.isEmpty();
+    }
+
+    public static DynamicFilter createDisabled()
+    {
+        return DynamicFilter.EMPTY;
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return toStringHelper(this)
+                .add("filterId", filterId)
+                .add("columnName", columnName)
+                .add("waitTimeout", waitTimeout)
+                .add("expectedPartitions", expectedPartitions)
+                .add("receivedPartitions", partitionsByFilterId.size())
+                .add("complete", fullyResolved)
+                .toString();
+    }
+
+    private void scheduleTick(long timeoutMs)
+    {
+        timeoutScheduler.schedule(this::onTick, timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void onTick()
+    {
+        boolean reschedule;
+        synchronized (this) {
+            if (constraintByFilterIdFuture.isDone()) {
+                return;
+            }
+            int currentReceived = partitionsByFilterId.size();
+            boolean progress = currentReceived > lastTickPartitionCount;
+            lastTickPartitionCount = currentReceived;
+            if (progress && extensionsUsed < maxWaitExtensions) {
+                extensionsUsed++;
+                reschedule = true;
+            }
+            else {
+                // Finalize inside the monitor so a concurrent addPartitionByFilterId either
+                // resolves the filter first (and this tick observes isDone) or sees the
+                // future already completed and bails — partial state is never exposed.
+                constraintByFilterIdFuture.complete(new DomainRuntimeFilter(TupleDomain.all()));
+                onTimeout();
+                reschedule = false;
+            }
+        }
+        if (reschedule) {
+            scheduleTick(waitTimeout.toMillis());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+// Wire form: a bare TupleDomain (no @kind field) decodes to DomainRuntimeFilter for back-compat.
+@JsonDeserialize(using = RuntimeFilterDeserializer.class)
+public interface RuntimeFilter
+{
+    /** Throws if representations are incompatible. */
+    RuntimeFilter mergeWith(RuntimeFilter other);
+
+    TupleDomain<String> toTupleDomain(String column, Type type);
+
+    boolean isAll();
+
+    boolean isNone();
+
+    long estimatedRetainedSizeInBytes();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilterDeserializer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/RuntimeFilterDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class RuntimeFilterDeserializer
+        extends JsonDeserializer<RuntimeFilter>
+{
+    private static final TypeReference<TupleDomain<String>> TUPLE_DOMAIN_TYPE = new TypeReference<TupleDomain<String>>() {};
+
+    @Override
+    public RuntimeFilter deserialize(JsonParser parser, DeserializationContext context)
+            throws IOException
+    {
+        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        JsonNode node = mapper.readTree(parser);
+        JsonNode kind = node.get("@kind");
+
+        if (kind != null && !"tupleDomain".equals(kind.asText())) {
+            throw new IOException("Unknown RuntimeFilter @kind: " + kind.asText());
+        }
+
+        JsonNode domainNode = (kind != null && node.has("domain")) ? node.get("domain") : node;
+        return new DomainRuntimeFilter(mapper.convertValue(domainNode, TUPLE_DOMAIN_TYPE));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -34,11 +34,14 @@ import com.facebook.presto.operator.ForScheduler;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodePoolType;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PartitioningHandle;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.sql.planner.NodePartitionMap;
@@ -47,6 +50,7 @@ import com.facebook.presto.sql.planner.PlanFragmenterUtils;
 import com.facebook.presto.sql.planner.SplitSourceFactory;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -62,6 +66,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -69,7 +75,9 @@ import java.util.function.Supplier;
 import static com.facebook.presto.SystemSessionProperties.getConcurrentLifespansPerNode;
 import static com.facebook.presto.SystemSessionProperties.getMaxTasksPerStage;
 import static com.facebook.presto.SystemSessionProperties.getWriterMinSize;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
 import static com.facebook.presto.SystemSessionProperties.isOptimizedScaleWriterProducerBuffer;
+import static com.facebook.presto.SystemSessionProperties.isVerboseRuntimeStatsEnabled;
 import static com.facebook.presto.execution.SqlStageExecution.createSqlStageExecution;
 import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsStageScheduler;
 import static com.facebook.presto.execution.scheduler.TableWriteInfo.createTableWriteInfo;
@@ -89,6 +97,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static com.google.common.collect.Streams.findLast;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -106,6 +115,7 @@ public class SectionExecutionFactory
     private final NodeScheduler nodeScheduler;
     private final int splitBatchSize;
     private final boolean isEnableWorkerIsolation;
+    private final DynamicFilterService dynamicFilterService;
 
     @Inject
     public SectionExecutionFactory(
@@ -117,7 +127,8 @@ public class SectionExecutionFactory
             FailureDetector failureDetector,
             SplitSchedulerStats schedulerStats,
             NodeScheduler nodeScheduler,
-            QueryManagerConfig queryManagerConfig)
+            QueryManagerConfig queryManagerConfig,
+            DynamicFilterService dynamicFilterService)
     {
         this(
                 metadata,
@@ -129,7 +140,8 @@ public class SectionExecutionFactory
                 schedulerStats,
                 nodeScheduler,
                 requireNonNull(queryManagerConfig, "queryManagerConfig is null").getScheduleSplitBatchSize(),
-                queryManagerConfig.isEnableWorkerIsolation());
+                queryManagerConfig.isEnableWorkerIsolation(),
+                dynamicFilterService);
     }
 
     public SectionExecutionFactory(
@@ -142,7 +154,8 @@ public class SectionExecutionFactory
             SplitSchedulerStats schedulerStats,
             NodeScheduler nodeScheduler,
             int splitBatchSize,
-            boolean isEnableWorkerIsolation)
+            boolean isEnableWorkerIsolation,
+            DynamicFilterService dynamicFilterService)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
@@ -154,6 +167,7 @@ public class SectionExecutionFactory
         this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
         this.splitBatchSize = splitBatchSize;
         this.isEnableWorkerIsolation = isEnableWorkerIsolation;
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
     }
 
     /**
@@ -175,6 +189,7 @@ public class SectionExecutionFactory
         Map<PartitioningHandle, NodePartitionMap> partitioningCache = new HashMap<>();
         TableWriteInfo tableWriteInfo = createTableWriteInfo(section.getPlan(), metadata, session);
         Optional<Predicate<Node>> nodePredicate = getNodePoolSelectionPredicate(section.getPlan());
+        splitSourceFactory.registerDynamicFilters(section.getPlan(), session);
         List<StageExecutionAndScheduler> sectionStages = createStreamingLinkedStageExecutions(
                 session,
                 locationsConsumer,
@@ -187,7 +202,23 @@ public class SectionExecutionFactory
                 splitSourceFactory,
                 attemptId,
                 cteMaterializationTracker);
-        StageExecutionAndScheduler rootStage = sectionStages.stream().reduce((first, second) -> second).get();
+        if (isDistributedDynamicFilterEnabled(session)) {
+            QueryId queryId = session.getQueryId();
+            DynamicFilterPusher pusher = new DynamicFilterPusher(
+                    session.getRuntimeStats(),
+                    isVerboseRuntimeStatsEnabled(session));
+            for (StageExecutionAndScheduler stageAndScheduler : sectionStages) {
+                SqlStageExecution stageExecution = stageAndScheduler.getStageExecution();
+                for (PlanNodeId scanNodeId : stageExecution.getFragment().getTableScanSchedulingOrder()) {
+                    Set<String> filterIds = dynamicFilterService.getFilterIdsForScan(queryId, scanNodeId);
+                    for (String filterId : filterIds) {
+                        dynamicFilterService.getFilter(queryId, filterId)
+                                .ifPresent(joinFilter -> pusher.startPushing(filterId, scanNodeId, joinFilter, stageExecution));
+                    }
+                }
+            }
+        }
+        StageExecutionAndScheduler rootStage = findLast(sectionStages.stream()).get();
         rootStage.getStageExecution().setOutputBuffers(outputBuffers);
         return new SectionExecution(rootStage, sectionStages);
     }
@@ -244,7 +275,7 @@ public class SectionExecutionFactory
                     attemptId,
                     cteMaterializationTracker);
             stageExecutionAndSchedulers.addAll(subTree);
-            childStagesBuilder.add(subTree.stream().reduce((first, second) -> second).get().getStageExecution());
+            childStagesBuilder.add(findLast(subTree.stream()).get().getStageExecution());
         }
         Set<SqlStageExecution> childStageExecutions = childStagesBuilder.build();
         stageExecution.addStateChangeListener(newState -> {
@@ -303,7 +334,37 @@ public class SectionExecutionFactory
             SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks);
 
             checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
-            return newSourcePartitionedSchedulerAsStageScheduler(stageExecution, planNodeId, splitSource, placementPolicy, splitBatchSize, cteMaterializationTracker);
+            splitSourceFactory.setTaskCountHint(nodeSelector.getActiveNodes().size());
+
+            boolean hasDpp = isDistributedDynamicFilterEnabled(session)
+                    && !dynamicFilterService.getAllFiltersForQuery(session.getQueryId()).isEmpty();
+
+            if (hasDpp) {
+                forEachJoinDynamicFilter(dynamicFilterService, session.getQueryId(), plan.getFragment().getRoot(), (filter, isBroadcastBuild) -> {
+                    if (isBroadcastBuild) {
+                        filter.setExpectedPartitions(1);
+                    }
+                });
+                AtomicBoolean nonBroadcastSized = new AtomicBoolean();
+                stageExecution.addStateChangeListener(newState -> {
+                    if (newState.ordinal() < StageExecutionState.FINISHED_TASK_SCHEDULING.ordinal()) {
+                        return;
+                    }
+                    if (!nonBroadcastSized.compareAndSet(false, true)) {
+                        return;
+                    }
+                    int actualTaskCount = stageExecution.getAllTasks().size();
+                    if (actualTaskCount > 0) {
+                        forEachJoinDynamicFilter(dynamicFilterService, session.getQueryId(), plan.getFragment().getRoot(), (filter, isBroadcastBuild) -> {
+                            if (!isBroadcastBuild) {
+                                filter.setExpectedPartitions(actualTaskCount);
+                            }
+                        });
+                    }
+                });
+            }
+
+            return newSourcePartitionedSchedulerAsStageScheduler(stageExecution, planNodeId, splitSource, placementPolicy, splitBatchSize, cteMaterializationTracker, hasDpp);
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
             Supplier<Collection<TaskStatus>> sourceTasksProvider = () -> childStageExecutions.stream()
@@ -335,6 +396,10 @@ public class SectionExecutionFactory
             if (!splitSources.isEmpty() && (plan.getFragment().getPartitioning().equals(SINGLE_DISTRIBUTION))) {
                 NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, null, nodePredicate);
                 List<InternalNode> nodes = nodeSelector.selectRandomNodes(1);
+                splitSourceFactory.setTaskCountHint(nodes.size());
+                if (isDistributedDynamicFilterEnabled(session)) {
+                    setExpectedPartitionsForFilters(dynamicFilterService, session.getQueryId(), plan.getFragment().getRoot(), nodes.size());
+                }
                 return new FixedSourcePartitionedScheduler(
                         stageExecution,
                         splitSources,
@@ -414,6 +479,10 @@ public class SectionExecutionFactory
                     bucketNodeMap = nodePartitionMap.asBucketNodeMap();
                 }
 
+                splitSourceFactory.setTaskCountHint(stageNodeList.size());
+                if (isDistributedDynamicFilterEnabled(session)) {
+                    setExpectedPartitionsForFilters(dynamicFilterService, session.getQueryId(), plan.getFragment().getRoot(), stageNodeList.size());
+                }
                 FixedSourcePartitionedScheduler fixedSourcePartitionedScheduler = new FixedSourcePartitionedScheduler(
                         stageExecution,
                         splitSources,
@@ -445,6 +514,9 @@ public class SectionExecutionFactory
                 List<InternalNode> partitionToNode = nodePartitionMap.getPartitionToNode();
                 // todo this should asynchronously wait a standard timeout period before failing
                 checkCondition(!partitionToNode.isEmpty(), NO_NODES_AVAILABLE, "No worker nodes available");
+                if (isDistributedDynamicFilterEnabled(session)) {
+                    setExpectedPartitionsForFilters(dynamicFilterService, session.getQueryId(), plan.getFragment().getRoot(), partitionToNode.size());
+                }
                 return new FixedCountScheduler(stageExecution, partitionToNode);
             }
         }
@@ -486,6 +558,42 @@ public class SectionExecutionFactory
             checkCondition(!partitionToNode.isEmpty(), NO_NODES_AVAILABLE, "No worker nodes available");
             return Optional.of(nodePartitionMap.getBucketToPartition());
         }
+    }
+
+    @VisibleForTesting
+    static void setExpectedPartitionsForFilters(DynamicFilterService dynamicFilterService, QueryId queryId, PlanNode root, int taskCount)
+    {
+        forEachJoinDynamicFilter(dynamicFilterService, queryId, root, (filter, isBroadcastBuild) -> filter.setExpectedPartitions(taskCount));
+    }
+
+    @VisibleForTesting
+    static void forEachJoinDynamicFilter(
+            DynamicFilterService dynamicFilterService,
+            QueryId queryId,
+            PlanNode root,
+            BiConsumer<JoinDynamicFilter, Boolean> action)
+    {
+        for (JoinNode joinNode : PlanNodeSearcher.searchFrom(root).where(node -> node instanceof JoinNode).<JoinNode>findAll()) {
+            boolean isBroadcastBuild = buildSubtreeIsReplicated(joinNode.getRight());
+            for (String filterId : joinNode.getDynamicFilters().keySet()) {
+                dynamicFilterService.getFilter(queryId, filterId).ifPresent(f -> action.accept(f, isBroadcastBuild));
+            }
+        }
+        for (SemiJoinNode semiJoinNode : PlanNodeSearcher.searchFrom(root).where(node -> node instanceof SemiJoinNode).<SemiJoinNode>findAll()) {
+            boolean isBroadcastBuild = buildSubtreeIsReplicated(semiJoinNode.getFilteringSource());
+            for (String filterId : semiJoinNode.getDynamicFilters().keySet()) {
+                dynamicFilterService.getFilter(queryId, filterId).ifPresent(f -> action.accept(f, isBroadcastBuild));
+            }
+        }
+    }
+
+    private static boolean buildSubtreeIsReplicated(PlanNode buildSubtree)
+    {
+        return PlanNodeSearcher.searchFrom(buildSubtree)
+                .where(node -> node instanceof RemoteSourceNode)
+                .<RemoteSourceNode>findFirst()
+                .map(node -> node.getExchangeType() == REPLICATE)
+                .orElse(false);
     }
 
     private static ListenableFuture<?> whenAllStages(Collection<SqlStageExecution> stageExecutions, Predicate<StageExecutionState> predicate)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -91,6 +91,7 @@ public class SourcePartitionedScheduler
     private final int splitBatchSize;
     private final PlanNodeId partitionedNode;
     private final boolean groupedExecution;
+    private final boolean hasDynamicPartitionPruning;
 
     // TODO: Add LIFESPAN_ADDED into SourcePartitionedScheduler#State and remove this boolean
     private boolean lifespanAdded;
@@ -106,7 +107,8 @@ public class SourcePartitionedScheduler
             SplitSource splitSource,
             SplitPlacementPolicy splitPlacementPolicy,
             int splitBatchSize,
-            boolean groupedExecution)
+            boolean groupedExecution,
+            boolean hasDynamicPartitionPruning)
     {
         this.stage = requireNonNull(stage, "stage is null");
         this.partitionedNode = requireNonNull(partitionedNode, "partitionedNode is null");
@@ -116,6 +118,7 @@ public class SourcePartitionedScheduler
         checkArgument(splitBatchSize > 0, "splitBatchSize must be at least one");
         this.splitBatchSize = splitBatchSize;
         this.groupedExecution = groupedExecution;
+        this.hasDynamicPartitionPruning = hasDynamicPartitionPruning;
     }
 
     public PlanNodeId getPlanNodeId()
@@ -136,9 +139,10 @@ public class SourcePartitionedScheduler
             SplitSource splitSource,
             SplitPlacementPolicy splitPlacementPolicy,
             int splitBatchSize,
-            CTEMaterializationTracker cteMaterializationTracker)
+            CTEMaterializationTracker cteMaterializationTracker,
+            boolean hasDynamicPartitionPruning)
     {
-        SourcePartitionedScheduler sourcePartitionedScheduler = new SourcePartitionedScheduler(stage, partitionedNode, splitSource, splitPlacementPolicy, splitBatchSize, false);
+        SourcePartitionedScheduler sourcePartitionedScheduler = new SourcePartitionedScheduler(stage, partitionedNode, splitSource, splitPlacementPolicy, splitBatchSize, false, hasDynamicPartitionPruning);
         sourcePartitionedScheduler.startLifespan(Lifespan.taskWide(), NOT_PARTITIONED);
 
         return new StageScheduler()
@@ -187,7 +191,7 @@ public class SourcePartitionedScheduler
             int splitBatchSize,
             boolean groupedExecution)
     {
-        return new SourcePartitionedScheduler(stage, partitionedNode, splitSource, splitPlacementPolicy, splitBatchSize, groupedExecution);
+        return new SourcePartitionedScheduler(stage, partitionedNode, splitSource, splitPlacementPolicy, splitBatchSize, groupedExecution, false);
     }
 
     @Override
@@ -362,7 +366,9 @@ public class SourcePartitionedScheduler
             return ScheduleResult.nonBlocked(false, overallNewTasks.build(), overallSplitAssignmentCount);
         }
 
-        if (anyBlockedOnPlacements) {
+        if (anyBlockedOnPlacements
+                || (hasDynamicPartitionPruning && anyBlockedOnNextSplitBatch
+                        && stage.getScheduledNodes().isEmpty())) {
             // In a broadcast join, output buffers of the tasks in build source stage have to
             // hold onto all data produced before probe side task scheduling finishes,
             // even if the data is acknowledged by all known consumers. This is because

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableScanDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/TableScanDynamicFilter.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.joining;
+
+@ThreadSafe
+public class TableScanDynamicFilter
+        implements DynamicFilter
+{
+    private final List<JoinDynamicFilter> filters;
+    private final Map<String, ColumnHandle> columnNameToHandle;
+    private final Duration waitTimeout;
+    private volatile int taskCountHint;
+
+    public TableScanDynamicFilter(List<JoinDynamicFilter> filters, Map<String, ColumnHandle> columnNameToHandle)
+    {
+        requireNonNull(filters, "filters is null");
+        requireNonNull(columnNameToHandle, "columnNameToHandle is null");
+        verify(!filters.isEmpty(), "filters list cannot be empty");
+
+        this.filters = ImmutableList.copyOf(filters);
+        this.columnNameToHandle = ImmutableMap.copyOf(columnNameToHandle);
+
+        for (JoinDynamicFilter filter : this.filters) {
+            String columnName = filter.getColumnName();
+            verify(this.columnNameToHandle.containsKey(columnName),
+                    "Dynamic filter column '%s' not found in scan columns: %s",
+                    columnName, this.columnNameToHandle.keySet());
+        }
+
+        this.waitTimeout = filters.stream()
+                .map(JoinDynamicFilter::getWaitTimeout)
+                .min(Comparator.comparing(Duration::toMillis))
+                .orElse(new Duration(0, MILLISECONDS));
+    }
+
+    public List<JoinDynamicFilter> getFilters()
+    {
+        return filters;
+    }
+
+    public void setTaskCountHint(int taskCountHint)
+    {
+        this.taskCountHint = taskCountHint;
+    }
+
+    @Override
+    public int getTaskCountHint()
+    {
+        return taskCountHint;
+    }
+
+    @Override
+    public TupleDomain<ColumnHandle> getCurrentPredicate()
+    {
+        return filters.stream()
+                .map(JoinDynamicFilter::getCurrentConstraintByColumnName)
+                .map(this::translateToColumnHandle)
+                .reduce(TupleDomain::intersect)
+                .orElse(TupleDomain.all());
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return isBlocked(Optional.empty());
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        filters.forEach(JoinDynamicFilter::startTimeout);
+
+        List<CompletableFuture<?>> pendingFutures = getRelevantFilters(relevantColumns).stream()
+                .map(JoinDynamicFilter::isBlocked)
+                .filter(future -> !future.isDone())
+                .collect(toImmutableList());
+
+        if (pendingFutures.isEmpty()) {
+            return NOT_BLOCKED;
+        }
+
+        return CompletableFuture.anyOf(pendingFutures.toArray(new CompletableFuture[0]));
+    }
+
+    @Override
+    public Duration getWaitTimeout()
+    {
+        return waitTimeout;
+    }
+
+    @Override
+    public boolean isComplete()
+    {
+        return isComplete(Optional.empty());
+    }
+
+    @Override
+    public boolean isComplete(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        return getRelevantFilters(relevantColumns).stream()
+                .allMatch(JoinDynamicFilter::isComplete);
+    }
+
+    @Override
+    public boolean hasAnyComplete(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        List<JoinDynamicFilter> relevant = getRelevantFilters(relevantColumns);
+        return relevant.isEmpty() || relevant.stream().anyMatch(JoinDynamicFilter::isComplete);
+    }
+
+    @Override
+    public Set<ColumnHandle> getPendingFilterColumns()
+    {
+        return filters.stream()
+                .filter(f -> !f.isComplete())
+                .map(f -> columnNameToHandle.get(f.getColumnName()))
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    private List<JoinDynamicFilter> getRelevantFilters(Optional<Set<ColumnHandle>> relevantColumns)
+    {
+        if (!relevantColumns.isPresent()) {
+            return filters;
+        }
+
+        Set<ColumnHandle> columns = relevantColumns.get();
+        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        for (Map.Entry<String, ColumnHandle> entry : columnNameToHandle.entrySet()) {
+            if (columns.contains(entry.getValue())) {
+                builder.add(entry.getKey());
+            }
+        }
+        Set<String> relevantColumnNames = builder.build();
+
+        return filters.stream()
+                .filter(f -> relevantColumnNames.contains(f.getColumnName()))
+                .collect(toImmutableList());
+    }
+
+    public String getFilterId()
+    {
+        return filters.stream()
+                .map(JoinDynamicFilter::getFilterId)
+                .collect(joining(","));
+    }
+
+    private TupleDomain<ColumnHandle> translateToColumnHandle(TupleDomain<String> columnNameDomain)
+    {
+        return columnNameDomain.transform(columnNameToHandle::get);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("filterCount", filters.size())
+                .add("filterIds", getFilterId())
+                .add("columnNameToHandle", columnNameToHandle)
+                .add("waitTimeout", waitTimeout)
+                .add("complete", isComplete())
+                .toString();
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/split/CloseableSplitSourceProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/split/CloseableSplitSourceProvider.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.TableFunctionHandle;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import java.io.Closeable;
@@ -51,6 +52,24 @@ public class CloseableSplitSourceProvider
     {
         checkState(!closed, "split source provider is closed");
         SplitSource splitSource = delegate.getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector);
+        splitSources.add(splitSource);
+        return splitSource;
+    }
+
+    @Override
+    public synchronized SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter)
+    {
+        checkState(!closed, "split source provider is closed");
+        SplitSource splitSource = delegate.getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector, dynamicFilter);
+        splitSources.add(splitSource);
+        return splitSource;
+    }
+
+    @Override
+    public synchronized SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter, Map<String, String> partitionColumnMapping)
+    {
+        checkState(!closed, "split source provider is closed");
+        SplitSource splitSource = delegate.getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector, dynamicFilter, partitionColumnMapping);
         splitSources.add(splitSource);
         return splitSource;
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/split/SplitManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/split/SplitManager.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;
 
@@ -75,7 +76,12 @@ public class SplitManager
         return getSplits(session, table, splitSchedulingStrategy, warningCollector, ImmutableMap.of());
     }
 
-    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, Map<String, String> partitionColumnMapping)
+    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter)
+    {
+        return getSplits(session, table, splitSchedulingStrategy, warningCollector, dynamicFilter, ImmutableMap.of());
+    }
+
+    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter, Map<String, String> partitionColumnMapping)
     {
         long startTime = System.nanoTime();
         ConnectorId connectorId = table.getConnectorId();
@@ -97,13 +103,19 @@ public class SplitManager
                 table.getTransaction(),
                 connectorSession,
                 layout,
-                new SplitSchedulingContext(splitSchedulingStrategy, preferSplitHostAddresses, warningCollector, partitionColumnMapping));
+                new SplitSchedulingContext(splitSchedulingStrategy, preferSplitHostAddresses, warningCollector, partitionColumnMapping),
+                dynamicFilter);
 
         SplitSource splitSource = new ConnectorAwareSplitSource(connectorId, table.getTransaction(), source);
         if (minScheduleSplitBatchSize > 1) {
             splitSource = new BufferingSplitSource(splitSource, minScheduleSplitBatchSize);
         }
         return splitSource;
+    }
+
+    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, Map<String, String> partitionColumnMapping)
+    {
+        return getSplits(session, table, splitSchedulingStrategy, warningCollector, DynamicFilter.EMPTY, partitionColumnMapping);
     }
 
     private ConnectorSplitManager getConnectorSplitManager(ConnectorId connectorId)

--- a/presto-main-base/src/main/java/com/facebook/presto/split/SplitSourceProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/split/SplitSourceProvider.java
@@ -18,12 +18,23 @@ import com.facebook.presto.metadata.TableFunctionHandle;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.connector.DynamicFilter;
 
 import java.util.Map;
 
 public interface SplitSourceProvider
 {
     SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector);
+
+    default SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter)
+    {
+        return getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector, dynamicFilter, java.util.Collections.emptyMap());
+    }
+
+    default SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, DynamicFilter dynamicFilter, Map<String, String> partitionColumnMapping)
+    {
+        return getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector);
+    }
 
     default SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector, Map<String, String> partitionColumnMapping)
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -14,19 +14,30 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.JoinDynamicFilter;
+import com.facebook.presto.execution.scheduler.StreamingSubPlan;
+import com.facebook.presto.execution.scheduler.TableScanDynamicFilter;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.connector.DynamicFilter;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.CallDistributedProcedureNode;
 import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IndexJoinNode;
 import com.facebook.presto.spi.plan.IndexSourceNode;
@@ -36,6 +47,7 @@ import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.MergeJoinNode;
 import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.OutputNode;
+import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.ProjectNode;
@@ -52,9 +64,11 @@ import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.split.SampledSplitSource;
 import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.split.SplitSourceProvider;
+import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -74,13 +88,22 @@ import com.facebook.presto.sql.planner.plan.UpdateNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterMaxSize;
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterMaxWaitExtensions;
+import static com.facebook.presto.SystemSessionProperties.getDistributedDynamicFilterMaxWaitTime;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
+import static com.facebook.presto.SystemSessionProperties.isVerboseRuntimeStatsEnabled;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.REWINDABLE_GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -94,12 +117,203 @@ public class SplitSourceFactory
     private final SplitSourceProvider splitSourceProvider;
     private final WarningCollector warningCollector;
     private final Metadata metadata;
+    private final DynamicFilterService dynamicFilterService;
+    private final List<TableScanDynamicFilter> createdDynamicFilters = new ArrayList<>();
 
-    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector, Metadata metadata)
+    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector, DynamicFilterService dynamicFilterService, Metadata metadata)
     {
         this.splitSourceProvider = requireNonNull(splitSourceProvider, "splitSourceProvider is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    public void registerDynamicFilters(StreamingSubPlan rootPlan, Session session)
+    {
+        if (!isDistributedDynamicFilterEnabled(session)) {
+            return;
+        }
+        QueryId queryId = session.getQueryId();
+        Duration waitTimeout = getDistributedDynamicFilterMaxWaitTime(session);
+
+        Map<PlanFragmentId, PlanFragment> fragmentIndex = new HashMap<>();
+        collectFragments(rootPlan, fragmentIndex);
+
+        registerFiltersInSubPlan(rootPlan, queryId, waitTimeout, session, fragmentIndex);
+    }
+
+    private static void collectFragments(StreamingSubPlan plan, Map<PlanFragmentId, PlanFragment> index)
+    {
+        index.put(plan.getFragment().getId(), plan.getFragment());
+        for (StreamingSubPlan child : plan.getChildren()) {
+            collectFragments(child, index);
+        }
+    }
+
+    private void registerFiltersInSubPlan(
+            StreamingSubPlan plan,
+            QueryId queryId,
+            Duration waitTimeout,
+            Session session,
+            Map<PlanFragmentId, PlanFragment> fragmentIndex)
+    {
+        registerFiltersForFragment(plan.getFragment(), queryId, waitTimeout, session, fragmentIndex);
+        for (StreamingSubPlan child : plan.getChildren()) {
+            registerFiltersInSubPlan(child, queryId, waitTimeout, session, fragmentIndex);
+        }
+    }
+
+    private void registerFiltersForFragment(
+            PlanFragment fragment,
+            QueryId queryId,
+            Duration waitTimeout,
+            Session session,
+            Map<PlanFragmentId, PlanFragment> fragmentIndex)
+    {
+        List<JoinNode> joinNodes = PlanNodeSearcher.searchFrom(fragment.getRoot())
+                .where(node -> node instanceof JoinNode)
+                .findAll();
+
+        for (JoinNode joinNode : joinNodes) {
+            if (joinNode.getDynamicFilters().isEmpty()) {
+                continue;
+            }
+
+            Map<VariableReferenceExpression, VariableReferenceExpression> buildToProbe = new HashMap<>();
+            for (EquiJoinClause clause : joinNode.getCriteria()) {
+                buildToProbe.put(clause.getRight(), clause.getLeft());
+            }
+
+            Map<String, Set<String>> localFilterColumns = new HashMap<>();
+            Set<String> joinFilterIds = joinNode.getDynamicFilters().keySet();
+            for (Map.Entry<String, VariableReferenceExpression> entry : joinNode.getDynamicFilters().entrySet()) {
+                VariableReferenceExpression probeVar = buildToProbe.get(entry.getValue());
+                String columnName = probeVar != null ? probeVar.getName() : "";
+                registerFilterIfAbsent(queryId, entry.getKey(), columnName, waitTimeout, session);
+                if (!columnName.isEmpty()) {
+                    localFilterColumns.computeIfAbsent(columnName, k -> new HashSet<>()).add(entry.getKey());
+                }
+            }
+
+            if (!localFilterColumns.isEmpty()) {
+                matchFiltersToScans(joinNode.getLeft(), localFilterColumns, queryId);
+            }
+
+            wireProbeChildFragments(joinNode.getLeft(), joinFilterIds, fragmentIndex, queryId, new HashSet<>());
+        }
+
+        List<SemiJoinNode> semiJoinNodes = PlanNodeSearcher.searchFrom(fragment.getRoot())
+                .where(node -> node instanceof SemiJoinNode)
+                .findAll();
+
+        for (SemiJoinNode semiJoinNode : semiJoinNodes) {
+            if (semiJoinNode.getDynamicFilters().isEmpty()) {
+                continue;
+            }
+
+            String columnName = semiJoinNode.getSourceJoinVariable().getName();
+            Map<String, Set<String>> localFilterColumns = new HashMap<>();
+            Set<String> semiJoinFilterIds = semiJoinNode.getDynamicFilters().keySet();
+            for (String filterId : semiJoinFilterIds) {
+                registerFilterIfAbsent(queryId, filterId, columnName, waitTimeout, session);
+                if (!columnName.isEmpty()) {
+                    localFilterColumns.computeIfAbsent(columnName, k -> new HashSet<>()).add(filterId);
+                }
+            }
+
+            if (!localFilterColumns.isEmpty()) {
+                matchFiltersToScans(semiJoinNode.getSource(), localFilterColumns, queryId);
+            }
+
+            wireProbeChildFragments(semiJoinNode.getSource(), semiJoinFilterIds, fragmentIndex, queryId, new HashSet<>());
+        }
+    }
+
+    private void wireProbeChildFragments(
+            PlanNode probeRoot,
+            Set<String> filterIds,
+            Map<PlanFragmentId, PlanFragment> fragmentIndex,
+            QueryId queryId,
+            Set<PlanFragmentId> visited)
+    {
+        Map<String, Set<String>> filterColumns = new HashMap<>();
+        for (String filterId : filterIds) {
+            dynamicFilterService.getFilter(queryId, filterId).ifPresent(f -> {
+                String col = f.getColumnName();
+                if (!col.isEmpty()) {
+                    filterColumns.computeIfAbsent(col, k -> new HashSet<>()).add(filterId);
+                }
+            });
+        }
+
+        if (filterColumns.isEmpty()) {
+            return;
+        }
+
+        for (RemoteSourceNode remoteSource : collectProbeChainRemoteSources(probeRoot)) {
+            for (PlanFragmentId childFragId : remoteSource.getSourceFragmentIds()) {
+                if (!visited.add(childFragId)) {
+                    continue;
+                }
+                PlanFragment childFragment = fragmentIndex.get(childFragId);
+                if (childFragment == null) {
+                    continue;
+                }
+                matchFiltersToScans(childFragment.getRoot(), filterColumns, queryId);
+                wireProbeChildFragments(childFragment.getRoot(), filterIds, fragmentIndex, queryId, visited);
+            }
+        }
+    }
+
+    private void registerFilterIfAbsent(QueryId queryId, String filterId, String columnName, Duration waitTimeout, Session session)
+    {
+        if (!dynamicFilterService.hasFilter(queryId, filterId)) {
+            JoinDynamicFilter filter = new JoinDynamicFilter(
+                    filterId,
+                    columnName,
+                    waitTimeout,
+                    getDistributedDynamicFilterMaxWaitExtensions(session),
+                    getDistributedDynamicFilterMaxSize(session).toBytes(),
+                    dynamicFilterService.getStats(),
+                    session.getRuntimeStats(),
+                    isVerboseRuntimeStatsEnabled(session));
+            dynamicFilterService.registerFilter(queryId, filterId, filter);
+        }
+    }
+
+    private void matchFiltersToScans(PlanNode root, Map<String, Set<String>> filterColumnToFilterIds, QueryId queryId)
+    {
+        Map<PlanNodeId, Map<String, String>> scanToFilterColumns = root.accept(new FilterToScanMatcher(), filterColumnToFilterIds);
+        for (Map.Entry<PlanNodeId, Map<String, String>> entry : scanToFilterColumns.entrySet()) {
+            PlanNodeId scanNodeId = entry.getKey();
+            Map<String, String> filterIdToLocalColumn = entry.getValue();
+            dynamicFilterService.registerScanFilterMapping(queryId, scanNodeId, filterIdToLocalColumn.keySet());
+        }
+    }
+
+    private static List<RemoteSourceNode> collectProbeChainRemoteSources(PlanNode node)
+    {
+        if (node instanceof RemoteSourceNode) {
+            return ImmutableList.of((RemoteSourceNode) node);
+        }
+        if (node instanceof JoinNode) {
+            return collectProbeChainRemoteSources(((JoinNode) node).getLeft());
+        }
+        if (node instanceof SemiJoinNode) {
+            return collectProbeChainRemoteSources(((SemiJoinNode) node).getSource());
+        }
+        ImmutableList.Builder<RemoteSourceNode> result = ImmutableList.builder();
+        for (PlanNode child : node.getSources()) {
+            result.addAll(collectProbeChainRemoteSources(child));
+        }
+        return result.build();
+    }
+
+    public void setTaskCountHint(int taskCountHint)
+    {
+        for (TableScanDynamicFilter filter : createdDynamicFilters) {
+            filter.setTaskCountHint(taskCountHint);
+        }
     }
 
     public Map<PlanNodeId, SplitSource> createSplitSources(PlanFragment fragment, Session session, TableWriteInfo tableWriteInfo)
@@ -158,16 +372,62 @@ public class SplitSourceFactory
         @Override
         public Map<PlanNodeId, SplitSource> visitTableScan(TableScanNode node, Context context)
         {
-            // get dataSource for table
             TableHandle table = node.getTable();
+
+            DynamicFilter dynamicFilter = DynamicFilter.EMPTY;
+            if (isDistributedDynamicFilterEnabled(session)) {
+                Set<String> filterIds = dynamicFilterService.getFilterIdsForScan(session.getQueryId(), node.getId());
+                if (!filterIds.isEmpty()) {
+                    Map<String, ColumnHandle> variableNameToHandle = new HashMap<>();
+                    for (Map.Entry<VariableReferenceExpression, ColumnHandle> assignment : node.getAssignments().entrySet()) {
+                        variableNameToHandle.put(assignment.getKey().getName(), assignment.getValue());
+                    }
+
+                    List<JoinDynamicFilter> matchingFilters = new ArrayList<>();
+                    Map<String, ColumnHandle> columnNameToHandle = new HashMap<>();
+                    for (String filterId : filterIds) {
+                        dynamicFilterService.getFilter(session.getQueryId(), filterId).ifPresent(joinFilter -> {
+                            ColumnHandle handle = variableNameToHandle.get(joinFilter.getColumnName());
+                            if (handle != null) {
+                                matchingFilters.add(joinFilter);
+                                columnNameToHandle.put(joinFilter.getColumnName(), handle);
+                            }
+                        });
+                    }
+
+                    if (!matchingFilters.isEmpty()) {
+                        if (table.getLayout().isPresent()) {
+                            TableLayout layout = metadata.getLayout(session, table);
+                            TupleDomain<ColumnHandle> predicate = layout.getPredicate();
+                            if (predicate.getDomains().isPresent()) {
+                                for (JoinDynamicFilter joinFilter : matchingFilters) {
+                                    ColumnHandle handle = columnNameToHandle.get(joinFilter.getColumnName());
+                                    if (handle != null) {
+                                        Domain columnDomain = predicate.getDomains().get().get(handle);
+                                        if (columnDomain != null) {
+                                            joinFilter.setProbeColumnDomain(columnDomain);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        TableScanDynamicFilter tableScanFilter = new TableScanDynamicFilter(matchingFilters, columnNameToHandle);
+                        createdDynamicFilters.add(tableScanFilter);
+                        dynamicFilter = tableScanFilter;
+                    }
+                }
+            }
+
             Map<String, String> partitionColumnMapping = stageExecutionDescriptor.isScanGroupedExecution(node.getId())
                     ? stageExecutionDescriptor.getPartitionColumnMapping(node.getId())
                     : ImmutableMap.of();
+            DynamicFilter finalDynamicFilter = dynamicFilter;
             Supplier<SplitSource> splitSourceSupplier = () -> splitSourceProvider.getSplits(
                     session,
                     table,
                     getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId()),
                     warningCollector,
+                    finalDynamicFilter,
                     partitionColumnMapping);
 
             SplitSource splitSource = new LazySplitSource(splitSourceSupplier);
@@ -534,6 +794,58 @@ public class SplitSourceFactory
         public Map<PlanNodeId, SplitSource> visitMergeProcessor(MergeProcessorNode node, Context context)
         {
             return node.getSource().accept(this, context);
+        }
+    }
+
+    private static final class FilterToScanMatcher
+            extends InternalPlanVisitor<Map<PlanNodeId, Map<String, String>>, Map<String, Set<String>>>
+    {
+        @Override
+        public Map<PlanNodeId, Map<String, String>> visitPlan(PlanNode node, Map<String, Set<String>> context)
+        {
+            ImmutableMap.Builder<PlanNodeId, Map<String, String>> result = ImmutableMap.builder();
+            for (PlanNode child : node.getSources()) {
+                result.putAll(child.accept(this, context));
+            }
+            return result.build();
+        }
+
+        @Override
+        public Map<PlanNodeId, Map<String, String>> visitTableScan(TableScanNode node, Map<String, Set<String>> filterColumnToFilterIds)
+        {
+            Map<String, String> filterIdToColumn = new HashMap<>();
+            for (Map.Entry<String, Set<String>> entry : filterColumnToFilterIds.entrySet()) {
+                String columnName = entry.getKey();
+                boolean columnInScan = node.getAssignments().keySet().stream()
+                        .anyMatch(var -> var.getName().equals(columnName));
+                if (columnInScan) {
+                    for (String filterId : entry.getValue()) {
+                        filterIdToColumn.put(filterId, columnName);
+                    }
+                }
+            }
+            if (filterIdToColumn.isEmpty()) {
+                return ImmutableMap.of();
+            }
+            return ImmutableMap.of(node.getId(), filterIdToColumn);
+        }
+
+        @Override
+        public Map<PlanNodeId, Map<String, String>> visitJoin(JoinNode node, Map<String, Set<String>> context)
+        {
+            return node.getLeft().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, Map<String, String>> visitSemiJoin(SemiJoinNode node, Map<String, Set<String>> context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, Map<String, String>> visitRemoteSource(RemoteSourceNode node, Map<String, Set<String>> context)
+        {
+            return ImmutableMap.of();
         }
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
@@ -14,17 +14,57 @@
 package com.facebook.presto.execution.scheduler;
 
 import com.facebook.airlift.units.Duration;
+import com.facebook.presto.Session;
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.Partitioning;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.StageExecutionDescriptor;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.split.SplitSource;
+import com.facebook.presto.split.SplitSourceProvider;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.SplitSourceFactory;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.facebook.presto.testing.TestingMetadata.TestingColumnHandle;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_DYNAMIC_FILTER_STRATEGY;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -285,6 +325,383 @@ public class TestDynamicFilterService
         service.removeFiltersForQuery(query1);
         assertTrue(service.getFilterIdsForScan(query1, scanNodeId).isEmpty());
         assertEquals(service.getFilterIdsForScan(query2, scanNodeId), ImmutableSet.of("filter_2"));
+    }
+
+    @Test
+    public void testSetExpectedPartitionsForRemoteSourceBuildSide()
+    {
+        QueryId queryId = QueryId.valueOf("test_remote_build");
+        String filterId = "514";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+        service.registerFilter(queryId, filterId, filter);
+
+        VariableReferenceExpression probeVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        VariableReferenceExpression buildVar = new VariableReferenceExpression(Optional.empty(), "customer_id_0", BigintType.BIGINT);
+        RemoteSourceNode probeSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("probe_source"), new PlanFragmentId(3),
+                ImmutableList.of(probeVar), false, Optional.empty(), REPARTITION);
+        RemoteSourceNode buildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("build_source"), new PlanFragmentId(4),
+                ImmutableList.of(buildVar), false, Optional.empty(), REPARTITION);
+        JoinNode joinNode = new JoinNode(
+                Optional.empty(),
+                new PlanNodeId("join_1"),
+                INNER,
+                probeSource,
+                buildSource,
+                ImmutableList.of(new EquiJoinClause(probeVar, buildVar)),
+                ImmutableList.of(probeVar, buildVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(filterId, buildVar));
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, com.facebook.presto.common.predicate.Domain.singleValue(BigintType.BIGINT, 1L))));
+        assertFalse(filter.isComplete(), "filter should not be complete before setExpectedPartitions");
+
+        SectionExecutionFactory.setExpectedPartitionsForFilters(service, queryId, joinNode, 1);
+
+        assertTrue(filter.isComplete(), "filter should complete after setExpectedPartitionsForFilters");
+    }
+
+    @Test
+    public void testForEachJoinDynamicFilterFlagsReplicateBuildAsBroadcast()
+    {
+        QueryId queryId = QueryId.valueOf("test_replicate_build");
+        String filterId = "f";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Map<String, Boolean> seen = new java.util.HashMap<>();
+        SectionExecutionFactory.forEachJoinDynamicFilter(
+                service, queryId, joinNodeWithRemoteBuild(filterId, REPLICATE),
+                (f, isBroadcastBuild) -> seen.put(f.getFilterId(), isBroadcastBuild));
+        assertEquals(seen.get(filterId), Boolean.TRUE);
+    }
+
+    @Test
+    public void testForEachJoinDynamicFilterFlagsRepartitionBuildAsNonBroadcast()
+    {
+        QueryId queryId = QueryId.valueOf("test_repartition_build");
+        String filterId = "f";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Map<String, Boolean> seen = new java.util.HashMap<>();
+        SectionExecutionFactory.forEachJoinDynamicFilter(
+                service, queryId, joinNodeWithRemoteBuild(filterId, REPARTITION),
+                (f, isBroadcastBuild) -> seen.put(f.getFilterId(), isBroadcastBuild));
+        assertEquals(seen.get(filterId), Boolean.FALSE);
+    }
+
+    @Test
+    public void testForEachJoinDynamicFilterFlagsLocalBuildAsNonBroadcast()
+    {
+        QueryId queryId = QueryId.valueOf("test_local_build");
+        String filterId = "f";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Map<String, Boolean> seen = new java.util.HashMap<>();
+        SectionExecutionFactory.forEachJoinDynamicFilter(
+                service, queryId, joinNodeWithLocalBuild(filterId),
+                (f, isBroadcastBuild) -> seen.put(f.getFilterId(), isBroadcastBuild));
+        assertEquals(seen.get(filterId), Boolean.FALSE);
+    }
+
+    @Test
+    public void testCrossFragmentFilterMatchingSimplePartitionedJoin()
+    {
+        String filterId = "100";
+        VariableReferenceExpression probeVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        VariableReferenceExpression buildVar = new VariableReferenceExpression(Optional.empty(), "customer_id_0", BigintType.BIGINT);
+
+        RemoteSourceNode probeSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("probe_source"), new PlanFragmentId(2),
+                ImmutableList.of(probeVar), false, Optional.empty(), REPARTITION);
+        RemoteSourceNode buildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("build_source"), new PlanFragmentId(3),
+                ImmutableList.of(buildVar), false, Optional.empty(), REPARTITION);
+        JoinNode joinNode = new JoinNode(
+                Optional.empty(),
+                new PlanNodeId("join_1"),
+                INNER,
+                probeSource,
+                buildSource,
+                ImmutableList.of(new EquiJoinClause(probeVar, buildVar)),
+                ImmutableList.of(probeVar, buildVar),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(filterId, buildVar));
+        PlanFragment parentFragment = new PlanFragment(
+                new PlanFragmentId(1),
+                joinNode,
+                ImmutableSet.of(probeVar, buildVar),
+                SINGLE_DISTRIBUTION,
+                ImmutableList.of(),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(probeVar, buildVar)),
+                Optional.empty(),
+                StageExecutionDescriptor.ungroupedExecution(),
+                false,
+                Optional.of(StatsAndCosts.empty()),
+                Optional.empty());
+
+        PlanNodeId probeScanId = new PlanNodeId("probe_scan");
+        VariableReferenceExpression probeChildVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        PlanFragment probeChildFragment = createScanFragment(2, probeScanId, probeChildVar, "customer_id");
+
+        PlanNodeId buildScanId = new PlanNodeId("build_scan");
+        VariableReferenceExpression buildChildVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        PlanFragment buildChildFragment = createScanFragment(3, buildScanId, buildChildVar, "customer_id");
+
+        Session session = createDppSession();
+        QueryId queryId = session.getQueryId();
+        SplitSourceFactory factory = createSplitSourceFactory();
+
+        StreamingSubPlan probeChild = new StreamingSubPlan(probeChildFragment, ImmutableList.of());
+        StreamingSubPlan buildChild = new StreamingSubPlan(buildChildFragment, ImmutableList.of());
+        StreamingSubPlan root = new StreamingSubPlan(parentFragment, ImmutableList.of(probeChild, buildChild));
+        factory.registerDynamicFilters(root, session);
+
+        assertTrue(service.hasFilter(queryId, filterId));
+        assertEquals(service.getFilterIdsForScan(queryId, probeScanId), ImmutableSet.of(filterId),
+                "Probe-side child fragment scan should be wired to filter");
+        assertTrue(service.getFilterIdsForScan(queryId, buildScanId).isEmpty(),
+                "Build-side child fragment scan must not be wired");
+    }
+
+    @Test
+    public void testDeepDescendantScansNotWiredToOuterJoinFilter()
+    {
+        String outerFilterId = "200";
+        String innerFilterId = "300";
+        VariableReferenceExpression customerIdVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        VariableReferenceExpression customerIdBuildVar = new VariableReferenceExpression(Optional.empty(), "customer_id_0", BigintType.BIGINT);
+        VariableReferenceExpression dimVar = new VariableReferenceExpression(Optional.empty(), "customer_id_1", BigintType.BIGINT);
+
+        RemoteSourceNode innerProbeSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("inner_probe_source"), new PlanFragmentId(2),
+                ImmutableList.of(customerIdVar), false, Optional.empty(), REPARTITION);
+        RemoteSourceNode innerBuildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("inner_build_source"), new PlanFragmentId(3),
+                ImmutableList.of(customerIdBuildVar), false, Optional.empty(), REPARTITION);
+        JoinNode innerJoin = new JoinNode(
+                Optional.empty(), new PlanNodeId("join_B"), INNER,
+                innerProbeSource, innerBuildSource,
+                ImmutableList.of(new EquiJoinClause(customerIdVar, customerIdBuildVar)),
+                ImmutableList.of(customerIdVar, customerIdBuildVar),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                ImmutableMap.of(innerFilterId, customerIdBuildVar));
+
+        RemoteSourceNode outerBuildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("outer_build_source"), new PlanFragmentId(4),
+                ImmutableList.of(dimVar), false, Optional.empty(), REPARTITION);
+        JoinNode outerJoin = new JoinNode(
+                Optional.empty(), new PlanNodeId("join_A"), INNER,
+                innerJoin, outerBuildSource,
+                ImmutableList.of(new EquiJoinClause(customerIdVar, dimVar)),
+                ImmutableList.of(customerIdVar, dimVar),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                ImmutableMap.of(outerFilterId, dimVar));
+
+        PlanFragment parentFragment = new PlanFragment(
+                new PlanFragmentId(1), outerJoin,
+                ImmutableSet.of(customerIdVar, dimVar), SINGLE_DISTRIBUTION, ImmutableList.of(),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(customerIdVar, dimVar)),
+                Optional.empty(), StageExecutionDescriptor.ungroupedExecution(), false,
+                Optional.of(StatsAndCosts.empty()), Optional.empty());
+
+        PlanNodeId factScanId = new PlanNodeId("fact_scan");
+        PlanFragment factFragment = createScanFragment(2, factScanId,
+                new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT), "customer_id");
+
+        PlanNodeId customerScanId = new PlanNodeId("customer_scan");
+        PlanFragment customerFragment = createScanFragment(3, customerScanId,
+                new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT), "customer_id");
+
+        PlanNodeId dimScanId = new PlanNodeId("dim_scan");
+        PlanFragment dimFragment = createScanFragment(4, dimScanId,
+                new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT), "customer_id");
+
+        Session session = createDppSession();
+        QueryId queryId = session.getQueryId();
+        SplitSourceFactory factory = createSplitSourceFactory();
+
+        StreamingSubPlan factChild = new StreamingSubPlan(factFragment, ImmutableList.of());
+        StreamingSubPlan customerChild = new StreamingSubPlan(customerFragment, ImmutableList.of());
+        StreamingSubPlan dimChild = new StreamingSubPlan(dimFragment, ImmutableList.of());
+        StreamingSubPlan root = new StreamingSubPlan(parentFragment, ImmutableList.of(factChild, customerChild, dimChild));
+        factory.registerDynamicFilters(root, session);
+
+        assertTrue(service.hasFilter(queryId, outerFilterId));
+        assertTrue(service.hasFilter(queryId, innerFilterId));
+
+        assertEquals(service.getFilterIdsForScan(queryId, factScanId), ImmutableSet.of(innerFilterId, outerFilterId),
+                "Fact scan should receive both filters via probe chain");
+        assertTrue(service.getFilterIdsForScan(queryId, customerScanId).isEmpty(),
+                "Customer scan (build side of inner join) must not be wired");
+        assertTrue(service.getFilterIdsForScan(queryId, dimScanId).isEmpty(),
+                "Dim scan (build side of outer join) must not be wired");
+    }
+
+    @Test
+    public void testSameFragmentFilterMatchesWhenRootProjectStripsProbeColumn()
+    {
+        String filterId = "500";
+        VariableReferenceExpression orderIdVar = new VariableReferenceExpression(Optional.empty(), "order_id", BigintType.BIGINT);
+        VariableReferenceExpression customerIdVar = new VariableReferenceExpression(Optional.empty(), "customer_id", BigintType.BIGINT);
+        VariableReferenceExpression buildVar = new VariableReferenceExpression(Optional.empty(), "customer_id_0", BigintType.BIGINT);
+
+        PlanNodeId factScanId = new PlanNodeId("fact_scan");
+        TableScanNode factScan = createTableScan(factScanId,
+                ImmutableList.of(orderIdVar, customerIdVar),
+                ImmutableMap.of(orderIdVar, "order_id", customerIdVar, "customer_id"));
+
+        RemoteSourceNode buildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("build_source"), new PlanFragmentId(2),
+                ImmutableList.of(buildVar), false, Optional.empty(), REPARTITION);
+        JoinNode joinNode = new JoinNode(
+                Optional.empty(), new PlanNodeId("join_1"), INNER,
+                factScan, buildSource,
+                ImmutableList.of(new EquiJoinClause(customerIdVar, buildVar)),
+                ImmutableList.of(orderIdVar, customerIdVar, buildVar),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                ImmutableMap.of(filterId, buildVar));
+
+        ProjectNode rootProject = new ProjectNode(
+                new PlanNodeId("project_root"),
+                joinNode,
+                Assignments.builder().put(orderIdVar, orderIdVar).build());
+
+        PlanFragment fragment = new PlanFragment(
+                new PlanFragmentId(1), rootProject,
+                ImmutableSet.of(orderIdVar), SOURCE_DISTRIBUTION, ImmutableList.of(factScanId),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(orderIdVar)),
+                Optional.empty(), StageExecutionDescriptor.ungroupedExecution(), false,
+                Optional.of(StatsAndCosts.empty()), Optional.empty());
+
+        Session session = createDppSession();
+        QueryId queryId = session.getQueryId();
+        SplitSourceFactory factory = createSplitSourceFactory();
+
+        factory.registerDynamicFilters(new StreamingSubPlan(fragment, ImmutableList.of()), session);
+
+        assertTrue(service.hasFilter(queryId, filterId));
+        assertEquals(service.getFilterIdsForScan(queryId, factScanId), ImmutableSet.of(filterId),
+                "Same-fragment filter should match probe-side scan even when root project strips probe column");
+    }
+
+    private JoinNode joinNodeWithRemoteBuild(String filterId, ExchangeNode.Type buildExchangeType)
+    {
+        VariableReferenceExpression probeVar = new VariableReferenceExpression(Optional.empty(), "probe", BigintType.BIGINT);
+        VariableReferenceExpression buildVar = new VariableReferenceExpression(Optional.empty(), "build", BigintType.BIGINT);
+        RemoteSourceNode probeSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("probe_src"), new PlanFragmentId(1),
+                ImmutableList.of(probeVar), false, Optional.empty(), REPARTITION);
+        RemoteSourceNode buildSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("build_src"), new PlanFragmentId(2),
+                ImmutableList.of(buildVar), false, Optional.empty(), buildExchangeType);
+        return joinNode(filterId, probeSource, buildSource, probeVar, buildVar);
+    }
+
+    private JoinNode joinNodeWithLocalBuild(String filterId)
+    {
+        VariableReferenceExpression probeVar = new VariableReferenceExpression(Optional.empty(), "probe", BigintType.BIGINT);
+        VariableReferenceExpression buildVar = new VariableReferenceExpression(Optional.empty(), "build", BigintType.BIGINT);
+        RemoteSourceNode probeSource = new RemoteSourceNode(
+                Optional.empty(), new PlanNodeId("probe_src"), new PlanFragmentId(1),
+                ImmutableList.of(probeVar), false, Optional.empty(), REPARTITION);
+        ValuesNode localBuild = new ValuesNode(
+                Optional.empty(), new PlanNodeId("local_build"),
+                ImmutableList.of(buildVar), ImmutableList.of(), Optional.empty());
+        return joinNode(filterId, probeSource, localBuild, probeVar, buildVar);
+    }
+
+    private JoinNode joinNode(String filterId, com.facebook.presto.spi.plan.PlanNode probe,
+            com.facebook.presto.spi.plan.PlanNode build,
+            VariableReferenceExpression probeVar, VariableReferenceExpression buildVar)
+    {
+        return new JoinNode(
+                Optional.empty(), new PlanNodeId("join"), INNER,
+                probe, build,
+                ImmutableList.of(new EquiJoinClause(probeVar, buildVar)),
+                ImmutableList.of(probeVar, buildVar),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                ImmutableMap.of(filterId, buildVar));
+    }
+
+    private static Session createDppSession()
+    {
+        return testSessionBuilder()
+                .setSystemProperty(DISTRIBUTED_DYNAMIC_FILTER_STRATEGY, "ALWAYS")
+                .setSystemProperty("distributed_dynamic_filter_max_wait_time", "2s")
+                .build();
+    }
+
+    private SplitSourceFactory createSplitSourceFactory()
+    {
+        return new SplitSourceFactory(
+                new SplitSourceProvider()
+                {
+                    @Override
+                    public SplitSource getSplits(Session s, com.facebook.presto.spi.TableHandle t,
+                            SplitSchedulingStrategy st, WarningCollector w)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public SplitSource getSplits(Session s, com.facebook.presto.metadata.TableFunctionHandle t)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+                },
+                WarningCollector.NOOP,
+                service,
+                MetadataManager.createTestMetadataManager());
+    }
+
+    private static PlanFragment createScanFragment(int fragmentId, PlanNodeId scanId,
+            VariableReferenceExpression variable, String columnName)
+    {
+        TableScanNode scan = createTableScan(scanId, variable, columnName);
+        return new PlanFragment(
+                new PlanFragmentId(fragmentId), scan,
+                ImmutableSet.of(variable), SOURCE_DISTRIBUTION, ImmutableList.of(scanId),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(variable)),
+                Optional.empty(), StageExecutionDescriptor.ungroupedExecution(), false,
+                Optional.of(StatsAndCosts.empty()), Optional.empty());
+    }
+
+    private static TableScanNode createTableScan(PlanNodeId scanId, VariableReferenceExpression variable,
+            String columnName)
+    {
+        return new TableScanNode(
+                Optional.empty(), scanId,
+                new TableHandle(new ConnectorId("test"), new TestingTableHandle(),
+                        TestingTransactionHandle.create(), Optional.empty()),
+                ImmutableList.of(variable),
+                ImmutableMap.of(variable, new TestingColumnHandle(columnName)),
+                TupleDomain.all(), TupleDomain.all(), Optional.empty());
+    }
+
+    private static TableScanNode createTableScan(PlanNodeId scanId, List<VariableReferenceExpression> variables,
+            Map<VariableReferenceExpression, String> variableToColumnName)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, com.facebook.presto.spi.ColumnHandle> assignments = ImmutableMap.builder();
+        for (Map.Entry<VariableReferenceExpression, String> entry : variableToColumnName.entrySet()) {
+            assignments.put(entry.getKey(), new TestingColumnHandle(entry.getValue()));
+        }
+        return new TableScanNode(
+                Optional.empty(), scanId,
+                new TableHandle(new ConnectorId("test"), new TestingTableHandle(),
+                        TestingTransactionHandle.create(), Optional.empty()),
+                variables, assignments.build(),
+                TupleDomain.all(), TupleDomain.all(), Optional.empty());
     }
 
     private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestDynamicFilterService.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestDynamicFilterService
+{
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+
+    private DynamicFilterService service;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        service = new DynamicFilterService();
+    }
+
+    @Test
+    public void testRegisterAndGet()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        String filterId = "filter_1";
+        JoinDynamicFilter filter = createTestFilter();
+
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertTrue(retrieved.isPresent());
+        assertEquals(retrieved.get(), filter);
+        assertEquals(service.getStats().getFilterRegistrations().getTotalCount(), 1);
+    }
+
+    @Test
+    public void testGetNonexistent()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+        String filterId = "nonexistent_filter";
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void testGetNonexistentFilter()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, "nonexistent_filter");
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void testHasFilter()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        String filterId = "filter_1";
+        JoinDynamicFilter filter = createTestFilter();
+
+        assertFalse(service.hasFilter(queryId, filterId));
+
+        service.registerFilter(queryId, filterId, filter);
+        assertTrue(service.hasFilter(queryId, filterId));
+
+        assertFalse(service.hasFilter(queryId, "other_filter"));
+    }
+
+    @Test
+    public void testRemoveFiltersForQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.hasFilter(queryId, "filter_2"));
+
+        service.removeFiltersForQuery(queryId);
+
+        assertFalse(service.hasFilter(queryId, "filter_1"));
+        assertFalse(service.hasFilter(queryId, "filter_2"));
+    }
+
+    @Test
+    public void testMultipleQueries()
+    {
+        QueryId queryId1 = QueryId.valueOf("test_query_1");
+        QueryId queryId2 = QueryId.valueOf("test_query_2");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId1, "filter_1", filter1);
+        service.registerFilter(queryId2, "filter_1", filter2);
+
+        java.util.Optional<JoinDynamicFilter> retrieved1 = service.getFilter(queryId1, "filter_1");
+        java.util.Optional<JoinDynamicFilter> retrieved2 = service.getFilter(queryId2, "filter_1");
+
+        assertTrue(retrieved1.isPresent());
+        assertTrue(retrieved2.isPresent());
+        assertEquals(retrieved1.get(), filter1);
+        assertEquals(retrieved2.get(), filter2);
+
+        service.removeFiltersForQuery(queryId1);
+        assertFalse(service.hasFilter(queryId1, "filter_1"));
+        assertTrue(service.hasFilter(queryId2, "filter_1"));
+    }
+
+    @Test
+    public void testMultipleFiltersPerQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+        JoinDynamicFilter filter3 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+        service.registerFilter(queryId, "filter_3", filter3);
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.hasFilter(queryId, "filter_2"));
+        assertTrue(service.hasFilter(queryId, "filter_3"));
+
+        assertEquals(service.getFilter(queryId, "filter_1").get(), filter1);
+        assertEquals(service.getFilter(queryId, "filter_2").get(), filter2);
+        assertEquals(service.getFilter(queryId, "filter_3").get(), filter3);
+        assertEquals(service.getStats().getFilterRegistrations().getTotalCount(), 3);
+    }
+
+    @Test
+    public void testGetAllFiltersForQuery()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_1");
+        JoinDynamicFilter filter1 = createTestFilter();
+        JoinDynamicFilter filter2 = createTestFilter();
+
+        service.registerFilter(queryId, "filter_1", filter1);
+        service.registerFilter(queryId, "filter_2", filter2);
+
+        Map<String, JoinDynamicFilter> allFilters = service.getAllFiltersForQuery(queryId);
+        assertEquals(allFilters.size(), 2);
+        assertEquals(allFilters.get("filter_1"), filter1);
+        assertEquals(allFilters.get("filter_2"), filter2);
+    }
+
+    @Test
+    public void testGetAllFiltersForNonexistentQuery()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+
+        Map<String, JoinDynamicFilter> allFilters = service.getAllFiltersForQuery(queryId);
+        assertTrue(allFilters.isEmpty());
+    }
+
+    @Test
+    public void testFilterIdPreserved()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_filter_id");
+        String filterId = "549";
+        JoinDynamicFilter filter = createTestFilterWithId(filterId);
+
+        service.registerFilter(queryId, filterId, filter);
+
+        java.util.Optional<JoinDynamicFilter> retrieved = service.getFilter(queryId, filterId);
+        assertTrue(retrieved.isPresent());
+        assertEquals(retrieved.get().getFilterId(), filterId);
+    }
+
+    @Test
+    public void testScanFilterMapping()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_scan_mapping");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+        Set<String> filterIds = ImmutableSet.of("filter_1", "filter_2");
+
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+
+        service.registerScanFilterMapping(queryId, scanNodeId, filterIds);
+
+        Set<String> retrieved = service.getFilterIdsForScan(queryId, scanNodeId);
+        assertEquals(retrieved, filterIds);
+    }
+
+    @Test
+    public void testScanFilterMappingMultipleScans()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_multi_scan");
+        PlanNodeId scan1 = new PlanNodeId("scan_1");
+        PlanNodeId scan2 = new PlanNodeId("scan_2");
+
+        service.registerScanFilterMapping(queryId, scan1, ImmutableSet.of("filter_1"));
+        service.registerScanFilterMapping(queryId, scan2, ImmutableSet.of("filter_2", "filter_3"));
+
+        assertEquals(service.getFilterIdsForScan(queryId, scan1), ImmutableSet.of("filter_1"));
+        assertEquals(service.getFilterIdsForScan(queryId, scan2), ImmutableSet.of("filter_2", "filter_3"));
+    }
+
+    @Test
+    public void testScanFilterMappingMergesOnDuplicateRegistration()
+    {
+        // Regression test: registerScanFilterMapping must merge filter IDs
+        // when called multiple times for the same scan (e.g., local filters
+        // from Step 1 and cross-fragment filters from Step 2).
+        QueryId queryId = QueryId.valueOf("test_query_merge");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_date"));
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_customer"));
+
+        assertEquals(service.getFilterIdsForScan(queryId, scanNodeId),
+                ImmutableSet.of("filter_date", "filter_customer"));
+    }
+
+    @Test
+    public void testScanFilterMappingNonexistent()
+    {
+        QueryId queryId = QueryId.valueOf("nonexistent_query");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+    }
+
+    @Test
+    public void testRemoveFiltersAlsoClearsScanMappings()
+    {
+        QueryId queryId = QueryId.valueOf("test_query_cleanup");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerFilter(queryId, "filter_1", createTestFilter());
+        service.registerScanFilterMapping(queryId, scanNodeId, ImmutableSet.of("filter_1"));
+
+        assertTrue(service.hasFilter(queryId, "filter_1"));
+        assertEquals(service.getFilterIdsForScan(queryId, scanNodeId), ImmutableSet.of("filter_1"));
+
+        service.removeFiltersForQuery(queryId);
+        assertFalse(service.hasFilter(queryId, "filter_1"));
+        assertTrue(service.getFilterIdsForScan(queryId, scanNodeId).isEmpty());
+    }
+
+    @Test
+    public void testScanFilterMappingIsolationBetweenQueries()
+    {
+        QueryId query1 = QueryId.valueOf("test_query_1");
+        QueryId query2 = QueryId.valueOf("test_query_2");
+        PlanNodeId scanNodeId = new PlanNodeId("scan_1");
+
+        service.registerScanFilterMapping(query1, scanNodeId, ImmutableSet.of("filter_1"));
+        service.registerScanFilterMapping(query2, scanNodeId, ImmutableSet.of("filter_2"));
+
+        assertEquals(service.getFilterIdsForScan(query1, scanNodeId), ImmutableSet.of("filter_1"));
+        assertEquals(service.getFilterIdsForScan(query2, scanNodeId), ImmutableSet.of("filter_2"));
+
+        service.removeFiltersForQuery(query1);
+        assertTrue(service.getFilterIdsForScan(query1, scanNodeId).isEmpty());
+        assertEquals(service.getFilterIdsForScan(query2, scanNodeId), ImmutableSet.of("filter_2"));
+    }
+
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private JoinDynamicFilter createTestFilter()
+    {
+        return new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+
+    private JoinDynamicFilter createTestFilterWithId(String filterId)
+    {
+        return new JoinDynamicFilter(
+                filterId,
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestJoinDynamicFilter.java
@@ -1,0 +1,1013 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COLLECTION_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_DOMAIN_RANGE_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PARTITIONS_RECEIVED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_SHORT_CIRCUITED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_TIMED_OUT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestJoinDynamicFilter
+{
+    private static final String DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE = DYNAMIC_FILTER_COLLECTION_TIME_NANOS + "[%s]";
+    public static final String DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE = DYNAMIC_FILTER_PARTITIONS_RECEIVED + "[%s]";
+    private static final String DYNAMIC_FILTER_TIMED_OUT_TEMPLATE = DYNAMIC_FILTER_TIMED_OUT + "[%s]";
+    private static final String DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE = DYNAMIC_FILTER_DOMAIN_RANGE_COUNT + "[%s]";
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private static final TaskId TASK_0 = TaskId.valueOf("query.0.0.0.0");
+    private static final TaskId TASK_1 = TaskId.valueOf("query.0.0.1.0");
+    private static final TaskId TASK_2 = TaskId.valueOf("query.0.0.2.0");
+
+    @Test
+    public void testPerFilterMetrics()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+
+        assertTrue(filter.isComplete());
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_PARTITIONS_RECEIVED),
+                "Aggregate PARTITIONS_RECEIVED should be present");
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_PARTITIONS_RECEIVED).getSum(), 2);
+
+        String perFilterPartitions = format(DYNAMIC_FILTER_PARTITIONS_RECEIVED_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterPartitions),
+                "Per-filter PARTITIONS_RECEIVED[549] should be present");
+        assertEquals(runtimeStats.getMetrics().get(perFilterPartitions).getSum(), 2);
+
+        String perFilterCollectionTime = format(DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterCollectionTime),
+                "Per-filter COLLECTION_TIME_NANOS[549] should be present");
+        assertTrue(runtimeStats.getMetrics().get(perFilterCollectionTime).getSum() > 0,
+                "Per-filter collection time should be positive");
+
+        String perFilterRangeCount = format(DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterRangeCount),
+                "Per-filter DOMAIN_RANGE_COUNT[549] should be present with extendedMetrics");
+        assertEquals(runtimeStats.getMetrics().get(perFilterRangeCount).getSum(), 2,
+                "Domain range count should be 2 for two single-value partitions");
+    }
+
+    @Test
+    public void testPeekFilterReturnsAllWhenNotResolved()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(3);
+
+        // No partitions received — should return all()
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // One partition finalized (partial w.r.t. expected) — should still return all()
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // Two partitions finalized (still partial) — should still return all()
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+        assertFalse(filter.isComplete());
+
+        // All three partitions finalized — now returns actual constraint
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        assertTrue(filter.isComplete());
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(), "Fully resolved filter should return actual constraint, not all()");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+    }
+
+    @Test
+    public void testTimeoutDoesNotResolveFilter()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                new Duration(100, TimeUnit.MILLISECONDS),
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        filter.startTimeout();
+        Thread.sleep(300);
+
+        // Future is done (timeout) but filter is NOT fully resolved
+        assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data should not be exposed after timeout");
+    }
+
+    @Test
+    public void testNoPerFilterMetricsWithEmptyFilterId()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(filter.isComplete());
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_PARTITIONS_RECEIVED));
+
+        assertFalse(runtimeStats.getMetrics().keySet().stream().anyMatch(k -> k.contains("[")),
+                "No bracket-notation metrics should be present with empty filterId");
+    }
+
+    @Test
+    public void testGetFilterId()
+    {
+        JoinDynamicFilter defaultFilter = new JoinDynamicFilter(
+                "",
+                "",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+        assertEquals(defaultFilter.getFilterId(), "");
+
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter namedFilter = new JoinDynamicFilter(
+                "549",
+                "column_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        assertEquals(namedFilter.getFilterId(), "549");
+    }
+
+    @Test
+    public void testIsBlockedBeforeAndAfterResolution()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        CompletableFuture<?> blocked = filter.isBlocked();
+        assertFalse(blocked.isDone());
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertTrue(blocked.isDone());
+
+        assertEquals(filter.isBlocked(), DynamicFilter.NOT_BLOCKED);
+    }
+
+    @Test
+    public void testGetWaitTimeout()
+    {
+        Duration timeout = new Duration(5, TimeUnit.SECONDS);
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "",
+                "",
+                timeout,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+
+        assertEquals(filter.getWaitTimeout(), timeout);
+    }
+
+    @Test
+    public void testCreateDisabled()
+    {
+        assertEquals(JoinDynamicFilter.createDisabled(), DynamicFilter.EMPTY);
+    }
+
+    @Test
+    public void testTimeoutEmitsMetric()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        DynamicFilterStats stats = new DynamicFilterStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                new Duration(100, TimeUnit.MILLISECONDS),
+                DEFAULT_MAX_SIZE_BYTES,
+                stats,
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        filter.startTimeout();
+        Thread.sleep(300);
+
+        assertFalse(filter.isComplete(), "Timeout should not mark filter as complete");
+
+        String timeoutKey = format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(timeoutKey),
+                "Timeout metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(timeoutKey).getSum(), 1);
+
+        assertEquals(stats.getFilterCollectionTimedOut().getTotalCount(), 1);
+
+        String collectionTimeKey = format(DYNAMIC_FILTER_COLLECTION_TIME_NANOS_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(collectionTimeKey),
+                "Collection time should be emitted on timeout with extendedMetrics");
+        assertTrue(runtimeStats.getMetrics().get(collectionTimeKey).getSum() > 0,
+                "Collection time should be positive");
+    }
+
+    @Test
+    public void testNoTimeoutMetricOnSuccess()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(filter.isComplete());
+
+        String timeoutKey = format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549");
+        assertFalse(runtimeStats.getMetrics().containsKey(timeoutKey),
+                "Timeout metric should not be emitted on successful completion");
+    }
+
+    @Test
+    public void testDomainRangeCountForNone()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.none());
+
+        assertTrue(filter.isComplete());
+
+        String rangeCountKey = format(DYNAMIC_FILTER_DOMAIN_RANGE_COUNT_TEMPLATE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(rangeCountKey),
+                "Domain range count should be emitted for none()");
+        assertEquals(runtimeStats.getMetrics().get(rangeCountKey).getSum(), 0,
+                "Domain range count should be 0 for none() domain");
+    }
+
+    @Test
+    public void testComputeRangeCount()
+    {
+        assertEquals(JoinDynamicFilter.computeRangeCount(TupleDomain.none()), 0);
+        assertEquals(JoinDynamicFilter.computeRangeCount(TupleDomain.all()), 0);
+
+        TupleDomain<String> singleValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 10L)));
+        assertEquals(JoinDynamicFilter.computeRangeCount(singleValue), 1);
+
+        TupleDomain<String> multiValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L))));
+        assertEquals(JoinDynamicFilter.computeRangeCount(multiValue), 3);
+    }
+
+    @Test
+    public void testNoCollapseWhenUnderSizeLimit()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        // Default max size (1 MB) — small discrete-value filters should complete normally,
+        // not be collapsed to range.
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1_048_576L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 3);
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE),
+                "Fallback metric should not be emitted when under size limit");
+    }
+
+    @Test
+    public void testEstimateRetainedSizeInBytes()
+    {
+        assertEquals(new DomainRuntimeFilter(TupleDomain.none()).estimatedRetainedSizeInBytes(), 0);
+        assertEquals(new DomainRuntimeFilter(TupleDomain.all()).estimatedRetainedSizeInBytes(), 0);
+
+        // block storage for low + high markers
+        TupleDomain<String> singleValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 10L)));
+        assertTrue(new DomainRuntimeFilter(singleValue).estimatedRetainedSizeInBytes() > 0);
+
+        TupleDomain<String> multiValue = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L))));
+        assertTrue(new DomainRuntimeFilter(multiValue).estimatedRetainedSizeInBytes() >
+                new DomainRuntimeFilter(singleValue).estimatedRetainedSizeInBytes());
+    }
+
+    @Test
+    public void testNoCollapseWithDefaultSize()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        // 100 values still well under 1 MB — should not collapse
+        List<Long> values = new ArrayList<>();
+        for (long i = 0; i < 100; i++) {
+            values.add(i);
+        }
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, values))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 100);
+    }
+
+    @Test
+    public void testShortCircuitWhenBuildCoversProbe()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L, 4L, 5L)))));
+
+        assertTrue(filter.isComplete());
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Filter should short-circuit to all() when build covers probe");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED),
+                "Aggregate short-circuit metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_SHORT_CIRCUITED).getSum(), 1);
+    }
+
+    @Test
+    public void testShortCircuitEmitsPerFilterMetric()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+
+        String perFilterKey = format("%s[%s]", DYNAMIC_FILTER_SHORT_CIRCUITED, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterKey),
+                "Per-filter DYNAMIC_FILTER_SHORT_CIRCUITED[549] should be present");
+        assertEquals(runtimeStats.getMetrics().get(perFilterKey).getSum(), 1);
+    }
+
+    @Test
+    public void testNoShortCircuitWhenBuildDoesNotCoverProbe()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L, 4L, 5L)));
+        filter.setExpectedPartitions(1);
+
+        // build covers [1,2,3] but probe has [1,2,3,4,5] — cannot short-circuit
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(),
+                "Filter should NOT short-circuit when build does not cover probe");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED),
+                "Short-circuit metric should NOT be emitted when build does not cover probe");
+    }
+
+    @Test
+    public void testNoShortCircuitWithoutProbeColumnDomain()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(),
+                "Filter should NOT short-circuit without probeColumnDomain");
+        assertEquals(
+                constraint,
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of("col_a", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testShortCircuitViaSetExpectedPartitions()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L)));
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+        assertFalse(filter.isComplete());
+
+        filter.setExpectedPartitions(1);
+        assertTrue(filter.isComplete());
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Short-circuit should fire via setExpectedPartitions path");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testShortCircuitWithExactMatch()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        Domain probeDomain = Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L));
+        filter.setProbeColumnDomain(probeDomain);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Exact match of build and probe domains should short-circuit");
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testNoShortCircuitWhenBuildIsNone()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.setProbeColumnDomain(Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)));
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.none());
+
+        assertTrue(filter.isComplete());
+
+        // none() should NOT be short-circuited — it means the build was empty and
+        // we should prune everything
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertTrue(constraint.isNone(),
+                "none() constraint should be preserved (empty build prunes everything)");
+        assertFalse(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_SHORT_CIRCUITED));
+    }
+
+    @Test
+    public void testSizeBasedCollapseToRange()
+    {
+        // With a tiny max-size, a multi-value domain must collapse to its [min, max]
+        // range when finalized. This exercises the post-Phase-2 completion path.
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L, // force range fallback
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete(),
+                "Range-fallback merge with finalized contributions must complete");
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1,
+                "Discrete values must collapse to a single range");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+        assertEquals(runtimeStats.getMetrics().get(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE).getSum(), 1);
+    }
+
+    @Test
+    public void testSizeBasedCollapseEmitsPerFilterMetric()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+
+        assertTrue(filter.isComplete());
+
+        String perFilterKey = format("%s[%s]", DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE, "549");
+        assertTrue(runtimeStats.getMetrics().containsKey(perFilterKey),
+                "Per-filter fallback-to-range metric should be emitted");
+        assertEquals(runtimeStats.getMetrics().get(perFilterKey).getSum(), 1);
+    }
+
+    @Test
+    public void testSizeBasedCollapseInSetExpectedPartitions()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                DEFAULT_TIMEOUT,
+                1L,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L)))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(30L, 40L)))));
+
+        filter.setExpectedPartitions(2);
+
+        assertTrue(filter.isComplete(),
+                "setExpectedPartitions should latch when all tasks already finalized");
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+    }
+
+    @Test
+    public void testCollapseToRange()
+    {
+        TupleDomain<String> multi = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 30L, 50L))));
+        TupleDomain<String> collapsed = JoinDynamicFilter.collapseToRange(multi);
+        Domain domain = collapsed.getDomains().get().get("col");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1);
+        assertTrue(domain.includesNullableValue(10L));
+        assertTrue(domain.includesNullableValue(30L));
+        assertTrue(domain.includesNullableValue(50L));
+        assertTrue(domain.includesNullableValue(40L), "Range collapse must span unseen values between min and max");
+
+        TupleDomain<String> single = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col", Domain.singleValue(INTEGER, 7L)));
+        assertEquals(JoinDynamicFilter.collapseToRange(single), single);
+
+        assertEquals(JoinDynamicFilter.collapseToRange(TupleDomain.none()), TupleDomain.none());
+        assertEquals(JoinDynamicFilter.collapseToRange(TupleDomain.all()), TupleDomain.all());
+    }
+
+    @Test
+    public void testPartitionedJoinRequiresAllTasksFinalized()
+    {
+        // expectedPartitions=3: completion only when 3 distinct tasks have finalized.
+        // Modeling a HASH-distributed join with 3 build workers.
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        assertFalse(filter.isComplete(), "1 of 3 finalized — not complete");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        assertFalse(filter.isComplete(), "2 of 3 finalized — not complete");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        assertTrue(filter.isComplete(), "3 of 3 finalized — complete");
+
+        assertEquals(filter.getCurrentConstraintByColumnName(),
+                TupleDomain.withColumnDomains(ImmutableMap.of("col_a",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+    }
+
+    @Test
+    public void testRangeFallbackCompletesOnAllContributionsReceived()
+    {
+        // Q21 wrong-results regression: expectedPartitions=2 with both tasks
+        // contributing — the merge falls back to range. Final constraint is
+        // the union of both contributions, collapsed to a single [min,max] span.
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, 1L /* force range */,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(2);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L, 30L)))));
+        assertFalse(filter.isComplete(), "1 of 2 received");
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.multipleValues(INTEGER, ImmutableList.of(50L, 60L, 70L)))));
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> constraint = filter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll());
+        Domain domain = constraint.getDomains().get().get("col_a");
+        assertEquals(domain.getValues().getRanges().getRangeCount(), 1);
+        assertTrue(domain.includesNullableValue(10L));
+        assertTrue(domain.includesNullableValue(70L));
+        assertTrue(domain.includesNullableValue(40L), "Range collapse spans 10-70");
+
+        assertTrue(runtimeStats.getMetrics().containsKey(DYNAMIC_FILTER_COORDINATOR_FALLBACK_TO_RANGE));
+    }
+
+    @Test
+    public void testLateFinalizationAfterFutureCompleteIsNoOp()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549", "col_a", DEFAULT_TIMEOUT, DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(), runtimeStats, false);
+        filter.setExpectedPartitions(1);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.singleValue(INTEGER, 42L))));
+        assertTrue(filter.isComplete());
+
+        TupleDomain<String> resolvedConstraint = filter.getCurrentConstraintByColumnName();
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(ImmutableMap.of("549",
+                        Domain.singleValue(INTEGER, 100L))));
+
+        assertEquals(filter.getCurrentConstraintByColumnName(), resolvedConstraint);
+    }
+
+    // BEGIN ADAPTIVE-WAIT TESTS
+    private static final Duration ADAPTIVE_CYCLE = new Duration(500, TimeUnit.MILLISECONDS);
+
+    /**
+     * Positive: contributions arrive across two cycles; the first cycle's tick sees
+     * progress (1 -> 2) and extends. The final contribution then resolves the filter
+     * via {@code addPartitionByFilterId} before the extension window expires.
+     */
+    @Test
+    public void testAdaptiveExtensionAllowsLateArrivalToResolve()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                2,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.startTimeout();
+
+        // Well before the first tick: add a second contribution so the tick observes
+        // progress (size went 1 -> 2 vs. baseline of 1) and extends.
+        Thread.sleep(150);
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+
+        // Wait for the first tick to fire and consume one extension, then deliver the
+        // third contribution. tryCompleteResolution on this add will resolve the filter
+        // synchronously since the extension is still in flight.
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis());
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+
+        assertTrue(filter.isComplete(), "Filter should resolve after late arrival within extension window");
+        assertFalse(runtimeStats.getMetrics().containsKey(format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549")),
+                "Filter resolved before timeout; no timed-out metric expected");
+    }
+
+    /**
+     * Negative: a contribution arrived before startTimeout, then no further progress.
+     * lastTickPartitionCount is baselined at startTimeout, so the first tick sees
+     * zero new progress and finalizes immediately without consuming any extension.
+     */
+    @Test
+    public void testNoProgressFinalizesAtFirstCycle()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                3,  // maxWaitExtensions — should NOT be consumed when no progress
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(3);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.startTimeout();
+
+        // Wait one cycle plus a buffer; with the startTimeout baseline in place the
+        // first tick observes zero progress and finalizes — no extension consumed.
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis() + 80);
+
+        assertFalse(filter.isComplete(), "Should not resolve without enough contributions");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data must not be exposed after timeout");
+        assertTrue(runtimeStats.getMetrics().containsKey(format(DYNAMIC_FILTER_TIMED_OUT_TEMPLATE, "549")),
+                "Filter must be marked timed out");
+    }
+
+    /**
+     * Cap: contributions trickle in every cycle but never reach the expected count.
+     * The filter must finalize after exactly (1 + maxWaitExtensions) cycles.
+     */
+    @Test
+    public void testExtensionsCappedByMaxWaitExtensions()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                2,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                true);
+        filter.setExpectedPartitions(100);
+        filter.startTimeout();
+
+        // Trickle one contribution per cycle for more cycles than the cap permits.
+        // After (1 + 2) = 3 cycles the filter must finalize even though contributions
+        // are still arriving.
+        for (int i = 0; i < 6; i++) {
+            Thread.sleep(ADAPTIVE_CYCLE.toMillis() / 2);
+            filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                    ImmutableMap.of("549", Domain.singleValue(INTEGER, (long) i))));
+        }
+        Thread.sleep(50);
+
+        assertFalse(filter.isComplete(), "Cap should fire before expectedPartitions reached");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial data must not be exposed after capped timeout");
+    }
+
+    /**
+     * Correctness: with adaptive extension enabled, the future is completed with
+     * all() on timeout and isComplete() / getCurrentConstraintByColumnName() preserve
+     * the 6c07185b guarantee (no partial constraint exposed).
+     */
+    @Test
+    public void testAdaptiveTimeoutPreservesAllOrNothingContract()
+            throws Exception
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        JoinDynamicFilter filter = new JoinDynamicFilter(
+                "549",
+                "col_a",
+                ADAPTIVE_CYCLE,
+                3,  // maxWaitExtensions
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                runtimeStats,
+                false);  // extendedMetrics off — exercise the non-diagnostic path
+        filter.setExpectedPartitions(4);
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 10L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 20L))));
+        filter.startTimeout();
+
+        // No further contributions. After capped finalize, partial union (10, 20)
+        // must NOT leak to callers; getCurrentConstraintByColumnName stays all().
+        Thread.sleep(ADAPTIVE_CYCLE.toMillis() * (1 + 3) + 80);
+
+        assertFalse(filter.isComplete(),
+                "Filter must remain incomplete after timeout despite partial contributions");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all(),
+                "Partial union (10, 20) must not be exposed to connector");
+        assertTrue(filter.isBlocked().isDone(),
+                "Future must be completed so the connector unblocks");
+
+        // Even a super-late arrival after the future completed must not flip fullyResolved.
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 30L))));
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 40L))));
+        assertFalse(filter.isComplete(),
+                "Late arrivals after timeout must not resolve the filter");
+        assertEquals(filter.getCurrentConstraintByColumnName(), TupleDomain.all());
+    }
+    // END ADAPTIVE-WAIT TESTS
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestRuntimeFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestRuntimeFilter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestRuntimeFilter
+{
+    private static final JsonCodec<RuntimeFilter> CODEC = jsonCodec(RuntimeFilter.class);
+
+    @Test
+    public void testDomainColumnWiseUnionMerge()
+    {
+        DomainRuntimeFilter a = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 1L))));
+        DomainRuntimeFilter b = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 2L))));
+
+        DomainRuntimeFilter merged = (DomainRuntimeFilter) a.mergeWith(b);
+
+        Domain expected = Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L));
+        assertEquals(merged.getDomain(), TupleDomain.withColumnDomains(ImmutableMap.of("k", expected)));
+    }
+
+    @Test
+    public void testMergeAcrossRepresentationsRejected()
+    {
+        DomainRuntimeFilter a = new DomainRuntimeFilter(
+                TupleDomain.withColumnDomains(ImmutableMap.of("k", Domain.singleValue(BIGINT, 1L))));
+        assertThrows(IllegalArgumentException.class, () -> a.mergeWith(new OtherRuntimeFilter()));
+    }
+
+    private static class OtherRuntimeFilter
+            implements RuntimeFilter
+    {
+        @Override
+        public RuntimeFilter mergeWith(RuntimeFilter other)
+        {
+            return this;
+        }
+
+        @Override
+        public TupleDomain<String> toTupleDomain(String column, com.facebook.presto.common.type.Type type)
+        {
+            return TupleDomain.all();
+        }
+
+        @Override
+        public boolean isAll()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isNone()
+        {
+            return false;
+        }
+
+        @Override
+        public long estimatedRetainedSizeInBytes()
+        {
+            return 0;
+        }
+    }
+
+    @Test
+    public void testNoneReflectsEmptyBuild()
+    {
+        assertTrue(new DomainRuntimeFilter(TupleDomain.none()).isNone());
+        assertFalse(new DomainRuntimeFilter(TupleDomain.all()).isNone());
+    }
+
+    @Test
+    public void testDomainJsonRoundTrip()
+    {
+        // TupleDomain.none() has simple JSON form and doesn't require block encoding.
+        DomainRuntimeFilter original = new DomainRuntimeFilter(TupleDomain.none());
+
+        String json = CODEC.toJson(original);
+        RuntimeFilter decoded = CODEC.fromJson(json);
+
+        assertTrue(decoded instanceof DomainRuntimeFilter);
+        assertTrue(((DomainRuntimeFilter) decoded).getDomain().isNone());
+    }
+
+    @Test
+    public void testBareWireBackCompat()
+    {
+        // A bare TupleDomain serialization (no @kind) must decode to DomainRuntimeFilter.
+        DomainRuntimeFilter original = new DomainRuntimeFilter(TupleDomain.none());
+        String wire = CODEC.toJson(original);
+        assertFalse(wire.contains("@kind"), "DomainRuntimeFilter must serialize without @kind: " + wire);
+
+        RuntimeFilter decoded = CODEC.fromJson(wire);
+        assertTrue(decoded instanceof DomainRuntimeFilter);
+        assertTrue(((DomainRuntimeFilter) decoded).getDomain().isNone());
+    }
+
+    @Test
+    public void testUnknownKindRejected()
+    {
+        assertThrows(Exception.class, () ->
+                CODEC.fromJson("{\"@kind\":\"bloom\"}"));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -337,7 +337,8 @@ public class TestSourcePartitionedScheduler
                     new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), createFixedSplitSource(20, TestingSplit::createRemoteSplit)),
                     new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(TestingSession.testSessionBuilder().build(), CONNECTOR_ID), stage::getAllTasks),
                     2,
-                    new CTEMaterializationTracker());
+                    new CTEMaterializationTracker(),
+                    false);
             scheduler.schedule();
 
             fail("expected PrestoException");
@@ -475,7 +476,7 @@ public class TestSourcePartitionedScheduler
                 new SimpleTtlNodeSelectorConfig());
         SplitSource splitSource = new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), connectorSplitSource);
         SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(TestingSession.testSessionBuilder().build(), splitSource.getConnectorId()), stage::getAllTasks);
-        return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize, new CTEMaterializationTracker());
+        return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize, new CTEMaterializationTracker(), false);
     }
 
     private static SubPlan createPlan()

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestTableScanDynamicFilter.java
@@ -1,0 +1,748 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.connector.DynamicFilter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTableScanDynamicFilter
+{
+    private static final Duration DEFAULT_TIMEOUT = new Duration(2, TimeUnit.SECONDS);
+    private static final TaskId TASK_0 = TaskId.valueOf("query.0.0.0.0");
+    private static final TaskId TASK_1 = TaskId.valueOf("query.0.0.1.0");
+
+    @Test
+    public void testSingleFilterComposite()
+    {
+        JoinDynamicFilter filter = createFilter("549", "customer_id");
+        filter.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of("customer_id", customerIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L))));
+    }
+
+    @Test
+    public void testTwoFiltersIntersection()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertFalse(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+
+        assertTrue(composite.isComplete());
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+    }
+
+    @Test
+    public void testProgressiveResolution()
+    {
+        JoinDynamicFilter filter1 = createFilter("797", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("798", "product_id");
+        JoinDynamicFilter filter3 = createFilter("799", "region_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        TestColumnHandle regionIdHandle = new TestColumnHandle("region_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle,
+                "region_id", regionIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getCurrentPredicate(), TupleDomain.all());
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("797", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("798", Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)))));
+        assertFalse(composite.isComplete());
+
+        filter3.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("799", Domain.singleValue(INTEGER, 100L))));
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)),
+                                (ColumnHandle) productIdHandle, Domain.multipleValues(INTEGER, ImmutableList.of(10L, 11L)),
+                                (ColumnHandle) regionIdHandle, Domain.singleValue(INTEGER, 100L))));
+        assertTrue(composite.isComplete());
+    }
+
+    @Test
+    public void testIsCompleteRequiresAllFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(2); // Needs 2 partitions
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        assertFalse(composite.isComplete());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 20L))));
+        assertTrue(composite.isComplete());
+    }
+
+    @Test
+    public void testOneFilterTimesOut()
+            throws Exception
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", DEFAULT_TIMEOUT);
+        filter1.setExpectedPartitions(2); // Won't get all partitions
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        composite.isBlocked();
+        Thread.sleep(300);
+
+        assertFalse(filter1.isComplete());
+        assertTrue(filter2.isComplete());
+        assertFalse(composite.isComplete());
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testMinimumTimeout()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(1000, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(500, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter3 = createFilter("551", "region_id", new Duration(2000, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"),
+                "region_id", new TestColumnHandle("region_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getWaitTimeout(), new Duration(500, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testGetFilterIdConcatenated()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        JoinDynamicFilter filter3 = createFilter("551", "region_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+        filter3.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"),
+                "region_id", new TestColumnHandle("region_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2, filter3), columnNameToHandle);
+
+        assertEquals(composite.getFilterId(), "549,550,551");
+    }
+
+    @Test
+    public void testIsBlockedFuture()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked = composite.isBlocked();
+        assertFalse(blocked.isDone());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(blocked.isDone());
+        assertTrue(composite.isComplete());
+        assertEquals(composite.isBlocked(), DynamicFilter.NOT_BLOCKED);
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testEmptyResultAfterIntersection()
+    {
+        TestColumnHandle colHandle = new TestColumnHandle("col");
+        JoinDynamicFilter filter1 = createFilter("549", "col");
+        JoinDynamicFilter filter2 = createFilter("550", "col");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of("col", colHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.multipleValues(INTEGER, ImmutableList.of(1L, 2L, 3L)))));
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.multipleValues(INTEGER, ImmutableList.of(4L, 5L, 6L)))));
+
+        assertTrue(composite.isComplete());
+
+        TupleDomain<ColumnHandle> result = composite.getCurrentPredicate();
+        assertTrue(result.isNone(), "Mutually exclusive constraints should produce none()");
+    }
+
+    @Test
+    public void testGetFiltersReturnsUnderlyingFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertEquals(composite.getFilters(), ImmutableList.of(filter1, filter2));
+    }
+
+    @Test
+    public void testIsBlockedStartsTimeoutForAllFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(100, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(2);
+        filter2.setExpectedPartitions(2);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked = composite.isBlocked();
+        assertFalse(blocked.isDone());
+    }
+
+    @Test
+    public void testIsBlockedProgressiveWakeup()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        CompletableFuture<?> blocked1 = composite.isBlocked();
+        assertFalse(blocked1.isDone());
+        assertFalse(composite.isComplete());
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertTrue(blocked1.isDone());
+        assertFalse(composite.isComplete());
+
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of((ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L))));
+
+        CompletableFuture<?> blocked2 = composite.isBlocked();
+        assertFalse(blocked2.isDone());
+
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        assertTrue(blocked2.isDone());
+        assertTrue(composite.isComplete());
+
+        assertEquals(composite.isBlocked(), DynamicFilter.NOT_BLOCKED);
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    @Test
+    public void testGetPendingFilterColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Both pending
+        Set<ColumnHandle> pending = composite.getPendingFilterColumns();
+        assertEquals(pending, ImmutableSet.of(customerIdHandle, productIdHandle));
+
+        // Resolve one
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        pending = composite.getPendingFilterColumns();
+        assertEquals(pending, ImmutableSet.of(productIdHandle));
+
+        // Resolve both
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+        pending = composite.getPendingFilterColumns();
+        assertTrue(pending.isEmpty());
+    }
+
+    @Test
+    public void testIsBlockedWithRelevantColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+
+        CompletableFuture<?> blocked = composite.isBlocked(relevantColumns);
+        assertFalse(blocked.isDone());
+
+        // Resolve the relevant filter
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        assertTrue(blocked.isDone());
+
+        // Even though product_id filter is pending, isBlocked with relevant=customer_id returns NOT_BLOCKED
+        assertEquals(composite.isBlocked(relevantColumns), DynamicFilter.NOT_BLOCKED);
+    }
+
+    @Test
+    public void testIsCompleteWithRelevantColumns()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+
+        assertFalse(composite.isComplete(relevantColumns));
+        assertFalse(composite.isComplete()); // global still false
+
+        // Resolve relevant filter only
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(composite.isComplete(relevantColumns));
+        assertFalse(composite.isComplete()); // global still false because product_id pending
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenNoneComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        assertFalse(composite.hasAnyComplete(Optional.empty()));
+        assertFalse(composite.hasAnyComplete(Optional.of(ImmutableSet.of(customerIdHandle))));
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenOneComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Resolve only filter1
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        // Key invariant: hasAnyComplete is true while isComplete is still false.
+        assertTrue(composite.hasAnyComplete(Optional.empty()));
+        assertFalse(composite.isComplete(Optional.empty()));
+    }
+
+    @Test
+    public void testHasAnyCompleteWhenAllComplete()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"),
+                "product_id", new TestColumnHandle("product_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        assertTrue(composite.hasAnyComplete(Optional.empty()));
+        assertTrue(composite.isComplete(Optional.empty()));
+    }
+
+    @Test
+    public void testHasAnyCompleteIgnoresIrrelevantCompletedFilter()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Resolve only filter2 (product_id), but ask about customer_id only.
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        Optional<Set<ColumnHandle>> relevant = Optional.of(ImmutableSet.of(customerIdHandle));
+        assertFalse(composite.hasAnyComplete(relevant),
+                "completed filter on irrelevant column should not satisfy hasAnyComplete");
+        assertTrue(composite.hasAnyComplete(Optional.of(ImmutableSet.of(productIdHandle))));
+    }
+
+    @Test
+    public void testHasAnyCompleteEmptyRelevantColumnsReturnsTrue()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(2); // deliberately not resolved
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> emptyRelevant = Optional.of(ImmutableSet.of());
+        assertTrue(composite.hasAnyComplete(emptyRelevant),
+                "Empty relevant column set means no filter to wait for");
+    }
+
+    @Test
+    public void testIsBlockedEmptyRelevantColumnsDelegatesToAll()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(1);
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> allRelevant = Optional.empty();
+
+        CompletableFuture<?> blocked = composite.isBlocked(allRelevant);
+        assertFalse(blocked.isDone(), "Optional.empty() should consider all columns and still block");
+        assertFalse(composite.isComplete(allRelevant), "Optional.empty() should consider all columns and return false");
+
+        // Resolve the filter
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+
+        assertTrue(blocked.isDone(), "Should unblock after filter resolves");
+        assertTrue(composite.isComplete(allRelevant), "Should be complete after filter resolves");
+    }
+
+    @Test
+    public void testEmptyRelevantColumnsCompletesImmediately()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        filter1.setExpectedPartitions(2); // deliberately not resolved
+
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", new TestColumnHandle("customer_id"));
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1), columnNameToHandle);
+
+        Optional<Set<ColumnHandle>> emptyRelevant = Optional.of(ImmutableSet.of());
+
+        assertTrue(composite.isComplete(emptyRelevant),
+                "Empty relevant column set should be immediately complete");
+
+        CompletableFuture<?> blocked = composite.isBlocked(emptyRelevant);
+        assertTrue(blocked.isDone(),
+                "Empty relevant column set should not block");
+
+        assertFalse(composite.isComplete(),
+                "Global isComplete should still be false (filter unresolved)");
+    }
+
+    @Test
+    public void testIsBlockedRelevantColumnsStartsAllTimeouts()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id", new Duration(100, TimeUnit.MILLISECONDS));
+        JoinDynamicFilter filter2 = createFilter("550", "product_id", new Duration(100, TimeUnit.MILLISECONDS));
+        filter1.setExpectedPartitions(2);
+        filter2.setExpectedPartitions(2);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Only wait on customer_id but all timeouts should be started
+        Optional<Set<ColumnHandle>> relevantColumns = Optional.of(ImmutableSet.of(customerIdHandle));
+        CompletableFuture<?> blocked = composite.isBlocked(relevantColumns);
+        assertFalse(blocked.isDone());
+        // Both filters should have their timeouts started (verified by isBlocked starting them)
+    }
+
+    @Test
+    public void testGetCurrentPredicateIncludesAllResolvedFilters()
+    {
+        JoinDynamicFilter filter1 = createFilter("549", "customer_id");
+        JoinDynamicFilter filter2 = createFilter("550", "product_id");
+        filter1.setExpectedPartitions(1);
+        filter2.setExpectedPartitions(1);
+
+        TestColumnHandle customerIdHandle = new TestColumnHandle("customer_id");
+        TestColumnHandle productIdHandle = new TestColumnHandle("product_id");
+        Map<String, ColumnHandle> columnNameToHandle = ImmutableMap.of(
+                "customer_id", customerIdHandle,
+                "product_id", productIdHandle);
+        TableScanDynamicFilter composite = new TableScanDynamicFilter(ImmutableList.of(filter1, filter2), columnNameToHandle);
+
+        // Only wait on customer_id (relevant)
+        composite.isBlocked(Optional.of(ImmutableSet.of(customerIdHandle)));
+
+        // Resolve both filters
+        filter1.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("549", Domain.singleValue(INTEGER, 1L))));
+        filter2.addPartitionByFilterId(TupleDomain.withColumnDomains(
+                ImmutableMap.of("550", Domain.singleValue(INTEGER, 10L))));
+
+        // getCurrentPredicate should include ALL resolved filters, not just relevant ones
+        assertEquals(
+                composite.getCurrentPredicate(),
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                (ColumnHandle) customerIdHandle, Domain.singleValue(INTEGER, 1L),
+                                (ColumnHandle) productIdHandle, Domain.singleValue(INTEGER, 10L))));
+    }
+
+    private JoinDynamicFilter createFilter(String filterId, String columnName)
+    {
+        return createFilter(filterId, columnName, DEFAULT_TIMEOUT);
+    }
+
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private JoinDynamicFilter createFilter(String filterId, String columnName, Duration timeout)
+    {
+        return new JoinDynamicFilter(
+                filterId,
+                columnName,
+                timeout,
+                DEFAULT_MAX_SIZE_BYTES,
+                new DynamicFilterStats(),
+                new RuntimeStats(),
+                false);
+    }
+
+    private static class TestColumnHandle
+            implements ColumnHandle
+    {
+        private final String name;
+
+        public TestColumnHandle(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestColumnHandle that = (TestColumnHandle) o;
+            return Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "TestColumnHandle{name='" + name + "'}";
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -26,6 +26,7 @@ import com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory;
 import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
 import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -58,6 +59,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -276,6 +278,12 @@ public class TestThriftTaskIntegration
 
                 @Override
                 public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Map<String, TupleDomain<String>> getDynamicFiltersSince(TaskId taskId, long sinceVersion)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -78,6 +78,8 @@ import com.facebook.presto.execution.TaskThresholdMemoryRevokingScheduler;
 import com.facebook.presto.execution.buffer.SpoolingOutputBufferFactory;
 import com.facebook.presto.execution.executor.MultilevelSplitQueue;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
 import com.facebook.presto.execution.scheduler.FlatNetworkTopology;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NetworkTopology;
@@ -159,6 +161,8 @@ import com.facebook.presto.resourcemanager.ResourceManagerConfig;
 import com.facebook.presto.resourcemanager.ResourceManagerInconsistentException;
 import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
 import com.facebook.presto.server.remotetask.DecompressionFilter;
+import com.facebook.presto.server.remotetask.DynamicFilterPushRequest;
+import com.facebook.presto.server.remotetask.DynamicFilterResponse;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
@@ -449,6 +453,9 @@ public class ServerMainModule
         binder.bind(NodeSchedulerExporter.class).in(Scopes.SINGLETON);
         binder.bind(NodeTaskMap.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeScheduler.class).withGeneratedName();
+        binder.bind(DynamicFilterService.class).in(Scopes.SINGLETON);
+        binder.bind(DynamicFilterStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(DynamicFilterStats.class).withGeneratedName();
 
         // network topology
         // TODO: move to CoordinatorModule when NodeScheduler is moved
@@ -617,6 +624,8 @@ public class ServerMainModule
         jsonCodecBinder(binder).bindJsonCodec(TaskSource.class);
         jsonCodecBinder(binder).bindJsonCodec(TableWriteInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+        jsonCodecBinder(binder).bindJsonCodec(DynamicFilterResponse.class);
+        jsonCodecBinder(binder).bindJsonCodec(DynamicFilterPushRequest.class);
         smileCodecBinder(binder).bindSmileCodec(TaskStatus.class);
         smileCodecBinder(binder).bindSmileCodec(TaskInfo.class);
         thriftCodecBinder(binder).bindThriftCodec(TaskStatus.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManager;
@@ -26,6 +27,7 @@ import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.OutputBufferInfo;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.server.remotetask.DynamicFilterResponse;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
@@ -51,6 +53,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -300,6 +303,27 @@ public class TaskResource
         requireNonNull(remoteSourceTaskId, "remoteSourceTaskId is null");
 
         taskManager.removeRemoteSource(taskId, remoteSourceTaskId);
+    }
+
+    @GET
+    @Path("{taskId}/dynamicFilters")
+    @Produces(APPLICATION_JSON)
+    public Response getDynamicFilters(
+            @PathParam("taskId") TaskId taskId,
+            @QueryParam("since") @DefaultValue("0") long sinceVersion)
+    {
+        requireNonNull(taskId, "taskId is null");
+        Map<String, TupleDomain<String>> filters = taskManager.getDynamicFiltersSince(taskId, sinceVersion);
+        return Response.ok(DynamicFilterResponse.incomplete(filters, sinceVersion)).build();
+    }
+
+    @DELETE
+    @Path("{taskId}/dynamicFilters")
+    public Response deleteDynamicFilters(
+            @PathParam("taskId") TaskId taskId)
+    {
+        requireNonNull(taskId, "taskId is null");
+        return Response.noContent().build();
     }
 
     private static boolean shouldSummarize(UriInfo uriInfo)

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterFetcher.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.scheduler.DomainRuntimeFilter;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
+import com.facebook.presto.execution.scheduler.JoinDynamicFilter;
+import com.facebook.presto.execution.scheduler.RuntimeFilter;
+import com.facebook.presto.server.RequestErrorTracker;
+import com.facebook.presto.server.SimpleHttpResponseCallback;
+import com.facebook.presto.server.SimpleHttpResponseHandler;
+import com.facebook.presto.server.smile.BaseResponse;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.netty.channel.EventLoop;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_COMPLETED_ID_DELIVERED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_FETCHERS_STARTED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_FETCHER_FINAL_FETCH_COMPLETED;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_FETCHER_POLLS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_FETCHER_STOPPED_BY_CLEANUP;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PARTITIONS_RECEIVED_FROM_TASK;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
+import static com.facebook.presto.server.RequestErrorTracker.taskRequestErrorTracker;
+import static com.facebook.presto.server.smile.AdaptingJsonResponseHandler.createAdaptingJsonResponseHandler;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Long-polls {@code GET /v1/task/{taskId}/dynamicFilters?since=N} to collect
+ * dynamic filters from build-side workers. Sends {@code DELETE ?through=N}
+ * after processing to free worker memory.
+ */
+public class DynamicFilterFetcher
+        implements SimpleHttpResponseCallback<DynamicFilterResponse>
+{
+    private static final Logger log = Logger.get(DynamicFilterFetcher.class);
+
+    private final TaskId taskId;
+    private final QueryId queryId;
+    private final URI taskLocation;
+    private final HttpClient httpClient;
+    private final EventLoop taskEventLoop;
+    private final JsonCodec<DynamicFilterResponse> filterCodec;
+    private final RemoteTaskStats stats;
+    private final DynamicFilterStats dynamicFilterStats;
+    private final RequestErrorTracker errorTracker;
+    private final DynamicFilterService dynamicFilterService;
+    private final boolean extendedMetrics;
+    private final String taskSuffix;
+
+    private final Consumer<Throwable> onFatal;
+
+    private final AtomicLong lastFetchedVersion = new AtomicLong(0);
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final Set<String> deliveredFilterIds = new HashSet<>();
+    private final Map<String, JoinDynamicFilter> filterCache = new HashMap<>();
+    private final Duration maxWait;
+
+    private volatile boolean isFinalFetch;
+    private volatile ListenableFuture<BaseResponse<DynamicFilterResponse>> future;
+    private long currentRequestStartNanos;
+
+    public DynamicFilterFetcher(
+            TaskId taskId,
+            URI taskLocation,
+            HttpClient httpClient,
+            EventLoop taskEventLoop,
+            Duration maxErrorDuration,
+            Duration maxWait,
+            RemoteTaskStats stats,
+            JsonCodec<DynamicFilterResponse> filterCodec,
+            DynamicFilterService dynamicFilterService,
+            QueryId queryId,
+            DynamicFilterStats dynamicFilterStats,
+            boolean extendedMetrics,
+            Consumer<Throwable> onFatal)
+    {
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.taskLocation = requireNonNull(taskLocation, "taskLocation is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.taskEventLoop = requireNonNull(taskEventLoop, "taskEventLoop is null");
+        this.maxWait = requireNonNull(maxWait, "maxWait is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.dynamicFilterStats = requireNonNull(dynamicFilterStats, "dynamicFilterStats is null");
+        this.filterCodec = requireNonNull(filterCodec, "filterCodec is null");
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        this.extendedMetrics = extendedMetrics;
+        this.onFatal = requireNonNull(onFatal, "onFatal is null");
+        this.taskSuffix = taskId.getStageExecutionId().getStageId().getId() + "." + taskId.getId();
+        this.errorTracker = taskRequestErrorTracker(
+                taskId,
+                taskLocation,
+                maxErrorDuration,
+                taskEventLoop,
+                "fetching dynamic filters for task");
+    }
+
+    public void start()
+    {
+        verify(started.compareAndSet(false, true), "start() already called");
+        dynamicFilterStats.getFetchersStarted().update(1);
+        dynamicFilterService.getAllFiltersForQuery(queryId).forEach(filterCache::putIfAbsent);
+        filterCache.values().stream()
+                .findFirst()
+                .map(JoinDynamicFilter::getRuntimeStats)
+                .ifPresent(rs -> rs.addMetricValue(DYNAMIC_FILTER_FETCHERS_STARTED, NONE, 1));
+        taskEventLoop.execute(this::sendFetchRequest);
+    }
+
+    private void sendFetchRequest()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        if (!running.get()) {
+            return;
+        }
+
+        if (future != null && !future.isDone()) {
+            return;
+        }
+
+        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        if (!errorRateLimit.isDone()) {
+            errorRateLimit.addListener(this::sendFetchRequest, taskEventLoop);
+            return;
+        }
+
+        long currentVersion = lastFetchedVersion.get();
+        URI uri = uriBuilderFrom(taskLocation)
+                .appendPath("dynamicFilters")
+                .addParameter("since", String.valueOf(currentVersion))
+                .build();
+
+        Request request = prepareGet()
+                .setUri(uri)
+                .setHeader(PRESTO_MAX_WAIT, maxWait.toString())
+                .build();
+
+        errorTracker.startRequest();
+        future = httpClient.executeAsync(request, createAdaptingJsonResponseHandler(filterCodec));
+        currentRequestStartNanos = System.nanoTime();
+
+        SimpleHttpResponseHandler<DynamicFilterResponse> callback = new SimpleHttpResponseHandler<>(
+                this,
+                request.getUri(),
+                stats.getHttpResponseStats(),
+                REMOTE_TASK_ERROR);
+
+        Futures.addCallback(future, callback, taskEventLoop);
+    }
+
+    @Override
+    public void success(DynamicFilterResponse response)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        long requestDurationNanos = System.nanoTime() - currentRequestStartNanos;
+        long roundTripMs = requestDurationNanos / 1_000_000;
+        stats.infoRoundTripMillis(roundTripMs);
+        dynamicFilterStats.recordFilterFetchRoundTripMillis(roundTripMs);
+        errorTracker.requestSucceeded();
+
+        long responseVersion = response.getVersion();
+        lastFetchedVersion.updateAndGet(current -> Math.max(current, responseVersion));
+
+        Map<String, RuntimeFilter> filters = response.getFilters();
+        dynamicFilterStats.getFilterFetchSuccess().update(1);
+
+        if (extendedMetrics) {
+            emitExtendedMetric(format("%s[%s]", DYNAMIC_FILTER_FETCHER_POLLS, taskSuffix), 1);
+            for (String filterId : filters.keySet()) {
+                emitExtendedMetric(format("%s[%s][%s]", DYNAMIC_FILTER_PARTITIONS_RECEIVED_FROM_TASK, filterId, taskSuffix), 1);
+            }
+            if (isFinalFetch && response.isOperatorCompleted()) {
+                emitExtendedMetric(format("%s[%s]", DYNAMIC_FILTER_FETCHER_FINAL_FETCH_COMPLETED, taskSuffix), 1);
+            }
+        }
+
+        if (!filters.isEmpty()) {
+            dynamicFilterStats.getFiltersCollected().update(filters.size());
+
+            for (Map.Entry<String, RuntimeFilter> entry : filters.entrySet()) {
+                String filterId = entry.getKey();
+                RuntimeFilter filterDomain = entry.getValue();
+                if (deliveredFilterIds.add(filterId)) {
+                    resolveFilter(filterId)
+                            .ifPresent(f -> f.addPartitionByFilterId(filterDomain));
+                }
+            }
+
+            sendDeleteRequest(responseVersion);
+        }
+
+        // Empty build: deliver none() so this task's partition counts toward quorum.
+        for (String filterId : response.getCompletedFilterIds()) {
+            if (deliveredFilterIds.add(filterId)) {
+                if (extendedMetrics) {
+                    emitExtendedMetric(format("%s[%s][%s]", DYNAMIC_FILTER_COMPLETED_ID_DELIVERED, filterId, taskSuffix), 1);
+                }
+                resolveFilter(filterId)
+                        .ifPresent(f -> f.addPartitionByFilterId(new DomainRuntimeFilter(TupleDomain.none())));
+            }
+        }
+
+        if (response.isOperatorCompleted()) {
+            dynamicFilterStats.getFilterFlushes().update(1);
+            stop();
+            return;
+        }
+
+        scheduleNextPoll();
+    }
+
+    private void sendDeleteRequest(long throughVersion)
+    {
+        URI uri = uriBuilderFrom(taskLocation)
+                .appendPath("dynamicFilters")
+                .addParameter("through", String.valueOf(throughVersion))
+                .build();
+        Request request = prepareDelete()
+                .setUri(uri)
+                .build();
+        httpClient.executeAsync(request, createStatusResponseHandler());
+    }
+
+    private void scheduleNextPoll()
+    {
+        if (!running.get()) {
+            return;
+        }
+
+        taskEventLoop.execute(() -> {
+            if (running.get()) {
+                sendFetchRequest();
+            }
+        });
+    }
+
+    @Override
+    public void failed(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+        dynamicFilterStats.getFilterFetchFailure().update(1);
+        if (extendedMetrics) {
+            emitExtendedMetric(format("dynamicFilterFetcherFailed[%s]", taskSuffix), 1);
+        }
+
+        try {
+            errorTracker.requestFailed(cause);
+        }
+        catch (PrestoException e) {
+            stop();
+            onFatal.accept(e);
+            return;
+        }
+
+        scheduleNextPoll();
+    }
+
+    @Override
+    public void fatal(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+        // Propagate rather than swallowing — a fatal parse error should fail the query, not silently time out the filter.
+        dynamicFilterStats.getFilterFetchFailure().update(1);
+        if (extendedMetrics) {
+            emitExtendedMetric(format("dynamicFilterFetcherFatal[%s]", taskSuffix), 1);
+        }
+        stop();
+        onFatal.accept(cause);
+    }
+
+    /**
+     * Stop polling. Pending requests are allowed to complete so late-arriving filters
+     * are still processed.
+     */
+    public void stop()
+    {
+        running.set(false);
+    }
+
+    /**
+     * Stop polling after one final immediate fetch to collect filter data from fast-completing
+     * tasks. Must be called from the event loop.
+     */
+    public void stopAfterFinalFetch()
+    {
+        verify(taskEventLoop.inEventLoop());
+        if (running.compareAndSet(true, false)) {
+            if (extendedMetrics) {
+                emitExtendedMetric(format("%s[%s]", DYNAMIC_FILTER_FETCHER_STOPPED_BY_CLEANUP, taskSuffix), 1);
+            }
+            isFinalFetch = true;
+            sendFinalFetchRequest();
+        }
+    }
+
+    private void sendFinalFetchRequest()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        long currentVersion = lastFetchedVersion.get();
+        URI uri = uriBuilderFrom(taskLocation)
+                .appendPath("dynamicFilters")
+                .addParameter("since", String.valueOf(currentVersion))
+                .build();
+
+        // No PRESTO_MAX_WAIT header — returns immediately with whatever data is available
+        Request request = prepareGet()
+                .setUri(uri)
+                .build();
+
+        future = httpClient.executeAsync(request, createAdaptingJsonResponseHandler(filterCodec));
+        currentRequestStartNanos = System.nanoTime();
+
+        Futures.addCallback(
+                future,
+                new SimpleHttpResponseHandler<>(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR),
+                taskEventLoop);
+    }
+
+    /** Cancels pending HTTP requests and stops polling. */
+    public void abort()
+    {
+        running.set(false);
+        // Do not cancel the final fetch — it must complete so the last partition is delivered.
+        if (isFinalFetch) {
+            return;
+        }
+        ListenableFuture<BaseResponse<DynamicFilterResponse>> pendingFuture = future;
+        if (pendingFuture != null && !pendingFuture.isDone()) {
+            pendingFuture.cancel(false);
+        }
+    }
+
+    private Optional<JoinDynamicFilter> resolveFilter(String filterId)
+    {
+        JoinDynamicFilter existing = filterCache.get(filterId);
+        if (existing != null) {
+            return Optional.of(existing);
+        }
+        Optional<JoinDynamicFilter> filter = dynamicFilterService.getFilter(queryId, filterId);
+        filter.ifPresent(f -> filterCache.put(filterId, f));
+        return filter;
+    }
+
+    private void emitExtendedMetric(String metricName, long value)
+    {
+        filterCache.values().stream()
+                .findFirst()
+                .map(JoinDynamicFilter::getRuntimeStats)
+                .ifPresent(runtimeStats -> runtimeStats.addMetricValue(metricName, NONE, value));
+    }
+
+    public TaskId getTaskId()
+    {
+        return taskId;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterPushRequest.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterPushRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.presto.execution.scheduler.RuntimeFilter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterPushRequest
+{
+    private final boolean complete;
+    private final String scanPlanNodeId;
+    private final RuntimeFilter filter;
+
+    @JsonCreator
+    public DynamicFilterPushRequest(
+            @JsonProperty("complete") boolean complete,
+            @JsonProperty("scanPlanNodeId") String scanPlanNodeId,
+            @JsonProperty("tupleDomain") RuntimeFilter filter)
+    {
+        this.complete = complete;
+        this.scanPlanNodeId = requireNonNull(scanPlanNodeId, "scanPlanNodeId is null");
+        this.filter = requireNonNull(filter, "filter is null");
+    }
+
+    @JsonProperty
+    public boolean isComplete()
+    {
+        return complete;
+    }
+
+    @JsonProperty
+    public String getScanPlanNodeId()
+    {
+        return scanPlanNodeId;
+    }
+
+    @JsonProperty("tupleDomain")
+    public RuntimeFilter getFilter()
+    {
+        return filter;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterResponse.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/DynamicFilterResponse.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.scheduler.DomainRuntimeFilter;
+import com.facebook.presto.execution.scheduler.RuntimeFilter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterResponse
+{
+    private final Map<String, RuntimeFilter> filters;
+    private final long version;
+    private final boolean operatorCompleted;
+    private final Set<String> completedFilterIds;
+
+    @JsonCreator
+    public DynamicFilterResponse(
+            @JsonProperty("filters") Map<String, RuntimeFilter> filters,
+            @JsonProperty("version") long version,
+            @JsonProperty("operatorCompleted") boolean operatorCompleted,
+            @JsonProperty("completedFilterIds") Set<String> completedFilterIds)
+    {
+        this.filters = ImmutableMap.copyOf(requireNonNull(filters, "filters is null"));
+        this.version = version;
+        this.operatorCompleted = operatorCompleted;
+        this.completedFilterIds = completedFilterIds == null ? ImmutableSet.of() : ImmutableSet.copyOf(completedFilterIds);
+    }
+
+    public static DynamicFilterResponse incomplete(Map<String, TupleDomain<String>> filters, long version)
+    {
+        return new DynamicFilterResponse(wrap(filters), version, false, ImmutableSet.of());
+    }
+
+    public static DynamicFilterResponse incomplete(Map<String, TupleDomain<String>> filters, long version, Set<String> completedFilterIds)
+    {
+        return new DynamicFilterResponse(wrap(filters), version, false, completedFilterIds);
+    }
+
+    public static DynamicFilterResponse completed(Map<String, TupleDomain<String>> filters, long version, Set<String> completedFilterIds)
+    {
+        return new DynamicFilterResponse(wrap(filters), version, true, completedFilterIds);
+    }
+
+    private static Map<String, RuntimeFilter> wrap(Map<String, TupleDomain<String>> filters)
+    {
+        ImmutableMap.Builder<String, RuntimeFilter> builder = ImmutableMap.builder();
+        for (Map.Entry<String, TupleDomain<String>> entry : filters.entrySet()) {
+            builder.put(entry.getKey(), new DomainRuntimeFilter(entry.getValue()));
+        }
+        return builder.build();
+    }
+
+    @JsonProperty
+    public Map<String, RuntimeFilter> getFilters()
+    {
+        return filters;
+    }
+
+    @JsonProperty
+    public long getVersion()
+    {
+        return version;
+    }
+
+    @JsonProperty
+    public boolean isOperatorCompleted()
+    {
+        return operatorCompleted;
+    }
+
+    @JsonProperty
+    public Set<String> getCompletedFilterIds()
+    {
+        return completedFilterIds;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DynamicFilterResponse{" +
+                "filters=" + filters +
+                ", version=" + version +
+                ", operatorCompleted=" + operatorCompleted +
+                ", completedFilterIds=" + completedFilterIds +
+                '}';
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -38,6 +38,8 @@ import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.InternalNode;
@@ -106,6 +108,10 @@ public class HttpRemoteTaskFactory
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
     private final Optional<SafeEventLoopGroup> eventLoopGroup;
+    private final DynamicFilterService dynamicFilterService;
+    private final DynamicFilterStats dynamicFilterStats;
+    private final JsonCodec<DynamicFilterResponse> dynamicFilterResponseCodec;
+    private final JsonCodec<DynamicFilterPushRequest> dynamicFilterPushRequestCodec;
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -128,7 +134,11 @@ public class HttpRemoteTaskFactory
             InternalCommunicationConfig communicationConfig,
             MetadataManager metadataManager,
             QueryManager queryManager,
-            HandleResolver handleResolver)
+            HandleResolver handleResolver,
+            DynamicFilterService dynamicFilterService,
+            DynamicFilterStats dynamicFilterStats,
+            JsonCodec<DynamicFilterResponse> dynamicFilterResponseCodec,
+            JsonCodec<DynamicFilterPushRequest> dynamicFilterPushRequestCodec)
     {
         this.httpClient = httpClient;
         this.locationFactory = locationFactory;
@@ -137,6 +147,10 @@ public class HttpRemoteTaskFactory
         this.taskInfoUpdateInterval = taskConfig.getInfoUpdateInterval();
         this.taskInfoRefreshMaxWait = taskConfig.getInfoRefreshMaxWait();
         this.handleResolver = handleResolver;
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        this.dynamicFilterStats = requireNonNull(dynamicFilterStats, "dynamicFilterStats is null");
+        this.dynamicFilterResponseCodec = requireNonNull(dynamicFilterResponseCodec, "dynamicFilterResponseCodec is null");
+        this.dynamicFilterPushRequestCodec = requireNonNull(dynamicFilterPushRequestCodec, "dynamicFilterPushRequestCodec is null");
 
         this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("remote-task-callback-%s"));
         this.executor = new BoundedExecutor(coreExecutor, config.getRemoteTaskMaxCallbackThreads());
@@ -280,6 +294,10 @@ public class HttpRemoteTaskFactory
                 taskUpdateSizeTrackingEnabled,
                 handleResolver,
                 schedulerStatsTracker,
-                (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.get().next());
+                (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.get().next(),
+                dynamicFilterService,
+                dynamicFilterResponseCodec,
+                dynamicFilterPushRequestCodec,
+                dynamicFilterStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
@@ -30,6 +30,7 @@ import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.execution.FutureStateChange;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
@@ -48,6 +49,9 @@ import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.PageBufferInfo;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
+import com.facebook.presto.execution.scheduler.RuntimeFilter;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.MetadataManager;
@@ -105,6 +109,18 @@ import static com.facebook.airlift.http.client.Request.Builder.preparePost;
 import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
+import static com.facebook.presto.SystemSessionProperties.isDistributedDynamicFilterEnabled;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
+import static com.facebook.presto.SystemSessionProperties.isVerboseRuntimeStatsEnabled;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_FAILURE_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_HTTP_STATUS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_LATENCY_MS;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_RETRIED_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_RETRY_GAVE_UP_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_SUCCESS_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_NOT_FOUND_COUNT;
+import static com.facebook.presto.common.RuntimeMetricName.DYNAMIC_FILTER_PUSH_TO_WORKER_THROTTLED_COUNT;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.execution.TaskInfo.createInitialTask;
 import static com.facebook.presto.execution.TaskState.ABORTED;
 import static com.facebook.presto.execution.TaskState.FAILED;
@@ -161,6 +177,8 @@ public final class HttpRemoteTaskWithEventLoop
     private static final double UPDATE_WITHOUT_PLAN_STATS_SAMPLE_RATE = 0.01;
     private static final ThreadMXBean THREAD_MX_BEAN = (ThreadMXBean) ManagementFactory.getThreadMXBean();
 
+    private final JsonCodec<DynamicFilterPushRequest> pushRequestCodec;
+
     private final TaskId taskId;
     private final URI taskLocation;
     private final URI remoteTaskLocation;
@@ -178,6 +196,7 @@ public final class HttpRemoteTaskWithEventLoop
     private final RemoteTaskStats stats;
     private final TaskInfoFetcherWithEventLoop taskInfoFetcher;
     private final ContinuousTaskStatusFetcherWithEventLoop taskStatusFetcher;
+    private final DynamicFilterFetcher dynamicFilterFetcher;
 
     private final LongArrayList taskUpdateTimeline = new LongArrayList();
     private Future<?> currentRequest;
@@ -235,6 +254,7 @@ public final class HttpRemoteTaskWithEventLoop
 
     private final SafeEventLoopGroup.SafeEventLoop taskEventLoop;
     private final String loggingPrefix;
+    private final boolean shouldFetchDynamicFilters;
 
     private long startTime;
     private long startedTime;
@@ -276,7 +296,11 @@ public final class HttpRemoteTaskWithEventLoop
             boolean taskUpdateSizeTrackingEnabled,
             HandleResolver handleResolver,
             SchedulerStatsTracker schedulerStatsTracker,
-            SafeEventLoopGroup.SafeEventLoop taskEventLoop)
+            SafeEventLoopGroup.SafeEventLoop taskEventLoop,
+            DynamicFilterService dynamicFilterService,
+            JsonCodec<DynamicFilterResponse> dynamicFilterResponseCodec,
+            JsonCodec<DynamicFilterPushRequest> dynamicFilterPushRequestCodec,
+            DynamicFilterStats dynamicFilterStats)
     {
         HttpRemoteTaskWithEventLoop task = new HttpRemoteTaskWithEventLoop(session,
                 taskId,
@@ -314,7 +338,11 @@ public final class HttpRemoteTaskWithEventLoop
                 taskUpdateSizeTrackingEnabled,
                 handleResolver,
                 schedulerStatsTracker,
-                taskEventLoop);
+                taskEventLoop,
+                dynamicFilterService,
+                dynamicFilterResponseCodec,
+                dynamicFilterPushRequestCodec,
+                dynamicFilterStats);
         task.initialize();
         return task;
     }
@@ -355,7 +383,11 @@ public final class HttpRemoteTaskWithEventLoop
             boolean taskUpdateSizeTrackingEnabled,
             HandleResolver handleResolver,
             SchedulerStatsTracker schedulerStatsTracker,
-            SafeEventLoopGroup.SafeEventLoop taskEventLoop)
+            SafeEventLoopGroup.SafeEventLoop taskEventLoop,
+            DynamicFilterService dynamicFilterService,
+            JsonCodec<DynamicFilterResponse> dynamicFilterResponseCodec,
+            JsonCodec<DynamicFilterPushRequest> dynamicFilterPushRequestCodec,
+            DynamicFilterStats dynamicFilterStats)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");
@@ -381,7 +413,11 @@ public final class HttpRemoteTaskWithEventLoop
         requireNonNull(taskUpdateRequestSize, "taskUpdateRequestSize cannot be null");
         requireNonNull(schedulerStatsTracker, "schedulerStatsTracker is null");
         requireNonNull(taskEventLoop, "taskEventLoop is null");
+        requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        requireNonNull(dynamicFilterResponseCodec, "dynamicFilterResponseCodec is null");
+        requireNonNull(dynamicFilterPushRequestCodec, "dynamicFilterPushRequestCodec is null");
 
+        this.pushRequestCodec = dynamicFilterPushRequestCodec;
         this.taskEventLoop = taskEventLoop;
         this.taskId = taskId;
         this.taskLocation = location;
@@ -477,6 +513,22 @@ public final class HttpRemoteTaskWithEventLoop
                 queryManager,
                 handleResolver,
                 thriftProtocol);
+        this.dynamicFilterFetcher = new DynamicFilterFetcher(
+                taskId,
+                location,
+                httpClient,
+                taskEventLoop,
+                maxErrorDuration,
+                taskStatusRefreshMaxWait,
+                stats,
+                dynamicFilterResponseCodec,
+                dynamicFilterService,
+                session.getQueryId(),
+                dynamicFilterStats,
+                isVerboseRuntimeStatsEnabled(session),
+                this::failTask);
+        // Build-side DPP collection is C++ only; Java workers use no fetcher.
+        this.shouldFetchDynamicFilters = isDistributedDynamicFilterEnabled(session) && isNativeExecutionEnabled(session);
         this.loggingPrefix = format("Query: %s, Task: %s", session.getQueryId(), taskId);
     }
 
@@ -495,6 +547,10 @@ public final class HttpRemoteTaskWithEventLoop
                 updateSplitQueueSpace();
             }
         });
+
+        if (shouldFetchDynamicFilters) {
+            dynamicFilterFetcher.start();
+        }
 
         updateTaskStats();
         safeExecuteOnEventLoop(this::updateSplitQueueSpace, "updateSplitQueueSpace");
@@ -1156,6 +1212,7 @@ public final class HttpRemoteTaskWithEventLoop
             }
 
             taskStatusFetcher.stop();
+            dynamicFilterFetcher.stopAfterFinalFetch();
 
             // The remote task is likely to get a delete from the PageBufferClient first.
             // We send an additional delete anyway to get the final TaskInfo
@@ -1258,6 +1315,7 @@ public final class HttpRemoteTaskWithEventLoop
         // the entire duration of abort retries. If the task is failed, it is not that important to actually
         // record the final statistics and the final information about a failed task.
         taskInfoFetcher.updateTaskInfo(getTaskInfo().withTaskStatus(failedTaskStatus));
+        dynamicFilterFetcher.abort();
 
         // Initiate abort request
         abort(failedTaskStatus);
@@ -1462,5 +1520,99 @@ public final class HttpRemoteTaskWithEventLoop
     private void safeExecuteOnEventLoop(Runnable r, String methodName)
     {
         taskEventLoop.execute(r, this::failTask, schedulerStatsTracker, loggingPrefix + ", method: " + methodName);
+    }
+
+    private static final int MAX_DYNAMIC_FILTER_PUSH_ATTEMPTS = 3;
+    private static final long MAX_DYNAMIC_FILTER_PUSH_RETRY_DELAY_MS = 5_000;
+
+    @Override
+    public void pushDynamicFilter(PlanNodeId scanNodeId, String filterId, RuntimeFilter constraint)
+    {
+        DynamicFilterPushRequest pushRequest = new DynamicFilterPushRequest(true, scanNodeId.toString(), constraint);
+        byte[] body = pushRequestCodec.toJsonBytes(pushRequest);
+
+        URI uri = uriBuilderFrom(taskLocation)
+                .appendPath("dynamicFilter")
+                .appendPath(filterId)
+                .build();
+
+        sendDynamicFilterPush(uri, body, filterId, 1);
+    }
+
+    private void sendDynamicFilterPush(URI uri, byte[] body, String filterId, int attempt)
+    {
+        Request request = preparePost()
+                .setUri(uri)
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(createStaticBodyGenerator(body))
+                .build();
+
+        long startMs = System.currentTimeMillis();
+        RuntimeStats runtimeStats = session.getRuntimeStats();
+
+        addCallback(httpClient.executeAsync(request, createStatusResponseHandler()), new FutureCallback<StatusResponse>()
+        {
+            @Override
+            public void onSuccess(StatusResponse result)
+            {
+                long latencyMs = System.currentTimeMillis() - startMs;
+                int statusCode = result.getStatusCode();
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_LATENCY_MS, NONE, latencyMs);
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_HTTP_STATUS, NONE, statusCode);
+                if (statusCode == 200) {
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_SUCCESS_COUNT, NONE, 1);
+                }
+                else if (statusCode == 404) {
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_TASK_NOT_FOUND_COUNT, NONE, 1);
+                    log.warn("Dynamic filter push: task %s not found on worker (filter %s, latency %dms)", taskId, filterId, latencyMs);
+                }
+                else if (statusCode == 503) {
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_THROTTLED_COUNT, NONE, 1);
+                    if (attempt >= MAX_DYNAMIC_FILTER_PUSH_ATTEMPTS) {
+                        runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_RETRY_GAVE_UP_COUNT, NONE, 1);
+                        log.warn(
+                                "Dynamic filter push to task %s rejected with HTTP 503 (filter %s, attempt %d, latency %dms); giving up",
+                                taskId, filterId, attempt, latencyMs);
+                        return;
+                    }
+                    long retryDelayMs = Math.min(parseRetryAfterMs(result), MAX_DYNAMIC_FILTER_PUSH_RETRY_DELAY_MS);
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_RETRIED_COUNT, NONE, 1);
+                    log.debug(
+                            "Dynamic filter push to task %s throttled by worker (filter %s, attempt %d); retrying after %dms",
+                            taskId, filterId, attempt, retryDelayMs);
+                    taskEventLoop.schedule(
+                            () -> sendDynamicFilterPush(uri, body, filterId, attempt + 1),
+                            retryDelayMs,
+                            TimeUnit.MILLISECONDS);
+                }
+                else {
+                    runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_FAILURE_COUNT, NONE, 1);
+                    log.warn("Dynamic filter push to task %s returned HTTP %d (filter %s, latency %dms)", taskId, statusCode, filterId, latencyMs);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable throwable)
+            {
+                long latencyMs = System.currentTimeMillis() - startMs;
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_LATENCY_MS, NONE, latencyMs);
+                runtimeStats.addMetricValue(DYNAMIC_FILTER_PUSH_TO_WORKER_FAILURE_COUNT, NONE, 1);
+                log.warn("Failed to push dynamic filter %s to task %s (latency %dms): %s", filterId, taskId, latencyMs, throwable.getMessage());
+            }
+        }, taskEventLoop);
+    }
+
+    private static long parseRetryAfterMs(StatusResponse response)
+    {
+        String header = response.getHeader("Retry-After");
+        if (header == null) {
+            return 1_000;
+        }
+        try {
+            return Math.max(0, Long.parseLong(header.trim()) * 1_000);
+        }
+        catch (NumberFormatException e) {
+            return 1_000;
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -25,6 +25,7 @@ import com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory;
 import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
 import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.StateMachine;
@@ -60,6 +61,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
@@ -241,6 +243,12 @@ public class TestThriftServerInfoIntegration
 
                 @Override
                 public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Map<String, TupleDomain<String>> getDynamicFiltersSince(TaskId taskId, long sinceVersion)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestDynamicFilterFetcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestDynamicFilterFetcher.java
@@ -1,0 +1,737 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.http.client.testing.TestingResponse;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.scheduler.DomainRuntimeFilter;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
+import com.facebook.presto.execution.scheduler.JoinDynamicFilter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static com.facebook.airlift.http.client.HttpStatus.OK;
+import static com.facebook.airlift.http.client.testing.TestingResponse.contentType;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestDynamicFilterFetcher
+{
+    private static final Duration POLL_TIMEOUT = new Duration(100, MILLISECONDS);
+    private static final Duration FAIL_TIMEOUT = new Duration(20, SECONDS);
+    private static final long DEFAULT_MAX_SIZE_BYTES = 1_048_576L; // 1 MB
+
+    private JsonCodec<DynamicFilterResponse> codec;
+    private DefaultEventLoopGroup eventLoopGroup;
+    private EventLoop eventLoop;
+    private DynamicFilterFetcher fetcher;
+
+    @BeforeClass
+    public void setupCodec()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                binder -> {
+                    FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+                    binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+                    binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class);
+                    jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+                    jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+                    jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+                    newSetBinder(binder, Type.class);
+                    jsonCodecBinder(binder).bindJsonCodec(DynamicFilterResponse.class);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+
+        codec = injector.getInstance(new Key<JsonCodec<DynamicFilterResponse>>() {});
+    }
+
+    @BeforeMethod
+    public void setup()
+    {
+        eventLoopGroup = new DefaultEventLoopGroup(1);
+        eventLoop = eventLoopGroup.next();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup()
+            throws Exception
+    {
+        if (fetcher != null) {
+            fetcher.stop();
+        }
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS).sync();
+        }
+    }
+
+    @Test(timeOut = 30000)
+    public void testStopsPollingAfterTooManyFailures()
+            throws Exception
+    {
+        AtomicInteger requestCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            requestCount.incrementAndGet();
+            throw new IOException("Connection refused");
+        });
+
+        DynamicFilterFetcher fetcher = createFetcher(httpClient, new Duration(1, MILLISECONDS));
+        fetcher.start();
+
+        poll(() -> requestCount.get() >= 3);
+
+        Thread.sleep(500);
+        int countAfterStop = requestCount.get();
+        assertTrue(countAfterStop >= 3, "Expected at least 3 requests (Backoff.MIN_RETRIES), got " + countAfterStop);
+
+        Thread.sleep(500);
+        assertEquals(requestCount.get(), countAfterStop,
+                "Fetcher should have stopped polling after too many failures");
+    }
+
+    @Test(timeOut = 30000)
+    public void testStopsPollingOnFatalError()
+            throws Exception
+    {
+        AtomicInteger requestCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            requestCount.incrementAndGet();
+            return new TestingResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ImmutableListMultimap.of(),
+                    "{}".getBytes());
+        });
+
+        DynamicFilterFetcher fetcher = createFetcher(httpClient, new Duration(30, SECONDS));
+        fetcher.start();
+
+        poll(() -> requestCount.get() >= 1);
+        Thread.sleep(500);
+        int countAfterFatal = requestCount.get();
+
+        Thread.sleep(500);
+        assertEquals(requestCount.get(), countAfterFatal,
+                "Fetcher should have stopped immediately on fatal error");
+        assertEquals(countAfterFatal, 1,
+                "Fatal error should stop after first request");
+    }
+
+    @Test(timeOut = 30000)
+    public void testRetriesTransientFailureThenContinues()
+            throws Exception
+    {
+        AtomicInteger requestCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            int count = requestCount.incrementAndGet();
+            if (count <= 2) {
+                throw new IOException("Transient failure");
+            }
+            byte[] body = codec.toJsonBytes(DynamicFilterResponse.incomplete(ImmutableMap.of(), (long) count));
+            return new TestingResponse(OK, contentType(JSON_UTF_8), body);
+        });
+
+        DynamicFilterFetcher fetcher = createFetcher(httpClient, new Duration(30, SECONDS));
+        fetcher.start();
+
+        poll(() -> requestCount.get() >= 5);
+    }
+
+    @Test(timeOut = 30000)
+    public void testPerFilterNoneDelivery()
+            throws Exception
+    {
+        String filterIdA = "filterA";
+        String filterIdB = "filterB";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter filterA = new JoinDynamicFilter(
+                filterIdA, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        filterA.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterIdA, filterA);
+
+        JoinDynamicFilter filterB = new JoinDynamicFilter(
+                filterIdB, "col2", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        filterB.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterIdB, filterB);
+
+        DynamicFilterResponse response = new DynamicFilterResponse(
+                ImmutableMap.of(),
+                1L,
+                false,
+                ImmutableSet.of(filterIdA));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            fetchCount.incrementAndGet();
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(response));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 3);
+
+        assertTrue(filterA.hasData(),
+                "Filter A should have received none() — its pipeline flushed");
+
+        assertFalse(filterB.hasData(),
+                "Filter B should not have received data — its pipeline hasn't flushed");
+    }
+
+    @Test(timeOut = 30000)
+    public void testCompletedFilterWithNoDataDeliversAll()
+            throws Exception
+    {
+        String filterId = "f1";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter joinFilter = new JoinDynamicFilter(
+                filterId, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        joinFilter.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterId, joinFilter);
+
+        TupleDomain<String> allDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, Domain.all(BIGINT)));
+        DynamicFilterResponse response = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterId, allDomain),
+                1L,
+                ImmutableSet.of(filterId));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            fetchCount.incrementAndGet();
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(response));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 1);
+        Thread.sleep(500);
+
+        assertTrue(joinFilter.hasData(), "Filter should have received data");
+        assertTrue(joinFilter.isComplete(), "Filter should be complete (1 of 1 partitions)");
+
+        TupleDomain<String> constraint = joinFilter.getCurrentConstraintByColumnName();
+        assertTrue(constraint.isAll(),
+                "Constraint should be all() (let everything through), but was: " + constraint);
+    }
+
+    @Test(timeOut = 30000)
+    public void testSecondFilterLostWhenFirstFlushSetsOperatorCompleted()
+            throws Exception
+    {
+        String filterIdA = "f1";
+        String filterIdB = "f2";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter filterA = new JoinDynamicFilter(
+                filterIdA, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        filterA.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterIdA, filterA);
+
+        JoinDynamicFilter filterB = new JoinDynamicFilter(
+                filterIdB, "col2", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        filterB.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterIdB, filterB);
+
+        TupleDomain<String> domainA = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterIdA, Domain.singleValue(BIGINT, 42L)));
+        DynamicFilterResponse firstResponse = DynamicFilterResponse.incomplete(
+                ImmutableMap.of(filterIdA, domainA),
+                1L);
+
+        TupleDomain<String> domainB = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterIdB, Domain.singleValue(BIGINT, 99L)));
+        DynamicFilterResponse secondResponse = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterIdB, domainB),
+                2L,
+                ImmutableSet.of(filterIdA, filterIdB));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            int count = fetchCount.incrementAndGet();
+            if (count == 1) {
+                return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(firstResponse));
+            }
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(secondResponse));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 1);
+        Thread.sleep(1000);
+
+        assertTrue(filterA.hasData(), "Filter A should have received data");
+        assertTrue(filterB.hasData(),
+                "Filter B should have received data, but fetcher stopped after first pipeline's flush");
+    }
+
+    @Test(timeOut = 30000)
+    public void testStopsPollingWhenFiltersArriveWithOperatorCompletion()
+            throws Exception
+    {
+        String filterId = "f1";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter joinFilter = new JoinDynamicFilter(
+                filterId, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        joinFilter.setExpectedPartitions(2);
+        dynamicFilterService.registerFilter(queryId, filterId, joinFilter);
+
+        TupleDomain<String> filterDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, Domain.singleValue(BIGINT, 42L)));
+        DynamicFilterResponse completionResponse = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterId, filterDomain),
+                1L,
+                ImmutableSet.of(filterId));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            int count = fetchCount.incrementAndGet();
+            if (count == 1) {
+                return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(completionResponse));
+            }
+            return new TestingResponse(OK, contentType(JSON_UTF_8),
+                    codec.toJsonBytes(DynamicFilterResponse.incomplete(ImmutableMap.of(), (long) count)));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 1);
+        Thread.sleep(500);
+
+        assertEquals(fetchCount.get(), 1,
+                "Fetcher should stop after processing filters with operator completion");
+
+        assertFalse(joinFilter.isComplete(),
+                "Filter should not be complete — only 1 of 2 expected partitions received");
+        assertTrue(joinFilter.hasData(), "Filter should have data from the real partition");
+    }
+
+    /**
+     * Verifies that a TupleDomain with a RANGE (min != max) round-trips
+     * correctly through DynamicFilterResponse JSON serialization. This is the
+     * code path the C++ HashBuild callback uses when VectorHasher overflows
+     * discrete tracking and falls back to min/max range. The C++ sends:
+     *
+     *   {"filters": {"filterId": {"columnDomains": [{"column": "filterId",
+     *      "domain": {"values": {"@type": "sortable", "type": "integer",
+     *        "ranges": [{"low": {"type": "integer", "valueBlock": "...",
+     *        "bound": "EXACTLY"}, "high": {"type": "integer",
+     *        "valueBlock": "...", "bound": "EXACTLY"}}]},
+     *      "nullAllowed": false}}]}}}
+     *
+     * The Marker.valueBlock is a base64-encoded Presto Block with a single
+     * integer value. If the Block round-trips with getValue() == null, the
+     * coordinator crashes with NPE in JoinDynamicFilter.addPartitionByFilterId.
+     */
+    @Test(timeOut = 30000)
+    public void testFilterWithDataAndCompletedIdMarksAsFinal()
+            throws Exception
+    {
+        String filterId = "f1";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter joinFilter = new JoinDynamicFilter(
+                filterId, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        joinFilter.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterId, joinFilter);
+
+        TupleDomain<String> filterDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, Domain.singleValue(BIGINT, 42L)));
+        DynamicFilterResponse response = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterId, filterDomain),
+                1L,
+                ImmutableSet.of(filterId));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            fetchCount.incrementAndGet();
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(response));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 1);
+        Thread.sleep(500);
+
+        assertTrue(joinFilter.isComplete(),
+                "Filter should complete when delivered with isFinal=true");
+        TupleDomain<String> constraint = joinFilter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(), "Constraint should reflect the delivered domain");
+    }
+
+    @Test(timeOut = 30000)
+    public void testFilterDeliveredOncePerTaskAcrossMultiplePolls()
+            throws Exception
+    {
+        String filterId = "f1";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter joinFilter = new JoinDynamicFilter(
+                filterId, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        joinFilter.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterId, joinFilter);
+
+        TupleDomain<String> partialDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, Domain.singleValue(BIGINT, 42L)));
+        DynamicFilterResponse partialResponse = DynamicFilterResponse.incomplete(
+                ImmutableMap.of(filterId, partialDomain),
+                1L);
+        DynamicFilterResponse completionResponse = DynamicFilterResponse.completed(
+                ImmutableMap.of(),
+                2L,
+                ImmutableSet.of(filterId));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            int count = fetchCount.incrementAndGet();
+            if (count == 1) {
+                return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(partialResponse));
+            }
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(completionResponse));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 2);
+        Thread.sleep(500);
+
+        assertTrue(joinFilter.isComplete(),
+                "Filter should complete after the second response marks the prior partial as final");
+        TupleDomain<String> constraint = joinFilter.getCurrentConstraintByColumnName();
+        assertFalse(constraint.isAll(),
+                "Final constraint should be the prior partial domain, not all()");
+        assertEquals(constraint,
+                TupleDomain.withColumnDomains(ImmutableMap.of("col1", Domain.singleValue(BIGINT, 42L))),
+                "Final constraint should be the partial domain delivered earlier");
+    }
+
+    @Test(timeOut = 30000)
+    public void testEmptyBuildPathDeliversNoneAsFinal()
+            throws Exception
+    {
+        String filterId = "f1";
+        QueryId queryId = new QueryId("test");
+
+        DynamicFilterService dynamicFilterService = new DynamicFilterService();
+        JoinDynamicFilter joinFilter = new JoinDynamicFilter(
+                filterId, "col1", new Duration(10, SECONDS), DEFAULT_MAX_SIZE_BYTES, new DynamicFilterStats(), new RuntimeStats(), false);
+        joinFilter.setExpectedPartitions(1);
+        dynamicFilterService.registerFilter(queryId, filterId, joinFilter);
+
+        DynamicFilterResponse response = DynamicFilterResponse.completed(
+                ImmutableMap.of(),
+                1L,
+                ImmutableSet.of(filterId));
+
+        AtomicInteger fetchCount = new AtomicInteger();
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            if ("DELETE".equals(request.getMethod())) {
+                return new TestingResponse(OK, ImmutableListMultimap.of(), new byte[0]);
+            }
+            fetchCount.incrementAndGet();
+            return new TestingResponse(OK, contentType(JSON_UTF_8), codec.toJsonBytes(response));
+        });
+
+        fetcher = createFetcher(httpClient, new Duration(30, SECONDS), dynamicFilterService);
+        fetcher.start();
+
+        poll(() -> fetchCount.get() >= 1);
+        Thread.sleep(500);
+
+        assertTrue(joinFilter.hasData(),
+                "Empty-build path must record a contribution (none())");
+        assertTrue(joinFilter.isComplete(),
+                "Empty-build delivery is final and must complete the filter");
+        TupleDomain<String> constraint = joinFilter.getCurrentConstraintByColumnName();
+        assertTrue(constraint.isNone(),
+                "Empty-build contribution should produce a none() constraint");
+    }
+
+    @Test
+    public void testRangeFilterRoundTrip()
+            throws Exception
+    {
+        Domain rangeDomain = Domain.create(
+                com.facebook.presto.common.predicate.ValueSet.ofRanges(
+                        com.facebook.presto.common.predicate.Range.range(
+                                BIGINT, 10L, true, 100000L, true)),
+                false);
+
+        String filterId = "test_filter";
+        TupleDomain<String> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, rangeDomain));
+
+        DynamicFilterResponse response = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterId, tupleDomain),
+                1L,
+                ImmutableSet.of(filterId));
+
+        byte[] jsonBytes = codec.toJsonBytes(response);
+        DynamicFilterResponse parsed = codec.fromJson(jsonBytes);
+
+        assertTrue(parsed.getFilters().containsKey(filterId),
+                "Parsed response should contain filter " + filterId);
+
+        TupleDomain<String> parsedDomain = asDomain(parsed.getFilters().get(filterId));
+        assertFalse(parsedDomain.isAll(), "Parsed domain should not be all()");
+        assertFalse(parsedDomain.isNone(), "Parsed domain should not be none()");
+
+        Domain parsedColumnDomain = parsedDomain.getDomains().get().get(filterId);
+        com.facebook.presto.common.predicate.SortedRangeSet rangeSet =
+                (com.facebook.presto.common.predicate.SortedRangeSet)
+                        parsedColumnDomain.getValues();
+
+        com.facebook.presto.common.predicate.Range parsedRange =
+                rangeSet.getOrderedRanges().get(0);
+        assertFalse(parsedRange.getLow().isLowerUnbounded(),
+                "Low bound should not be unbounded");
+        assertFalse(parsedRange.getHigh().isUpperUnbounded(),
+                "High bound should not be unbounded");
+        assertEquals(parsedRange.getLow().getValue(), 10L,
+                "Low bound value should be 10");
+        assertEquals(parsedRange.getHigh().getValue(), 100000L,
+                "High bound value should be 100000");
+    }
+
+    /**
+     * Same as testRangeFilterRoundTrip but uses INTEGER type (not BIGINT)
+     * to match the production c_customer_sk column type. The C++ code's
+     * toTypedVariant returns variant(int32_t) for INTEGER, which might
+     * serialize differently than variant(int64_t) for BIGINT.
+     */
+    @Test
+    public void testRangeFilterRoundTripInteger()
+            throws Exception
+    {
+        com.facebook.presto.common.type.Type integerType =
+                com.facebook.presto.common.type.IntegerType.INTEGER;
+        Domain rangeDomain = Domain.create(
+                com.facebook.presto.common.predicate.ValueSet.ofRanges(
+                        com.facebook.presto.common.predicate.Range.range(
+                                integerType, (long) 10, true, (long) 100000, true)),
+                false);
+
+        String filterId = "test_filter_int";
+        TupleDomain<String> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(filterId, rangeDomain));
+
+        DynamicFilterResponse response = DynamicFilterResponse.completed(
+                ImmutableMap.of(filterId, tupleDomain),
+                1L,
+                ImmutableSet.of(filterId));
+
+        byte[] jsonBytes = codec.toJsonBytes(response);
+        DynamicFilterResponse parsed = codec.fromJson(jsonBytes);
+
+        TupleDomain<String> parsedDomain = asDomain(parsed.getFilters().get(filterId));
+        Domain parsedColumnDomain = parsedDomain.getDomains().get().get(filterId);
+        com.facebook.presto.common.predicate.SortedRangeSet rangeSet =
+                (com.facebook.presto.common.predicate.SortedRangeSet)
+                        parsedColumnDomain.getValues();
+
+        com.facebook.presto.common.predicate.Range parsedRange =
+                rangeSet.getOrderedRanges().get(0);
+        assertEquals(parsedRange.getLow().getValue(), (long) 10,
+                "INTEGER low bound should round-trip as long 10");
+        assertEquals(parsedRange.getHigh().getValue(), (long) 100000,
+                "INTEGER high bound should round-trip as long 100000");
+    }
+
+    /**
+     * Tests deserialization of a DynamicFilterResponse JSON constructed to
+     * match what the C++ native worker sends. The valueBlock bytes are
+     * manually constructed in Presto's block encoding format (INT_ARRAY
+     * for integer, same format as PrestoVectorSerde's serializeSingleColumn).
+     * <p>
+     * Format for INT_ARRAY with 1 non-null value (22 bytes):
+     *   [4 bytes: encoding name length = 9]
+     *   [9 bytes: "INT_ARRAY"]
+     *   [4 bytes: positionCount = 1]
+     *   [1 byte : hasNulls = 0]
+     *   [4 bytes: int32 value, little-endian]
+     * <p>
+     * If this test fails, the C++ PrestoVectorSerde format does NOT match
+     * Java's BlockEncodingSerde expectations.
+     */
+    @Test
+    public void testCppSerializedBlockDeserialization()
+            throws Exception
+    {
+        // Construct the raw bytes that C++ PrestoVectorSerde.serializeSingleColumn
+        // would produce for a ConstantVector<int32_t>(42) of size 1.
+        byte[] blockBytes = new byte[] {
+                // Encoding name length = 9 (little-endian int32)
+                0x09, 0x00, 0x00, 0x00,
+                // Encoding name "INT_ARRAY"
+                0x49, 0x4E, 0x54, 0x5F, 0x41, 0x52, 0x52, 0x41, 0x59,
+                // positionCount = 1 (little-endian int32)
+                0x01, 0x00, 0x00, 0x00,
+                // hasNulls = false (single byte)
+                0x00,
+                // values[0] = 42 (little-endian int32)
+                0x2A, 0x00, 0x00, 0x00
+        };
+        String base64Block = java.util.Base64.getMimeEncoder(-1, new byte[0]).encodeToString(blockBytes);
+
+        String json = String.format(
+                "{\"filters\":{\"test_filter\":{\"columnDomains\":[{\"column\":\"test_filter\","
+                        + "\"domain\":{\"values\":{\"@type\":\"sortable\",\"type\":\"integer\","
+                        + "\"ranges\":[{\"low\":{\"type\":\"integer\",\"valueBlock\":\"%s\","
+                        + "\"bound\":\"EXACTLY\"},\"high\":{\"type\":\"integer\","
+                        + "\"valueBlock\":\"%s\",\"bound\":\"EXACTLY\"}}]},"
+                        + "\"nullAllowed\":false}}]}},"
+                        + "\"version\":1,\"operatorCompleted\":true,"
+                        + "\"completedFilterIds\":[\"test_filter\"]}",
+                base64Block, base64Block);
+
+        DynamicFilterResponse parsed = codec.fromJson(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        TupleDomain<String> parsedDomain = asDomain(parsed.getFilters().get("test_filter"));
+        assertFalse(parsedDomain.isNone(), "Parsed domain should not be none()");
+        assertFalse(parsedDomain.isAll(), "Parsed domain should not be all()");
+
+        Domain columnDomain = parsedDomain.getDomains().get().get("test_filter");
+        com.facebook.presto.common.predicate.SortedRangeSet rangeSet =
+                (com.facebook.presto.common.predicate.SortedRangeSet) columnDomain.getValues();
+
+        com.facebook.presto.common.predicate.Range range = rangeSet.getOrderedRanges().get(0);
+        assertEquals(range.getLow().getValue(), 42L,
+                "C++ serialized INT_ARRAY block should deserialize with value 42");
+        assertEquals(range.getHigh().getValue(), 42L,
+                "C++ serialized INT_ARRAY block should deserialize with value 42");
+    }
+
+    private DynamicFilterFetcher createFetcher(TestingHttpClient httpClient, Duration maxErrorDuration)
+    {
+        return createFetcher(httpClient, maxErrorDuration, new DynamicFilterService());
+    }
+
+    private DynamicFilterFetcher createFetcher(TestingHttpClient httpClient, Duration maxErrorDuration, DynamicFilterService dynamicFilterService)
+    {
+        fetcher = new DynamicFilterFetcher(
+                new TaskId("test", 1, 0, 2, 0),
+                URI.create("http://fake.invalid/task/node-id/"),
+                httpClient,
+                eventLoop,
+                maxErrorDuration,
+                new Duration(100, MILLISECONDS),
+                new RemoteTaskStats(),
+                codec,
+                dynamicFilterService,
+                new QueryId("test"),
+                new DynamicFilterStats(),
+                false,
+                throwable -> {});
+        return fetcher;
+    }
+
+    private static TupleDomain<String> asDomain(Object filter)
+    {
+        return ((DomainRuntimeFilter) filter).getDomain();
+    }
+
+    private static void poll(BooleanSupplier success)
+            throws InterruptedException
+    {
+        long failAt = System.nanoTime() + FAIL_TIMEOUT.roundTo(NANOSECONDS);
+        while (!success.getAsBoolean()) {
+            long millisUntilFail = (failAt - System.nanoTime()) / 1_000_000;
+            if (millisUntilFail <= 0) {
+                throw new AssertionError("Timeout of " + FAIL_TIMEOUT + " reached");
+            }
+            Thread.sleep(min(POLL_TIMEOUT.toMillis(), millisUntilFail));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestDynamicFilterResponse.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestDynamicFilterResponse.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.scheduler.DomainRuntimeFilter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDynamicFilterResponse
+{
+    private JsonCodec<DynamicFilterResponse> codec;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                binder -> {
+                    FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+                    binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+                    binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class);
+                    jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+                    jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+                    jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+                    newSetBinder(binder, Type.class);
+                    jsonCodecBinder(binder).bindJsonCodec(DynamicFilterResponse.class);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+
+        codec = injector.getInstance(new Key<JsonCodec<DynamicFilterResponse>>() {});
+    }
+
+    @Test
+    public void testEmptyFilters()
+    {
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(ImmutableMap.of(), 1L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        assertEquals(deserialized.getFilters().size(), 0);
+        assertEquals(deserialized.getVersion(), 1L);
+    }
+
+    @Test
+    public void testSingleFilter()
+    {
+        TupleDomain<String> filter = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col1", Domain.singleValue(BIGINT, 42L)));
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(
+                ImmutableMap.of("filter1", filter), 2L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        assertEquals(deserialized.getFilters().size(), 1);
+        assertEquals(deserialized.getVersion(), 2L);
+        assertTrue(deserialized.getFilters().containsKey("filter1"));
+
+        TupleDomain<String> deserializedFilter = asDomain(deserialized.getFilters().get("filter1"));
+        assertNotNull(deserializedFilter);
+        assertTrue(deserializedFilter.getDomains().isPresent());
+        assertEquals(deserializedFilter.getDomains().get().size(), 1);
+    }
+
+    @Test
+    public void testMultipleFilters()
+    {
+        TupleDomain<String> filter1 = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col1", Domain.singleValue(BIGINT, 1L)));
+        TupleDomain<String> filter2 = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col2", Domain.singleValue(VARCHAR, utf8Slice("value"))));
+        TupleDomain<String> filter3 = TupleDomain.withColumnDomains(
+                ImmutableMap.of("col3", Domain.singleValue(BIGINT, 100L)));
+
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(
+                ImmutableMap.of("filter1", filter1, "filter2", filter2, "filter3", filter3), 5L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        assertEquals(deserialized.getFilters().size(), 3);
+        assertEquals(deserialized.getVersion(), 5L);
+        assertTrue(deserialized.getFilters().containsKey("filter1"));
+        assertTrue(deserialized.getFilters().containsKey("filter2"));
+        assertTrue(deserialized.getFilters().containsKey("filter3"));
+    }
+
+    @Test
+    public void testVersionField()
+    {
+        DynamicFilterResponse response1 = DynamicFilterResponse.incomplete(ImmutableMap.of(), 0L);
+        DynamicFilterResponse response2 = DynamicFilterResponse.incomplete(ImmutableMap.of(), Long.MAX_VALUE);
+
+        DynamicFilterResponse deserialized1 = codec.fromJson(codec.toJson(response1));
+        DynamicFilterResponse deserialized2 = codec.fromJson(codec.toJson(response2));
+
+        assertEquals(deserialized1.getVersion(), 0L);
+        assertEquals(deserialized2.getVersion(), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testTupleDomainAll()
+    {
+        TupleDomain<String> filter = TupleDomain.all();
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(
+                ImmutableMap.of("allFilter", filter), 3L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        TupleDomain<String> deserializedFilter = asDomain(deserialized.getFilters().get("allFilter"));
+        assertNotNull(deserializedFilter);
+        assertTrue(deserializedFilter.isAll());
+    }
+
+    @Test
+    public void testTupleDomainNone()
+    {
+        TupleDomain<String> filter = TupleDomain.none();
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(
+                ImmutableMap.of("noneFilter", filter), 4L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        TupleDomain<String> deserializedFilter = asDomain(deserialized.getFilters().get("noneFilter"));
+        assertNotNull(deserializedFilter);
+        assertTrue(deserializedFilter.isNone());
+    }
+
+    @Test
+    public void testTupleDomainWithDomains()
+    {
+        Map<String, Domain> domains = ImmutableMap.of(
+                "bigint_col", Domain.singleValue(BIGINT, 123L),
+                "varchar_col", Domain.singleValue(VARCHAR, utf8Slice("test_value")));
+        TupleDomain<String> filter = TupleDomain.withColumnDomains(domains);
+        DynamicFilterResponse original = DynamicFilterResponse.incomplete(
+                ImmutableMap.of("complexFilter", filter), 6L);
+
+        String json = codec.toJson(original);
+        DynamicFilterResponse deserialized = codec.fromJson(json);
+
+        TupleDomain<String> deserializedFilter = asDomain(deserialized.getFilters().get("complexFilter"));
+        assertNotNull(deserializedFilter);
+        assertTrue(deserializedFilter.getDomains().isPresent());
+        assertEquals(deserializedFilter.getDomains().get().size(), 2);
+
+        Domain bigintDomain = deserializedFilter.getDomains().get().get("bigint_col");
+        Domain varcharDomain = deserializedFilter.getDomains().get().get("varchar_col");
+        assertNotNull(bigintDomain);
+        assertNotNull(varcharDomain);
+        assertTrue(bigintDomain.isSingleValue());
+        assertTrue(varcharDomain.isSingleValue());
+        assertEquals(bigintDomain.getSingleValue(), 123L);
+        assertEquals(varcharDomain.getSingleValue(), utf8Slice("test_value"));
+    }
+
+    private static TupleDomain<String> asDomain(Object filter)
+    {
+        return ((DomainRuntimeFilter) filter).getDomain();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
@@ -52,6 +52,8 @@ import com.facebook.presto.execution.TaskTestUtils;
 import com.facebook.presto.execution.TestQueryManager;
 import com.facebook.presto.execution.TestSqlTaskManager;
 import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
 import com.facebook.presto.execution.scheduler.ExecutionWriterTarget;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.ColumnHandleJacksonModule;
@@ -777,7 +779,11 @@ public class TestHttpRemoteTaskConnectorCodec
                                 internalCommunicationConfig,
                                 createTestMetadataManager(),
                                 new TestQueryManager(),
-                                new HandleResolver());
+                                new HandleResolver(),
+                                new DynamicFilterService(),
+                                new DynamicFilterStats(),
+                                JsonCodec.jsonCodec(DynamicFilterResponse.class),
+                                JsonCodec.jsonCodec(DynamicFilterPushRequest.class));
                     }
                 });
         Injector injector = app

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
@@ -50,6 +50,8 @@ import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.TestQueryManager;
 import com.facebook.presto.execution.TestSqlTaskManager;
 import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
+import com.facebook.presto.execution.scheduler.DynamicFilterStats;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.HandleJsonModule;
@@ -463,7 +465,11 @@ public class TestHttpRemoteTaskWithEventLoop
                                 internalCommunicationConfig,
                                 createTestMetadataManager(),
                                 new TestQueryManager(),
-                                new HandleResolver());
+                                new HandleResolver(),
+                                new DynamicFilterService(),
+                                new DynamicFilterStats(),
+                                JsonCodec.jsonCodec(DynamicFilterResponse.class),
+                                JsonCodec.jsonCodec(DynamicFilterPushRequest.class));
                     }
                 });
         Injector injector = app

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spark.node;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -27,9 +28,11 @@ import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class PrestoSparkTaskManager
@@ -129,5 +132,11 @@ public class PrestoSparkTaskManager
     public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, TupleDomain<String>> getDynamicFiltersSince(TaskId taskId, long sinceVersion)
+    {
+        return ImmutableMap.of();
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -20,6 +20,7 @@ import com.facebook.airlift.units.DataSize;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.scheduler.DynamicFilterService;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
@@ -230,7 +231,7 @@ public class PrestoSparkRddFactory
         List<PrestoSparkSource> sources = findTableScanNodes(fragment.getRoot());
         if (!sources.isEmpty()) {
             try (CloseableSplitSourceProvider splitSourceProvider = new CloseableSplitSourceProvider(splitManager)) {
-                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP, metadata);
+                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP, new DynamicFilterService(), metadata);
                 Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(fragment, session, tableWriteInfo);
                 taskSourceRdd = Optional.of(createTaskSourcesRdd(
                         fragment.getId(),


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

