### PR TITLE
test(native): Add E2E tests for regexp_extract, regexp_extract_all, regexp_replace and regexp_split

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRegularExpressionFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRegularExpressionFunctions.java
@@ -119,4 +119,90 @@ public class TestRegularExpressionFunctions
                 "SELECT regexp_like(name, '*a') FROM nation",
                 ".*(?:invalid regular expression|error parsing regexp).*");
     }
+
+    @Test
+    public void testRegexpExtract()
+    {
+        assertQuery("SELECT regexp_extract(name, 'A.*') FROM nation");
+        assertQuery("SELECT regexp_extract(name, '[A-Z]+') FROM nation");
+        assertQuery("SELECT regexp_extract(name, '([A-Z])([A-Z])') FROM nation");
+        assertQuery("SELECT regexp_extract(name, '([A-Z])([A-Z])', 0) FROM nation");
+        assertQuery("SELECT regexp_extract(name, '([A-Z])([A-Z])', 1) FROM nation");
+        assertQuery("SELECT regexp_extract(name, '([A-Z])([A-Z])', 2) FROM nation");
+        assertQuery("SELECT regexp_extract(comment, '\\bhaggle\\b') FROM nation");
+        assertQuery("SELECT regexp_extract(comment, '(\\w+)\\s+(\\w+)', 1) FROM nation");
+        assertQuery("SELECT regexp_extract(comment, '(\\w+)\\s+(\\w+)', 2) FROM nation");
+        assertQuery("SELECT regexp_extract(name, 'ZZZ') FROM nation");
+        assertQuery("SELECT regexp_extract(IF(nationkey = 0, CAST(NULL AS VARCHAR), name), 'A.*') FROM nation");
+        assertQuery("SELECT regexp_extract(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '[^\\.]+') FROM nation");
+        assertQuery("SELECT regexp_extract(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '([^\\.]+)\\.([^\\.]+)', 1) FROM nation");
+        assertQuery("SELECT regexp_extract(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '([^\\.]+)\\.([^\\.]+)', 2) FROM nation");
+
+        assertQueryFails(
+                "SELECT regexp_extract(name, '(') FROM nation",
+                ".*missing.*\\).*");
+        assertQueryFails(
+                "SELECT regexp_extract(comment, '(\\w+)\\s+(\\w+)', 3) FROM nation",
+                ".*(?:Cannot access group|No group).*");
+        assertQueryFails(
+                "SELECT regexp_extract(comment, '(\\w+)\\s+(\\w+)', -1) FROM nation",
+                ".*(?:cannot be negative|No group).*");
+    }
+
+    @Test
+    public void testRegexpExtractAll()
+    {
+        assertQuery("SELECT regexp_extract_all(name, '[A-Z]') FROM nation");
+        assertQuery("SELECT regexp_extract_all(name, '[A-Z]+') FROM nation");
+        assertQuery("SELECT regexp_extract_all(comment, '\\w+') FROM nation");
+        assertQuery("SELECT regexp_extract_all(comment, '(\\w+)\\s+(\\w+)', 1) FROM nation");
+        assertQuery("SELECT regexp_extract_all(comment, '(\\w+)\\s+(\\w+)', 2) FROM nation");
+        assertQuery("SELECT regexp_extract_all(name, 'ZZZ') FROM nation");
+        assertQuery("SELECT cardinality(regexp_extract_all(comment, '\\w+')) FROM nation");
+        assertQuery("SELECT regexp_extract_all(IF(nationkey = 0, CAST(NULL AS VARCHAR), name), '[A-Z]') FROM nation");
+        assertQuery("SELECT regexp_extract_all(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '[^\\.]+') FROM nation");
+        assertQuery("SELECT regexp_extract_all(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '([^\\.]+)\\.([^\\.]+)', 1) FROM nation");
+        assertQuery("SELECT regexp_extract_all(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '([^\\.]+)\\.([^\\.]+)', 2) FROM nation");
+
+        assertQueryFails(
+                "SELECT regexp_extract_all(name, '(') FROM nation",
+                ".*missing.*\\).*");
+    }
+
+    @Test
+    public void testRegexpReplace()
+    {
+        assertQuery("SELECT regexp_replace(name, 'A') FROM nation");
+        assertQuery("SELECT regexp_replace(comment, '\\s') FROM nation");
+        assertQuery("SELECT regexp_replace(comment, '[aeiou]') FROM nation");
+        assertQuery("SELECT regexp_replace(name, 'A', 'X') FROM nation");
+        assertQuery("SELECT regexp_replace(comment, '\\s+', '_') FROM nation");
+        assertQuery("SELECT regexp_replace(name, '', '-') FROM nation");
+        assertQuery("SELECT regexp_replace(name, 'A', '') FROM nation");
+        assertQuery("SELECT regexp_replace(name, '([A-Z])([A-Z])', '$2$1') FROM nation");
+        assertQuery("SELECT regexp_replace(name, '(?<first>[A-Z])(?<second>[A-Z])', '${second}${first}') FROM nation");
+        assertQuery("SELECT regexp_replace(name, '([A-Z])', x -> lower(x[1])) FROM nation");
+        assertQuery("SELECT regexp_replace(comment, '(\\w)(\\w)', x -> concat(x[2], x[1])) FROM nation");
+        assertQuery("SELECT regexp_replace(IF(nationkey = 0, CAST(NULL AS VARCHAR), name), 'A', 'X') FROM nation");
+
+        assertQueryFails(
+                "SELECT regexp_replace(name, '(', 'X') FROM nation",
+                ".*missing.*\\).*");
+    }
+
+    @Test
+    public void testRegexpSplit()
+    {
+        assertQuery("SELECT regexp_split(name, 'A') FROM nation");
+        assertQuery("SELECT regexp_split(comment, '\\s+') FROM nation");
+        assertQuery("SELECT regexp_split(comment, '[aeiou]') FROM nation");
+        assertQuery("SELECT regexp_split(name, 'ZZZ') FROM nation");
+        assertQuery("SELECT cardinality(regexp_split(comment, '\\s')) FROM nation");
+        assertQuery("SELECT regexp_split(concat(name, '.', cast(regionkey AS VARCHAR), '.', cast(nationkey AS VARCHAR)), '\\.') FROM nation");
+        assertQuery("SELECT regexp_split(IF(nationkey = 0, CAST(NULL AS VARCHAR), name), 'A') FROM nation");
+
+        assertQueryFails(
+                "SELECT regexp_split(name, '(') FROM nation",
+                ".*missing.*\\).*");
+    }
 }


### PR DESCRIPTION
Extends TestRegularExpressionFunctions with regexp_extract, regexp_extract_all, regexp_replace (including numeric/named group references and the lambda overload) and regexp_split, which previously had little or no native e2e coverage.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Extend native end-to-end coverage for regular expression functions in the nation dataset tests.

Tests:
- Add E2E tests for regexp_extract and regexp_extract_all, including group index variants and null/concatenated input cases.
- Add E2E tests for regexp_replace, covering basic replacements, group references (numeric and named), and lambda-based transformations.
- Add E2E tests for regexp_split, including splitting on various patterns, computing cardinality, and handling null inputs.
- Add negative tests verifying error handling for invalid regular expressions across regexp_extract, regexp_extract_all, regexp_replace, and regexp_split.