### PR TITLE
feat(planner): Pull row-local operator chain above repartition exchange

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -1129,6 +1129,22 @@ pulled up, and for multi-source (``UNION``) exchanges only constants that are id
 sources are pulled up. This is the session-level counterpart of the configuration property
 :ref:`admin/properties:\`\`optimizer.pull-constant-projection-above-exchange\`\``.
 
+``pull_row_local_chain_above_exchange_strategy``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Allowed values:** ``DISABLED``, ``ALWAYS_ENABLED``, ``COST_BASED``
+* **Default value:** ``DISABLED``
+
+Strategy for pulling a chain of row-local operators (``UNNEST`` and deterministic projections) above a
+repartitioning remote ``ExchangeNode`` so the exchange shuffles the smaller pre-expansion input rather
+than the post-expansion (fanned-out and widened) rows. With ``ALWAYS_ENABLED`` the rewrite is applied
+whenever it is legal (every partitioning, hashing, or ordering variable is produced unchanged below the
+chain), independent of cost or statistics. ``COST_BASED`` currently behaves like ``ALWAYS_ENABLED``;
+cost-based selection is a separate layer to be added later. This is the session-level counterpart of the
+configuration property
+:ref:`admin/properties:\`\`optimizer.pull-row-local-chain-above-exchange-strategy\`\``.
+
 ``grouped_execution``
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1005,6 +1005,22 @@ constants that are identical across all sources are pulled up.
 
 The corresponding session property is :ref:`admin/properties-session:\`\`pull_constant_projection_above_exchange\`\``.
 
+``optimizer.pull-row-local-chain-above-exchange-strategy``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Allowed values:** ``DISABLED``, ``ALWAYS_ENABLED``, ``COST_BASED``
+* **Default value:** ``DISABLED``
+
+Strategy for pulling a chain of row-local operators (``UNNEST`` and deterministic projections)
+above a repartitioning remote ``ExchangeNode`` so the exchange shuffles the smaller pre-expansion
+input rather than the post-expansion (fanned-out and widened) rows. With ``ALWAYS_ENABLED`` the
+rewrite is applied whenever it is legal (every partitioning, hashing, or ordering variable is
+produced unchanged below the chain), independent of cost or statistics. ``COST_BASED`` currently
+behaves like ``ALWAYS_ENABLED``; cost-based selection is a separate layer to be added later.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`pull_row_local_chain_above_exchange_strategy\`\``.
+
 ``optimizer.push-aggregation-through-join``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.LocalExchangeParentPrefer
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.PullRowLocalChainAboveExchangeStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PushDownFilterThroughCrossJoinStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeNullSourceKeyInSemiJoinStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy;
@@ -396,6 +397,7 @@ public final class SystemSessionProperties
     public static final String TABLE_SCAN_SHUFFLE_STRATEGY = "table_scan_shuffle_strategy";
     public static final String SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION = "skip_pushdown_through_exchange_for_remote_projection";
     public static final String PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE = "pull_constant_projection_above_exchange";
+    public static final String PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY = "pull_row_local_chain_above_exchange_strategy";
     public static final String REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM = "remote_function_names_for_fixed_parallelism";
     public static final String REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT = "remote_function_fixed_parallelism_task_count";
     public static final String RPC_FUNCTION_PARALLELISM = "rpc_function_parallelism";
@@ -2328,6 +2330,18 @@ public final class SystemSessionProperties
                         "Pull constant assignments in projections above remote exchanges to reduce network I/O",
                         featuresConfig.isPullConstantProjectionAboveExchange(),
                         false),
+                new PropertyMetadata<>(
+                        PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY,
+                        format("Strategy for pulling a chain of row-local operators (unnest, deterministic projections) above a remote exchange so the exchange shuffles the smaller pre-expansion input. Options are %s",
+                                Stream.of(PullRowLocalChainAboveExchangeStrategy.values())
+                                        .map(PullRowLocalChainAboveExchangeStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        PullRowLocalChainAboveExchangeStrategy.class,
+                        featuresConfig.getPullRowLocalChainAboveExchangeStrategy(),
+                        false,
+                        value -> PullRowLocalChainAboveExchangeStrategy.valueOf(((String) value).toUpperCase()),
+                        PullRowLocalChainAboveExchangeStrategy::name),
                 stringProperty(
                         REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM,
                         "Regex pattern to match remote function names that should use fixed parallelism",
@@ -4044,6 +4058,11 @@ public final class SystemSessionProperties
     public static boolean isPullConstantProjectionAboveExchange(Session session)
     {
         return session.getSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, Boolean.class);
+    }
+
+    public static PullRowLocalChainAboveExchangeStrategy getPullRowLocalChainAboveExchangeStrategy(Session session)
+    {
+        return session.getSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, PullRowLocalChainAboveExchangeStrategy.class);
     }
 
     public static String getRemoteFunctionNamesForFixedParallelism(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -359,6 +359,7 @@ public class FeaturesConfig
     private ShuffleForTableScanStrategy tableScanShuffleStrategy = ShuffleForTableScanStrategy.DISABLED;
     private boolean skipPushdownThroughExchangeForRemoteProjection;
     private boolean pullConstantProjectionAboveExchange;
+    private PullRowLocalChainAboveExchangeStrategy pullRowLocalChainAboveExchangeStrategy = PullRowLocalChainAboveExchangeStrategy.DISABLED;
     private String remoteFunctionNamesForFixedParallelism = "";
     private int remoteFunctionFixedParallelismTaskCount = 10;
 
@@ -531,6 +532,15 @@ public class FeaturesConfig
     {
         DISABLED,
         ALWAYS_ENABLED,
+        COST_BASED
+    }
+
+    public enum PullRowLocalChainAboveExchangeStrategy
+    {
+        DISABLED,
+        ALWAYS_ENABLED,
+        // TODO: COST_BASED currently applies the rewrite structurally (same as ALWAYS_ENABLED);
+        // cost-based selection is a separate layer to be implemented later.
         COST_BASED
     }
 
@@ -3713,6 +3723,19 @@ public class FeaturesConfig
     public FeaturesConfig setPullConstantProjectionAboveExchange(boolean pullConstantProjectionAboveExchange)
     {
         this.pullConstantProjectionAboveExchange = pullConstantProjectionAboveExchange;
+        return this;
+    }
+
+    public PullRowLocalChainAboveExchangeStrategy getPullRowLocalChainAboveExchangeStrategy()
+    {
+        return pullRowLocalChainAboveExchangeStrategy;
+    }
+
+    @Config("optimizer.pull-row-local-chain-above-exchange-strategy")
+    @ConfigDescription("Strategy for pulling a chain of row-local operators (unnest, deterministic projections) above a remote exchange so the exchange shuffles the smaller pre-expansion input. Options are DISABLED, ALWAYS_ENABLED, COST_BASED")
+    public FeaturesConfig setPullRowLocalChainAboveExchangeStrategy(PullRowLocalChainAboveExchangeStrategy pullRowLocalChainAboveExchangeStrategy)
+    {
+        this.pullRowLocalChainAboveExchangeStrategy = pullRowLocalChainAboveExchangeStrategy;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -100,6 +100,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PullConstantProjectionAboveExchange;
 import com.facebook.presto.sql.planner.iterative.rule.PullConstantsAboveGroupBy;
+import com.facebook.presto.sql.planner.iterative.rule.PullRowLocalChainAboveExchange;
 import com.facebook.presto.sql.planner.iterative.rule.PullUpExpressionInLambdaRules;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughDisjointUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
@@ -1124,6 +1125,16 @@ public class PlanOptimizers
                 statsCalculator,
                 costCalculator,
                 ImmutableSet.of(new PullConstantProjectionAboveExchange())));
+        // Pull a chain of row-local operators (unnest + deterministic projections) above a remote
+        // repartition exchange so the exchange shuffles the smaller pre-expansion input. Placed after
+        // the final projectionPushDown so PushProjectionThroughExchange will not push the chain back
+        // below the exchange. Cost-based and gated (default off).
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new PullRowLocalChainAboveExchange(metadata.getFunctionAndTypeManager()))));
         builder.add(new UnaliasSymbolReferences(metadata.getFunctionAndTypeManager())); // Run unalias after merging projections to simplify projections more efficiently
         builder.add(new PruneUnreferencedOutputs());
         builder.add(new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullRowLocalChainAboveExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullRowLocalChainAboveExchange.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnnestNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.VariablesExtractor;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.getPullRowLocalChainAboveExchangeStrategy;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.PullRowLocalChainAboveExchangeStrategy.DISABLED;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Pulls a maximal chain of row-local operators (deterministic {@link ProjectNode}s and
+ * {@link UnnestNode}s) above a repartitioning remote {@link ExchangeNode}, so the exchange
+ * shuffles the smaller pre-expansion input instead of the post-expansion (fanned-out / widened)
+ * rows.
+ * <p>
+ * Transforms:
+ * <pre>
+ *  Exchange(REPARTITION, K)
+ *    [Project? / Unnest]*           (chain; contains at least one Unnest)
+ *      Barrier(Join / Aggregation / TableScan / Exchange / ...)
+ * </pre>
+ * to:
+ * <pre>
+ *  [Project? / Unnest]*             (same chain, reparented)
+ *    Exchange(REPARTITION, K)       (now shuffles the barrier output)
+ *      Barrier
+ * </pre>
+ * The rewrite is semantics-preserving when every partitioning / hash / ordering variable {@code K}
+ * is produced unchanged by the barrier (i.e. passes through the chain). Since {@code UNNEST} only
+ * fans out its array/map elements and the projections are deterministic and row-local, applying the
+ * chain after the shuffle yields the same multiset of output rows.
+ * <p>
+ * Gated behind the {@code pull_row_local_chain_above_exchange_strategy} session property (default
+ * {@code DISABLED}); for {@code ALWAYS_ENABLED} (and, for now, {@code COST_BASED}) it fires whenever
+ * the rewrite is legal, independent of cost/statistics. Cost-based selection can be layered on
+ * separately later under {@code COST_BASED}.
+ * Generalizes {@link PullConstantProjectionAboveExchange} (which pulls only constant projection
+ * assignments above an exchange) and subsumes pushing a lone {@code UNNEST} below a repartition.
+ */
+public class PullRowLocalChainAboveExchange
+        implements Rule<ExchangeNode>
+{
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .matching(exchange -> exchange.getType() == REPARTITION
+                    && exchange.getScope().isRemote()
+                    && !exchange.getPartitioningScheme().isReplicateNullsAndAny());
+
+    private final RowExpressionDeterminismEvaluator determinismEvaluator;
+
+    public PullRowLocalChainAboveExchange(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.determinismEvaluator = new RowExpressionDeterminismEvaluator(requireNonNull(functionAndTypeManager, "functionAndTypeManager is null"));
+    }
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        // Fire when the strategy is not DISABLED. ALWAYS_ENABLED and COST_BASED both currently apply
+        // the rewrite whenever it is legal; cost-based selection is a separate layer for later.
+        return getPullRowLocalChainAboveExchangeStrategy(session) != DISABLED;
+    }
+
+    @Override
+    public Result apply(ExchangeNode exchange, Captures captures, Context context)
+    {
+        // Single-source exchange only (a chain feeds exactly one exchange input).
+        if (exchange.getSources().size() != 1) {
+            return Result.empty();
+        }
+
+        // Only handle exchanges that do not rename their input columns; otherwise the reparented
+        // chain would not produce the variables the consumer above the exchange expects.
+        List<VariableReferenceExpression> outputLayout = exchange.getPartitioningScheme().getOutputLayout();
+        if (!exchange.getInputs().get(0).equals(outputLayout)) {
+            return Result.empty();
+        }
+
+        // Walk down the maximal chain of row-local operators (deterministic projects, unnests).
+        List<PlanNode> chain = new ArrayList<>();
+        boolean hasUnnest = false;
+        PlanNode current = context.getLookup().resolve(exchange.getSources().get(0));
+        while (true) {
+            if (current instanceof UnnestNode) {
+                chain.add(current);
+                hasUnnest = true;
+                current = context.getLookup().resolve(((UnnestNode) current).getSource());
+            }
+            else if (current instanceof ProjectNode) {
+                ProjectNode project = (ProjectNode) current;
+                // A non-deterministic expression must not move across the exchange; treat such a
+                // projection as the barrier (it stays below the exchange, computed once).
+                if (!project.getAssignments().getExpressions().stream().allMatch(determinismEvaluator::isDeterministic)) {
+                    break;
+                }
+                chain.add(current);
+                current = context.getLookup().resolve(project.getSource());
+            }
+            else {
+                break;
+            }
+        }
+        PlanNode barrier = current;
+
+        // Require at least one unnest in the chain. Pulling a pure-projection chain up is the job of
+        // PullConstantProjectionAboveExchange / PushProjectionThroughExchange; requiring an unnest
+        // keeps this rule focused on the data-expansion case and avoids fighting those rules.
+        if (!hasUnnest) {
+            return Result.empty();
+        }
+
+        // The exchange's partitioning / hash / ordering variables must be produced by the barrier
+        // (i.e. pass through the chain unchanged) so the exchange can be applied below the chain.
+        List<VariableReferenceExpression> barrierOutputs = barrier.getOutputVariables();
+        Set<VariableReferenceExpression> requiredByExchange = new HashSet<>(exchange.getPartitioningScheme().getPartitioning().getVariableReferences());
+        exchange.getPartitioningScheme().getHashColumn().ifPresent(requiredByExchange::add);
+        exchange.getOrderingScheme().ifPresent(ordering -> requiredByExchange.addAll(ordering.getOrderByVariables()));
+        if (!barrierOutputs.containsAll(requiredByExchange)) {
+            return Result.empty();
+        }
+
+        // Narrow the exchange output (correct by construction, not relying on a later prune pass) to
+        // only the barrier columns the chain actually consumes plus the partitioning / hash / ordering
+        // variables (K) — so the exchange shuffles only the fields that must cross it.
+        Set<VariableReferenceExpression> chainReferencedVariables = new HashSet<>();
+        for (PlanNode chainNode : chain) {
+            if (chainNode instanceof UnnestNode) {
+                UnnestNode unnest = (UnnestNode) chainNode;
+                chainReferencedVariables.addAll(unnest.getReplicateVariables());
+                chainReferencedVariables.addAll(unnest.getUnnestVariables().keySet());
+            }
+            else {
+                chainReferencedVariables.addAll(VariablesExtractor.extractUnique(((ProjectNode) chainNode).getAssignments().getExpressions()));
+            }
+        }
+        List<VariableReferenceExpression> exchangeOutputLayout = barrierOutputs.stream()
+                .filter(variable -> chainReferencedVariables.contains(variable) || requiredByExchange.contains(variable))
+                .collect(toImmutableList());
+
+        // Build the exchange below the chain: same partitioning, narrowed output, single identity source.
+        PartitioningScheme oldScheme = exchange.getPartitioningScheme();
+        PartitioningScheme newScheme = new PartitioningScheme(
+                oldScheme.getPartitioning(),
+                exchangeOutputLayout,
+                oldScheme.getHashColumn(),
+                oldScheme.isReplicateNullsAndAny(),
+                oldScheme.isScaleWriters(),
+                oldScheme.getEncoding(),
+                oldScheme.getBucketToPartition());
+        ExchangeNode newExchange = new ExchangeNode(
+                exchange.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                exchange.getType(),
+                exchange.getScope(),
+                newScheme,
+                ImmutableList.of(barrier),
+                ImmutableList.of(exchangeOutputLayout),
+                exchange.isEnsureSourceOrdering(),
+                exchange.getOrderingScheme());
+
+        // Reparent the chain on top of the new exchange, bottom-up, allocating a fresh PlanNodeId for
+        // each relocated node (never reuse the original plan node ids).
+        PlanNode result = newExchange;
+        for (int i = chain.size() - 1; i >= 0; i--) {
+            result = withNewIdAndSource(chain.get(i), result, context);
+        }
+        return Result.ofPlanNode(result);
+    }
+
+    private static PlanNode withNewIdAndSource(PlanNode node, PlanNode newSource, Context context)
+    {
+        if (node instanceof UnnestNode) {
+            UnnestNode unnest = (UnnestNode) node;
+            return new UnnestNode(
+                    unnest.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newSource,
+                    unnest.getReplicateVariables(),
+                    unnest.getUnnestVariables(),
+                    unnest.getOrdinalityVariable());
+        }
+        if (node instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) node;
+            return new ProjectNode(
+                    project.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newSource,
+                    project.getAssignments(),
+                    project.getLocality());
+        }
+        throw new IllegalArgumentException(format("Unexpected node type in row-local chain: %s", node.getClass().getName()));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -313,6 +313,7 @@ public class TestFeaturesConfig
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.DISABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(false)
                 .setPullConstantProjectionAboveExchange(false)
+                .setPullRowLocalChainAboveExchangeStrategy(FeaturesConfig.PullRowLocalChainAboveExchangeStrategy.DISABLED)
                 .setUseConnectorProvidedSerializationCodecs(false)
                 .setRemoteFunctionNamesForFixedParallelism("")
                 .setRemoteFunctionFixedParallelismTaskCount(10));
@@ -571,6 +572,7 @@ public class TestFeaturesConfig
                 .put("optimizer.table-scan-shuffle-strategy", "ALWAYS_ENABLED")
                 .put("optimizer.skip-pushdown-through-exchange-for-remote-projection", "true")
                 .put("optimizer.pull-constant-projection-above-exchange", "true")
+                .put("optimizer.pull-row-local-chain-above-exchange-strategy", "ALWAYS_ENABLED")
                 .put("use-connector-provided-serialization-codecs", "true")
                 .put("optimizer.remote-function-names-for-fixed-parallelism", "remote_.*")
                 .put("optimizer.remote-function-fixed-parallelism-task-count", "100")
@@ -827,6 +829,7 @@ public class TestFeaturesConfig
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.ALWAYS_ENABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(true)
                 .setPullConstantProjectionAboveExchange(true)
+                .setPullRowLocalChainAboveExchangeStrategy(FeaturesConfig.PullRowLocalChainAboveExchangeStrategy.ALWAYS_ENABLED)
                 .setUseConnectorProvidedSerializationCodecs(true)
                 .setRemoteFunctionNamesForFixedParallelism("remote_.*")
                 .setPushPartialAggregationThroughJoin(true)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullRowLocalChainAboveExchange.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullRowLocalChainAboveExchange.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.SystemSessionProperties.PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.unnest;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+
+public class TestPullRowLocalChainAboveExchange
+        extends BaseRuleTest
+{
+    private static final ArrayType ARRAY_OF_BIGINT = new ArrayType(BIGINT);
+
+    // Exchange[REPARTITION on partitionKey] -> Project -> Unnest(arr -> elem) -> Values(k, arr).
+    // When partitionOnUnnestedVariable is false the key is the replicate column k (legal to pull up);
+    // when true it is the unnested output elem (illegal).
+    private static Function<PlanBuilder, PlanNode> repartitionOverUnnest(boolean partitionOnUnnestedVariable)
+    {
+        return p -> {
+            VariableReferenceExpression k = p.variable("k", BIGINT);
+            VariableReferenceExpression arr = p.variable("arr", ARRAY_OF_BIGINT);
+            VariableReferenceExpression elem = p.variable("elem", BIGINT);
+            VariableReferenceExpression partitionKey = partitionOnUnnestedVariable ? elem : k;
+            return p.exchange(e -> e
+                    .type(REPARTITION)
+                    .addSource(
+                            p.project(
+                                    Assignments.builder().put(k, k).put(elem, elem).build(),
+                                    p.unnest(
+                                            p.values(k, arr),
+                                            ImmutableList.of(k),
+                                            ImmutableMap.of(arr, ImmutableList.of(elem)),
+                                            Optional.empty())))
+                    .addInputsSet(k, elem)
+                    .fixedHashDistributionPartitioningScheme(ImmutableList.of(k, elem), ImmutableList.of(partitionKey)));
+        };
+    }
+
+    @Test
+    public void testPullsChainAboveExchange()
+    {
+        // When enabled the rule fires whenever the rewrite is legal, independent of cost/statistics.
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .on(repartitionOverUnnest(false))
+                .matches(
+                        project(
+                                unnest(
+                                        exchange(
+                                                values("k", "arr")))));
+    }
+
+    @Test
+    public void testDoesNotFireWhenDisabled()
+    {
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .on(repartitionOverUnnest(false))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenPartitionKeyIsUnnestedVariable()
+    {
+        // Partitioning on the unnested output (elem) cannot be pushed below the unnest.
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .on(repartitionOverUnnest(true))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithNonDeterministicProjectionInChain()
+    {
+        // A non-deterministic projection between the exchange and the unnest is treated as a barrier,
+        // so the chain (and the unnest below it) is never pulled across the exchange.
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .on(p -> {
+                    VariableReferenceExpression k = p.variable("k", BIGINT);
+                    VariableReferenceExpression arr = p.variable("arr", ARRAY_OF_BIGINT);
+                    VariableReferenceExpression elem = p.variable("elem", BIGINT);
+                    VariableReferenceExpression rnd = p.variable("rnd", DOUBLE);
+                    return p.exchange(e -> e
+                            .type(REPARTITION)
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(k, k)
+                                                    .put(elem, elem)
+                                                    .put(rnd, p.rowExpression("random()"))
+                                                    .build(),
+                                            p.unnest(
+                                                    p.values(k, arr),
+                                                    ImmutableList.of(k),
+                                                    ImmutableMap.of(arr, ImmutableList.of(elem)),
+                                                    Optional.empty())))
+                            .addInputsSet(k, elem, rnd)
+                            .fixedHashDistributionPartitioningScheme(ImmutableList.of(k, elem, rnd), ImmutableList.of(k)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenNoUnnestInChain()
+    {
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .on(p -> {
+                    VariableReferenceExpression k = p.variable("k", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    return p.exchange(e -> e
+                            .type(REPARTITION)
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder().put(k, k).put(v, v).build(),
+                                            p.values(k, v)))
+                            .addInputsSet(k, v)
+                            .fixedHashDistributionPartitioningScheme(ImmutableList.of(k, v), ImmutableList.of(k)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.SystemSessionProperties.PREFILTER_FOR_GROUPBY_
 import static com.facebook.presto.SystemSessionProperties.PRE_AGGREGATE_BEFORE_GROUPING_SETS;
 import static com.facebook.presto.SystemSessionProperties.PRE_PROCESS_METADATA_CALLS;
 import static com.facebook.presto.SystemSessionProperties.PULL_EXPRESSION_FROM_LAMBDA_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.PUSH_AGGREGATION_THROUGH_DISJOINT_UNION;
 import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN;
 import static com.facebook.presto.SystemSessionProperties.PUSH_FILTER_THROUGH_SELECTING_AGGREGATION;
@@ -722,6 +723,50 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT a.col0 FROM (VALUES ROW(CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a) WHERE a.col0 < a.col1", "SELECT 1");
         assertQuery("SELECT SUM(a.col0) FROM (VALUES ROW(CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a) WHERE a.col0 < a.col1", "SELECT 1");
         assertQuery("SELECT SUM(a.col0) FROM (VALUES ROW(CAST(ROW(1, 2) AS ROW(col0 integer, col1 integer)))) AS t (a) WHERE a.col0 > a.col1", "SELECT null");
+    }
+
+    @Test
+    public void testPullRowLocalChainAboveExchange()
+    {
+        // Result-equality (enabled vs disabled) over CROSS JOIN UNNEST shapes where a repartitioning
+        // exchange sits above a row-local chain (unnest + projections) keyed on a replicate column.
+        // Checksums are order-independent, so they are robust to the plan differences the rule introduces.
+        // checksum() returns varbinary; wrap it in to_hex() so the two-runner comparison compares
+        // varchar rather than varbinary (raw varbinary is materialized inconsistently across the two
+        // result sets -- ByteBuffer vs byte[] -- and would never compare equal).
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "DISABLED")
+                .build();
+
+        // Repartition on a replicate column (custkey) carried through UNNEST, feeding a downstream aggregation.
+        @Language("SQL") String aggregateOverUnnest =
+                "SELECT to_hex(checksum(custkey)), to_hex(checksum(total)) FROM (" +
+                "  SELECT o.custkey, sum(t.elem) AS total" +
+                "  FROM orders o" +
+                "  CROSS JOIN UNNEST(sequence(1, (o.orderkey % 5) + 1)) AS t(elem)" +
+                "  GROUP BY o.custkey)";
+        assertQueryWithSameQueryRunner(enabled, aggregateOverUnnest, disabled);
+
+        // Repartition (join) on a replicate column carried through UNNEST.
+        @Language("SQL") String joinOverUnnest =
+                "SELECT to_hex(checksum(u.elem)) FROM (" +
+                "  SELECT o.custkey AS k, t.elem" +
+                "  FROM orders o" +
+                "  CROSS JOIN UNNEST(sequence(1, (o.orderkey % 4) + 1)) AS t(elem)) u" +
+                "  JOIN customer c ON u.k = c.custkey";
+        assertQueryWithSameQueryRunner(enabled, joinOverUnnest, disabled);
+
+        // WITH ORDINALITY variant: the ordinality column is an unnest output and must not be a partition key.
+        @Language("SQL") String withOrdinality =
+                "SELECT to_hex(checksum(custkey)), to_hex(checksum(total)) FROM (" +
+                "  SELECT o.custkey, sum(t.elem * t.ord) AS total" +
+                "  FROM orders o" +
+                "  CROSS JOIN UNNEST(sequence(1, (o.orderkey % 5) + 1)) WITH ORDINALITY AS t(elem, ord)" +
+                "  GROUP BY o.custkey)";
+        assertQueryWithSameQueryRunner(enabled, withOrdinality, disabled);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds an optimizer rule **`PullRowLocalChainAboveExchange`** that pulls a maximal chain of row-local operators (`UNNEST` and deterministic projections) **above** a repartitioning remote `ExchangeNode`, so the exchange shuffles the smaller **pre-expansion** input instead of the post-expansion (fanned-out / widened) rows.

```
Before:  Exchange[REPARTITION/SCALED, K] -> [Project? / Unnest]* -> Barrier(Join/Agg/Scan/...)   (shuffles post-expansion rows)
After:   [Project? / Unnest]* -> Exchange[REPARTITION/SCALED, K] -> Barrier                       (shuffles pre-expansion rows)
```

This targets plans where an `UNNEST` below a repartition or scaled-writer exchange replicates wide carry-through columns across the fan-out *before* the shuffle — e.g. `INSERT … SELECT … CROSS JOIN UNNEST(…)` that writes wide per-element rows. The fan-out then happens locally on the consumer side, after a much smaller shuffle.

Generalizes `PullConstantProjectionAboveExchange` (#27499), which pulls only constant projection assignments above an exchange.

Resolves #28078.

## How it works

`Rule<ExchangeNode>`. Fires only when the rewrite is legal:
- exchange is a **single-source remote `REPARTITION`** (covers the `SCALED_WRITER` partitioning case, `K = ∅`), not `replicateNullsAndAny`;
- the chain below it is a maximal run of `{ deterministic ProjectNode, UnnestNode }` ending at a barrier, and **contains at least one `UNNEST`**;
- every partitioning / hash / ordering variable (`K`) is produced unchanged by the barrier (passes through the chain), so the exchange can be applied below the chain.

It allocates **fresh `PlanNodeId`s** for every relocated node, and is registered **after** the final projection-pushdown pass so `PushProjectionThroughExchange` won't push the chain back down.

## Gating

Session property **`pull_row_local_chain_above_exchange_strategy`** (config `optimizer.pull-row-local-chain-above-exchange-strategy`), default **`DISABLED`**:
- `ALWAYS_ENABLED` — apply the rewrite whenever it is legal, independent of cost/statistics.
- `COST_BASED` — reserved for a separate cost-based selection layer (currently behaves like `ALWAYS_ENABLED`).

Modeled on the existing `ShuffleForTableScanStrategy` enum property.

## Tests

- **Unit** (`TestPullRowLocalChainAboveExchange`): fires on the `Exchange → Project → Unnest` shape; does not fire when disabled, when there's no `UNNEST` in the chain, or when a partition key is an unnested output.
- **e2e** (`AbstractTestQueries#testPullRowLocalChainAboveExchange`): enabled-vs-disabled result equality (checksum) over `CROSS JOIN UNNEST` with aggregation, join, and `WITH ORDINALITY` on TPC-H tables.
- `TestFeaturesConfig` coverage for the new property; docs added to `properties-session.rst` / `properties.rst`.

## Validation

Validated on a production `INSERT … SELECT … CROSS JOIN UNNEST(…)` (wide fact table ⋈ DISTINCT-key subquery, fanned out into wide per-element rows).

**Plan effect (confirmed):** with the rule enabled, the scaled-writer exchange moves below the row-local chain and shuffles the **pre-unnest** join output; the fan-out (≈7.7B → ≈18.9B rows) happens locally in the writer fragment.

**Controlled A/B — same idle cluster, identical query, both ran to full completion (~18.9B output rows):**

| | Rule OFF | Rule ON |
|---|---|---|
| Wall | ~110 min | **~50 min** (~2.2× faster) |
| CPU | ~76 CPU-days | ~37 CPU-days (~2× less) |
| Writer remote exchange | ~1.74 PB (post-unnest) | **~0.24 PB** (pre-unnest) — **~7× less** |

**Original production incident (motivation):** on a contended production cluster the same query repeatedly hit the **3h** execution-time limit and aborted with **0 rows** committed.

The fan-out now happens locally on the writer side instead of crossing the network; `TableWriter` work itself is unchanged (~45 vs ~44 CPU-days), so this is a pure shuffle/network reduction — which is why it's safe to keep statistics-independent.

```
== RELEASE NOTES ==

General Changes
* Add session property ``pull_row_local_chain_above_exchange_strategy`` (default ``DISABLED``) that pulls a chain of row-local operators (``UNNEST`` and deterministic projections) above a repartitioning remote exchange so the exchange shuffles the smaller pre-expansion input, reducing network shuffle. :pr:`28079`
```
