### PR TITLE
test: Add regression test for deep expression JSON serialization

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -66,6 +66,7 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -201,6 +202,25 @@ public class TestRowExpressionSerde
     public void testUnserializableType()
     {
         assertThrowsWhenSerialize("CAST('$.a' AS JsonPath)", true);
+    }
+
+    @Test
+    public void testDeeplyNestedExpressionSerialization()
+    {
+        // Guards against a regression where serializing a deeply nested RowExpression tree failed
+        // once Jackson enforced a default StreamWriteConstraints nesting cap of 1000. Additive
+        // chains such as the ones LightGBM calibrators emit (add(add(A, B), C), ...) plan into
+        // add(add(A, B), C) -> CallExpression["arguments"] -> CallExpression["arguments"] -> ...,
+        // so the nesting depth grows with the number of terms; wide models push plan serialization
+        // (e.g. HBO plan canonicalization in CanonicalPlanGenerator) past the cap.
+        FunctionHandle addHandle = operator(ADD, BIGINT, BIGINT);
+        RowExpression expression = constant(0L, BIGINT);
+        // Each add(...) contributes an object plus its "arguments" array (~2 nesting levels), so
+        // 600 terms nests ~1200 levels deep -- comfortably past the default cap of 1000.
+        for (int i = 0; i < 600; i++) {
+            expression = call(ADD.name(), addHandle, BIGINT, expression, constant(1L, BIGINT));
+        }
+        assertTrue(codec.toJson(expression).length() > 0);
     }
 
     private void assertThrowsWhenSerialize(@Language("SQL") String sql, boolean optimize)


### PR DESCRIPTION
Summary:
## Description

Adds a unit test to `TestRowExpressionSerde` that serializes a deeply nested `CallExpression` tree — a long left-deep additive chain of the form `add(add(A, B), C), ...` — through the `RowExpression` JSON codec and asserts that serialization succeeds. The chain is built ~600 terms deep, which nests roughly 1200 levels in the emitted JSON (each `CallExpression` contributes its object plus its `arguments` array), well past Jackson's default `StreamWriteConstraints` maximum nesting depth of 1000.

## Motivation and Context

Query plans can contain very deep expression trees. Expression chains that combine a large number of terms compile to left-deep `add(add(A, B), C), ...` `CallExpression` trees whose nesting depth grows with the number of terms. Serializing such an expression to JSON — for instance during history-based-optimization plan canonicalization in `CanonicalPlanGenerator`, or when serializing a `PlanFragment` for task distribution — fails once the tree is deeper than Jackson's default nesting cap, surfacing as `Document nesting depth (N) exceeds the maximum allowed (1000, from StreamWriteConstraints.getMaxNestingDepth())`.

This test exercises the serialization path with a tree deeper than 1000 levels so the failure cannot silently reappear if the effective nesting limit is lowered (for example, by a future Jackson upgrade that enables stricter `StreamWriteConstraints` defaults).

## Impact

Test only. No functional or public API change.

## Test Plan

- `mvn -pl presto-main-base test -Dtest=TestRowExpressionSerde` — all tests pass, including the new `testDeeplyNestedExpressionSerialization`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D110375098

## Summary by Sourcery

Tests:
- Add a unit test that builds a deeply nested additive RowExpression chain and verifies JSON serialization succeeds, guarding against regressions from Jackson nesting depth constraints.