### PR TITLE
fix: Address update failure when using partitioned semi-join

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -3479,6 +3479,23 @@ public abstract class IcebergDistributedTestBase
         assertQuery("SELECT a, b FROM " + tableName, "VALUES (3,'first'), (4,'4th'), (3,'third')");
     }
 
+    @Test
+    public void testUpdateWithSemiJoinWhereCondition()
+    {
+        String tableName = "test_update_with_semi_join_where_condition_" + randomTableSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'first'), (2, 'second'), (3, 'third')", 3);
+
+            assertUpdate("UPDATE " + tableName + " SET a = a + 100 WHERE b IN" +
+                    " (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col))", 2);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(101, 'first'), (2, 'second'), (103, 'third')");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
     @DataProvider
     public Object[][] partitionedProvider()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -3421,6 +3421,23 @@ public abstract class IcebergDistributedTestBase
         assertQuery("SELECT a, b FROM " + tableName, "VALUES (3,'first'), (4,'4th'), (3,'third')");
     }
 
+    @Test
+    public void testUpdateWithSemiJoinWhereCondition()
+    {
+        String tableName = "test_update_with_semi_join_where_condition_" + randomTableSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'first'), (2, 'second'), (3, 'third')", 3);
+
+            assertUpdate("UPDATE " + tableName + " SET a = a + 100 WHERE b IN" +
+                    " (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col))", 2);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(101, 'first'), (2, 'second'), (103, 'third')");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
     @DataProvider
     public Object[][] partitionedProvider()
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -215,7 +215,7 @@ import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
 import com.facebook.presto.sql.planner.optimizations.ReplaceConstantVariableReferencesWithConstants;
-import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
+import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDeleteOrUpdate;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.RewriteWriterTarget;
 import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
@@ -1045,7 +1045,7 @@ public class PlanOptimizers
                         ImmutableSet.of(new ScaledWriterRule())));
 
         if (!noExchange) {
-            builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges
+            builder.add(new ReplicateSemiJoinInDeleteOrUpdate()); // Must run before AddExchanges
 
             builder.add(new IterativeOptimizer(
                     metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -217,7 +217,7 @@ import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
 import com.facebook.presto.sql.planner.optimizations.ReplaceConstantVariableReferencesWithConstants;
-import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
+import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDeleteOrUpdate;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.RewriteWriterTarget;
 import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
@@ -1061,7 +1061,7 @@ public class PlanOptimizers
                         ImmutableSet.of(new ScaledWriterRule())));
 
         if (!noExchange) {
-            builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges
+            builder.add(new ReplicateSemiJoinInDeleteOrUpdate()); // Must run before AddExchanges
 
             builder.add(new IterativeOptimizer(
                     metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDeleteOrUpdate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDeleteOrUpdate.java
@@ -22,12 +22,13 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.UpdateNode;
 
 import static com.facebook.presto.SystemSessionProperties.isBroadcastSemiJoinForDeleteEnabled;
 import static com.facebook.presto.spi.plan.SemiJoinNode.DistributionType.REPLICATED;
 import static java.util.Objects.requireNonNull;
 
-public class ReplicateSemiJoinInDelete
+public class ReplicateSemiJoinInDeleteOrUpdate
         implements PlanOptimizer
 {
     @Override
@@ -46,6 +47,7 @@ public class ReplicateSemiJoinInDelete
             extends SimplePlanRewriter<Void>
     {
         private boolean isDeleteQuery;
+        private boolean isUpdateQuery;
         private boolean planChanged;
 
         public boolean isPlanChanged()
@@ -72,7 +74,7 @@ public class ReplicateSemiJoinInDelete
                     node.getDistributionType(),
                     node.getDynamicFilters());
 
-            if (isDeleteQuery) {
+            if (isDeleteQuery || isUpdateQuery) {
                 planChanged = true;
                 return rewrittenNode.withDistributionType(REPLICATED);
             }
@@ -94,6 +96,22 @@ public class ReplicateSemiJoinInDelete
                     node.getRowId(),
                     node.getOutputVariables(),
                     node.getInputDistribution());
+        }
+
+        @Override
+        public PlanNode visitUpdate(UpdateNode node, RewriteContext<Void> context)
+        {
+            // For update queries, the TableScan node that corresponds to the table being updated must be collocated with the Update node,
+            // so you can't do a distributed semi-join
+            isUpdateQuery = true;
+            PlanNode rewrittenSource = context.rewrite(node.getSource());
+            return new UpdateNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    rewrittenSource,
+                    node.getRowId(),
+                    node.getColumnValueAndRowIdSymbols(),
+                    node.getOutputVariables());
         }
     }
 }


### PR DESCRIPTION
## Description

When the default distributed type is set to PARTITIONED (either via `join-distribution-type=PARTITIONED` in the config file or via `set session join_distribution_type = 'PARTITIONED'`), executing the follwing statement:

```
UPDATE test_table SET a = a + 100 WHERE b
    IN (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col));
```

This statement would fail because the PARTITIONED semi-join introduces an exchange node between the target table scan node and the update node. This breaks the precondition for the update to execute correctly, which leads to execution failure.

This PR ensures that the UPDATE statements with semi-join explicitly use REPLICATED semi-join, following the same processing logic as the DELETE statements.

## Motivation and Context

Address update failure when using partitioned semi-join

## Impact

N/A

## Test Plan

Added a test case to cover the scenario described in the PR description.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Prevent update failures caused by partitioned semi-joins by forcing replicated distribution for update operations.

Bug Fixes:
- Ensure UPDATE statements use replicated semi-joins so partitioned semi-join execution no longer breaks update operations.

Enhancements:
- Extend the existing delete semi-join optimization to cover update plans.

Tests:
- Add coverage for updates with semi-join predicates when partitioned join distribution is configured.