### PR TITLE
fix: Fix UPDATE with semi-join wrongly processing iceberg deleted rows

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -3396,6 +3396,30 @@ public abstract class IcebergDistributedTestBase
         assertQuery("SELECT int_t, row_t.f1, row_t.f2 FROM " + tableName, "VALUES (0, 2, 3), (11, 12, 14), (21, 44, 23)");
     }
 
+    @Test
+    public void testUpdateWithDeletedRowsOnSemiJoinWhereCondition()
+    {
+        String tableName = "test_update_with_delete_rows_on_semi_join_" + randomTableSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'first'), (2, 'second'), (3, 'third')", 3);
+
+            assertUpdate("DELETE FROM " + tableName + " WHERE b = 'third'", 1);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(1, 'first'), (2, 'second')");
+
+            assertUpdate("UPDATE " + tableName + " SET a = a + 100 WHERE b IN" +
+                    " (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col))", 1);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(101, 'first'), (2, 'second')");
+
+            assertUpdate("UPDATE " + tableName + " SET a = a + 100 WHERE b IN" +
+                    " (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col))", 1);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(201, 'first'), (2, 'second')");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
     public void testUpdateOnPartitionTable()
     {
         String tableName = "test_update_partition_column_" + randomTableSuffix();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -3421,6 +3421,23 @@ public abstract class IcebergDistributedTestBase
         assertQuery("SELECT a, b FROM " + tableName, "VALUES (3,'first'), (4,'4th'), (3,'third')");
     }
 
+    @Test
+    public void testUpdateWithSemiJoinWhereCondition()
+    {
+        String tableName = "test_update_with_semi_join_where_condition_" + randomTableSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'first'), (2, 'second'), (3, 'third')", 3);
+
+            assertUpdate("UPDATE " + tableName + " SET a = a + 100 WHERE b IN" +
+                    " (SELECT col FROM (VALUES('first'), ('third'), ('fourth')) AS t(col))", 2);
+            assertQuery("SELECT  * FROM " + tableName, "VALUES(101, 'first'), (2, 'second'), (103, 'third')");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
     @DataProvider
     public Object[][] partitionedProvider()
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -215,7 +215,7 @@ import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin;
 import com.facebook.presto.sql.planner.optimizations.RemoveRedundantDistinctAggregation;
 import com.facebook.presto.sql.planner.optimizations.ReplaceConstantVariableReferencesWithConstants;
-import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
+import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDeleteOrUpdate;
 import com.facebook.presto.sql.planner.optimizations.RewriteIfOverAggregation;
 import com.facebook.presto.sql.planner.optimizations.RewriteWriterTarget;
 import com.facebook.presto.sql.planner.optimizations.RpcExecutionPolicy;
@@ -1045,7 +1045,7 @@ public class PlanOptimizers
                         ImmutableSet.of(new ScaledWriterRule())));
 
         if (!noExchange) {
-            builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges
+            builder.add(new ReplicateSemiJoinInDeleteOrUpdate()); // Must run before AddExchanges
 
             builder.add(new IterativeOptimizer(
                     metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -950,7 +950,13 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitUpdate(UpdateNode node, RewriteContext<Set<VariableReferenceExpression>> context)
         {
-            return new UpdateNode(node.getSourceLocation(), node.getId(), node.getSource(), node.getRowId(), node.getColumnValueAndRowIdSymbols(), node.getOutputVariables());
+            ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
+            node.getRowId().ifPresent(r -> builder.add(r));
+            for (VariableReferenceExpression variable : node.getColumnValueAndRowIdSymbols()) {
+                builder.add(variable);
+            }
+            PlanNode source = context.rewrite(node.getSource(), builder.build());
+            return new UpdateNode(node.getSourceLocation(), node.getId(), source, node.getRowId(), node.getColumnValueAndRowIdSymbols(), node.getOutputVariables());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDeleteOrUpdate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDeleteOrUpdate.java
@@ -22,12 +22,13 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.UpdateNode;
 
 import static com.facebook.presto.SystemSessionProperties.isBroadcastSemiJoinForDeleteEnabled;
 import static com.facebook.presto.spi.plan.SemiJoinNode.DistributionType.REPLICATED;
 import static java.util.Objects.requireNonNull;
 
-public class ReplicateSemiJoinInDelete
+public class ReplicateSemiJoinInDeleteOrUpdate
         implements PlanOptimizer
 {
     @Override
@@ -46,6 +47,7 @@ public class ReplicateSemiJoinInDelete
             extends SimplePlanRewriter<Void>
     {
         private boolean isDeleteQuery;
+        private boolean isUpdateQuery;
         private boolean planChanged;
 
         public boolean isPlanChanged()
@@ -72,7 +74,7 @@ public class ReplicateSemiJoinInDelete
                     node.getDistributionType(),
                     node.getDynamicFilters());
 
-            if (isDeleteQuery) {
+            if (isDeleteQuery || isUpdateQuery) {
                 planChanged = true;
                 return rewrittenNode.withDistributionType(REPLICATED);
             }
@@ -94,6 +96,22 @@ public class ReplicateSemiJoinInDelete
                     node.getRowId(),
                     node.getOutputVariables(),
                     node.getInputDistribution());
+        }
+
+        @Override
+        public PlanNode visitUpdate(UpdateNode node, RewriteContext<Void> context)
+        {
+            // For update queries, the TableScan node that corresponds to the table being updated must be collocated with the Update node,
+            // so you can't do a distributed semi-join
+            isUpdateQuery = true;
+            PlanNode rewrittenSource = context.rewrite(node.getSource());
+            return new UpdateNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    rewrittenSource,
+                    node.getRowId(),
+                    node.getColumnValueAndRowIdSymbols(),
+                    node.getOutputVariables());
         }
     }
 }


### PR DESCRIPTION
## Description

Waiting for #28080 to be merged.

For UPDATE statements with semi-join WHERE conditions, the optimizer currently does not properly prune unreferenced outputs from the target table scan node. For Iceberg target tables, this results in the scan node retaining the `$deleted` and `$delete_file_path` metadata columns, which in turn causes the deleted columns to appear in the scan result.

The Update operator does not distinguish between these rows, and therefore updates both the existing and the deleted rows (i.e., it deletes and rewrites them). More critically, because Iceberg implements updates via a delete-plus-insert approach, this leads to a problem where the data grows larger with each update with semi-join.

This PR updates `PruneUnreferencedOutputs` to handle unreferenced output pruning for UpdateNode's children in the same manner as DeleteNode, which fixes this issue.

## Motivation and Context

Fix UPDATE with semi-join wrongly processing iceberg deleted rows

## Impact

N/A

## Test Plan

Added a test case to cover the scenario described in the PR description.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure update queries with semi-join filters work correctly when rows have been deleted, and align planner optimizations accordingly.

Bug Fixes:
- Fix incorrect handling of semi-join distribution in update queries, preventing invalid distributed execution when updating tables.
- Prevent pruning of necessary inputs in update nodes so update plans retain required row IDs and column symbols.

Enhancements:
- Extend the semi-join replication optimizer to handle both delete and update plans for consistent behavior.
- Wire the updated semi-join replication optimizer into the main optimizer pipeline.

Tests:
- Add Iceberg distributed tests covering update statements with semi-join WHERE conditions, including scenarios with deleted rows.