### PR TITLE
feat: Pass filter condition to conflict detection during Iceberg update

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -208,6 +208,10 @@ public class Analysis
     private Optional<List<ColumnMetadata>> updatedColumns = Optional.empty();
     private Optional<MergeAnalysis> mergeAnalysis = Optional.empty();
 
+    // The update/delete WHERE predicate (empty when there is no WHERE),
+    // carried to the connector at execution time so it can restrict the conflict detection scope.
+    private Optional<RowExpression> writePredicateScope = Optional.empty();
+
     // for describe input and describe output
     private final boolean isDescribe;
 
@@ -808,6 +812,16 @@ public class Analysis
     public Optional<List<ColumnMetadata>> getUpdatedColumns()
     {
         return updatedColumns;
+    }
+
+    public void setWritePredicateScope(Optional<RowExpression> writePredicateScope)
+    {
+        this.writePredicateScope = writePredicateScope;
+    }
+
+    public Optional<RowExpression> getWritePredicateScope()
+    {
+        return writePredicateScope;
     }
 
     public Optional<MergeAnalysis> getMergeAnalysis()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -29,11 +29,13 @@ import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.hive.BaseHiveColumnHandle;
 import com.facebook.presto.hive.HiveOutputInfo;
 import com.facebook.presto.hive.HiveOutputMetadata;
 import com.facebook.presto.hive.HivePartition;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.PartitionSet;
+import com.facebook.presto.hive.SubfieldExtractor;
 import com.facebook.presto.hive.UnknownTableTypeException;
 import com.facebook.presto.iceberg.changelog.ChangelogOperation;
 import com.facebook.presto.iceberg.changelog.ChangelogUtil;
@@ -82,6 +84,7 @@ import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.procedure.BaseProcedure;
 import com.facebook.presto.spi.procedure.DistributedProcedure;
 import com.facebook.presto.spi.procedure.ProcedureRegistry;
+import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.security.ViewSecurity;
@@ -775,7 +778,11 @@ public abstract class IcebergAbstractMetadata
                 .collect(toImmutableList()), icebergTable.location())));
     }
 
-    private Optional<ConnectorOutputMetadata> finishWrite(ConnectorSession session, SchemaTableName tableName, IcebergWritableTableHandle writableTableHandle, Collection<Slice> fragments, ChangelogOperation operationType)
+    private Optional<ConnectorOutputMetadata> finishWrite(ConnectorSession session, SchemaTableName tableName,
+                                                          IcebergWritableTableHandle writableTableHandle,
+                                                          Collection<Slice> fragments,
+                                                          ChangelogOperation operationType,
+                                                          Optional<RowExpression> writeScope)
     {
         if (fragments.isEmpty()) {
             return Optional.empty();
@@ -792,6 +799,22 @@ public abstract class IcebergAbstractMetadata
         Optional<String> branchName = writableTableHandle.getTableName().getBranchName();
         if (branchName.isPresent()) {
             rowDelta.toBranch(branchName.get());
+        }
+
+        if (writeScope != null && writeScope.isPresent()) {
+            DomainTranslator.ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
+                    .fromPredicate(session, writeScope.get(), new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session).toColumnExtractor());
+
+            Map<String, IcebergColumnHandle> nameToColumnHandlesMapping = getColumns(icebergTable.schema(), icebergTable.spec(), typeManager)
+                    .stream()
+                    .collect(Collectors.toMap(BaseHiveColumnHandle::getName, e -> e));
+            TupleDomain<IcebergColumnHandle> entireColumnDomain = decomposedFilter.getTupleDomain()
+                    .transform(subfield -> subfield.getPath().isEmpty() ? subfield.getRootName() : null)
+                    .transform(nameToColumnHandlesMapping::get);
+
+            if (!entireColumnDomain.isAll()) {
+                rowDelta.conflictDetectionFilter(toIcebergExpression(entireColumnDomain));
+            }
         }
 
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
@@ -970,7 +993,7 @@ public abstract class IcebergAbstractMetadata
 
         finishWrite(session,
                 new SchemaTableName(insertTableHandle.getSchemaName(), insertTableHandle.getTableName().getTableName()),
-                insertTableHandle, fragments, UPDATE_AFTER);
+                insertTableHandle, fragments, UPDATE_AFTER, Optional.empty());
     }
 
     @Override
@@ -1822,7 +1845,7 @@ public abstract class IcebergAbstractMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
@@ -1841,6 +1864,7 @@ public abstract class IcebergAbstractMetadata
             throw new RuntimeException("Iceberg table updates require at least format version 2 and update mode must be merge-on-read");
         }
         validateTableMode(session, icebergTable);
+        this.transactionContext.setQueryWriteScope(session.getQueryId(), updateScope);
         return handle
                 .withUpdatedColumns(updatedColumns.stream()
                         .map(IcebergColumnHandle.class::cast)
@@ -1863,7 +1887,8 @@ public abstract class IcebergAbstractMetadata
                 getCompressionCodec(session),
                 icebergTable.properties(),
                 handle.getSortOrder());
-        finishWrite(session, handle.getSchemaTableName(), outputTableHandle, fragments, UPDATE_AFTER);
+        finishWrite(session, handle.getSchemaTableName(), outputTableHandle, fragments, UPDATE_AFTER,
+                this.transactionContext.getQueryWriteScope(session.getQueryId()));
     }
 
     protected Optional<String> getDataLocationBasedOnWarehouseDataDir(SchemaTableName schemaTableName)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -784,6 +784,7 @@ public abstract class IcebergAbstractMetadata
                                                           ChangelogOperation operationType,
                                                           Optional<RowExpression> writeScope)
     {
+        requireNonNull(writeScope, "writeScope is null");
         if (fragments.isEmpty()) {
             return Optional.empty();
         }
@@ -801,9 +802,9 @@ public abstract class IcebergAbstractMetadata
             rowDelta.toBranch(branchName.get());
         }
 
-        if (writeScope != null && writeScope.isPresent()) {
+        writeScope.ifPresent(scope -> {
             DomainTranslator.ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
-                    .fromPredicate(session, writeScope.get(), new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session).toColumnExtractor());
+                    .fromPredicate(session, scope, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session).toColumnExtractor());
 
             Map<String, IcebergColumnHandle> nameToColumnHandlesMapping = getColumns(icebergTable.schema(), icebergTable.spec(), typeManager)
                     .stream()
@@ -815,7 +816,7 @@ public abstract class IcebergAbstractMetadata
             if (!entireColumnDomain.isAll()) {
                 rowDelta.conflictDetectionFilter(toIcebergExpression(entireColumnDomain));
             }
-        }
+        });
 
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
@@ -15,6 +15,7 @@ package com.facebook.presto.iceberg.transaction;
 
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
@@ -49,7 +50,9 @@ import java.util.function.Function;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_TRANSACTION_CONFLICT_ERROR;
 import static com.facebook.presto.iceberg.IcebergUtil.opsFromTable;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterators.getOnlyElement;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.IcebergLibUtils.getScanContext;
 
@@ -61,12 +64,16 @@ public class IcebergTransactionContext
     private final Map<SchemaTableName, Table> initiallyReadTables;
     private final AtomicReference<Runnable> callbacksOnCommit = new AtomicReference<>();
 
+    // The update/delete WHERE predicate (empty when there is no WHERE), used for restricting the conflict detection scope.
+    private final Map<String, Optional<RowExpression>> queryWriteScopes;
+
     public IcebergTransactionContext(IsolationLevel isolationLevel, boolean autoCommitContext)
     {
         this.isolationLevel = requireNonNull(isolationLevel, "isolationLevel is null");
         this.autoCommitContext = autoCommitContext;
         txByTable = new ConcurrentHashMap<>();
         initiallyReadTables = new ConcurrentHashMap<>();
+        queryWriteScopes = new ConcurrentHashMap<>();
     }
 
     public IsolationLevel getIsolationLevel()
@@ -134,6 +141,18 @@ public class IcebergTransactionContext
         this.callbacksOnCommit.set(callback);
     }
 
+    public void setQueryWriteScope(String queryId, Optional<RowExpression> writeScope)
+    {
+        verify(!this.queryWriteScopes.containsKey(queryId),
+                format("write scope for query %s must not null present", queryId));
+        this.queryWriteScopes.put(queryId, writeScope);
+    }
+
+    public Optional<RowExpression> getQueryWriteScope(String queryId)
+    {
+        return this.queryWriteScopes.containsKey(queryId) ? this.queryWriteScopes.get(queryId) : Optional.empty();
+    }
+
     public void commit()
     {
         if (!txByTable.isEmpty()) {
@@ -144,6 +163,7 @@ public class IcebergTransactionContext
             txByTable.clear();
         }
         initiallyReadTables.clear();
+        queryWriteScopes.clear();
         callbacksOnCommit.set(null);
     }
 
@@ -151,6 +171,7 @@ public class IcebergTransactionContext
     {
         txByTable.clear();
         initiallyReadTables.clear();
+        queryWriteScopes.clear();
     }
 
     /**

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
@@ -144,13 +144,13 @@ public class IcebergTransactionContext
     public void setQueryWriteScope(String queryId, Optional<RowExpression> writeScope)
     {
         verify(!this.queryWriteScopes.containsKey(queryId),
-                format("write scope for query %s must not null present", queryId));
+                format("write scope for query %s must not be present", queryId));
         this.queryWriteScopes.put(queryId, writeScope);
     }
 
     public Optional<RowExpression> getQueryWriteScope(String queryId)
     {
-        return this.queryWriteScopes.containsKey(queryId) ? this.queryWriteScopes.get(queryId) : Optional.empty();
+        return this.queryWriteScopes.getOrDefault(queryId, Optional.empty());
     }
 
     public void commit()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -758,4 +758,118 @@ public abstract class TestIcebergDistributedQueries
 
         assertUpdate("drop table " + tableName);
     }
+
+    @Test
+    public void testMultipleConcurrentUpdatesWithNoConflicts()
+    {
+        Session session = getQueryRunner().getDefaultSession();
+        String tableName = "multiple_concurrent_updates_with_no_conflicts";
+        assertUpdate(session, format("create table %s(a int, b varchar) with(partitioning = ARRAY['a'])", tableName));
+        assertUpdate(session, format("insert into %s values(1, '1001'), (2, '1002')", tableName), 2);
+
+        Session txnSession1 = assertStartTransaction(session, "START TRANSACTION");
+        Session txnSession2 = assertStartTransaction(session, "START TRANSACTION");
+
+        assertUpdate(txnSession1, format("update %s set b = '1101' where a = 1", tableName), 1);
+        assertUpdate(txnSession2, format("update %s set b = '1102' where a = 2", tableName), 1);
+
+        // transaction1 can just read its own writes
+        assertQuery(txnSession1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+        // Cannot read any change outside transaction1 and transaction2
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1001'), (2, '1002')");
+
+        // transaction1 commit successfully
+        Session session1 = assertEndTransaction(txnSession1, "commit");
+        // Can read the writes of transaction1 from outside
+        assertQuery(session1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes, unaware of outside change
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+
+        // transaction2 commit successfully
+        Session session2 = assertEndTransaction(txnSession2, "commit");
+        assertQuery(session1, "select * from " + tableName, "values(1, '1101'), (2, '1102')");
+        assertQuery(session2, "select * from " + tableName, "values(1, '1101'), (2, '1102')");
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1102')");
+
+        assertUpdate("drop table " + tableName);
+    }
+
+    @Test
+    public void testMultipleConcurrentUpdatesWithConflictsOnNonPartitionedTable()
+    {
+        Session session = getQueryRunner().getDefaultSession();
+        String tableName = "multiple_concurrent_updates_with_conflicts_non_part";
+        assertUpdate(session, format("create table %s(a int, b varchar)", tableName));
+        assertUpdate(session, format("insert into %s values(1, '1001'), (2, '1002')", tableName), 2);
+
+        Session txnSession1 = assertStartTransaction(session, "START TRANSACTION");
+        Session txnSession2 = assertStartTransaction(session, "START TRANSACTION");
+
+        assertUpdate(txnSession1, format("update %s set b = '1101' where a = 1", tableName), 1);
+        assertUpdate(txnSession2, format("update %s set b = '1102' where a = 2", tableName), 1);
+
+        // transaction1 can just read its own writes
+        assertQuery(txnSession1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+        // Cannot read any change outside transaction1 and transaction2
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1001'), (2, '1002')");
+
+        // transaction1 commit successfully
+        Session session1 = assertEndTransaction(txnSession1, "commit");
+        // Can read the writes of transaction1 from outside
+        assertQuery(session1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes, unaware of outside change
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+
+        // transaction2 commission failed with conflicting delete files
+        assertQueryFails(txnSession2, "commit",
+                "Found new conflicting delete files that can apply to records matching .*");
+
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+
+        assertUpdate("drop table " + tableName);
+    }
+
+    @Test
+    public void testMultipleConcurrentUpdatesWithConflictsOnPartitionedTable()
+    {
+        Session session = getQueryRunner().getDefaultSession();
+        String tableName = "test_multiple_concurrent_updates_with_conflicts";
+        assertUpdate(session, format("create table %s(a int, b varchar) with(partitioning = ARRAY['a'])", tableName));
+        assertUpdate(session, format("insert into %s values(1, '1001'), (2, '1002')", tableName), 2);
+
+        Session txnSession1 = assertStartTransaction(session, "START TRANSACTION");
+        Session txnSession2 = assertStartTransaction(session, "START TRANSACTION");
+
+        assertUpdate(txnSession1, format("update %s set b = '1101' where b = '1001'", tableName), 1);
+        assertUpdate(txnSession2, format("update %s set b = '1102' where b = '1002'", tableName), 1);
+
+        // transaction1 can just read its own writes
+        assertQuery(txnSession1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+        // Cannot read any change outside transaction1 and transaction2
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1001'), (2, '1002')");
+
+        // transaction1 commit successfully
+        Session session1 = assertEndTransaction(txnSession1, "commit");
+        // Can read the writes of transaction1 from outside
+        assertQuery(session1, "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+        // transaction2 can just read its own writes, unaware of outside change
+        assertQuery(txnSession2, "select * from " + tableName, "values(1, '1001'), (2, '1102')");
+
+        // transaction2 commission failed with conflicting delete files
+        assertQueryFails(txnSession2, "commit",
+                "Found new conflicting delete files that can apply to records matching .*");
+
+        assertQuery(getSession(), "select * from " + tableName, "values(1, '1101'), (2, '1002')");
+
+        assertUpdate("drop table " + tableName);
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieRestCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieRestCatalogDistributedQueries.java
@@ -105,6 +105,33 @@ public class TestIcebergNessieRestCatalogDistributedQueries
                 .build().getQueryRunner();
     }
 
+    @Override
+    public void testMultipleConcurrentUpdatesWithNoConflicts()
+    {
+        // The current behavior of Nessie's Iceberg REST is to return only the most recent Iceberg snapshot.
+        // For concurrently executed operations, this will cause the later one to always fail upon commit,
+        // regardless of whether there is a conflict. see issue: https://github.com/projectnessie/nessie/issues/10013
+        // TODO: https://github.com/projectnessie/nessie/pull/10033 tries to fix this issue, enable the test after it's merged
+    }
+
+    @Override
+    public void testMultipleConcurrentUpdatesWithConflictsOnNonPartitionedTable()
+    {
+        // The current behavior of Nessie's Iceberg REST is to return only the most recent Iceberg snapshot.
+        // For concurrently executed operations, this will cause the later one to always fail upon commit,
+        // regardless of whether there is a conflict. see issue: https://github.com/projectnessie/nessie/issues/10013
+        // TODO: https://github.com/projectnessie/nessie/pull/10033 tries to fix this issue, enable the test after it's merged
+    }
+
+    @Override
+    public void testMultipleConcurrentUpdatesWithConflictsOnPartitionedTable()
+    {
+        // The current behavior of Nessie's Iceberg REST is to return only the most recent Iceberg snapshot.
+        // For concurrently executed operations, this will cause the later one to always fail upon commit,
+        // regardless of whether there is a conflict. see issue: https://github.com/projectnessie/nessie/issues/10013
+        // TODO: https://github.com/projectnessie/nessie/pull/10033 tries to fix this issue, enable the test after it's merged
+    }
+
     protected org.apache.hadoop.fs.Path getCatalogDataDirectory()
     {
         return new org.apache.hadoop.fs.Path(URI.create(format("s3a://%s/%s", bucketName, WAREHOUSE_DATA_DIR)));

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -442,9 +442,9 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
     {
-        return delegate.beginUpdate(session, tableHandle, updatedColumns);
+        return delegate.beginUpdate(session, tableHandle, updatedColumns, updateScope);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -391,9 +391,11 @@ public interface Metadata
     void finishCallDistributedProcedure(Session session, DistributedProcedureHandle procedureHandle, QualifiedObjectName procedureName, Collection<Slice> fragments);
 
     /**
-     * Begin update query
+     * Begin update query, carrying the update predicate scope (the analysis-time WHERE predicate;
+     * {@code Optional.empty()} when there is no WHERE) so the engine/connector can restrict the
+     * conflict detection scope if needed.
      */
-    TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns);
+    TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope);
 
     /**
      * Finish update query

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1119,11 +1119,11 @@ public class MetadataManager
     }
 
     @Override
-    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadataForWrite(session, connectorId);
-        ConnectorTableHandle newHandle = metadata.beginUpdate(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), updatedColumns);
+        ConnectorTableHandle newHandle = metadata.beginUpdate(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), updatedColumns, updateScope);
         return new TableHandle(tableHandle.getConnectorId(), newHandle, tableHandle.getTransaction(), tableHandle.getLayout());
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -425,11 +425,11 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
-    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
     {
         long startTime = System.nanoTime();
         try {
-            return delegate.beginUpdate(session, tableHandle, updatedColumns);
+            return delegate.beginUpdate(session, tableHandle, updatedColumns, updateScope);
         }
         finally {
             stats.recordBeginUpdateCall(System.nanoTime() - startTime);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -3592,7 +3592,22 @@ class StatementAnalyzer
                     warningCollector);
 
             Scope tableScope = analyzer.analyze(table, scope);
-            update.getWhere().ifPresent(where -> analyzeWhere(update, tableScope, where));
+            Optional<RowExpression> updateScopePredicate = update.getWhere().map(whereExpression -> {
+                analyzeWhere(update, tableScope, whereExpression);
+                try {
+                    return SqlToRowExpressionTranslator.translate(
+                            whereExpression,
+                            analysis.getTypes(),
+                            ImmutableMap.of(),
+                            metadata.getFunctionAndTypeManager(),
+                            session);
+                }
+                catch (Exception e) {
+                    // Returns Optional.empty() if the WHERE condition cannot be translated.
+                    return null;
+                }
+            });
+            analysis.setWritePredicateScope(updateScopePredicate);
 
             ImmutableList.Builder<ExpressionAnalysis> analysesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> expressionTypesBuilder = ImmutableList.builder();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -3643,7 +3643,22 @@ class StatementAnalyzer
                     warningCollector);
 
             Scope tableScope = analyzer.analyze(table, scope);
-            update.getWhere().ifPresent(where -> analyzeWhere(update, tableScope, where));
+            Optional<RowExpression> updateScopePredicate = update.getWhere().map(whereExpression -> {
+                analyzeWhere(update, tableScope, whereExpression);
+                try {
+                    return SqlToRowExpressionTranslator.translate(
+                            whereExpression,
+                            analysis.getTypes(),
+                            ImmutableMap.of(),
+                            metadata.getFunctionAndTypeManager(),
+                            session);
+                }
+                catch (Exception e) {
+                    // Returns Optional.empty() if the WHERE condition cannot be translated.
+                    return null;
+                }
+            });
+            analysis.setWritePredicateScope(updateScopePredicate);
 
             ImmutableList.Builder<ExpressionAnalysis> analysesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> expressionTypesBuilder = ImmutableList.builder();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -408,7 +408,7 @@ public class QueryPlanner
             rewriteAsMerge = false;
         }
         if (!rewriteAsMerge) {
-            handle = metadata.beginUpdate(session, handle, updatedColumns);
+            handle = metadata.beginUpdate(session, handle, updatedColumns, analysis.getWritePredicateScope());
         }
 
         String catalogName = handle.getConnectorId().getCatalogName();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -466,7 +466,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -678,6 +678,16 @@ public interface ConnectorMetadata
         return Optional.empty();
     }
 
+    /**
+     * Begin update query, carrying the update predicate scope: the {@code UPDATE}
+     * {@code WHERE} predicate captured at analysis time ({@code Optional.empty()} when there is no WHERE).
+     * Connectors that want to restrict the conflict detection scope should override this;
+     */
+    default ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
+    {
+        return beginUpdate(session, tableHandle, updatedColumns);
+    }
+
     default ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support update");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -721,6 +721,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns, Optional<RowExpression> updateScope)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginUpdate(session, tableHandle, updatedColumns, updateScope);
+        }
+    }
+
+    @Override
     public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description

This PR pass the filter condition to conflict detection during Iceberg update. This reduces unnecessary transaction failures caused by overly broad conflict detection during the commission of update operation.

## Motivation and Context

To reduce unnecessary transaction failures caused by overly broad conflict detection.

## Impact

N/A

## Test Plan

Added test cases to verify both conflicting and non-conflicting update scenarios.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Propagate UPDATE statement filter predicates through analysis, planning, and Iceberg connector execution so Iceberg update conflict detection can be restricted to the affected rows, and add coverage for concurrent update scenarios.

New Features:
- Allow connectors to receive the UPDATE WHERE predicate scope when beginning an update, enabling predicate-aware conflict detection.

Enhancements:
- Restrict Iceberg update conflict detection using the analyzed write predicate scope when available.
- Track per-query write predicate scopes in the Iceberg transaction context and clear them on commit or rollback.

Tests:
- Add distributed query tests for concurrent Iceberg UPDATE operations covering non-conflicting and conflicting scenarios on partitioned and non-partitioned tables.
- Override new concurrent update tests in the Nessie Iceberg REST catalog tests due to current catalog limitations.