### PR TITLE
chore(ci): Advance Velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -573,6 +573,14 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
       auto spillDiskOpts =
           getTaskSpillOptions(taskId, planFragment, queryCtx, baseSpillDir);
 
+      // taskUniqueId namespaces the ids AssignUniqueId generates across the
+      // tasks of a stage; Velox reads it from PlanFragment. Last 10 bits of
+      // stageId | last 14 bits of taskId fits PlanFragment's 24-bit budget.
+      auto taskPlanFragment = planFragment;
+      taskPlanFragment.taskUniqueId =
+          (prestoTask->id.stageId() & ((1 << 10) - 1)) << 14 |
+          (prestoTask->id.id() & ((1 << 14) - 1));
+
       // Uses a temp variable to store the created velox task to destroy it
       // under presto task lock if spill directory setup fails. Otherwise, the
       // concurrent task creation retry from the coordinator might see the
@@ -581,7 +589,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
       // root memory pool.
       auto newExecTask = exec::Task::create(
           taskId,
-          planFragment,
+          taskPlanFragment,
           prestoTask->id.id(),
           std::move(queryCtx),
           exec::Task::ExecutionMode::kParallel,

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1809,21 +1809,9 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::AssignUniqueId>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
-  const auto prestoTaskId = PrestoTaskId(taskId);
-  // `taskUniqueId` is an integer to uniquely identify the generated id
-  // across all the nodes executing the same query stage in a distributed
-  // query execution.
-  //
-  // 10 bit for stageId && 14-bit for taskId should be sufficient
-  // given the max stage per query is 100 by default.
-
-  // taskUniqueId = last 10 bit of stageId | last 14 bits of taskId
-  int32_t taskUniqueId = (prestoTaskId.stageId() & ((1 << 10) - 1)) << 14 |
-      (prestoTaskId.id() & ((1 << 14) - 1));
   return std::make_shared<core::AssignUniqueIdNode>(
       node->id,
       node->idVariable.name,
-      taskUniqueId,
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 


### PR DESCRIPTION
Adapt to "refactor(exec): Move AssignUniqueId task id to PlanFragment"
(https://github.com/facebookincubator/velox/pull/17915): taskUniqueId
moved off AssignUniqueIdNode and onto core::PlanFragment, supplied at
task creation, so a plan can be shared across the tasks of a stage.

PrestoToVeloxQueryPlan now constructs AssignUniqueIdNode without
taskUniqueId and instead sets PlanFragment::taskUniqueId in the
fragment-level converter, using the same stageId/taskId packing as
before (last 10 bits of stageId | last 14 bits of taskId).

== RELEASE NOTES ==

No release note required.

## Summary by Sourcery

Enhancements:
- Stop passing taskUniqueId into AssignUniqueIdNode and instead compute and set it on core::PlanFragment during fragment conversion, preserving the existing stage/task ID packing scheme.