### PR TITLE
fix(plugin-iceberg): Fix failed delete operation after expire_snapshots

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1569,7 +1569,7 @@ public abstract class IcebergAbstractMetadata
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
 
         RowDelta rowDelta = icebergTable.newRowDelta();
-
+        handle.getIcebergTableName().getSnapshotId().map(rowDelta::validateFromSnapshot);
         Optional<String> branchName = handle.getIcebergTableName().getBranchName();
         if (branchName.isPresent()) {
             rowDelta.toBranch(branchName.get());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1569,7 +1569,7 @@ public abstract class IcebergAbstractMetadata
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
 
         RowDelta rowDelta = icebergTable.newRowDelta();
-        handle.getIcebergTableName().getSnapshotId().map(rowDelta::validateFromSnapshot);
+        handle.getIcebergTableName().getSnapshotId().ifPresent(rowDelta::validateFromSnapshot);
         Optional<String> branchName = handle.getIcebergTableName().getBranchName();
         if (branchName.isPresent()) {
             rowDelta.toBranch(branchName.get());

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2795,6 +2795,40 @@ public abstract class IcebergDistributedTestBase
         }
     }
 
+    @Test
+    public void testExecutingDeletionAfterExpireSnapshots()
+    {
+        String schema = getSession().getSchema().get();
+        String tableName = "test_delete_after_expire_snapshots";
+        try {
+            assertUpdate(format("create table %s (a int, b varchar)", tableName));
+            assertUpdate(format("insert into %s values(1, '1001'), (1, '1002')", tableName), 2);
+            Table table = loadTable(tableName);
+            long snapshotId1 = table.currentSnapshot().snapshotId();
+
+            table.updateProperties()
+                    .set("gc.enabled", "true")
+                    .commit();
+
+            assertUpdate(format("insert into %s values(2, '1003'), (2, '1004')", tableName), 2);
+            table = loadTable(tableName);
+            long snapshotId2 = table.currentSnapshot().snapshotId();
+
+            assertQuery(format("select snapshot_id from \"%s$snapshots\"", tableName), "values " + snapshotId1 + ", " + snapshotId2);
+
+            // Expire previous snapshot to retain only the newest one
+            assertUpdate(format("call system.expire_snapshots(schema => '%s', table_name => '%s', snapshot_ids => %s)", schema, tableName, "ARRAY[" + snapshotId1 + "]"));
+            assertQuery(format("select snapshot_id from \"%s$snapshots\"", tableName), "values " + snapshotId2);
+
+            // After this, the delete operation should execute successfully
+            assertUpdate(format("delete from %s where a > 1 and b < '1004'", tableName), 1);
+            assertQuery("select * from " + tableName, "values(1, '1001'), (1, '1002'), (2, '1004')");
+        }
+        finally {
+            assertUpdate("drop table if exists " + tableName);
+        }
+    }
+
     private void testPathHiddenColumn()
     {
         assertEquals(computeActual("SELECT \"$path\", * FROM test_hidden_columns").getRowCount(), 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2806,6 +2806,8 @@ public abstract class IcebergDistributedTestBase
             Table table = loadTable(tableName);
             long snapshotId1 = table.currentSnapshot().snapshotId();
 
+            // Explicitly set `gc.enabled = true` to guarantee snapshot expiration works across all catalogs.
+            // Some catalogs (like Nessie) default to `false`, which would break snapshot expiration functionality.
             table.updateProperties()
                     .set("gc.enabled", "true")
                     .commit();


### PR DESCRIPTION
## Description

In the `finishDeleteWithOutput` method of `IcebergAbstractMetadata`, the rowDelta is currently not explicitly assigned a starting snapshot via `validateFromSnapshot`. This unnecessarily widens the validation scope. More critically, if the target table has undergone `expire_snapshots` — resulting in an incomplete snapshot history — validation fails with the following error:

```
Cannot determine history between starting snapshot null and the last known ancestor 123456
```

This PR addresses the issue by assigning the snapshot carried by table handle as the rowDelta's starting snapshot.

## Motivation and Context

Fix the issue where delete operation fails after executing `expire_snapshots`

## Impact

N/A

## Test Plan

Added a test case to cover the scenario described in the PR description

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure Iceberg deletes succeed after snapshots have been expired by validating row delta operations against the correct snapshot.

Bug Fixes:
- Fix delete operations on Iceberg tables that fail after running the expire_snapshots procedure by validating from the appropriate snapshot.

Enhancements:
- Expose getTimestampString helper for reuse in tests and procedures.

Tests:
- Add a distributed Iceberg test verifying delete behavior after expire_snapshots retains only the newest snapshot.

## Summary by Sourcery

Fix Iceberg delete operations to correctly validate row delta against the snapshot carried by the table handle, ensuring deletes succeed after snapshot expiration.

Bug Fixes:
- Prevent delete operations on Iceberg tables from failing after expire_snapshots by validating row delta from the appropriate starting snapshot.

Enhancements:
- Expose the getTimestampString helper for reuse outside orphan-files tests.

Tests:
- Add a distributed Iceberg test that verifies delete behavior succeeds after expire_snapshots retains only the newest snapshot.