### PR TITLE
feat(plugin-iceberg)!: Add binpack strategy for rewrite_data_files

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1475,17 +1475,21 @@ Argument Name         required   type            Description
 
 ``table_name``        Yes        string          Name of the table to update.
 
-``filter``                       string          Predicate as a string used for filtering the files. Currently
-                                                 only rewrite of whole partitions is supported. Filter on partition
-                                                 columns. The default value is ``true``.
+``strategy``                     string          Name of the strategy - binpack or sort. Defaults to binpack.
+                                                 Must be ``'sort'`` when using ``sorted_by``.
 
 ``sorted_by``                    array of        Specify an array of one or more columns to use for sorting. When
                                  strings         performing a rewrite, the specified sorting definition must be
                                                  compatible with the table's own sorting property, if one exists.
                                                  Supports standard column sorting (example, ``'col ASC'``) and
                                                  z-order sorting (example, ``'zorder(col1, col2)'``).
+                                                 **Requires** ``strategy`` to be set to ``'sort'``.
 
 ``options``                      map             Options to be used for data files rewrite. See options table below.
+
+``filter``                       string          Predicate as a string used for filtering the files. Currently
+                                                 only rewrite of whole partitions is supported. Filter on partition
+                                                 columns. The default value is ``true``.
 ===================== ========== =============== =======================================================================
 
 Rewrite Options
@@ -1535,13 +1539,11 @@ Examples
 
 * Rewrite the data files in partitions specified by a filter in table ``db.sample`` to the newest partition spec::
 
-    CALL iceberg.system.rewrite_data_files('db', 'sample', 'partition_key = 1');
     CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', filter => 'partition_key = 1');
 
 * Rewrite the data files in partitions specified by a filter in table ``db.sample`` to the newest partition spec and a sorting definition::
 
-    CALL iceberg.system.rewrite_data_files('db', 'sample', 'partition_key = 1', ARRAY['join_date DESC NULLS FIRST', 'emp_id ASC NULLS LAST']);
-    CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', filter => 'partition_key = 1', sorted_by => ARRAY['join_date']);
+    CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', strategy => 'sort', sorted_by => ARRAY['join_date DESC NULLS FIRST', 'emp_id ASC NULLS LAST'], filter => 'partition_key = 1');
 
 * Rewrite only small files (less than 100MB) in table ``db.sample``::
 
@@ -1583,9 +1585,10 @@ Examples
     CALL iceberg.system.rewrite_data_files(
         schema => 'db',
         table_name => 'sample',
-        filter => 'partition_key = 1',
+        strategy => 'sort',
         sorted_by => ARRAY['join_date'],
-        options => map(array['min-input-files'], array['3'])
+        options => map(array['min-input-files'], array['3']),
+        filter => 'partition_key = 1'
     );
 
 * Use z-order sorting for multi-dimensional data clustering::
@@ -1593,12 +1596,45 @@ Examples
     CALL iceberg.system.rewrite_data_files(
         schema => 'db',
         table_name => 'sample',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(customer_id, order_date)']
     );
 
   Z-order sorting creates a space-filling curve that interleaves bits from multiple columns,
   providing better data locality for queries that filter on multiple dimensions. This is
   particularly useful for tables with multiple commonly-queried columns.
+
+* Use binpack strategy (default) for fast file consolidation without sorting::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample'
+    );
+
+  Binpack is the default strategy and is ideal for simple file consolidation where data ordering
+  is not important. It's significantly faster and uses less memory than sorting.
+
+* Use sort strategy to sort by table's default sort order::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        strategy => 'sort'
+    );
+
+  When strategy is ``'sort'`` without ``sorted_by``, it uses the table's default sort order.
+
+* Use sort strategy with explicit sorting columns::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        strategy => 'sort',
+        sorted_by => ARRAY['join_date']
+    );
+
+  Sort strategy is required when using ``sorted_by``. It provides better compression and query
+  performance through data clustering but is slower and more memory-intensive than binpack.
 
 Rewrite Manifests
 ^^^^^^^^^^^^^^^^^
@@ -1686,6 +1722,7 @@ performance.
     CALL iceberg.system.rewrite_data_files(
         schema => 'sales',
         table_name => 'orders',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(customer_id, order_date)']
     );
 
@@ -1694,6 +1731,7 @@ performance.
     CALL iceberg.system.rewrite_data_files(
         schema => 'analytics',
         table_name => 'events',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(user_id, event_time, event_type)']
     );
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1519,17 +1519,21 @@ Argument Name         required   type            Description
 
 ``table_name``        Yes        string          Name of the table to update.
 
-``filter``                       string          Predicate as a string used for filtering the files. Currently
-                                                 only rewrite of whole partitions is supported. Filter on partition
-                                                 columns. The default value is ``true``.
+``strategy``                     string          Name of the strategy - binpack or sort. Defaults to binpack.
+                                                 Must be ``'sort'`` when using ``sorted_by``.
 
 ``sorted_by``                    array of        Specify an array of one or more columns to use for sorting. When
                                  strings         performing a rewrite, the specified sorting definition must be
                                                  compatible with the table's own sorting property, if one exists.
                                                  Supports standard column sorting (example, ``'col ASC'``) and
                                                  z-order sorting (example, ``'zorder(col1, col2)'``).
+                                                 **Requires** ``strategy`` to be set to ``'sort'``.
 
 ``options``                      map             Options to be used for data files rewrite. See options table below.
+
+``filter``                       string          Predicate as a string used for filtering the files. Currently
+                                                 only rewrite of whole partitions is supported. Filter on partition
+                                                 columns. The default value is ``true``.
 ===================== ========== =============== =======================================================================
 
 Rewrite Options
@@ -1579,13 +1583,11 @@ Examples
 
 * Rewrite the data files in partitions specified by a filter in table ``db.sample`` to the newest partition spec::
 
-    CALL iceberg.system.rewrite_data_files('db', 'sample', 'partition_key = 1');
     CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', filter => 'partition_key = 1');
 
 * Rewrite the data files in partitions specified by a filter in table ``db.sample`` to the newest partition spec and a sorting definition::
 
-    CALL iceberg.system.rewrite_data_files('db', 'sample', 'partition_key = 1', ARRAY['join_date DESC NULLS FIRST', 'emp_id ASC NULLS LAST']);
-    CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', filter => 'partition_key = 1', sorted_by => ARRAY['join_date']);
+    CALL iceberg.system.rewrite_data_files(schema => 'db', table_name => 'sample', strategy => 'sort', sorted_by => ARRAY['join_date DESC NULLS FIRST', 'emp_id ASC NULLS LAST'], filter => 'partition_key = 1');
 
 * Rewrite only small files (less than 100MB) in table ``db.sample``::
 
@@ -1627,9 +1629,10 @@ Examples
     CALL iceberg.system.rewrite_data_files(
         schema => 'db',
         table_name => 'sample',
-        filter => 'partition_key = 1',
+        strategy => 'sort',
         sorted_by => ARRAY['join_date'],
-        options => map(array['min-input-files'], array['3'])
+        options => map(array['min-input-files'], array['3']),
+        filter => 'partition_key = 1'
     );
 
 * Use z-order sorting for multi-dimensional data clustering::
@@ -1637,12 +1640,45 @@ Examples
     CALL iceberg.system.rewrite_data_files(
         schema => 'db',
         table_name => 'sample',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(customer_id, order_date)']
     );
 
   Z-order sorting creates a space-filling curve that interleaves bits from multiple columns,
   providing better data locality for queries that filter on multiple dimensions. This is
   particularly useful for tables with multiple commonly-queried columns.
+
+* Use binpack strategy (default) for fast file consolidation without sorting::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample'
+    );
+
+  Binpack is the default strategy and is ideal for simple file consolidation where data ordering
+  is not important. It's significantly faster and uses less memory than sorting.
+
+* Use sort strategy to sort by table's default sort order::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        strategy => 'sort'
+    );
+
+  When strategy is ``'sort'`` without ``sorted_by``, it uses the table's default sort order.
+
+* Use sort strategy with explicit sorting columns::
+
+    CALL iceberg.system.rewrite_data_files(
+        schema => 'db',
+        table_name => 'sample',
+        strategy => 'sort',
+        sorted_by => ARRAY['join_date']
+    );
+
+  Sort strategy is required when using ``sorted_by``. It provides better compression and query
+  performance through data clustering but is slower and more memory-intensive than binpack.
 
 Rewrite Manifests
 ^^^^^^^^^^^^^^^^^
@@ -1730,6 +1766,7 @@ performance.
     CALL iceberg.system.rewrite_data_files(
         schema => 'sales',
         table_name => 'orders',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(customer_id, order_date)']
     );
 
@@ -1738,6 +1775,7 @@ performance.
     CALL iceberg.system.rewrite_data_files(
         schema => 'analytics',
         table_name => 'events',
+        strategy => 'sort',
         sorted_by => ARRAY['zorder(user_id, event_time, event_type)']
     );
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -258,6 +258,14 @@ public final class IcebergUtil
 
     public static final int DEFAULT_MIN_INPUT_FILES = 5;
 
+    public enum RewriteStrategy
+    {
+        SORT,
+        BINPACK
+    }
+
+    public static final RewriteStrategy DEFAULT_REWRITE_STRATEGY = RewriteStrategy.BINPACK;
+
     private static final Schema LINEAGE_ONLY_SCHEMA = new Schema(LAST_UPDATED_SEQUENCE_NUMBER);
     private static final InclusiveMetricsEvaluator MATCH_ALL_LINEAGE_EVALUATOR =
             new InclusiveMetricsEvaluator(LINEAGE_ONLY_SCHEMA, alwaysTrue());
@@ -1913,5 +1921,29 @@ public final class IcebergUtil
             return (minFileSizeBytes > 0 && fileSize < minFileSizeBytes) ||
                     (maxFileSizeBytes > 0 && fileSize > maxFileSizeBytes);
         });
+    }
+
+    /**
+     * Parses and validates the rewrite strategy option.
+     * Returns the parsed RewriteStrategy value, or DEFAULT_REWRITE_STRATEGY (BINPACK) if the option is not present.
+     *
+     * @param options rewrite options map
+     * @return the rewrite strategy to use
+     * @throws IllegalArgumentException if the value is invalid
+     */
+    public static RewriteStrategy parseRewriteStrategy(Map<String, String> options)
+    {
+        String strategyStr = options.get("strategy");
+        if (strategyStr == null) {
+            return DEFAULT_REWRITE_STRATEGY;
+        }
+
+        try {
+            return RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                String.format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr), e);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -264,8 +264,6 @@ public final class IcebergUtil
         BINPACK
     }
 
-    public static final RewriteStrategy DEFAULT_REWRITE_STRATEGY = RewriteStrategy.BINPACK;
-
     private static final Schema LINEAGE_ONLY_SCHEMA = new Schema(LAST_UPDATED_SEQUENCE_NUMBER);
     private static final InclusiveMetricsEvaluator MATCH_ALL_LINEAGE_EVALUATOR =
             new InclusiveMetricsEvaluator(LINEAGE_ONLY_SCHEMA, alwaysTrue());
@@ -1923,29 +1921,5 @@ public final class IcebergUtil
             return (minFileSizeBytes > 0 && fileSize < minFileSizeBytes) ||
                     (maxFileSizeBytes > 0 && fileSize > maxFileSizeBytes);
         });
-    }
-
-    /**
-     * Parses and validates the rewrite strategy option.
-     * Returns the parsed RewriteStrategy value, or DEFAULT_REWRITE_STRATEGY (BINPACK) if the option is not present.
-     *
-     * @param options rewrite options map
-     * @return the rewrite strategy to use
-     * @throws IllegalArgumentException if the value is invalid
-     */
-    public static RewriteStrategy parseRewriteStrategy(Map<String, String> options)
-    {
-        String strategyStr = options.get("strategy");
-        if (strategyStr == null) {
-            return DEFAULT_REWRITE_STRATEGY;
-        }
-
-        try {
-            return RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
-        }
-        catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
-                String.format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr), e);
-        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -258,6 +258,14 @@ public final class IcebergUtil
 
     public static final int DEFAULT_MIN_INPUT_FILES = 5;
 
+    public enum RewriteStrategy
+    {
+        SORT,
+        BINPACK
+    }
+
+    public static final RewriteStrategy DEFAULT_REWRITE_STRATEGY = RewriteStrategy.BINPACK;
+
     private static final Schema LINEAGE_ONLY_SCHEMA = new Schema(LAST_UPDATED_SEQUENCE_NUMBER);
     private static final InclusiveMetricsEvaluator MATCH_ALL_LINEAGE_EVALUATOR =
             new InclusiveMetricsEvaluator(LINEAGE_ONLY_SCHEMA, alwaysTrue());
@@ -1915,5 +1923,29 @@ public final class IcebergUtil
             return (minFileSizeBytes > 0 && fileSize < minFileSizeBytes) ||
                     (maxFileSizeBytes > 0 && fileSize > maxFileSizeBytes);
         });
+    }
+
+    /**
+     * Parses and validates the rewrite strategy option.
+     * Returns the parsed RewriteStrategy value, or DEFAULT_REWRITE_STRATEGY (BINPACK) if the option is not present.
+     *
+     * @param options rewrite options map
+     * @return the rewrite strategy to use
+     * @throws IllegalArgumentException if the value is invalid
+     */
+    public static RewriteStrategy parseRewriteStrategy(Map<String, String> options)
+    {
+        String strategyStr = options.get("strategy");
+        if (strategyStr == null) {
+            return DEFAULT_REWRITE_STRATEGY;
+        }
+
+        try {
+            return RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                String.format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr), e);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -59,6 +59,7 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -70,6 +71,7 @@ import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpressio
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.getSupportedSortFields;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.Z_ORDER;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
+import static com.facebook.presto.iceberg.IcebergUtil.RewriteStrategy;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByFile;
 import static com.facebook.presto.iceberg.IcebergUtil.filterByGroup;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
@@ -114,15 +116,19 @@ public class RewriteDataFilesProcedure
                 ImmutableList.of(
                         new Argument(SCHEMA, VARCHAR),
                         new Argument(TABLE_NAME, VARCHAR),
-                        new Argument("filter", VARCHAR, false, "TRUE"),
+                        new Argument("strategy", VARCHAR, false, null),
                         new Argument("sorted_by", "array(varchar)", false, null),
-                        new Argument("options", "map(varchar, varchar)", false, null)),
+                        new Argument("options", "map(varchar, varchar)", false, null),
+                        new Argument("filter", VARCHAR, false, "TRUE")),
                 (session, procedureContext, tableLayoutHandle, arguments, sortOrderIndex) -> beginCallDistributedProcedure(session, (IcebergRewriteDataFilesProcedureContext) procedureContext, (IcebergTableLayoutHandle) tableLayoutHandle, arguments, sortOrderIndex),
                 ((session, procedureContext, tableHandle, fragments) -> finishCallDistributedProcedure(session, (IcebergRewriteDataFilesProcedureContext) procedureContext, tableHandle, fragments)),
                 arguments -> {
                     // Context provider receives [Table, Transaction, procedureArguments]
                     checkArgument(arguments.length >= 2, format("invalid number of arguments: %s (should have at least %s)", arguments.length, 2));
                     checkArgument(arguments[0] instanceof Table && arguments[1] instanceof IcebergAbstractMetadata, "Invalid arguments, required: [Table, IcebergAbstractMetadata]");
+
+                    // Validate strategy argument early
+                    validateStrategy(arguments);
 
                     // Extract and validate options from procedure arguments if present
                     Map<String, String> options = extractAndValidateOptions(arguments);
@@ -131,12 +137,38 @@ public class RewriteDataFilesProcedure
                 });
     }
 
+    private static void validateStrategy(Object[] contextProviderArgs)
+    {
+        if (contextProviderArgs.length > 2 && contextProviderArgs[2] instanceof Object[]) {
+            Object[] procedureArgs = (Object[]) contextProviderArgs[2];
+            // Strategy is the 3rd procedure parameter (index 2)
+            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
+            if (procedureArgs.length > 2 && procedureArgs[2] != null) {
+                String strategyStr;
+                if (procedureArgs[2] instanceof Slice) {
+                    strategyStr = ((Slice) procedureArgs[2]).toStringUtf8();
+                }
+                else {
+                    strategyStr = procedureArgs[2].toString();
+                }
+                try {
+                    RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
+                }
+                catch (IllegalArgumentException e) {
+                    throw new PrestoException(NOT_SUPPORTED,
+                            format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr));
+                }
+            }
+        }
+    }
+
     private static Map<String, String> extractAndValidateOptions(Object[] contextProviderArgs)
     {
         Map<String, String> options = ImmutableMap.of();
         if (contextProviderArgs.length > 2 && contextProviderArgs[2] instanceof Object[]) {
             Object[] procedureArgs = (Object[]) contextProviderArgs[2];
             // Options is the 5th procedure parameter (index 4)
+            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
             if (procedureArgs.length > 4 && procedureArgs[4] != null && procedureArgs[4] instanceof Map) {
                 options = (Map<String, String>) procedureArgs[4];
 
@@ -161,33 +193,65 @@ public class RewriteDataFilesProcedure
             Table icebergTable = procedureContext.getTable();
             IcebergTableHandle tableHandle = layoutHandle.getTable();
 
+            // Extract strategy argument (3rd argument, index 2)
+            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
+            // Strategy is already validated in the context provider
+            RewriteStrategy strategy = RewriteStrategy.BINPACK; // default
+            if (arguments.length > 2 && arguments[2] != null) {
+                String strategyStr;
+                if (arguments[2] instanceof Slice) {
+                    strategyStr = ((Slice) arguments[2]).toStringUtf8();
+                }
+                else {
+                    strategyStr = arguments[2].toString();
+                }
+                // No validation needed here - already done in context provider
+                strategy = RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
+            }
+
             SortOrder sortOrder = icebergTable.sortOrder();
             Optional<List<String>> zOrderColumns = Optional.empty();
             List<String> sortFieldStrings = extractSortFieldStrings(arguments, sortOrderIndex);
-            if (!sortFieldStrings.isEmpty()) {
-                zOrderColumns = extractZOrderColumns(sortFieldStrings);
 
-                // Validate that zorder is not mixed with regular column names
-                boolean hasZOrder = zOrderColumns.isPresent();
-                List<String> nonZOrderFields = sortFieldStrings.stream()
-                        .filter(str -> !str.startsWith("zorder"))
-                        .collect(toImmutableList());
-                boolean hasRegularColumns = !nonZOrderFields.isEmpty();
+            // Validate strategy and sorted_by interaction
+            if (!sortFieldStrings.isEmpty() && strategy == RewriteStrategy.BINPACK) {
+                throw new PrestoException(NOT_SUPPORTED,
+                        "Cannot use binpack strategy with sorted_by option. Use sort strategy when specifying sort order.");
+            }
 
-                if (hasZOrder && hasRegularColumns) {
-                    throw new PrestoException(NOT_SUPPORTED,
-                            "Cannot mix zorder function with regular column names in sorted_by. " +
-                            "Use either zorder function alone or regular column names, but not both.");
-                }
+            // Handle sort order based on strategy
+            if (strategy == RewriteStrategy.SORT) {
+                // Sort strategy: use sorted_by if specified, otherwise use table's sort order
+                if (!sortFieldStrings.isEmpty()) {
+                    zOrderColumns = extractZOrderColumns(sortFieldStrings);
 
-                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields);
-                if (specifiedSortOrder.satisfies(sortOrder)) {
-                    // If the specified sort order satisfies the target table's internal sort order, use the specified sort order
-                    sortOrder = specifiedSortOrder;
+                    // Validate that zorder is not mixed with regular column names
+                    boolean hasZOrder = zOrderColumns.isPresent();
+                    List<String> nonZOrderFields = sortFieldStrings.stream()
+                            .filter(str -> !str.startsWith("zorder"))
+                            .collect(toImmutableList());
+                    boolean hasRegularColumns = !nonZOrderFields.isEmpty();
+
+                    if (hasZOrder && hasRegularColumns) {
+                        throw new PrestoException(NOT_SUPPORTED,
+                                "Cannot mix zorder function with regular column names in sorted_by. " +
+                                "Use either zorder function alone or regular column names, but not both.");
+                    }
+
+                    SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields);
+                    if (specifiedSortOrder.satisfies(sortOrder)) {
+                        // If the specified sort order satisfies the target table's internal sort order, use the specified sort order
+                        sortOrder = specifiedSortOrder;
+                    }
+                    else {
+                        throw new PrestoException(NOT_SUPPORTED, "Specified sort order is incompatible with the target table's internal sort order");
+                    }
                 }
-                else {
-                    throw new PrestoException(NOT_SUPPORTED, "Specified sort order is incompatible with the target table's internal sort order");
-                }
+                // else: keep the table's default sortOrder
+            }
+            else if (strategy == RewriteStrategy.BINPACK) {
+                // For binpack strategy, clear the sort order to avoid sorting
+                sortOrder = SortOrder.unsorted();
             }
 
             List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -95,6 +95,10 @@ import static java.util.Objects.requireNonNull;
 public class RewriteDataFilesProcedure
         implements Provider<DistributedProcedure>
 {
+    // Positions within the procedure arguments: [schema, table_name, strategy, sorted_by, options, filter]
+    private static final int STRATEGY_ARGUMENT_INDEX = 2;
+    private static final int OPTIONS_ARGUMENT_INDEX = 4;
+
     TypeManager typeManager;
     JsonCodec<CommitTaskData> commitTaskCodec;
 
@@ -123,61 +127,65 @@ public class RewriteDataFilesProcedure
                 (session, procedureContext, tableLayoutHandle, arguments, sortOrderIndex) -> beginCallDistributedProcedure(session, (IcebergRewriteDataFilesProcedureContext) procedureContext, (IcebergTableLayoutHandle) tableLayoutHandle, arguments, sortOrderIndex),
                 ((session, procedureContext, tableHandle, fragments) -> finishCallDistributedProcedure(session, (IcebergRewriteDataFilesProcedureContext) procedureContext, tableHandle, fragments)),
                 arguments -> {
-                    // Context provider receives [Table, Transaction, procedureArguments]
+                    // Context provider receives [Table, IcebergAbstractMetadata, procedureArguments]
                     checkArgument(arguments.length >= 2, format("invalid number of arguments: %s (should have at least %s)", arguments.length, 2));
                     checkArgument(arguments[0] instanceof Table && arguments[1] instanceof IcebergAbstractMetadata, "Invalid arguments, required: [Table, IcebergAbstractMetadata]");
 
-                    // Validate strategy argument early
-                    validateStrategy(arguments);
+                    Object[] procedureArguments = extractProcedureArguments(arguments);
+
+                    // Parse and validate the strategy eagerly, so invalid values fail before the query executes
+                    RewriteStrategy strategy = parseStrategy(procedureArguments);
 
                     // Extract and validate options from procedure arguments if present
-                    Map<String, String> options = extractAndValidateOptions(arguments);
+                    Map<String, String> options = extractAndValidateOptions(procedureArguments);
 
-                    return new IcebergRewriteDataFilesProcedureContext((Table) arguments[0], (IcebergAbstractMetadata) arguments[1], options);
+                    return new IcebergRewriteDataFilesProcedureContext((Table) arguments[0], (IcebergAbstractMetadata) arguments[1], strategy, options);
                 });
     }
 
-    private static void validateStrategy(Object[] contextProviderArgs)
+    private static Object[] extractProcedureArguments(Object[] contextProviderArgs)
     {
         if (contextProviderArgs.length > 2 && contextProviderArgs[2] instanceof Object[]) {
-            Object[] procedureArgs = (Object[]) contextProviderArgs[2];
-            // Strategy is the 3rd procedure parameter (index 2)
-            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
-            if (procedureArgs.length > 2 && procedureArgs[2] != null) {
-                String strategyStr;
-                if (procedureArgs[2] instanceof Slice) {
-                    strategyStr = ((Slice) procedureArgs[2]).toStringUtf8();
-                }
-                else {
-                    strategyStr = procedureArgs[2].toString();
-                }
-                try {
-                    RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
-                }
-                catch (IllegalArgumentException e) {
-                    throw new PrestoException(NOT_SUPPORTED,
-                            format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr));
-                }
-            }
+            return (Object[]) contextProviderArgs[2];
+        }
+        return new Object[0];
+    }
+
+    /**
+     * Parses the `strategy` procedure argument, defaulting to {@link RewriteStrategy#BINPACK} when it is not specified.
+     *
+     * @throws PrestoException if the value is not a recognized strategy
+     */
+    private static RewriteStrategy parseStrategy(Object[] procedureArgs)
+    {
+        if (procedureArgs.length <= STRATEGY_ARGUMENT_INDEX || procedureArgs[STRATEGY_ARGUMENT_INDEX] == null) {
+            return RewriteStrategy.BINPACK;
+        }
+
+        Object strategyArgument = procedureArgs[STRATEGY_ARGUMENT_INDEX];
+        String strategyStr = strategyArgument instanceof Slice ?
+                ((Slice) strategyArgument).toStringUtf8() :
+                strategyArgument.toString();
+        try {
+            return RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(NOT_SUPPORTED,
+                    format("Invalid rewrite strategy: %s. Valid values are 'sort' or 'binpack'.", strategyStr));
         }
     }
 
-    private static Map<String, String> extractAndValidateOptions(Object[] contextProviderArgs)
+    private static Map<String, String> extractAndValidateOptions(Object[] procedureArgs)
     {
         Map<String, String> options = ImmutableMap.of();
-        if (contextProviderArgs.length > 2 && contextProviderArgs[2] instanceof Object[]) {
-            Object[] procedureArgs = (Object[]) contextProviderArgs[2];
-            // Options is the 5th procedure parameter (index 4)
-            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
-            if (procedureArgs.length > 4 && procedureArgs[4] != null && procedureArgs[4] instanceof Map) {
-                options = (Map<String, String>) procedureArgs[4];
+        if (procedureArgs.length > OPTIONS_ARGUMENT_INDEX && procedureArgs[OPTIONS_ARGUMENT_INDEX] instanceof Map) {
+            options = (Map<String, String>) procedureArgs[OPTIONS_ARGUMENT_INDEX];
 
-                // Validate options if present using utility methods
-                parseMinInputFiles(options);
-                parseMinFileSize(options);
-                parseMaxFileSize(options);
-                parseRewriteAll(options);
-            }
+            // Validate options if present using utility methods
+            parseMinInputFiles(options);
+            parseMinFileSize(options);
+            parseMaxFileSize(options);
+            parseRewriteAll(options);
         }
         return options;
     }
@@ -193,21 +201,8 @@ public class RewriteDataFilesProcedure
             Table icebergTable = procedureContext.getTable();
             IcebergTableHandle tableHandle = layoutHandle.getTable();
 
-            // Extract strategy argument (3rd argument, index 2)
-            // Arguments: [schema, table_name, strategy, sorted_by, options, filter]
-            // Strategy is already validated in the context provider
-            RewriteStrategy strategy = RewriteStrategy.BINPACK; // default
-            if (arguments.length > 2 && arguments[2] != null) {
-                String strategyStr;
-                if (arguments[2] instanceof Slice) {
-                    strategyStr = ((Slice) arguments[2]).toStringUtf8();
-                }
-                else {
-                    strategyStr = arguments[2].toString();
-                }
-                // No validation needed here - already done in context provider
-                strategy = RewriteStrategy.valueOf(strategyStr.trim().toUpperCase(Locale.ENGLISH));
-            }
+            // Parsed and validated when the procedure context was created
+            RewriteStrategy strategy = procedureContext.getStrategy();
 
             SortOrder sortOrder = icebergTable.sortOrder();
             Optional<List<String>> zOrderColumns = Optional.empty();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergSplitSource;
+import com.facebook.presto.iceberg.IcebergUtil.RewriteStrategy;
 import com.facebook.presto.iceberg.procedure.splits.RewriteDataFilesIcebergSplitSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.collect.ImmutableMap;
@@ -33,12 +34,14 @@ public class IcebergRewriteDataFilesProcedureContext
 {
     final Table table;
     final IcebergAbstractMetadata metadata;
+    final RewriteStrategy strategy;
     final Map<String, String> options;
 
-    public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata, Map<String, String> options)
+    public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata, RewriteStrategy strategy, Map<String, String> options)
     {
         this.table = requireNonNull(table, "table is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.strategy = requireNonNull(strategy, "strategy is null");
         this.options = ImmutableMap.copyOf(requireNonNull(options, "options is null"));
     }
 
@@ -50,6 +53,11 @@ public class IcebergRewriteDataFilesProcedureContext
     public IcebergAbstractMetadata getMetadata()
     {
         return metadata;
+    }
+
+    public RewriteStrategy getStrategy()
+    {
+        return strategy;
     }
 
     public Map<String, String> getOptions()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1899,7 +1899,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1922,7 +1922,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1946,7 +1946,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1969,7 +1969,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1996,7 +1996,7 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "DESC"));
             }
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -2022,10 +2022,10 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "ASC"));
             }
 
-            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'])", schema, tableName),
+            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'])", schema, tableName),
                     "Specified sort order is incompatible with the target table's internal sort order");
 
-            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['emp_name ASC', 'id ASC'])", schema, tableName),
+            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['emp_name ASC', 'id ASC'])", schema, tableName),
                     "Specified sort order is incompatible with the target table's internal sort order");
         }
         finally {
@@ -2052,6 +2052,7 @@ public abstract class IcebergDistributedTestBase
                     "CALL system.rewrite_data_files(" +
                             "schema => '%s', " +
                             "table_name => '%s', " +
+                            "strategy => 'sort', " +
                             "filter => 'emp_name = ''AAAAA''', " +
                             "sorted_by => ARRAY['id desc'], " +
                             "options => map(array['rewrite-all'], array['true']))",
@@ -2062,6 +2063,7 @@ public abstract class IcebergDistributedTestBase
                     "CALL system.rewrite_data_files(" +
                             "schema => '%s', " +
                             "table_name => '%s', " +
+                            "strategy => 'sort', " +
                             "filter => 'emp_name = ''BBBBB''', " +
                             "sorted_by => ARRAY['id asc'], " +
                             "options => map(array['rewrite-all'], array['true']))",

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1912,7 +1912,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1935,7 +1935,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -1959,7 +1959,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'DDDD')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'FFFF')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -1982,7 +1982,7 @@ public abstract class IcebergDistributedTestBase
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'BBBB'), (4,'AAAA')", 2);
             assertUpdate("INSERT INTO " + tableName + " VALUES (9, 'CCCC'), (11,'BBBB')", 2);
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 3);
             for (Object filePath : result.getOnlyColumnAsSet()) {
@@ -2009,7 +2009,7 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "DESC"));
             }
 
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC', 'emp_name ASC'], options => map(array['rewrite-all'], array['true']))", schema, tableName), 7);
             MaterializedResult result = computeActual("SELECT file_path from \"" + tableName + "$files\"");
             assertEquals(result.getOnlyColumnAsSet().size(), 1);
             String filePath = String.valueOf(result.getOnlyValue());
@@ -2035,10 +2035,10 @@ public abstract class IcebergDistributedTestBase
                 assertTrue(isFileSorted(String.valueOf(filePath), "id", "ASC"));
             }
 
-            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id DESC'])", schema, tableName),
+            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['id DESC'])", schema, tableName),
                     "Specified sort order is incompatible with the target table's internal sort order");
 
-            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['emp_name ASC', 'id ASC'])", schema, tableName),
+            assertQueryFails(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', sorted_by => ARRAY['emp_name ASC', 'id ASC'])", schema, tableName),
                     "Specified sort order is incompatible with the target table's internal sort order");
         }
         finally {
@@ -2065,6 +2065,7 @@ public abstract class IcebergDistributedTestBase
                     "CALL system.rewrite_data_files(" +
                             "schema => '%s', " +
                             "table_name => '%s', " +
+                            "strategy => 'sort', " +
                             "filter => 'emp_name = ''AAAAA''', " +
                             "sorted_by => ARRAY['id desc'], " +
                             "options => map(array['rewrite-all'], array['true']))",
@@ -2075,6 +2076,7 @@ public abstract class IcebergDistributedTestBase
                     "CALL system.rewrite_data_files(" +
                             "schema => '%s', " +
                             "table_name => '%s', " +
+                            "strategy => 'sort', " +
                             "filter => 'emp_name = ''BBBBB''', " +
                             "sorted_by => ARRAY['id asc'], " +
                             "options => map(array['rewrite-all'], array['true']))",

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -1300,7 +1300,7 @@ public class TestRewriteDataFilesProcedure
 
             // Test rewrite_data_files with sorted_by using zorder function
             // The zorder function now uses ROW type: zorder(ROW(orderkey, partkey))
-            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)'], options => map(array['rewrite-all'], array['true']))",
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                     TEST_SCHEMA, tableName), 6);
 
             table.refresh();
@@ -1357,13 +1357,13 @@ public class TestRewriteDataFilesProcedure
 
             // Test that mixing zorder with regular column names fails
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)', 'comment'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)', 'comment'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Cannot mix zorder function with regular column names in sorted_by.*");
 
             // Also test the reverse order
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['comment', 'zorder(orderkey, partkey)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['comment', 'zorder(orderkey, partkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Cannot mix zorder function with regular column names in sorted_by.*");
         }
@@ -1382,7 +1382,7 @@ public class TestRewriteDataFilesProcedure
 
             // Test that using decimal type in zorder fails
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(price, quantity)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(price, quantity)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Cannot use column of type .* in ZOrdering, the type is unsupported.*");
         }
@@ -1401,19 +1401,19 @@ public class TestRewriteDataFilesProcedure
 
             // Test that using non-existent column in zorder fails with clear error
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(invalid_column, partkey)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(invalid_column, partkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Z-order column\\(s\\) not found in table: \\[invalid_column\\].*");
 
             // Test with multiple invalid columns
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(invalid1, invalid2, partkey)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(invalid1, invalid2, partkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Z-order column\\(s\\) not found in table: \\[invalid1, invalid2\\].*");
 
             // Test with all invalid columns
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(nonexistent1, nonexistent2)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(nonexistent1, nonexistent2)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Z-order column\\(s\\) not found in table: \\[nonexistent1, nonexistent2\\].*");
         }
@@ -1432,19 +1432,19 @@ public class TestRewriteDataFilesProcedure
 
             // Test malformed zorder expression (missing closing parenthesis)
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Malformed zorder\\(\\.\\.\\.\\) expression.*");
 
             // Test malformed zorder expression (invalid syntax)
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey partkey)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey partkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Malformed zorder\\(\\.\\.\\.\\) expression.*");
 
             // Test malformed zorder expression (extra characters)
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey))'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey))'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Malformed zorder\\(\\.\\.\\.\\) expression.*");
         }
@@ -1463,9 +1463,183 @@ public class TestRewriteDataFilesProcedure
 
             // Test multiple zorder expressions
             assertQueryFails(
-                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)', 'zorder(suppkey)'], options => map(array['rewrite-all'], array['true']))",
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['zorder(orderkey, partkey)', 'zorder(suppkey)'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
                             TEST_SCHEMA, tableName),
                     ".*Multiple zorder\\(\\.\\.\\.\\) expressions are not supported in sorted_by.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesWithBinpackStrategy()
+    {
+        String tableName = "test_binpack_strategy";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c'), (1, 'a'), (2, 'b')", 3);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (6, 'f'), (4, 'd'), (5, 'e')", 3);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Rewrite with binpack strategy - should combine files without sorting
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'binpack', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 6);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+
+            // Verify all data is present (binpack preserves data)
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 6");
+            assertQuery("SELECT * FROM " + tableName,
+                    "VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesWithSortStrategy()
+    {
+        String tableName = "test_sort_strategy";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c'), (1, 'a'), (2, 'b')", 3);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (6, 'f'), (4, 'd'), (5, 'e')", 3);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Rewrite with sort strategy and sorted_by
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 6);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+
+            // Verify data IS sorted
+            assertQuery("SELECT id FROM " + tableName, "VALUES 1, 2, 3, 4, 5, 6");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesStrategyDefaultsToBinpack()
+    {
+        String tableName = "test_default_strategy";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c'), (1, 'a'), (2, 'b')", 3);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (6, 'f'), (4, 'd'), (5, 'e')", 3);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Rewrite without specifying strategy - should default to binpack
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 6);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+
+            // Verify all data is present (default binpack behavior)
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 6");
+            assertQuery("SELECT * FROM " + tableName,
+                    "VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesInvalidStrategyThrows()
+    {
+        String tableName = "test_invalid_strategy";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            // Test invalid strategy value
+            assertQueryFails(
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'invalid')",
+                            TEST_SCHEMA, tableName),
+                    ".*Invalid rewrite strategy.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesSortedByRequiresSortStrategy()
+    {
+        String tableName = "test_sorted_by_requires_sort";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a'), (2, 'b')", 2);
+
+            // Test that sorted_by with binpack strategy fails
+            assertQueryFails(
+                    format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', sorted_by => ARRAY['id'], strategy => 'binpack')",
+                            TEST_SCHEMA, tableName),
+                    ".*Cannot use binpack strategy with sorted_by option.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesBinpackWithoutSortedBy()
+    {
+        String tableName = "test_binpack_no_sorted_by";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c'), (1, 'a')", 2);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'b')", 1);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Binpack without sorted_by should work
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'binpack', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 3);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (3, 'c'), (1, 'a'), (2, 'b')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRewriteDataFilesSortStrategyWithoutSortedBy()
+    {
+        String tableName = "test_sort_no_sorted_by";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c'), (1, 'a')", 2);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'b')", 1);
+
+            Table table = loadTable(tableName);
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Sort strategy without sorted_by should use table's default sort order (or no sort if none)
+            assertUpdate(format("CALL system.rewrite_data_files(schema => '%s', table_name => '%s', strategy => 'sort', options => map(array['rewrite-all'], array['true']))",
+                    TEST_SCHEMA, tableName), 3);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 1);
+            // Should have all data
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 3");
         }
         finally {
             dropTable(tableName);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Adds explicit `strategy` option to Iceberg's `rewrite_data_files` procedure, allowing users to choose between `binpack` (default) and `sort` strategies.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Aligns Presto's Iceberg connector with Apache Iceberg's native API design, which provides separate `binPack()` and `sort()` methods. This gives users explicit control over the speed vs. query-performance trade-off:

- **Binpack**: Optimizes for rewrite speed - ideal for file consolidation and compaction
- **Sort**: Optimizes for query performance - required for z-ordering and better pruning

Internally requested to match Apache Iceberg's behavior and provide users with performance tuning options.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
**BREAKING CHANGE - Default Behavior Changed:**

The default strategy has changed from **sort** (using table's sort order) to **binpack** (no sorting). This affects all existing queries.

**Previous Default Behavior:**
- Automatically sorted data using the table's default sort order
- Slower but better query performance

**New Default Behavior:**
- Uses binpack strategy (no sorting)
- Faster rewrites but no data ordering

**Migration Required for All Users:**

1. **To maintain previous sorting behavior:**
```sql
-- Add strategy => 'sort' to preserve old behavior
CALL system.rewrite_data_files(
    schema => 'db', 
    table_name => 'table',
    strategy => 'sort'  -- Explicitly request sorting
);
```

2. **Queries with sorted_by (now require explicit strategy):**
```sql
-- Before: sorted_by implied sort strategy
CALL system.rewrite_data_files('db', 'table', 'TRUE', ARRAY['id']);

-- After: Must explicitly specify sort strategy
CALL system.rewrite_data_files(
    schema => 'db', 
    table_name => 'table',
    strategy => 'sort',
    sorted_by => ARRAY['id']
);
```

3. **To use new faster binpack (no changes needed):**
```sql
-- Binpack is now the default - no strategy parameter needed
CALL system.rewrite_data_files(
    schema => 'db',
    table_name => 'table'
);
```

**API Changes:** New optional `strategy` procedure parameter:
- **Parameter position:** 3rd parameter (after `schema` and `table_name`)
- **Default:** `binpack` (not backward compatible - previous default was sort)
- **Validation:** Rejects invalid strategy values and `binpack` + `sorted_by` combination
- **Error handling:** Early validation in context provider provides clear error messages before query execution

**Performance Impact:**
- **Binpack (new default):** Faster rewrites with no sorting overhead (O(n) complexity)
- **Sort (old default):** Slower rewrites with sorting overhead (O(n log n) complexity), but provides data ordering benefits for subsequent queries
- **Recommendation:** Users should explicitly choose `strategy => 'sort'` if they rely on data ordering for query performance

## Test Plan
<!---Please fill in how you tested your change-->
Added comprehensive test coverage in `TestRewriteDataFilesProcedure.java`:

1. **Strategy behavior tests:**
   - `testRewriteDataFilesWithBinpackStrategy` - Validates binpack combines files without sorting
   - `testRewriteDataFilesWithSortStrategy` - Validates sort strategy with sorted_by
   - `testRewriteDataFilesSortStrategyWithoutSortedBy` - Sort uses table's default sort order
   - `testRewriteDataFilesBinpackWithoutSortedBy` - Binpack works independently

2. **Default behavior:**
   - `testRewriteDataFilesStrategyDefaultsToBinpack` - Confirms binpack is default

3. **Error handling:**
   - `testRewriteDataFilesInvalidStrategyThrows` - Rejects invalid strategy values
   - `testRewriteDataFilesSortedByRequiresSortStrategy` - Prevents binpack + sorted_by

All tests pass successfully:
- Validates correct file counts after rewrite
- Confirms strategy behavior matches expectations
- Tests edge cases and error conditions

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add explicit strategy parameter to rewrite_data_files procedure with binpack and sort strategies. Breaking change: Default behavior changed from sort to binpack for faster rewrites. Existing queries that rely on data ordering must add strategy => 'sort' to maintain previous behavior. Queries using sorted_by must now explicitly specify strategy => 'sort'.
```

## Summary by Sourcery

Add a configurable rewrite strategy to the Iceberg rewrite_data_files procedure and update sorting behavior to distinguish between binpack and sort modes.

New Features:
- Introduce a new optional strategy parameter for the Iceberg rewrite_data_files procedure to choose between binpack and sort strategies.

Enhancements:
- Default rewrite_data_files behavior now uses a binpack strategy (no sorting) instead of relying on the table's sort order.
- Validate rewrite strategy values early and enforce that binpack cannot be combined with explicit sorted_by options.
- Adjust sort-order handling so sort strategy can use either explicit sorted_by columns or the table's default sort order.

Tests:
- Extend Iceberg rewrite_data_files tests to cover binpack and sort strategies, defaulting behavior, invalid strategies, and interactions with sorted_by and zorder expressions.