### PR TITLE
chore(build): Add @imjalpreet and @kevintang2022 as module committers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -116,7 +116,7 @@ CODEOWNERS @prestodb/team-tsc
 #####################################################################
 # Prestissimo module
 /presto-native-execution @prestodb/team-velox @prestodb/committers
-/presto-native-sidecar-plugin @pdabre12 @prestodb/team-velox @prestodb/committers
+/presto-native-sidecar-plugin @pdabre12 @kevintang2022 @prestodb/team-velox @prestodb/committers
 /presto-native-tests @prestodb/team-velox @prestodb/committers
 /presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java  @prestodb/team-velox @prestodb/committers
 /.github/workflows/prestocpp-* @prestodb/team-velox @prestodb/committers
@@ -133,7 +133,7 @@ CODEOWNERS @prestodb/team-tsc
 /presto-hudi @vinothchandar @7c00 @prestodb/committers
 
 # Iceberg connector
-/presto-iceberg @hantangwangd @ZacBlanco @prestodb/committers
+/presto-iceberg @hantangwangd @ZacBlanco @imjalpreet @prestodb/committers
 
 # Ranger Hive plugin
 /presto-hive/**/com/facebook/presto/hive/security/ranger @agrawalreetika @prestodb/committers


### PR DESCRIPTION
## Description
The TSC voted and approved @imjalpreet to be a module committer for Iceberg and @kevintang2022 to be a module committer for the sidecar module.  Updating the codeowner file to reflect that.

@czentgr was approved to be module committer for the native execution module, however this is tracked via team membership in @prestodb/team-velox.  @imjalpreet was also approved to be a general commiter, this is tracked via @prestodb/committers membership.

## Motivation and Context
Expand the folks who can help merge code.

## Impact


## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update repository ownership metadata to reflect newly approved module committers in CODEOWNERS.

Chores:
- Add @imjalpreet as module committer for the Iceberg module in CODEOWNERS.
- Add @kevintang2022 as module committer for the sidecar module in CODEOWNERS.