### PR TITLE
refactor: Remove deprecated toHiveTableHandle overload

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -831,32 +831,6 @@ connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
   }
 }
 
-// DEPRECATED: delegates to the overload that takes `indexColumns`; retained for
-// backward compatibility while callers are migrated, and will be removed.
-std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
-    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
-    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
-    const std::string& tableName,
-    const protocol::List<protocol::Column>& dataColumns,
-    const protocol::TableHandle& tableHandle,
-    const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
-        columnHandles,
-    const protocol::Map<protocol::String, protocol::String>& tableParameters,
-    const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser) {
-  return toHiveTableHandle(
-      domainPredicate,
-      remainingPredicate,
-      tableName,
-      dataColumns,
-      /*indexColumns=*/{},
-      tableHandle,
-      columnHandles,
-      tableParameters,
-      exprConverter,
-      typeParser);
-}
-
 std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
     const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
     const std::shared_ptr<protocol::RowExpression>& remainingPredicate,

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
@@ -52,21 +52,6 @@ velox::common::CompressionKind toFileCompressionKind(
 velox::connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
     protocol::hive::ColumnType type);
 
-/// DEPRECATED: prefer the overload below that takes `indexColumns`. This
-/// signature is retained only for backward compatibility while callers are
-/// migrated, and will be removed.
-std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
-    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
-    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
-    const std::string& tableName,
-    const protocol::List<protocol::Column>& dataColumns,
-    const protocol::TableHandle& tableHandle,
-    const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
-        columnHandles,
-    const protocol::Map<protocol::String, protocol::String>& tableParameters,
-    const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser);
-
 /// Threads index columns into the resulting handle so index lookups can reuse
 /// this conversion path. Index columns are placed right after dataColumns to
 /// mirror the velox HiveTableHandle constructor ordering.


### PR DESCRIPTION
Summary: All callers now use the `toHiveTableHandle` overload that takes `indexColumns` (after `dataColumns`). Remove the deprecated overload that omitted `indexColumns` along with its delegating implementation, leaving a single conversion entry point.

Reviewed By: xiaoxmeng

## Summary by Sourcery

Enhancements:
- Simplify Presto-to-Velox Hive table handle conversion API by relying solely on the indexColumns-aware toHiveTableHandle signature.

## Release Notes

```
== NO RELEASE NOTE ==
```
