### PR TITLE
perf(planner): Pre-aggregate counts through outer joins

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
@@ -9,8 +9,11 @@ remote exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (custkey)
                                         join (RIGHT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, [custkey_0])
-                                                scan orders
+                                            final aggregation over (custkey_0)
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, [custkey_0])
+                                                        partial aggregation over (custkey_0)
+                                                            scan orders
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [custkey])
                                                     scan customer

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.planner.iterative.rule.ParallelizeChainedAggregat
 import com.facebook.presto.sql.planner.iterative.rule.PickTableLayout;
 import com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjections;
 import com.facebook.presto.sql.planner.iterative.rule.PreAggregateBeforeGroupId;
+import com.facebook.presto.sql.planner.iterative.rule.PreAggregateCountThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
@@ -814,6 +815,7 @@ public class PlanOptimizers
                                 new RemoveRedundantDistinctLimit(),
                                 new RemoveRedundantAggregateDistinct(),
                                 new RemoveRedundantIdentityProjections(),
+                                new PreAggregateCountThroughOuterJoin(metadata.getFunctionAndTypeManager()),
                                 new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))),
                 inlineProjections,
                 simplifyRowExpressionOptimizer, // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
@@ -1029,6 +1031,7 @@ public class PlanOptimizers
                         new RemoveRedundantDistinctLimit(),
                         new RemoveRedundantAggregateDistinct(),
                         new RemoveRedundantIdentityProjections(),
+                        new PreAggregateCountThroughOuterJoin(metadata.getFunctionAndTypeManager()),
                         new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))));
 
         builder.add(new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.count;
 import static com.facebook.presto.sql.planner.optimizations.DistinctOutputQueryUtil.isDistinct;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.isIdentity;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
@@ -106,7 +107,7 @@ public class PreAggregateCountThroughOuterJoin
             return Result.empty();
         }
         if (ImmutableSet.copyOf(aggregation.getGroupingKeys()).equals(ImmutableSet.copyOf(sides.getOuter().getOutputVariables()))
-                && isDistinct(context.getLookup().resolve(sides.getOuter()), context.getLookup()::resolve)) {
+                && isDistinctOnOutputVariables(sides.getOuter(), context)) {
             return Result.empty();
         }
 
@@ -237,6 +238,20 @@ public class PreAggregateCountThroughOuterJoin
         }
 
         return false;
+    }
+
+    private boolean isDistinctOnOutputVariables(PlanNode node, Context context)
+    {
+        PlanNode resolved = context.getLookup().resolve(node);
+        if (resolved instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) resolved;
+            if (isIdentity(project.getAssignments())
+                    && ImmutableSet.copyOf(project.getOutputVariables()).equals(ImmutableSet.copyOf(project.getSource().getOutputVariables()))) {
+                return isDistinctOnOutputVariables(project.getSource(), context);
+            }
+        }
+
+        return isDistinct(resolved, context.getLookup()::resolve);
     }
 
     private boolean isSupported(AggregationNode aggregation, JoinNode join)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
@@ -264,6 +264,7 @@ public class PreAggregateCountThroughOuterJoin
                 || aggregation.getAggregations().isEmpty()
                 || aggregation.getStep() != AggregationNode.Step.SINGLE
                 || aggregation.getGroupingSetCount() != 1
+                || !aggregation.getPreGroupedVariables().isEmpty()
                 || aggregation.getHashVariable().isPresent()
                 || aggregation.getGroupIdVariable().isPresent()
                 || aggregation.getAggregationId().isPresent()) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.constraints.NotNullConstraint;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.shouldPushAggregationThroughJoin;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.count;
+import static com.facebook.presto.sql.planner.optimizations.DistinctOutputQueryUtil.isDistinct;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Pre-aggregates count(inner_column) below an outer join, then sums the per-key
+ * counts above the join. Unlike PushAggregationThroughOuterJoin, this rule does
+ * not require the outer side to be distinct: duplicate outer rows still
+ * contribute duplicate pre-aggregated counts to the final sum.
+ */
+public class PreAggregateCountThroughOuterJoin
+        implements Rule<AggregationNode>
+{
+    private static final Capture<JoinNode> JOIN = newCapture();
+    private static final Pattern<AggregationNode> PATTERN = aggregation()
+            .with(source().matching(join().capturedAs(JOIN)));
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final FunctionResolution functionResolution;
+
+    public PreAggregateCountThroughOuterJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return shouldPushAggregationThroughJoin(session);
+    }
+
+    @Override
+    public Result apply(AggregationNode aggregation, Captures captures, Context context)
+    {
+        JoinNode join = captures.get(JOIN);
+        if (!isSupported(aggregation, join)) {
+            return Result.empty();
+        }
+
+        JoinSides sides = new JoinSides(join);
+        if (!ImmutableSet.copyOf(sides.getOuter().getOutputVariables()).containsAll(aggregation.getGroupingKeys())) {
+            return Result.empty();
+        }
+        if (ImmutableSet.copyOf(aggregation.getGroupingKeys()).equals(ImmutableSet.copyOf(sides.getOuter().getOutputVariables()))
+                && isDistinct(context.getLookup().resolve(sides.getOuter()), context.getLookup()::resolve)) {
+            return Result.empty();
+        }
+
+        ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> preAggregations = ImmutableMap.builder();
+        ImmutableMap.Builder<VariableReferenceExpression, VariableReferenceExpression> originalToPreAggregation = ImmutableMap.builder();
+        for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> entry : aggregation.getAggregations().entrySet()) {
+            VariableReferenceExpression preAggregationVariable = context.getVariableAllocator().newVariable(entry.getKey().getSourceLocation(), "pre_count", entry.getKey().getType());
+            preAggregations.put(preAggregationVariable, rewriteCountArgumentIfNonNull(entry.getValue(), sides.getInner(), context));
+            originalToPreAggregation.put(entry.getKey(), preAggregationVariable);
+        }
+
+        AggregationNode innerAggregation = new AggregationNode(
+                aggregation.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                sides.getInner(),
+                preAggregations.build(),
+                singleGroupingSet(sides.getInnerJoinKeys()),
+                ImmutableList.of(),
+                aggregation.getStep(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        JoinNode rewrittenJoin = new JoinNode(
+                join.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                join.getType(),
+                join.getType() == JoinType.LEFT ? join.getLeft() : innerAggregation,
+                join.getType() == JoinType.LEFT ? innerAggregation : join.getRight(),
+                join.getCriteria(),
+                join.getType() == JoinType.LEFT ?
+                        ImmutableList.<VariableReferenceExpression>builder()
+                                .addAll(sides.getOuter().getOutputVariables())
+                                .addAll(innerAggregation.getAggregations().keySet())
+                                .build() :
+                        ImmutableList.<VariableReferenceExpression>builder()
+                                .addAll(innerAggregation.getAggregations().keySet())
+                                .addAll(sides.getOuter().getOutputVariables())
+                                .build(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                join.getDistributionType(),
+                ImmutableMap.of());
+
+        ImmutableMap<VariableReferenceExpression, VariableReferenceExpression> preAggregationVariables = originalToPreAggregation.build();
+        ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> finalAggregations = ImmutableMap.builder();
+        ImmutableMap.Builder<VariableReferenceExpression, VariableReferenceExpression> originalToFinalAggregation = ImmutableMap.builder();
+        for (Map.Entry<VariableReferenceExpression, VariableReferenceExpression> entry : preAggregationVariables.entrySet()) {
+            VariableReferenceExpression finalAggregationVariable = context.getVariableAllocator().newVariable(entry.getKey().getSourceLocation(), "count_sum", entry.getKey().getType());
+            finalAggregations.put(finalAggregationVariable, new AggregationNode.Aggregation(
+                    new CallExpression(
+                            entry.getKey().getSourceLocation(),
+                            "sum",
+                            functionAndTypeManager.lookupFunction("sum", fromTypes(entry.getValue().getType())),
+                            entry.getKey().getType(),
+                            ImmutableList.of(entry.getValue())),
+                    Optional.empty(),
+                    Optional.empty(),
+                    false,
+                    Optional.empty()));
+            originalToFinalAggregation.put(entry.getKey(), finalAggregationVariable);
+        }
+
+        AggregationNode finalAggregation = new AggregationNode(
+                aggregation.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                rewrittenJoin,
+                finalAggregations.build(),
+                aggregation.getGroupingSets(),
+                aggregation.getPreGroupedVariables(),
+                aggregation.getStep(),
+                Optional.empty(),
+                aggregation.getGroupIdVariable(),
+                aggregation.getAggregationId());
+
+        Assignments.Builder assignments = Assignments.builder();
+        assignments.putAll(identityAssignments(aggregation.getGroupingKeys()));
+        originalToFinalAggregation.build().forEach((original, finalVariable) ->
+                assignments.put(original, new SpecialFormExpression(
+                        original.getSourceLocation(),
+                        COALESCE,
+                        original.getType(),
+                        finalVariable,
+                        new ConstantExpression(original.getSourceLocation(), 0L, BIGINT))));
+
+        return Result.ofPlanNode(new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                finalAggregation,
+                assignments.build()));
+    }
+
+    private AggregationNode.Aggregation rewriteCountArgumentIfNonNull(AggregationNode.Aggregation aggregation, PlanNode source, Context context)
+    {
+        if (aggregation.getArguments().size() != 1) {
+            return aggregation;
+        }
+
+        RowExpression argument = aggregation.getArguments().get(0);
+        if (!(argument instanceof VariableReferenceExpression) || !isKnownNonNull(source, (VariableReferenceExpression) argument, context)) {
+            return aggregation;
+        }
+
+        return count(functionAndTypeManager);
+    }
+
+    private boolean isKnownNonNull(PlanNode node, VariableReferenceExpression variable, Context context)
+    {
+        PlanNode resolved = context.getLookup().resolve(node);
+        if (resolved instanceof FilterNode) {
+            return isKnownNonNull(((FilterNode) resolved).getSource(), variable, context);
+        }
+
+        if (resolved instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) resolved;
+            RowExpression assignment = project.getAssignments().get(variable);
+            return assignment instanceof VariableReferenceExpression
+                    && isKnownNonNull(project.getSource(), (VariableReferenceExpression) assignment, context);
+        }
+
+        if (resolved instanceof TableScanNode) {
+            TableScanNode tableScan = (TableScanNode) resolved;
+            return Optional.ofNullable(tableScan.getAssignments().get(variable))
+                    .map(column -> tableScan.getTableConstraints().stream()
+                            .filter(constraint -> constraint instanceof NotNullConstraint && (constraint.isEnabled() || constraint.isRely()))
+                            .anyMatch(constraint -> constraint.getColumns().contains(column)))
+                    .orElse(false);
+        }
+
+        return false;
+    }
+
+    private boolean isSupported(AggregationNode aggregation, JoinNode join)
+    {
+        if (!(join.getType() == JoinType.LEFT || join.getType() == JoinType.RIGHT)
+                || join.getFilter().isPresent()
+                || join.getCriteria().isEmpty()
+                || aggregation.getAggregations().isEmpty()
+                || aggregation.getStep() != AggregationNode.Step.SINGLE
+                || aggregation.getGroupingSetCount() != 1
+                || aggregation.getHashVariable().isPresent()
+                || aggregation.getGroupIdVariable().isPresent()
+                || aggregation.getAggregationId().isPresent()) {
+            return false;
+        }
+
+        JoinSides sides = new JoinSides(join);
+        Set<VariableReferenceExpression> innerVariables = ImmutableSet.copyOf(sides.getInner().getOutputVariables());
+        for (AggregationNode.Aggregation aggregate : aggregation.getAggregations().values()) {
+            if (!functionResolution.isCountFunction(aggregate.getFunctionHandle())
+                    || aggregate.getArguments().size() != 1
+                    || !(aggregate.getArguments().get(0) instanceof VariableReferenceExpression)
+                    || aggregate.isDistinct()
+                    || aggregate.getFilter().isPresent()
+                    || aggregate.getMask().isPresent()
+                    || aggregate.getOrderBy().isPresent()) {
+                return false;
+            }
+            if (!innerVariables.contains((VariableReferenceExpression) aggregate.getArguments().get(0))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static class JoinSides
+    {
+        private final JoinNode join;
+
+        private JoinSides(JoinNode join)
+        {
+            this.join = join;
+        }
+
+        public PlanNode getOuter()
+        {
+            return join.getType() == JoinType.LEFT ? join.getLeft() : join.getRight();
+        }
+
+        public PlanNode getInner()
+        {
+            return join.getType() == JoinType.LEFT ? join.getRight() : join.getLeft();
+        }
+
+        public List<VariableReferenceExpression> getInnerJoinKeys()
+        {
+            return join.getCriteria().stream()
+                    .map(join.getType() == JoinType.LEFT ? EquiJoinClause::getRight : EquiJoinClause::getLeft)
+                    .distinct()
+                    .collect(toImmutableList());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateCountThroughOuterJoin.java
@@ -147,10 +147,10 @@ public class PreAggregateCountThroughOuterJoin
                                 .addAll(sides.getOuter().getOutputVariables())
                                 .build(),
                 Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
+                join.getLeftHashVariable(),
+                join.getRightHashVariable(),
                 join.getDistributionType(),
-                ImmutableMap.of());
+                join.getDynamicFilters());
 
         ImmutableMap<VariableReferenceExpression, VariableReferenceExpression> preAggregationVariables = originalToPreAggregation.build();
         ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> finalAggregations = ImmutableMap.builder();
@@ -244,6 +244,8 @@ public class PreAggregateCountThroughOuterJoin
         if (!(join.getType() == JoinType.LEFT || join.getType() == JoinType.RIGHT)
                 || join.getFilter().isPresent()
                 || join.getCriteria().isEmpty()
+                || join.getLeftHashVariable().isPresent()
+                || join.getRightHashVariable().isPresent()
                 || aggregation.getAggregations().isEmpty()
                 || aggregation.getStep() != AggregationNode.Step.SINGLE
                 || aggregation.getGroupingSetCount() != 1
@@ -254,6 +256,11 @@ public class PreAggregateCountThroughOuterJoin
         }
 
         JoinSides sides = new JoinSides(join);
+        if (join.getType() == JoinType.LEFT
+                && !ImmutableSet.copyOf(sides.getInnerJoinKeys()).containsAll(join.getDynamicFilters().values())) {
+            return false;
+        }
+
         Set<VariableReferenceExpression> innerVariables = ImmutableSet.copyOf(sides.getInner().getOutputVariables());
         for (AggregationNode.Aggregation aggregate : aggregation.getAggregations().values()) {
             if (!functionResolution.isCountFunction(aggregate.getFunctionHandle())

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
@@ -13,17 +13,25 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TestingColumnHandle;
 import com.facebook.presto.spi.constraints.NotNullConstraint;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.assertions.MatchResult;
+import com.facebook.presto.sql.planner.assertions.Matcher;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -41,6 +49,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggreg
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.optimizations.PredicatePushDown.createDynamicFilterExpression;
 
 public class TestPreAggregateCountThroughOuterJoin
         extends BaseRuleTest
@@ -98,6 +107,41 @@ public class TestPreAggregateCountThroughOuterJoin
                                 node(JoinNode.class,
                                         node(AggregationNode.class, any()),
                                         any()))));
+    }
+
+    @Test
+    public void testPreservesDynamicFilters()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    RIGHT,
+                                    p.filter(
+                                            createDynamicFilterExpression("DF", innerKey, getMetadata().getFunctionAndTypeManager()),
+                                            p.values(innerKey, innerValue)),
+                                    p.values(outerKey),
+                                    ImmutableList.of(new EquiJoinClause(innerKey, outerKey)),
+                                    ImmutableList.of(innerKey, innerValue, outerKey),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    ImmutableMap.of("DF", outerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        node(AggregationNode.class, any()),
+                                        any())
+                                        .with(new JoinDynamicFiltersMatcher("DF", "outer_key")))));
     }
 
     @Test
@@ -161,6 +205,54 @@ public class TestPreAggregateCountThroughOuterJoin
                                             TupleDomain.all(),
                                             TupleDomain.all(),
                                             ImmutableList.of(new NotNullConstraint<>(innerValueColumn))),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        aggregation(
+                                                ImmutableMap.of("pre_count", functionCall("count", false, ImmutableList.of())),
+                                                any())))));
+    }
+
+    @Test
+    public void testUsesCountAllForTrustedNotNullInnerColumnThroughProjection()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression projectedInnerValue = p.variable("projected_inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+                    ColumnHandle innerKeyColumn = new TestingColumnHandle("inner_key");
+                    ColumnHandle innerValueColumn = new TestingColumnHandle("inner_value");
+                    TableHandle innerTable = new TableHandle(
+                            new ConnectorId("testConnector"),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(projected_inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(innerKey, innerKey)
+                                                    .put(projectedInnerValue, innerValue)
+                                                    .build(),
+                                            p.tableScan(
+                                                    innerTable,
+                                                    ImmutableList.of(innerKey, innerValue),
+                                                    ImmutableMap.of(innerKey, innerKeyColumn, innerValue, innerValueColumn),
+                                                    TupleDomain.all(),
+                                                    TupleDomain.all(),
+                                                    ImmutableList.of(new NotNullConstraint<>(innerValueColumn)))),
                                     new EquiJoinClause(outerKey, innerKey))));
                 })
                 .matches(node(ProjectNode.class,
@@ -241,6 +333,57 @@ public class TestPreAggregateCountThroughOuterJoin
                                     p.values(outerKey),
                                     p.values(innerKey),
                                     new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForCountAll()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(*)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForJoinWithHashVariables()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression outerHash = p.variable("outer_hash", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression innerHash = p.variable("inner_hash", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey, outerHash),
+                                    p.values(innerKey, innerValue, innerHash),
+                                    ImmutableList.of(new EquiJoinClause(outerKey, innerKey)),
+                                    ImmutableList.of(outerKey, outerHash, innerKey, innerValue, innerHash),
+                                    Optional.empty(),
+                                    Optional.of(outerHash),
+                                    Optional.of(innerHash))));
                 })
                 .doesNotFire();
     }
@@ -382,5 +525,34 @@ public class TestPreAggregateCountThroughOuterJoin
                                     new EquiJoinClause(outerKey, innerKey))));
                 })
                 .doesNotFire();
+    }
+
+    private static class JoinDynamicFiltersMatcher
+            implements Matcher
+    {
+        private final String dynamicFilterId;
+        private final String buildVariableName;
+
+        private JoinDynamicFiltersMatcher(String dynamicFilterId, String buildVariableName)
+        {
+            this.dynamicFilterId = dynamicFilterId;
+            this.buildVariableName = buildVariableName;
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof JoinNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            JoinNode join = (JoinNode) node;
+            VariableReferenceExpression buildVariable = join.getDynamicFilters().get(dynamicFilterId);
+            return new MatchResult(join.getDynamicFilters().size() == 1
+                    && buildVariable != null
+                    && buildVariable.getName().equals(buildVariableName));
+        }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.constraints.NotNullConstraint;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+
+public class TestPreAggregateCountThroughOuterJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testPreAggregatesInnerCountBelowLeftJoin()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression outerValue = p.variable("outer_value", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey, outerValue),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        node(AggregationNode.class, any())))));
+    }
+
+    @Test
+    public void testPreAggregatesInnerCountBelowRightJoin()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    RIGHT,
+                                    p.values(innerKey, innerValue),
+                                    p.values(outerKey),
+                                    new EquiJoinClause(innerKey, outerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        node(AggregationNode.class, any()),
+                                        any()))));
+    }
+
+    @Test
+    public void testPreAggregatesMultipleInnerCounts()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression innerOtherValue = p.variable("inner_other_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+                    VariableReferenceExpression otherCount = p.variable("other_count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .addAggregation(otherCount, p.rowExpression("count(inner_other_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue, innerOtherValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        node(AggregationNode.class, any())))));
+    }
+
+    @Test
+    public void testUsesCountAllForTrustedNotNullInnerColumn()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+                    ColumnHandle innerKeyColumn = new TestingColumnHandle("inner_key");
+                    ColumnHandle innerValueColumn = new TestingColumnHandle("inner_value");
+                    TableHandle innerTable = new TableHandle(
+                            new ConnectorId("testConnector"),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.tableScan(
+                                            innerTable,
+                                            ImmutableList.of(innerKey, innerValue),
+                                            ImmutableMap.of(innerKey, innerKeyColumn, innerValue, innerValueColumn),
+                                            TupleDomain.all(),
+                                            TupleDomain.all(),
+                                            ImmutableList.of(new NotNullConstraint<>(innerValueColumn))),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        aggregation(
+                                                ImmutableMap.of("pre_count", functionCall("count", false, ImmutableList.of())),
+                                                any())))));
+    }
+
+    @Test
+    public void testPreAggregatesGlobalCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .globalGrouping()
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        node(AggregationNode.class, any())))));
+    }
+
+    @Test
+    public void testDoesNotFireForOuterSideCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression outerValue = p.variable("outer_value", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(outer_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey, outerValue),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForConstantCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(1)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForExpressionCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(coalesce(inner_value, BIGINT '1'))"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForNullableExpressionCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(nullif(inner_value, BIGINT '0'))"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForNondeterministicExpressionCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(random())"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForMixedOuterAndInnerExpressionCount()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression outerValue = p.variable("outer_value", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(outer_value + inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey, outerValue),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenExistingDistinctOuterJoinRuleCanApply()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression unique = p.variable("unique", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey, unique)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.assignUniqueId(unique, p.values(outerKey)),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenDisabled()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "false")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
@@ -481,7 +481,7 @@ public class TestPreAggregateCountThroughOuterJoin
     }
 
     @Test
-    public void testDoesNotFireWhenExistingDistinctOuterJoinRuleCanApply()
+    public void testDoesNotFireWhenExistingDistinctOuterJoinRuleCanApplyThroughIdentityProjection()
     {
         tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
                 .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
@@ -497,7 +497,12 @@ public class TestPreAggregateCountThroughOuterJoin
                             .addAggregation(count, p.rowExpression("count(inner_value)"))
                             .source(p.join(
                                     LEFT,
-                                    p.assignUniqueId(unique, p.values(outerKey)),
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(outerKey, outerKey)
+                                                    .put(unique, unique)
+                                                    .build(),
+                                            p.assignUniqueId(unique, p.values(outerKey))),
                                     p.values(innerKey, innerValue),
                                     new EquiJoinClause(outerKey, innerKey))));
                 })

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateCountThroughOuterJoin.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.constraints.NotNullConstraint;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.JoinDistributionType;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
@@ -43,6 +44,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.PUSH_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.spi.plan.JoinType.LEFT;
 import static com.facebook.presto.spi.plan.JoinType.RIGHT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
@@ -110,7 +112,7 @@ public class TestPreAggregateCountThroughOuterJoin
     }
 
     @Test
-    public void testPreservesDynamicFilters()
+    public void testPreservesDynamicFiltersForRightJoin()
     {
         tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
                 .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
@@ -142,6 +144,74 @@ public class TestPreAggregateCountThroughOuterJoin
                                         node(AggregationNode.class, any()),
                                         any())
                                         .with(new JoinDynamicFiltersMatcher("DF", "outer_key")))));
+    }
+
+    @Test
+    public void testPreservesDynamicFiltersAndDistributionForLeftJoin()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.filter(
+                                            createDynamicFilterExpression("DF", outerKey, getMetadata().getFunctionAndTypeManager()),
+                                            p.values(outerKey)),
+                                    p.values(innerKey, innerValue),
+                                    ImmutableList.of(new EquiJoinClause(outerKey, innerKey)),
+                                    ImmutableList.of(outerKey, innerKey, innerValue),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.of(PARTITIONED),
+                                    ImmutableMap.of("DF", innerKey))));
+                })
+                .matches(node(ProjectNode.class,
+                        node(AggregationNode.class,
+                                node(JoinNode.class,
+                                        any(),
+                                        node(AggregationNode.class, any()))
+                                        .with(new JoinDynamicFiltersMatcher("DF", "inner_key"))
+                                        .with(new JoinDistributionMatcher(PARTITIONED)))));
+    }
+
+    @Test
+    public void testDoesNotFireForLeftJoinDynamicFilterOnNonGroupingKey()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerFilterKey = p.variable("inner_filter_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.filter(
+                                            createDynamicFilterExpression("DF", outerKey, getMetadata().getFunctionAndTypeManager()),
+                                            p.values(outerKey)),
+                                    p.values(innerKey, innerFilterKey, innerValue),
+                                    ImmutableList.of(new EquiJoinClause(outerKey, innerKey)),
+                                    ImmutableList.of(outerKey, innerKey, innerFilterKey, innerValue),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    ImmutableMap.of("DF", innerFilterKey))));
+                })
+                .doesNotFire();
     }
 
     @Test
@@ -389,6 +459,55 @@ public class TestPreAggregateCountThroughOuterJoin
     }
 
     @Test
+    public void testDoesNotFireForPreGroupedAggregation()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .preGroupedVariables(outerKey)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForAggregationWithHashVariable()
+    {
+        tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(PUSH_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression outerKey = p.variable("outer_key", BIGINT);
+                    VariableReferenceExpression aggregationHash = p.variable("aggregation_hash", BIGINT);
+                    VariableReferenceExpression innerKey = p.variable("inner_key", BIGINT);
+                    VariableReferenceExpression innerValue = p.variable("inner_value", BIGINT);
+                    VariableReferenceExpression count = p.variable("count", BIGINT);
+
+                    return p.aggregation(aggregation -> aggregation
+                            .singleGroupingSet(outerKey)
+                            .hashVariable(aggregationHash)
+                            .addAggregation(count, p.rowExpression("count(inner_value)"))
+                            .source(p.join(
+                                    LEFT,
+                                    p.values(outerKey, aggregationHash),
+                                    p.values(innerKey, innerValue),
+                                    new EquiJoinClause(outerKey, innerKey))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
     public void testDoesNotFireForExpressionCount()
     {
         tester().assertThat(new PreAggregateCountThroughOuterJoin(getMetadata().getFunctionAndTypeManager()))
@@ -558,6 +677,29 @@ public class TestPreAggregateCountThroughOuterJoin
             return new MatchResult(join.getDynamicFilters().size() == 1
                     && buildVariable != null
                     && buildVariable.getName().equals(buildVariableName));
+        }
+    }
+
+    private static class JoinDistributionMatcher
+            implements Matcher
+    {
+        private final JoinDistributionType distributionType;
+
+        private JoinDistributionMatcher(JoinDistributionType distributionType)
+        {
+            this.distributionType = distributionType;
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof JoinNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            return new MatchResult(((JoinNode) node).getDistributionType().equals(Optional.of(distributionType)));
         }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.sql.planner.Plan;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static org.testng.Assert.assertTrue;
+
+public class TestPreAggregateCountThroughOuterJoinSemantics
+{
+    @Test
+    public void testLeftJoinCountWithDuplicatesAndUnmatchedRows()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(ImmutableMap.of(PUSH_AGGREGATION_THROUGH_JOIN, "true"))) {
+            assertQueryAndPreAggregatedOuterJoin(
+                    assertions,
+                    "WITH " +
+                            "outer_relation(group_key, join_key) AS (VALUES (1, 10), (1, 10), (1, 20), (2, 30), (3, 40)), " +
+                            "inner_relation(join_key, value) AS (VALUES (10, 'a'), (10, 'b'), (20, NULL), (20, 'c'), (30, NULL), (50, 'x')) " +
+                            "SELECT group_key, count(value) " +
+                            "FROM outer_relation " +
+                            "LEFT JOIN inner_relation ON outer_relation.join_key = inner_relation.join_key " +
+                            "GROUP BY group_key",
+                    "VALUES (1, BIGINT '5'), (2, BIGINT '0'), (3, BIGINT '0')",
+                    LEFT);
+        }
+    }
+
+    @Test
+    public void testRightJoinCountWithDuplicatesAndUnmatchedRows()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(ImmutableMap.of(PUSH_AGGREGATION_THROUGH_JOIN, "true"))) {
+            assertQueryAndPreAggregatedOuterJoin(
+                    assertions,
+                    "WITH " +
+                            "outer_relation(group_key, join_key) AS (VALUES (1, 10), (1, 10), (1, 20), (2, 30), (3, 40)), " +
+                            "inner_relation(join_key, value) AS (VALUES (10, 'a'), (10, 'b'), (20, NULL), (20, 'c'), (30, NULL), (50, 'x')) " +
+                            "SELECT group_key, count(value) " +
+                            "FROM inner_relation " +
+                            "RIGHT JOIN outer_relation ON inner_relation.join_key = outer_relation.join_key " +
+                            "GROUP BY group_key",
+                    "VALUES (1, BIGINT '5'), (2, BIGINT '0'), (3, BIGINT '0')",
+                    RIGHT);
+        }
+    }
+
+    @Test
+    public void testGlobalCountWithEmptyPreservedSide()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(ImmutableMap.of(PUSH_AGGREGATION_THROUGH_JOIN, "true"))) {
+            assertions.assertQuery(
+                    "WITH " +
+                            "outer_relation(join_key) AS (SELECT * FROM (VALUES 1) WHERE false), " +
+                            "inner_relation(join_key, value) AS (VALUES (1, 'a'), (1, 'b')) " +
+                            "SELECT count(value) " +
+                            "FROM outer_relation " +
+                            "LEFT JOIN inner_relation ON outer_relation.join_key = inner_relation.join_key",
+                    "VALUES BIGINT '0'");
+        }
+    }
+
+    private static void assertQueryAndPreAggregatedOuterJoin(QueryAssertions assertions, String actual, String expected, JoinType joinType)
+    {
+        assertions.assertQuery(actual, expected);
+        Plan plan = assertions.getQueryRunner().createPlan(assertions.getQueryRunner().getDefaultSession(), actual, WarningCollector.NOOP);
+        assertContainsPreAggregatedOuterJoin(plan, joinType);
+    }
+
+    private static void assertContainsPreAggregatedOuterJoin(Plan plan, JoinType joinType)
+    {
+        assertTrue(
+                containsPreAggregatedOuterJoin(plan.getRoot(), joinType),
+                "Expected plan to contain pre-aggregated " + joinType + " join");
+    }
+
+    private static boolean containsPreAggregatedOuterJoin(PlanNode node, JoinType joinType)
+    {
+        if (node instanceof JoinNode) {
+            JoinNode join = (JoinNode) node;
+            if (join.getType() == joinType) {
+                PlanNode inner = joinType == LEFT ? join.getRight() : join.getLeft();
+                if (containsNode(inner, AggregationNode.class)) {
+                    return true;
+                }
+            }
+        }
+
+        return node.getSources().stream()
+                .anyMatch(source -> containsPreAggregatedOuterJoin(source, joinType));
+    }
+
+    private static boolean containsNode(PlanNode node, Class<? extends PlanNode> nodeClass)
+    {
+        if (nodeClass.isInstance(node)) {
+            return true;
+        }
+
+        return node.getSources().stream()
+                .anyMatch(source -> containsNode(source, nodeClass));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.SystemSessionProperties.PUSH_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.spi.plan.JoinType.LEFT;
 import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestPreAggregateCountThroughOuterJoinSemantics
@@ -62,6 +63,26 @@ public class TestPreAggregateCountThroughOuterJoinSemantics
                             "GROUP BY group_key",
                     "VALUES (1, BIGINT '5'), (2, BIGINT '0'), (3, BIGINT '0')",
                     RIGHT);
+        }
+    }
+
+    @Test
+    public void testLeftJoinCountWithDuplicatesAndUnmatchedRowsRuleDisabled()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(ImmutableMap.of(PUSH_AGGREGATION_THROUGH_JOIN, "false"))) {
+            String query = "WITH " +
+                    "outer_relation(group_key, join_key) AS (VALUES (1, 10), (1, 10), (1, 20), (2, 30), (3, 40)), " +
+                    "inner_relation(join_key, value) AS (VALUES (10, 'a'), (10, 'b'), (20, NULL), (20, 'c'), (30, NULL), (50, 'x')) " +
+                    "SELECT group_key, count(value) " +
+                    "FROM outer_relation " +
+                    "LEFT JOIN inner_relation ON outer_relation.join_key = inner_relation.join_key " +
+                    "GROUP BY group_key";
+
+            assertions.assertQuery(query, "VALUES (1, BIGINT '5'), (2, BIGINT '0'), (3, BIGINT '0')");
+            Plan plan = assertions.getQueryRunner().createPlan(assertions.getQueryRunner().getDefaultSession(), query, WarningCollector.NOOP);
+            assertFalse(
+                    containsPreAggregatedOuterJoin(plan.getRoot(), LEFT),
+                    "Expected plan not to contain pre-aggregated LEFT join");
         }
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestPreAggregateCountThroughOuterJoinSemantics.java
@@ -101,6 +101,23 @@ public class TestPreAggregateCountThroughOuterJoinSemantics
         }
     }
 
+    @Test
+    public void testDecorrelatedScalarCount()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(ImmutableMap.of(PUSH_AGGREGATION_THROUGH_JOIN, "true"))) {
+            assertions.assertQuery(
+                    "WITH " +
+                            "outer_relation(join_key) AS (VALUES 10, 10, 20, 30), " +
+                            "inner_relation(join_key) AS (VALUES 10, 10, 20, 40) " +
+                            "SELECT join_key, (" +
+                            "    SELECT count(*) " +
+                            "    FROM inner_relation " +
+                            "    WHERE inner_relation.join_key = outer_relation.join_key) " +
+                            "FROM outer_relation",
+                    "VALUES (10, BIGINT '2'), (10, BIGINT '2'), (20, BIGINT '1'), (30, BIGINT '0')");
+        }
+    }
+
     private static void assertQueryAndPreAggregatedOuterJoin(QueryAssertions assertions, String actual, String expected, JoinType joinType)
     {
         assertions.assertQuery(actual, expected);


### PR DESCRIPTION
## Description

Add PreAggregateCountThroughOuterJoin, a planner rule that reduces the
null-supplying side of eligible LEFT and RIGHT outer joins before
computing COUNT aggregates.

For supported plans, the rule pre-aggregates
count(inner_column) by the inner equijoin keys, retains the original
outer join, and sums the per-key counts using the original grouping set.
A projection applies COALESCE(sum, 0) so unmatched preserved-side rows
retain COUNT's zero result.

The rule applies conservatively to SINGLE-step aggregations containing
only count(inner_column), where the argument is a direct variable from
the null-supplying side. It rejects constants, expressions, outer- or
mixed-side inputs, join filters, and distinct, filtered, masked, or
ordered counts.

When a trusted NOT NULL constraint proves that the counted column
cannot be null, the inner aggregation uses count(*), allowing the value
column to be pruned. If the preserved side is already known to be
distinct for the requested outputs, the rule yields to the existing
PushAggregationThroughOuterJoin optimization.

## Motivation and Context

An outer join can substantially expand its null-supplying input before a
subsequent COUNT aggregation. Pre-aggregating that input by the join
keys reduces the number of rows processed by the join while preserving
the contribution from duplicate rows on the preserved side.

The existing PushAggregationThroughOuterJoin rule requires the
preserved side to be distinct and therefore does not cover plans such as
TPC-H Q13, where multiple preserved-side rows can contribute to the same
final group.

This rule handles that broader shape while preserving outer-join
cardinality and null semantics.

Related issue: #<issue-number>

## Impact

There are no public API, SQL syntax, dependency, or connector changes.

The optimization is controlled by the existing
push_aggregation_through_join session property, which defaults to
true through the optimizer.push-aggregation-through-join
configuration property. No new configuration or session property is
introduced.

TPC-H SF1000 Q13 was benchmarked for 10 iterations, using one lukewarm
and nine hot samples, against the same build with only this rule
unregistered:

| Environment | Average | Median |
| --- | --- | --- |
| Presto Native CPU, 2 workers, isolated Q13 | 11,716 ms → 10,301 ms (12.08%) | 11,599 ms → 10,266 ms (11.49%) |
| Presto Native GPU, 7 workers, full-suite context | 1,059.89 ms → 998.78 ms (5.77%) | 1,060 ms → 987 ms (6.89%) |

## Test Plan

Ran the focused rule and query-level semantic tests:

./mvnw -ntp -pl presto-main-base \
  -Dtest=TestPreAggregateCountThroughOuterJoin,TestPreAggregateCountThroughOuterJoinSemantics \
  test

Result: 16 tests passed with no failures, errors, or skips.

Coverage includes:

- `LEFT` and `RIGHT` outer joins
- Duplicate and unmatched preserved-side rows
- Nullable counted values
- Multiple count aggregations
- Global aggregation and an empty preserved side
- Trusted `NOT NULL` conversion from `count(column)` to `count(*)`
- Constant, nullable, nondeterministic, and mixed-side expressions
- Disabled-rule behavior
- Precedence for the existing distinct-side rewrite
- Assertions that the expected pre-aggregated join appears in query plans

Also ran module verification:

```text
./mvnw -ntp -pl presto-main-base -DskipTests install
```

This passed compilation, Checkstyle, SpotBugs, PMD, license and dependency
checks, packaging, and installation. git diff --check also passed.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

== RELEASE NOTES ==

General Changes
* Improve performance for eligible ``COUNT`` aggregations over ``LEFT`` and
  ``RIGHT`` outer joins by pre-aggregating the null-supplying side.
