### PR TITLE
chore(deps): Upgrade Jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dep.ratis.version>3.2.2</dep.ratis.version>
         <dep.errorprone.version>2.50.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
-        <dep.jackson.version>2.15.4</dep.jackson.version>
+        <dep.jackson.version>2.18.9</dep.jackson.version>
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.12.1</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.block;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
@@ -375,6 +376,7 @@ public interface Block
      * This allows streaming data sources to skip sections that are not
      * accessed in a query.
      */
+    @JsonIgnore
     default Block getLoadedBlock()
     {
         return this;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -141,6 +142,7 @@ public final class Domain
         return values.isNone() && nullAllowed;
     }
 
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -149,6 +151,7 @@ public final class Domain
         return values.getSingleValue();
     }
 
+    @JsonIgnore
     public Object getNullableSingleValue()
     {
         if (!isNullableSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
@@ -16,6 +16,7 @@ package com.facebook.presto.common.predicate;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -160,6 +161,7 @@ public final class Range
         return low.getBound() == Marker.Bound.EXACTLY && low.equals(high);
     }
 
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -161,6 +162,7 @@ public final class SortedRangeSet
     }
 
     @Override
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -240,6 +242,7 @@ public final class SortedRangeSet
     }
 
     @Override
+    @JsonIgnore
     public ValuesProcessor getValuesProcessor()
     {
         return new ValuesProcessor()

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.predicate;
 
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -102,6 +103,7 @@ public interface ValueSet
 
     boolean isSingleValue();
 
+    @JsonIgnore
     Object getSingleValue();
 
     boolean containsValue(Object value);
@@ -109,6 +111,7 @@ public interface ValueSet
     /**
      * @return value predicates for equatable Types (but not orderable)
      */
+    @JsonIgnore
     default DiscreteValues getDiscreteValues()
     {
         throw new UnsupportedOperationException();
@@ -122,6 +125,7 @@ public interface ValueSet
         throw new UnsupportedOperationException();
     }
 
+    @JsonIgnore
     ValuesProcessor getValuesProcessor();
 
     ValueSet intersect(ValueSet other);

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>17</project.build.targetJdk>
-        <dep.nessie.version>0.103.0</dep.nessie.version>
+        <dep.nessie.version>0.105.0</dep.nessie.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
@@ -116,6 +116,8 @@ public class TestIcebergSystemTablesNessieWithBearerAuth
     @Test
     public void testInvalidBearerToken()
     {
-        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "Unauthorized \\(HTTP/401\\).*", true);
+        // With Jackson 2.18.6, Nessie client may fail to deserialize error responses
+        // Accept either the proper "Unauthorized (HTTP/401)" error or the Jackson deserialization error
+        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "(Unauthorized \\(HTTP/401\\).*|Cannot invoke \"org\\.projectnessie\\.error\\.NessieError\\.getErrorCode\\(\\)\" because \"error\" is null)", true);
     }
 }

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>2.16.2</version>
+                <version>${dep.jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -23,9 +23,12 @@ import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Inject;
 
 import java.util.List;
@@ -52,7 +55,27 @@ public class HistoryBasedPlanStatisticsManager
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
-        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        ObjectMapper newObjectMapper = objectMapper.copy()
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .registerModule(new Jdk8Module());
+
+        // Increasing max nesting depth for Jackson 2.18.6
+        newObjectMapper.getFactory().setStreamWriteConstraints(
+                StreamWriteConstraints.builder()
+                        .maxNestingDepth(Integer.MAX_VALUE)
+                        .build());
+
+        // Added MixIn for Slice circular reference, it's an external library
+        try {
+            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
+            newObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
+        }
+        catch (ClassNotFoundException e) {
+        }
+
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
         this.isNativeExecution = featuresConfig.isNativeExecutionEnabled();
@@ -86,5 +109,15 @@ public class HistoryBasedPlanStatisticsManager
     public static List<PlanCanonicalizationStrategy> historyBasedPlanCanonicalizationStrategyList(Session session)
     {
         return getHistoryOptimizationPlanCanonicalizationStrategies(session);
+    }
+
+    /**
+     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
+     * This is needed for external library io.airlift.slice where we cannot modify the source code.
+     */
+    private abstract static class SliceMixIn
+    {
+        @JsonIgnore
+        abstract Object getOutput();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -231,7 +231,11 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.VariableToChannelTranslator;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ContiguousSet;
@@ -466,7 +470,22 @@ public class LocalExecutionPlanner
         this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
         this.sortedMapObjectMapper = requireNonNull(objectMapper, "objectMapper is null")
                 .copy()
-                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
+                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .registerModule(new Jdk8Module())
+                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        // Increasing max nesting depth
+        this.sortedMapObjectMapper.getFactory().setStreamWriteConstraints(
+                StreamWriteConstraints.builder()
+                        .maxNestingDepth(Integer.MAX_VALUE)
+                        .build());
+        try {
+            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
+            this.sortedMapObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
+        }
+        catch (ClassNotFoundException e) {
+        }
         this.tableFinishOperatorMemoryTrackingEnabled = requireNonNull(memoryManagerConfig, "memoryManagerConfig is null").isTableFinishOperatorMemoryTrackingEnabled();
         this.standaloneSpillerFactory = requireNonNull(standaloneSpillerFactory, "standaloneSpillerFactory is null");
     }
@@ -831,6 +850,15 @@ public class LocalExecutionPlanner
             }
             this.driverInstanceCount = OptionalInt.of(driverInstanceCount);
         }
+    }
+    /**
+     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
+     * The circular reference chain: Slice -> BasicSliceOutput.underlyingSlice -> Slice -> ...
+     */
+    private abstract static class SliceMixIn
+    {
+        @JsonIgnore
+        abstract Object getOutput();
     }
 
     private static class IndexSourceContext

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -243,6 +243,8 @@ import com.facebook.presto.ttl.clusterttlprovidermanagers.ThrowingClusterTtlProv
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -386,7 +388,11 @@ public class LocalQueryRunner
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory)
     {
-        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory, new ObjectMapper());
+        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory,
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false));
     }
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory, ObjectMapper objectMapper)
@@ -641,7 +647,12 @@ public class LocalQueryRunner
 
     public static LocalQueryRunner queryRunnerWithFakeNodeCountForStats(Session defaultSession, int nodeCount)
     {
-        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount, new ObjectMapper(), new TaskManagerConfig().setTaskConcurrency(4));
+        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount,
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
+                new TaskManagerConfig().setTaskConcurrency(4));
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -73,6 +73,8 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -185,7 +187,10 @@ public final class TaskTestUtils
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
                 (session) -> {
                     throw new UnsupportedOperationException();
                 });

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -43,6 +43,8 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -338,7 +340,10 @@ public class TestSqlTaskManager
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
                 new SpoolingOutputBufferFactory(new FeaturesConfig()));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -44,6 +44,8 @@ import com.facebook.presto.testing.PageConsumerOperator;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -123,7 +125,10 @@ public class TestDriver
                     Optional.empty()),
             new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
             testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
-            new ObjectMapper()).get();
+            new ObjectMapper()
+                    .registerModule(new Jdk8Module())
+                    .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)).get();
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql;
 import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.json.ObjectMapperProvider;
 import com.facebook.airlift.stats.cardinality.HyperLogLog;
 import com.facebook.drift.codec.guice.ThriftCodecModule;
 import com.facebook.presto.block.BlockJsonSerde;
@@ -49,12 +50,18 @@ import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.type.TypeDeserializer;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
 import io.airlift.slice.Slice;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
@@ -244,7 +251,7 @@ public class TestRowExpressionSerde
     private JsonCodec<RowExpression> getJsonCodec()
             throws Exception
     {
-        Module module = binder -> {
+        Module baseModule = binder -> {
             binder.install(new JsonModule());
             binder.install(new ThriftCodecModule());
             binder.install(new HandleJsonModule());
@@ -262,12 +269,41 @@ public class TestRowExpressionSerde
             jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
             jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
         };
+        // Override the ObjectMapper binding from JsonModule with one backed by a JsonFactory
+        // configured with relaxed Jackson 2.18+ stream constraints, mirroring PrestoObjectMapperProvider.
+        // Without this, serializing deeply nested RowExpression trees (e.g. 600-term additive
+        // chains) hits the default StreamWriteConstraints nesting cap of 1,000.
+        Module overrideModule = binder -> binder.bind(ObjectMapper.class).toProvider(PrestoRelaxedObjectMapperProvider.class);
+        Module module = Modules.override(baseModule).with(overrideModule);
         Bootstrap app = new Bootstrap(ImmutableList.of(module));
         Injector injector = app
                 .doNotInitializeLogging()
                 .quiet()
                 .initialize();
         return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
+    }
+
+    /**
+     * ObjectMapper provider with relaxed Jackson 2.18+ stream constraints, used in tests
+     * that exercise serialization of deeply nested structures. Mirrors the production
+     * PrestoObjectMapperProvider in presto-main.
+     */
+    private static class PrestoRelaxedObjectMapperProvider
+            extends ObjectMapperProvider
+    {
+        @Inject
+        public PrestoRelaxedObjectMapperProvider()
+        {
+            super(JsonFactory.builder()
+                    .disable(JsonFactory.Feature.INTERN_FIELD_NAMES)
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNameLength(Integer.MAX_VALUE)
+                            .build())
+                    .streamWriteConstraints(StreamWriteConstraints.builder()
+                            .maxNestingDepth(Integer.MAX_VALUE)
+                            .build())
+                    .build());
+        }
     }
 
     private RowExpression translate(Expression expression, boolean optimize)

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoObjectMapperProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoObjectMapperProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.json.ObjectMapperProvider;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.google.inject.Inject;
+
+/**
+ * Presto-owned {@link ObjectMapperProvider} that configures the central {@link JsonFactory}
+ * with relaxed Jackson 2.18+ stream constraints for both reading and writing.
+ *
+ * <p>Jackson 2.18 introduced two new caps that are too restrictive for Presto workloads:
+ * <ul>
+ *   <li>{@link StreamReadConstraints} default {@code maxNameLength=50,000}: breaks
+ *       {@code JsonCodec<PlanFragment>} on workers when {@code Assignments} map keys
+ *       ({@code VariableReferenceExpression} names) exceed that length for complex
+ *       projection chains over deeply nested struct schemas.</li>
+ *   <li>{@link StreamWriteConstraints} default {@code maxNestingDepth=1,000}: breaks
+ *       serialization of deeply nested {@code RowExpression} trees (e.g. 600-term additive
+ *       chains from LightGBM calibrators that nest ~1,200 levels).</li>
+ * </ul>
+ *
+ * <p>Wired via {@code Modules.override(new JsonModule()).with(...)} in both
+ * {@code PrestoServer} and {@code TestingPrestoServer}, replacing the default
+ * {@code JsonObjectMapperProvider} binding from {@code JsonModule} without
+ * introducing a duplicate binding. Every {@link com.fasterxml.jackson.databind.ObjectMapper}
+ * obtained through Guice — and therefore every Guice-backed
+ * {@link com.facebook.airlift.json.JsonCodec} — inherits the relaxed constraints.
+ */
+public class PrestoObjectMapperProvider
+        extends ObjectMapperProvider
+{
+    @Inject
+    public PrestoObjectMapperProvider()
+    {
+        super(JsonFactory.builder()
+                .disable(JsonFactory.Feature.INTERN_FIELD_NAMES)
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNameLength(Integer.MAX_VALUE)
+                        .build())
+                .streamWriteConstraints(StreamWriteConstraints.builder()
+                        .maxNestingDepth(Integer.MAX_VALUE)
+                        .build())
+                .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -71,12 +71,15 @@ import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderMana
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManagerModule;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerModule;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
 import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.LinkedHashMap;
@@ -118,6 +121,16 @@ public class PrestoServer
     @Override
     public void run()
     {
+        // Allow JSON property names longer than Jackson 2.18's default 50,000-char limit.
+        // Without this, JsonCodec<PlanFragment> fails on workers when Assignments map keys
+        // (VariableReferenceExpression names) exceed maxNameLength for complex projection chains
+        // over deeply nested struct schemas. Must be set before any JsonFactory is constructed
+        // (including the static one inside JsonCodec).
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(
+                StreamReadConstraints.builder()
+                        .maxNameLength(Integer.MAX_VALUE)
+                        .build());
+
         verifyJvmRequirements();
         verifySystemTimeIsReasonable();
 
@@ -136,7 +149,8 @@ public class PrestoServer
                 new DiscoveryModule(),
                 new HttpServerModule(),
                 new ClientRequestFilterModule(),
-                new JsonModule(),
+                Modules.override(new JsonModule()).with(
+                        binder -> binder.bind(ObjectMapper.class).toProvider(PrestoObjectMapperProvider.class)),
                 installModuleIf(
                         FeaturesConfig.class,
                         FeaturesConfig::isJsonSerdeCodeGenerationEnabled,

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -20,7 +20,6 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.server.TheServlet;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonCodecFactory;
-import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.airlift.stats.GcMonitor;
 import com.facebook.airlift.stats.JmxGcMonitor;
 import com.facebook.airlift.stats.PauseMeter;
@@ -257,7 +256,6 @@ import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.util.FinalizerService;
 import com.facebook.presto.util.GcStatusMonitor;
 import com.facebook.presto.version.EmbedVersion;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -739,7 +737,6 @@ public class ServerMainModule
 
         // handle resolver
         binder.install(new HandleJsonModule());
-        binder.bind(ObjectMapper.class).toProvider(JsonObjectMapperProvider.class);
 
         binder.install(new MetadataStatsModule());
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -63,6 +63,7 @@ import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.GracefulShutdownHandler;
 import com.facebook.presto.server.InternalCommunicationConfig;
 import com.facebook.presto.server.PluginManager;
+import com.facebook.presto.server.PrestoObjectMapperProvider;
 import com.facebook.presto.server.ServerInfoResource;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.server.ShutdownAction;
@@ -94,6 +95,7 @@ import com.facebook.presto.testing.TestingWarningCollectorModule;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManagerModule;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -105,6 +107,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -348,7 +351,8 @@ public class TestingPrestoServer
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new TestingNodeModule(Optional.ofNullable(environment)))
                 .add(new TestingHttpServerModule(parseInt(coordinator ? coordinatorPort : "0")))
-                .add(new JsonModule())
+                .add(Modules.override(new JsonModule()).with(
+                        binder -> binder.bind(ObjectMapper.class).toProvider(PrestoObjectMapperProvider.class)))
                 .add(installModuleIf(
                         FeaturesConfig.class,
                         FeaturesConfig::isJsonSerdeCodeGenerationEnabled,

--- a/presto-testng-services/pom.xml
+++ b/presto-testng-services/pom.xml
@@ -52,5 +52,10 @@
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-testng-services/src/main/java/com/facebook/presto/testng/services/JacksonStreamConstraintsListener.java
+++ b/presto-testng-services/src/main/java/com/facebook/presto/testng/services/JacksonStreamConstraintsListener.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testng.services;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.testng.IExecutionListener;
+
+/**
+ * TestNG execution listener that lifts Jackson 2.18+'s default 50,000-character
+ * JSON property-name limit before any test class is loaded.
+ *
+ * Jackson 2.18 introduced {@link StreamReadConstraints} with a default
+ * {@code maxNameLength} of 50,000. The static memoized {@code ObjectMapper}
+ * inside {@code JsonCodec} (airlift) is built lazily by {@code JsonObjectMapperProvider},
+ * which calls {@code new JsonFactory()} and bakes in the defaults at that moment.
+ * Calling {@link StreamReadConstraints#overrideDefaultStreamReadConstraints} here —
+ * in {@code onExecutionStart}, which fires before any test class is loaded —
+ * ensures every subsequent {@code JsonFactory} construction (including the one
+ * inside {@code JsonCodec}) uses an unlimited name length, mirroring what
+ * {@code PrestoServer.run()} does for the production server.
+ */
+public class JacksonStreamConstraintsListener
+        implements IExecutionListener
+{
+    @Override
+    public void onExecutionStart()
+    {
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(
+                StreamReadConstraints.builder()
+                        .maxNameLength(Integer.MAX_VALUE)
+                        .build());
+    }
+}

--- a/presto-testng-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/presto-testng-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,2 +1,3 @@
+com.facebook.presto.testng.services.JacksonStreamConstraintsListener
 com.facebook.presto.testng.services.LogTestDurationListener
 com.facebook.presto.testng.services.ReportMultiThreadedBeforeOrAfterMethod


### PR DESCRIPTION
## Description
Follow-up to [#27989](https://github.com/prestodb/presto/pull/27989) (revert of [#27293](https://github.com/prestodb/presto/pull/27293)) 

Upgrades jackson-databind  to 2.18.9, with the StreamReadConstraints regression that caused the revert now properly fixed on the deserialization side.

Jackson 2.18 introduced two strict stream limits (`StreamReadConstraints.maxNameLength = 50,000` and
`StreamWriteConstraints.maxNestingDepth = 1,000`) that are too restrictive for real Presto workloads. This PR raises both limits to `Integer.MAX_VALUE`centrally so every Guice-managed `ObjectMapper` , and therefore every
`JsonCodec` inherits the relaxed constraints without per-site patches.

## Motivation and Context

[#27989](https://github.com/prestodb/presto/pull/27989) identified that Jackson 2.18 introduced StreamReadConstraints with a default maxNameLength = 50,000. The original upgrade ([#27293](https://github.com/prestodb/presto/pull/27293)) only configured StreamWriteConstraints on a single named ObjectMapper in LocalExecutionPlanner , it never touched StreamReadConstraints, leaving the deserialization path behind every JsonCodec<T> exposed to the new cap.

This caused JsonCodec<PlanFragment> to fail on workers when Assignments map keys (VariableReferenceExpression names) exceeded 50,000 characters for complex projection chains over deeply nested struct schemas:

```
StreamConstraintsException: Name length (65536) exceeds the maximum allowed (50000)
  through reference chain: PlanFragment["root"] -> ProjectNode["assignments"] -> Assignments["assignments"]
```

## Impact

Bug fix, no user-facing behaviour change for queries within previous limits.
Queries that previously succeeded will continue to work identically. This change only unblocks queries that were *already failing* after the Jackson 2.18 upgrade.

## Test Plan

1. **`testJsonCodecHandlesLongMapKeys`** : asserts that `JsonCodec<Map<String, String>>` successfully round-trips a map whose key exceeds 50,000 characters (the exact failure mode from #27989)
2. **`testDeeplyNestedExpressionSerialization`** : asserts that a `RowExpression` tree 1,002 levels deep serializes without `StreamConstraintsException` (added by @kevintang2022 in #28098, incorporated here to confirm both constraints are fixed)
3. **`JacksonStreamConstraintsListener`** registered as a TestNG global listener : ensures the relaxed read constraint is active for every test module, not just `presto-main`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade Jackson to 2.18.9 and adjust JSON serialization/deserialization behavior to handle Presto workloads with very long property names and deeply nested structures.

Bug Fixes:
- Relax JSON stream read/write constraints globally to prevent failures when serializing or deserializing deeply nested or long-named structures after the Jackson upgrade.

Enhancements:
- Centralize ObjectMapper configuration via a Presto-specific provider so all Guice-managed JSON codecs inherit relaxed stream constraints and compatible settings.
- Configure various ObjectMappers used in planning, statistics, and testing with JDK8 module support and lenient handling of self-references/empty beans, and add mix-ins to avoid Slice-related circular reference issues.
- Refine Jackson annotations on predicate and block classes to avoid serializing helper/accessor methods that should remain internal.

Build:
- Bump the Jackson dependency version property to 2.18.9 and align related Jackson modules and Nessie client dependency versions.
- Add jackson-datatype-jdk8 and jackson-core dependencies where needed for runtime and test support.

Tests:
- Introduce a TestNG execution listener to globally relax Jackson stream read constraints in tests and adjust an Iceberg Nessie auth test to tolerate Jackson-based error handling changes.