### PR TITLE
fix: Fix Parquet RLE and PLAIN dictionary decoding for decimals backed by byte arrays

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -1125,6 +1125,58 @@ public abstract class AbstractTestParquetReader
     }
 
     @Test
+    public void testRLELongDecimalBackedByBinary()
+            throws Exception
+    {
+        int precision = 38;
+        int scale = 4;
+        MessageType parquetSchema = parseMessageType(
+                format("message hive_decimal { optional BINARY test (DECIMAL(%d, %d)); }", precision, scale));
+
+        List<HiveDecimal> writeValues = new ArrayList<>();
+        List<SqlDecimal> expectedValues = new ArrayList<>();
+        BigInteger base = BigInteger.TEN.pow(precision - 1);
+        for (int i = 0; i < 2000; i++) {
+            BigInteger v = base.add(BigInteger.valueOf(i % 50));
+            writeValues.add(HiveDecimal.create(v, scale));
+            expectedValues.add(new SqlDecimal(v, precision, scale));
+        }
+
+        tester.testRoundTrip(
+                new JavaHiveDecimalObjectInspector(new DecimalTypeInfo(precision, scale)),
+                writeValues,
+                expectedValues,
+                createDecimalType(precision, scale),
+                Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testRLEShortDecimalBackedByBinary()
+            throws Exception
+    {
+        int precision = 3;
+        int scale = 2;
+        MessageType parquetSchema = parseMessageType(
+                format("message hive_decimal { optional BINARY test (DECIMAL(%d, %d)); }", precision, scale));
+
+        List<HiveDecimal> writeValues = new ArrayList<>();
+        List<SqlDecimal> expectedValues = new ArrayList<>();
+        BigInteger base = BigInteger.TEN.pow(precision - 1);
+        for (int i = 0; i < 2000; i++) {
+            BigInteger v = base.add(BigInteger.valueOf(i % 50));
+            writeValues.add(HiveDecimal.create(v, scale));
+            expectedValues.add(new SqlDecimal(v, precision, scale));
+        }
+
+        tester.testRoundTrip(
+                new JavaHiveDecimalObjectInspector(new DecimalTypeInfo(precision, scale)),
+                writeValues,
+                expectedValues,
+                createDecimalType(precision, scale),
+                Optional.of(parquetSchema));
+    }
+
+    @Test
     public void testSchemaWithRepeatedOptionalRequiredFields()
             throws Exception
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -208,6 +208,12 @@ public class Decoders
                     return new TimestampRLEDictionaryValuesDecoder(bitWidth, inputStream, (TimestampDictionary) dictionary);
                 }
                 case BINARY: {
+                    if (isDecimalType(columnDescriptor)) {
+                        if (isShortDecimalType(columnDescriptor)) {
+                            return new ShortDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
+                        }
+                        return new LongDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
+                    }
                     return new BinaryRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
                 }
                 case FIXED_LEN_BYTE_ARRAY:

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestValuesDecoders.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestValuesDecoders.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.parquet.batchreader.decoders;
 
+import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.parquet.DictionaryPage;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.BinaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.BooleanValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int32ValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimeAndTimestampMicrosValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64ValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.LongDecimalValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.ShortDecimalValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.TimestampValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.UuidValuesDecoder;
@@ -37,17 +39,24 @@ import com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryVa
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.LongDecimalRLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.TimestampRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.UuidRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.dictionary.BinaryBatchDictionary;
 import com.facebook.presto.parquet.batchreader.dictionary.TimestampDictionary;
 import com.facebook.presto.parquet.dictionary.IntegerDictionary;
 import com.facebook.presto.parquet.dictionary.LongDictionary;
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,6 +65,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
@@ -81,6 +91,16 @@ public abstract class TestValuesDecoders
     private static BinaryValuesDecoder binaryDictionary(byte[] pageBytes, int dictionarySize, BinaryBatchDictionary dictionary)
     {
         return new BinaryRLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
+    }
+
+    private static LongDecimalValuesDecoder binaryLongDecimalDictionary(byte[] pageBytes, int dictionarySize, BinaryBatchDictionary dictionary)
+    {
+        return new LongDecimalRLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
+    }
+
+    private static ShortDecimalValuesDecoder binaryShortDecimalDictionary(byte[] pageBytes, int dictionarySize, BinaryBatchDictionary dictionary)
+    {
+        return new ShortDecimalRLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
     }
 
     private static Int64ValuesDecoder int64Plain(byte[] pageBytes)
@@ -218,6 +238,54 @@ public abstract class TestValuesDecoders
             }
 
             inputOffset += readBatchSize;
+
+            int skipBatchSize = min(skipSize, valueCount - inputOffset);
+            decoder.skip(skipBatchSize);
+            inputOffset += skipBatchSize;
+        }
+    }
+
+    private static void longDecimalBatchReadWithSkipHelper(int batchSize, int skipSize, int valueCount, LongDecimalValuesDecoder decoder, List<BigInteger> expectedValues)
+            throws IOException
+    {
+        long[] actualValues = new long[valueCount * 2];
+        int inputOffset = 0;
+        int outputOffset = 0;
+        while (inputOffset < valueCount) {
+            int readBatchSize = min(batchSize, valueCount - inputOffset);
+            decoder.readNext(actualValues, outputOffset, readBatchSize);
+
+            for (int i = 0; i < readBatchSize; i++) {
+                Slice expected = Decimals.encodeUnscaledValue(expectedValues.get(inputOffset + i));
+                assertEquals(actualValues[2 * (outputOffset + i)], expected.getLong(0));
+                assertEquals(actualValues[2 * (outputOffset + i) + 1], expected.getLong(SIZE_OF_LONG));
+            }
+
+            inputOffset += readBatchSize;
+            outputOffset += readBatchSize;
+
+            int skipBatchSize = min(skipSize, valueCount - inputOffset);
+            decoder.skip(skipBatchSize);
+            inputOffset += skipBatchSize;
+        }
+    }
+
+    private static void shortDecimalBatchReadWithSkipHelper(int batchSize, int skipSize, int valueCount, ShortDecimalValuesDecoder decoder, List<BigInteger> expectedValues)
+            throws IOException
+    {
+        long[] actualValues = new long[valueCount];
+        int inputOffset = 0;
+        int outputOffset = 0;
+        while (inputOffset < valueCount) {
+            int readBatchSize = min(batchSize, valueCount - inputOffset);
+            decoder.readNext(actualValues, outputOffset, readBatchSize);
+
+            for (int i = 0; i < readBatchSize; i++) {
+                assertEquals(actualValues[outputOffset + i], expectedValues.get(inputOffset + i).longValueExact());
+            }
+
+            inputOffset += readBatchSize;
+            outputOffset += readBatchSize;
 
             int skipBatchSize = min(skipSize, valueCount - inputOffset);
             decoder.skip(skipBatchSize);
@@ -460,6 +528,78 @@ public abstract class TestValuesDecoders
         binaryBatchReadWithSkipHelper(256, 29, valueCount, binaryDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
         binaryBatchReadWithSkipHelper(89, 29, valueCount, binaryDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
         binaryBatchReadWithSkipHelper(1024, 1024, valueCount, binaryDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+    }
+
+    @Test
+    public void testBinaryLongDecimalRLEDictionary()
+            throws IOException
+    {
+        int valueCount = 2048;
+        int dictionarySize = 29;
+
+        PlainValuesWriter writer = new PlainValuesWriter(64, 1024, new HeapByteBufferAllocator());
+        List<BigInteger> dictionary = new ArrayList<>();
+        BigInteger base = BigInteger.TEN.pow(30);
+        for (int i = 0; i < dictionarySize; i++) {
+            BigInteger v = base.add(BigInteger.valueOf(i));
+            dictionary.add(v);
+            byte[] bytes = v.toByteArray();
+            writer.writeBytes(Binary.fromConstantByteArray(bytes, 0, bytes.length));
+        }
+        byte[] dictionaryPage = writer.getBytes().toByteArray();
+
+        List<Integer> dictionaryIds = new ArrayList<>();
+        byte[] dataPage = generateDictionaryIdPage2048(dictionarySize - 1, dictionaryIds);
+
+        List<BigInteger> expectedValues = dictionaryIds.stream().map(dictionary::get).collect(toImmutableList());
+
+        BinaryBatchDictionary binaryDictionary = new BinaryBatchDictionary(
+                new DictionaryPage(Slices.wrappedBuffer(dictionaryPage), dictionarySize, PLAIN_DICTIONARY));
+
+        longDecimalBatchReadWithSkipHelper(valueCount, 0, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        longDecimalBatchReadWithSkipHelper(29, 0, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        longDecimalBatchReadWithSkipHelper(89, 0, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        longDecimalBatchReadWithSkipHelper(1024, 0, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+
+        longDecimalBatchReadWithSkipHelper(256, 29, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        longDecimalBatchReadWithSkipHelper(89, 29, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        longDecimalBatchReadWithSkipHelper(1024, 1024, valueCount, binaryLongDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+    }
+
+    @Test
+    public void testBinaryShortDecimalRLEDictionary()
+            throws IOException
+    {
+        int valueCount = 2048;
+        int dictionarySize = 29;
+
+        PlainValuesWriter writer = new PlainValuesWriter(64, 1024, new HeapByteBufferAllocator());
+        List<BigInteger> dictionary = new ArrayList<>();
+        BigInteger base = BigInteger.TEN.pow(3);
+        for (int i = 0; i < dictionarySize; i++) {
+            BigInteger v = base.add(BigInteger.valueOf(i));
+            dictionary.add(v);
+            byte[] bytes = v.toByteArray();
+            writer.writeBytes(Binary.fromConstantByteArray(bytes, 0, bytes.length));
+        }
+        byte[] dictionaryPage = writer.getBytes().toByteArray();
+
+        List<Integer> dictionaryIds = new ArrayList<>();
+        byte[] dataPage = generateDictionaryIdPage2048(dictionarySize - 1, dictionaryIds);
+
+        List<BigInteger> expectedValues = dictionaryIds.stream().map(dictionary::get).collect(toImmutableList());
+
+        BinaryBatchDictionary binaryDictionary = new BinaryBatchDictionary(
+                new DictionaryPage(Slices.wrappedBuffer(dictionaryPage), dictionarySize, PLAIN_DICTIONARY));
+
+        shortDecimalBatchReadWithSkipHelper(valueCount, 0, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        shortDecimalBatchReadWithSkipHelper(29, 0, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        shortDecimalBatchReadWithSkipHelper(89, 0, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        shortDecimalBatchReadWithSkipHelper(1024, 0, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+
+        shortDecimalBatchReadWithSkipHelper(256, 29, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        shortDecimalBatchReadWithSkipHelper(89, 29, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
+        shortDecimalBatchReadWithSkipHelper(1024, 1024, valueCount, binaryShortDecimalDictionary(dataPage, dictionarySize, binaryDictionary), expectedValues);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes the `ClassCastException` when reading Parquet Decimals backed by Binary and dictionary encoding enabled.

Schema:
`id_number:                      OPTIONAL BINARY L:DECIMAL(25,0) R:0 D:1`

Stack trace:
`SQL Error [65536]: Query failed (#20260623_150757_00489_8szn4): class com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder cannot be cast to class com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder$LongDecimalValuesDecoder (com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder and com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder$LongDecimalValuesDecoder are in unnamed module of loader com.facebook.presto.server.PluginClassLoader @4d682552)`

## Motivation and Context
Fixes #28070.

This kind of data is generated using an Informatica Data Engineering (DEI) dynamic mapping and therefore that data is not currently readable from Presto.

## Test Plan

- Decoder tests in presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestValuesDecoders.java
- End-to-end tests in presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix Parquet RLE and PLAIN dictionary decoding for decimals backed by byte arrays
```

## Summary by Sourcery

Fix Parquet RLE dictionary decoding for BINARY-backed decimal columns and validate end-to-end Hive Parquet decimal round trips.

Bug Fixes:
- Correctly route BINARY decimal columns to short and long decimal RLE dictionary decoders to avoid ClassCastException when reading dictionary-encoded decimals.

Enhancements:
- Add helper utilities and unit tests for long and short decimal RLE dictionary decoders backed by binary arrays.
- Add Hive Parquet round-trip tests for RLE-encoded short and long decimals stored as BINARY to ensure compatibility with external writers.