### PR TITLE
Increase default max task update size

### DIFF
--- a/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
+++ b/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
@@ -44,7 +44,7 @@ public class InternalCommunicationConfig
     private boolean taskUpdateRequestThriftSerdeEnabled;
     private boolean taskInfoResponseThriftSerdeEnabled;
     private Protocol thriftProtocol = Protocol.BINARY;
-    private DataSize maxTaskUpdateSize = new DataSize(16, MEGABYTE);
+    private DataSize maxTaskUpdateSize = new DataSize(32, MEGABYTE);
     private CommunicationProtocol taskCommunicationProtocol = CommunicationProtocol.HTTP;
     private CommunicationProtocol serverInfoCommunicationProtocol = CommunicationProtocol.HTTP;
     private CommunicationProtocol resourceManagerCommunicationProtocol = CommunicationProtocol.THRIFT;

--- a/presto-internal-communication/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
+++ b/presto-internal-communication/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
@@ -42,7 +42,7 @@ public class TestInternalCommunicationConfig
                 .setExcludeCipherSuites(null)
                 .setKerberosUseCanonicalHostname(true)
                 .setBinaryTransportEnabled(false)
-                .setMaxTaskUpdateSize(new DataSize(16, MEGABYTE))
+                .setMaxTaskUpdateSize(new DataSize(32, MEGABYTE))
                 .setTaskCommunicationProtocol(CommunicationProtocol.HTTP)
                 .setServerInfoCommunicationProtocol(CommunicationProtocol.HTTP)
                 .setThriftTransportEnabled(false)


### PR DESCRIPTION
## Description
Increase the default value of `experimental.internal-communication.max-task-update-size` from `16MB` to `32MB`.

Fixes #28074

## Motivation and Context
PR #27220 already overrides this property to `32MB` in `StandaloneQueryRunner` after a generated wide-column test exceeded the `16MB` default. Large production queries with complex task updates can also exceed the current default, with observed failures around the 30-40MB range.

This keeps the limit conservative while aligning the default with the OSS test override. Deployments that need a different value can continue to configure the property explicitly.

## Impact
Clusters that do not override `experimental.internal-communication.max-task-update-size` will allow task update requests up to `32MB` before failing the task.

## Test Plan
`./mvnw -pl presto-internal-communication -Dtest=TestInternalCommunicationConfig test`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Increase the default value of `experimental.internal-communication.max-task-update-size` from `16MB` to `32MB`.
```

## Summary by Sourcery

Increase the default maximum task update size limit in internal communication configuration.

Enhancements:
- Raise the default internal max task update size configuration from 16MB to 32MB to better support larger task update payloads.

Documentation:
- Document the new 32MB default for max task update size in the release notes.