### PR TITLE
feat(plugin-iceberg): Enhance support in the Iceberg REST catalog

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -219,7 +219,8 @@ Property Name                                        Description
                                                      Example: ``https://localhost:8181``
 
 ``iceberg.rest.auth.type``                           The authentication type to use.
-                                                     Available values are ``NONE`` or ``OAUTH2`` (default: ``NONE``).
+                                                     Available values are ``NONE``, ``BASIC`` or ``OAUTH2``
+                                                     (default: ``NONE``).
                                                      ``OAUTH2`` requires either a credential or token.
 
 ``iceberg.rest.auth.oauth2.uri``                     OAUTH2 server endpoint URI.
@@ -235,6 +236,12 @@ Property Name                                        Description
                                                      This property is only applicable when using
                                                      ``iceberg.rest.auth.oauth2.credential``.
                                                      Example: ``PRINCIPAL_ROLE:ALL``
+
+``iceberg.rest.auth.basic.username``                 Username for Basic Auth against the REST catalog server
+                                                     Example: ``test_user``
+
+``iceberg.rest.auth.basic.password``                 Password for Basic Auth against the REST catalog server
+                                                     Example: ``my$ecretPass``
 
 ``iceberg.rest.nested.namespace.enabled``            In REST Catalogs, tables are grouped into namespaces, that can be
                                                      nested. But if a large number of recursive namespaces result in

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -254,6 +254,23 @@ Property Name                                        Description
 ``iceberg.catalog.warehouse``                        A catalog warehouse root path for Iceberg tables (optional).
                                                      Example: ``s3://warehouse/``
 
+``iceberg.rest.tls.enabled``                         Whether to enable TLS for REST catalog communication
+                                                     (default: ``false``).
+
+``iceberg.rest.tls.keystore-path``                   The path to the keystore file for mutual TLS authentication with the REST
+                                                     catalog server (PEM or JKS format).
+                                                     Example: ``/path/to/keystore.jks``
+
+``iceberg.rest.tls.keystore-password``               The password for the keystore file.
+                                                     Example: ``keystore_password``
+
+``iceberg.rest.tls.truststore-path``                 The path to the truststore file for REST catalog TLS communication
+                                                     (PEM or JKS format).
+                                                     Example: ``/path/to/truststore.jks``
+
+``iceberg.rest.tls.truststore-password``             The password for the truststore file for REST catalog TLS communication.
+                                                     Example: ``truststore_password``
+
 ==================================================== ============================================================
 
 Hadoop catalog

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/AuthenticationType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/AuthenticationType.java
@@ -16,5 +16,6 @@ package com.facebook.presto.iceberg.rest;
 public enum AuthenticationType
 {
     NONE,
-    OAUTH2
+    OAUTH2,
+    BASIC
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -32,12 +32,14 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTUtil;
 
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static com.facebook.presto.iceberg.rest.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
 import static com.facebook.presto.iceberg.rest.SessionType.USER;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -47,6 +49,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogUtil.configureHadoopConf;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_BASIC;
+import static org.apache.iceberg.rest.auth.AuthProperties.BASIC_PASSWORD;
+import static org.apache.iceberg.rest.auth.AuthProperties.BASIC_USERNAME;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.JWT_TOKEN_TYPE;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
@@ -129,6 +135,15 @@ public class IcebergRestCatalogFactory
                 catalogConfig.getCredential().ifPresent(credential -> properties.put(CREDENTIAL, credential));
                 catalogConfig.getToken().ifPresent(token -> properties.put(TOKEN, token));
                 catalogConfig.getScope().ifPresent(scope -> properties.put(SCOPE, scope));
+            }
+            if (type == BASIC) {
+                String basicAuthUsername = catalogConfig.getBasicAuthUsername().orElseThrow(
+                        () -> new IllegalStateException("iceberg.rest.auth.basic.username must be set for REST catalog when BASIC authentication is enabled"));
+                String basicAuthPassword = catalogConfig.getBasicAuthPassword().orElseThrow(
+                        () -> new IllegalStateException("iceberg.rest.auth.basic.password must be set for REST catalog when BASIC authentication is enabled"));
+                properties.put(AUTH_TYPE, AUTH_TYPE_BASIC);
+                properties.put(BASIC_USERNAME, basicAuthUsername);
+                properties.put(BASIC_PASSWORD, basicAuthPassword);
             }
         });
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
-import org.apache.iceberg.rest.RESTUtil;
 
 import java.util.Date;
 import java.util.Map;
@@ -41,6 +40,11 @@ import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.iceberg.rest.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.KEYSTORE_PASSWORD;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.KEYSTORE_PATH;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TLS_CONFIGURER_IMPL;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TRUSTSTORE_PASSWORD;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TRUSTSTORE_PATH;
 import static com.facebook.presto.iceberg.rest.SessionType.USER;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -121,6 +125,14 @@ public class IcebergRestCatalogFactory
 
         properties.put(URI, catalogConfig.getServerUri().orElseThrow(
                 () -> new IllegalStateException("iceberg.rest.uri must be set for REST catalog")));
+
+        if (catalogConfig.isTlsEnabled()) {
+            properties.put(TLS_CONFIGURER_IMPL, PrestoRestTLSConfigurer.class.getName());
+            catalogConfig.getKeystorePath().ifPresent(path -> properties.put(KEYSTORE_PATH, path));
+            catalogConfig.getKeystorePassword().ifPresent(password -> properties.put(KEYSTORE_PASSWORD, password));
+            catalogConfig.getTruststorePath().ifPresent(path -> properties.put(TRUSTSTORE_PATH, path));
+            catalogConfig.getTruststorePassword().ifPresent(password -> properties.put(TRUSTSTORE_PASSWORD, password));
+        }
 
         catalogConfig.getAuthenticationType().ifPresent(type -> {
             if (type == OAUTH2) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
@@ -15,6 +15,8 @@ package com.facebook.presto.iceberg.rest;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
@@ -31,6 +33,11 @@ public class IcebergRestConfig
     private boolean nestedNamespaceEnabled = true;
     private String basicAuthUsername;
     private String basicAuthPassword;
+    private boolean tlsEnabled;
+    private String keystorePath;
+    private String keystorePassword;
+    private String truststorePath;
+    private String truststorePassword;
 
     @NotNull
     public Optional<String> getServerUri()
@@ -162,6 +169,89 @@ public class IcebergRestConfig
     {
         this.basicAuthPassword = basicAuthPassword;
         return this;
+    }
+
+    public Optional<String> getKeystorePath()
+    {
+        return Optional.ofNullable(keystorePath);
+    }
+
+    @Config("iceberg.rest.tls.keystore-path")
+    @ConfigDescription("The path to the keystore file for REST catalog TLS communication (mutual TLS)")
+    public IcebergRestConfig setKeystorePath(String keystorePath)
+    {
+        this.keystorePath = keystorePath;
+        return this;
+    }
+
+    public Optional<String> getKeystorePassword()
+    {
+        return Optional.ofNullable(keystorePassword);
+    }
+
+    @Config("iceberg.rest.tls.keystore-password")
+    @ConfigDescription("The password for the keystore file for REST catalog TLS communication")
+    @ConfigSecuritySensitive
+    public IcebergRestConfig setKeystorePassword(String keystorePassword)
+    {
+        this.keystorePassword = keystorePassword;
+        return this;
+    }
+
+    public boolean isTlsEnabled()
+    {
+        return tlsEnabled;
+    }
+
+    @Config("iceberg.rest.tls.enabled")
+    @ConfigDescription("Whether to enable TLS for REST catalog communication")
+    public IcebergRestConfig setTlsEnabled(boolean tlsEnabled)
+    {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public Optional<String> getTruststorePath()
+    {
+        return Optional.ofNullable(truststorePath);
+    }
+
+    @Config("iceberg.rest.tls.truststore-path")
+    @ConfigDescription("The path to the truststore file for REST catalog TLS communication")
+    public IcebergRestConfig setTruststorePath(String truststorePath)
+    {
+        this.truststorePath = truststorePath;
+        return this;
+    }
+
+    public Optional<String> getTruststorePassword()
+    {
+        return Optional.ofNullable(truststorePassword);
+    }
+
+    @Config("iceberg.rest.tls.truststore-password")
+    @ConfigDescription("The password for the truststore file for REST catalog TLS communication")
+    @ConfigSecuritySensitive
+    public IcebergRestConfig setTruststorePassword(String truststorePassword)
+    {
+        this.truststorePassword = truststorePassword;
+        return this;
+    }
+
+    @AssertTrue(message = "iceberg.rest.tls.keystore-path and iceberg.rest.tls.keystore-password must be set together; " +
+            "iceberg.rest.tls.truststore-path and iceberg.rest.tls.truststore-password must be set together; " +
+            "at least one of keystore or truststore must be configured when TLS is enabled")
+    public boolean isValidTlsConfig()
+    {
+        if (!tlsEnabled) {
+            return true;
+        }
+        boolean validKeystore = (keystorePath == null && keystorePassword == null) ||
+                (keystorePath != null && keystorePassword != null);
+        boolean validTruststore = (truststorePath == null && truststorePassword == null) ||
+                (truststorePath != null && truststorePassword != null);
+        boolean atLeastOneStoreConfigured = keystorePath != null || truststorePath != null;
+        return validKeystore && validTruststore && atLeastOneStoreConfigured;
     }
 
     public boolean credentialOrTokenExists()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
@@ -29,6 +29,8 @@ public class IcebergRestConfig
     private String token;
     private String scope;
     private boolean nestedNamespaceEnabled = true;
+    private String basicAuthUsername;
+    private String basicAuthPassword;
 
     @NotNull
     public Optional<String> getServerUri()
@@ -63,7 +65,7 @@ public class IcebergRestConfig
     }
 
     @Config("iceberg.rest.auth.type")
-    @ConfigDescription("The authentication type to use for communicating with REST catalog server (NONE | OAUTH2)")
+    @ConfigDescription("The authentication type to use for communicating with REST catalog server (NONE | OAUTH2 | BASIC)")
     public IcebergRestConfig setAuthenticationType(AuthenticationType authenticationType)
     {
         this.authenticationType = authenticationType;
@@ -132,6 +134,33 @@ public class IcebergRestConfig
     public IcebergRestConfig setNestedNamespaceEnabled(boolean nestedNamespaceEnabled)
     {
         this.nestedNamespaceEnabled = nestedNamespaceEnabled;
+        return this;
+    }
+
+    public Optional<String> getBasicAuthUsername()
+    {
+        return Optional.ofNullable(basicAuthUsername);
+    }
+
+    @Config("iceberg.rest.auth.basic.username")
+    @ConfigDescription("Username for Basic Auth against the REST catalog server; requires iceberg.rest.auth.basic.password")
+    public IcebergRestConfig setBasicAuthUsername(String basicAuthUsername)
+    {
+        this.basicAuthUsername = basicAuthUsername;
+        return this;
+    }
+
+    public Optional<String> getBasicAuthPassword()
+    {
+        return Optional.ofNullable(basicAuthPassword);
+    }
+
+    @Config("iceberg.rest.auth.basic.password")
+    @ConfigDescription("Password for Basic Auth against the REST catalog server; requires iceberg.rest.auth.basic.username")
+    @ConfigSecuritySensitive
+    public IcebergRestConfig setBasicAuthPassword(String basicAuthPassword)
+    {
+        this.basicAuthPassword = basicAuthPassword;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/PrestoRestTLSConfigurer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/PrestoRestTLSConfigurer.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.plugin.base.security.SslContextProvider;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.iceberg.rest.auth.TLSConfigurer;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+
+/**
+ * Iceberg {@link TLSConfigurer} that configures TLS for the REST catalog HTTP client,
+ * delegating SSL context creation to {@link SslContextProvider} (supports both PEM and JKS formats).
+ * Activated by setting {@code rest.client.tls.configurer-impl} in the catalog properties to the
+ * fully-qualified name of this class. At least one of keystore or truststore must be provided:
+ * <ul>
+ *   <li>{@code rest.client.tls.keystore-path} – path to the keystore file for mutual TLS (optional)</li>
+ *   <li>{@code rest.client.tls.keystore-password} – keystore password (optional)</li>
+ *   <li>{@code rest.client.tls.truststore-path} – path to the truststore file (optional)</li>
+ *   <li>{@code rest.client.tls.truststore-password} – truststore password (optional)</li>
+ * </ul>
+ */
+public class PrestoRestTLSConfigurer
+        implements TLSConfigurer
+{
+    static final String TLS_CONFIGURER_IMPL = "rest.client.tls.configurer-impl";
+    static final String KEYSTORE_PATH = "rest.client.tls.keystore-path";
+    static final String KEYSTORE_PASSWORD = "rest.client.tls.keystore-password";
+    static final String TRUSTSTORE_PATH = "rest.client.tls.truststore-path";
+    static final String TRUSTSTORE_PASSWORD = "rest.client.tls.truststore-password";
+
+    private SSLContext sslContext;
+
+    @Override
+    public void initialize(Map<String, String> properties)
+    {
+        String keystorePath = properties.get(KEYSTORE_PATH);
+        String truststorePath = properties.get(TRUSTSTORE_PATH);
+
+        if (keystorePath == null && truststorePath == null) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR,
+                    "At least one of iceberg.rest.tls.keystore-path or iceberg.rest.tls.truststore-path " +
+                            "must be configured when iceberg.rest.tls.enabled is true");
+        }
+
+        SslContextProvider sslContextProvider = new SslContextProvider(
+                Optional.ofNullable(keystorePath).map(File::new),
+                Optional.ofNullable(properties.get(KEYSTORE_PASSWORD)),
+                Optional.ofNullable(truststorePath).map(File::new),
+                Optional.ofNullable(properties.get(TRUSTSTORE_PASSWORD)));
+
+        this.sslContext = sslContextProvider.buildSslContext()
+                .orElseThrow(() -> new PrestoException(GENERIC_INTERNAL_ERROR,
+                        "Failed to build SSL context for REST catalog TLS communication"));
+    }
+
+    @Override
+    public SSLContext sslContext()
+    {
+        return sslContext;
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
@@ -37,7 +37,9 @@ public class TestIcebergRestConfig
                 .setToken(null)
                 .setScope(null)
                 .setSessionType(null)
-                .setNestedNamespaceEnabled(true));
+                .setNestedNamespaceEnabled(true)
+                .setBasicAuthUsername(null)
+                .setBasicAuthPassword(null));
     }
 
     @Test
@@ -52,6 +54,8 @@ public class TestIcebergRestConfig
                 .put("iceberg.rest.auth.oauth2.scope", "PRINCIPAL_ROLE:ALL")
                 .put("iceberg.rest.session.type", "USER")
                 .put("iceberg.rest.nested.namespace.enabled", "false")
+                .put("iceberg.rest.auth.basic.username", "admin")
+                .put("iceberg.rest.auth.basic.password", "l8USQsHp6glQ")
                 .build();
 
         IcebergRestConfig expected = new IcebergRestConfig()
@@ -62,7 +66,9 @@ public class TestIcebergRestConfig
                 .setToken("SXVLUXUhIExFQ0tFUiEK")
                 .setScope("PRINCIPAL_ROLE:ALL")
                 .setSessionType(USER)
-                .setNestedNamespaceEnabled(false);
+                .setNestedNamespaceEnabled(false)
+                .setBasicAuthUsername("admin")
+                .setBasicAuthPassword("l8USQsHp6glQ");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
@@ -23,6 +23,8 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
 import static com.facebook.presto.iceberg.rest.SessionType.USER;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergRestConfig
 {
@@ -39,7 +41,12 @@ public class TestIcebergRestConfig
                 .setSessionType(null)
                 .setNestedNamespaceEnabled(true)
                 .setBasicAuthUsername(null)
-                .setBasicAuthPassword(null));
+                .setBasicAuthPassword(null)
+                .setTlsEnabled(false)
+                .setKeystorePath(null)
+                .setKeystorePassword(null)
+                .setTruststorePath(null)
+                .setTruststorePassword(null));
     }
 
     @Test
@@ -56,6 +63,11 @@ public class TestIcebergRestConfig
                 .put("iceberg.rest.nested.namespace.enabled", "false")
                 .put("iceberg.rest.auth.basic.username", "admin")
                 .put("iceberg.rest.auth.basic.password", "l8USQsHp6glQ")
+                .put("iceberg.rest.tls.enabled", "true")
+                .put("iceberg.rest.tls.keystore-path", "/path/to/keystore")
+                .put("iceberg.rest.tls.keystore-password", "keystorePassword")
+                .put("iceberg.rest.tls.truststore-path", "/path/to/truststore")
+                .put("iceberg.rest.tls.truststore-password", "truststorePassword")
                 .build();
 
         IcebergRestConfig expected = new IcebergRestConfig()
@@ -68,8 +80,93 @@ public class TestIcebergRestConfig
                 .setSessionType(USER)
                 .setNestedNamespaceEnabled(false)
                 .setBasicAuthUsername("admin")
-                .setBasicAuthPassword("l8USQsHp6glQ");
+                .setBasicAuthPassword("l8USQsHp6glQ")
+                .setTlsEnabled(true)
+                .setKeystorePath("/path/to/keystore")
+                .setKeystorePassword("keystorePassword")
+                .setTruststorePath("/path/to/truststore")
+                .setTruststorePassword("truststorePassword");
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testTlsDisabledIsAlwaysValid()
+    {
+        // TLS disabled: any store config combination is valid (ignored)
+        assertTrue(new IcebergRestConfig().setTlsEnabled(false).isValidTlsConfig());
+        assertTrue(new IcebergRestConfig().setTlsEnabled(false)
+                .setKeystorePath("/path/to/keystore")
+                .isValidTlsConfig());
+        assertTrue(new IcebergRestConfig().setTlsEnabled(false)
+                .setTruststorePath("/path/to/truststore")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledWithTruststoreOnly()
+    {
+        assertTrue(new IcebergRestConfig().setTlsEnabled(true)
+                .setTruststorePath("/path/to/truststore")
+                .setTruststorePassword("secret")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledWithKeystoreOnly()
+    {
+        assertTrue(new IcebergRestConfig().setTlsEnabled(true)
+                .setKeystorePath("/path/to/keystore")
+                .setKeystorePassword("secret")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledWithBothStores()
+    {
+        assertTrue(new IcebergRestConfig().setTlsEnabled(true)
+                .setKeystorePath("/path/to/keystore")
+                .setKeystorePassword("keystoreSecret")
+                .setTruststorePath("/path/to/truststore")
+                .setTruststorePassword("truststoreSecret")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledNoStoresIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig().setTlsEnabled(true).isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledKeystorePathWithoutPasswordIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig().setTlsEnabled(true)
+                .setKeystorePath("/path/to/keystore")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledKeystorePasswordWithoutPathIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig().setTlsEnabled(true)
+                .setKeystorePassword("secret")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledTruststorePathWithoutPasswordIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig().setTlsEnabled(true)
+                .setTruststorePath("/path/to/truststore")
+                .isValidTlsConfig());
+    }
+
+    @Test
+    public void testTlsEnabledTruststorePasswordWithoutPathIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig().setTlsEnabled(true)
+                .setTruststorePassword("secret")
+                .isValidTlsConfig());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -37,19 +37,26 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.rest.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.lang.String.format;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_BASIC;
+import static org.apache.iceberg.rest.auth.AuthProperties.BASIC_PASSWORD;
+import static org.apache.iceberg.rest.auth.AuthProperties.BASIC_USERNAME;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 @Test
 public class TestIcebergSmokeRest
@@ -144,5 +151,38 @@ public class TestIcebergSmokeRest
         RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
 
         assertEquals(catalog.properties().get(OAUTH2_SERVER_URI), authEndpoint);
+    }
+
+    @Test
+    public void testBasicAuthCatalogProperties()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri)
+                .setAuthenticationType(BASIC)
+                .setBasicAuthUsername("alice")
+                .setBasicAuthPassword("s3cr3t");
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
+        Map<String, String> properties = catalog.properties();
+
+        assertEquals(properties.get(AUTH_TYPE), AUTH_TYPE_BASIC);
+        assertEquals(properties.get(BASIC_USERNAME), "alice");
+        assertEquals(properties.get(BASIC_PASSWORD), "s3cr3t");
+    }
+
+    @Test
+    public void testNoAuthTypeLeavesAuthPropertiesAbsent()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri);
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
+        Map<String, String> properties = catalog.properties();
+
+        assertNull(properties.get(AUTH_TYPE));
+        assertNull(properties.get(BASIC_USERNAME));
+        assertNull(properties.get(BASIC_PASSWORD));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestPrestoRestTLSConfigurer.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestPrestoRestTLSConfigurer.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.tests.SslKeystoreManager;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLContext;
+
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.KEYSTORE_PASSWORD;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.KEYSTORE_PATH;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TRUSTSTORE_PASSWORD;
+import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TRUSTSTORE_PATH;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.tests.SslKeystoreManager.SSL_STORE_PASSWORD;
+import static com.facebook.presto.tests.SslKeystoreManager.getKeystorePath;
+import static com.facebook.presto.tests.SslKeystoreManager.getTruststorePath;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestPrestoRestTLSConfigurer
+{
+    @BeforeClass
+    public void setUp()
+    {
+        SslKeystoreManager.initializeKeystoreAndTruststore();
+    }
+
+    @Test
+    public void testInitializeWithTruststoreOnly()
+    {
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        configurer.initialize(ImmutableMap.of(TRUSTSTORE_PATH, getTruststorePath(),
+                TRUSTSTORE_PASSWORD, SSL_STORE_PASSWORD));
+
+        SSLContext sslContext = configurer.sslContext();
+        assertNotNull(sslContext, "SSLContext should be created with truststore only");
+        assertEquals(sslContext.getProtocol(), "TLS");
+    }
+
+    @Test
+    public void testInitializeWithKeystoreOnly()
+    {
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        configurer.initialize(ImmutableMap.of(
+                KEYSTORE_PATH, getKeystorePath(),
+                KEYSTORE_PASSWORD, SSL_STORE_PASSWORD));
+
+        SSLContext sslContext = configurer.sslContext();
+        assertNotNull(sslContext, "SSLContext should be created with keystore only");
+        assertEquals(sslContext.getProtocol(), "TLS");
+    }
+
+    @Test
+    public void testInitializeWithKeystoreAndTruststore()
+    {
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        configurer.initialize(ImmutableMap.of(
+                KEYSTORE_PATH, getKeystorePath(),
+                KEYSTORE_PASSWORD, SSL_STORE_PASSWORD,
+                TRUSTSTORE_PATH, getTruststorePath(),
+                TRUSTSTORE_PASSWORD, SSL_STORE_PASSWORD));
+
+        SSLContext sslContext = configurer.sslContext();
+        assertNotNull(sslContext, "SSLContext should be created with both keystore and truststore");
+        assertEquals(sslContext.getProtocol(), "TLS");
+    }
+
+    @Test(expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = ".*iceberg\\.rest\\.tls\\.keystore-path.*iceberg\\.rest\\.tls\\.truststore-path.*")
+    public void testInitializeWithNoStoreThrows()
+    {
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        configurer.initialize(ImmutableMap.of());
+    }
+
+    @Test(expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = ".*iceberg\\.rest\\.tls\\.keystore-path.*iceberg\\.rest\\.tls\\.truststore-path.*")
+    public void testInitializeWithPasswordOnlyThrows()
+    {
+        // Password without a path should still fail the "at least one path" check
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        Map<String, String> properties = ImmutableMap.of(TRUSTSTORE_PASSWORD, SSL_STORE_PASSWORD);
+        configurer.initialize(properties);
+    }
+
+    @Test
+    public void testInitializeWithNoStoreThrowsInternalErrorCode()
+    {
+        PrestoRestTLSConfigurer configurer = new PrestoRestTLSConfigurer();
+        try {
+            configurer.initialize(ImmutableMap.of());
+            throw new AssertionError("Expected PrestoException");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+        }
+    }
+}


### PR DESCRIPTION
## Description
Enhance support in the Iceberg REST catalog.
Covers - 
1. Add support to enable TLS for REST catalog communication
2. Add support for Basic Auth against the REST catalog server

## Motivation and Context
Enhance support in the Iceberg REST catalog.
Covers - 
1. Add support to enable TLS for REST catalog communication
2. Add support for Basic Auth against the REST catalog server

## Impact
New addition

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support to enable TLS for REST catalog communication
* Add support for Basic Auth against the REST catalog server
```

## Summary by Sourcery

Add TLS and basic authentication support for the Iceberg REST catalog and wire the new configuration into the catalog factory and TLS client setup.

New Features:
- Introduce configuration options to enable TLS for Iceberg REST catalog communication, including truststore path and password.
- Add basic authentication support for the Iceberg REST catalog with configurable username and password.
- Provide a Presto-specific TLS configurer for the Iceberg REST client to load a custom JKS truststore.

Documentation:
- Update Iceberg connector documentation to describe new REST catalog TLS and basic authentication configuration options.

Tests:
- Extend Iceberg REST configuration tests to cover the new TLS and basic authentication properties.