### PR TITLE
test(planner): Add renaming-exchange guard test for PullRowLocalChainAboveExchange

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullRowLocalChainAboveExchange.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullRowLocalChainAboveExchange.java
@@ -130,6 +130,39 @@ public class TestPullRowLocalChainAboveExchange
     }
 
     @Test
+    public void testDoesNotFireWhenExchangeRenamesOutput()
+    {
+        // The rule only handles single-source exchanges whose output layout equals their input (identity
+        // mapping); a renaming exchange (output variables differ from the input) is left alone, because the
+        // reparented chain would no longer produce the variables the consumer above the exchange expects.
+        // In practice the planner does not emit a renaming SINGLE-source exchange (renaming only happens on
+        // multi-source UNION exchanges, which are already excluded), so this locks in that defensive guard.
+        // Here inputs = [k, elem] but the output layout is [k_out, elem_out], i.e. a rename.
+        tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))
+                .setSystemProperty(PULL_ROW_LOCAL_CHAIN_ABOVE_EXCHANGE_STRATEGY, "ALWAYS_ENABLED")
+                .on(p -> {
+                    VariableReferenceExpression k = p.variable("k", BIGINT);
+                    VariableReferenceExpression arr = p.variable("arr", ARRAY_OF_BIGINT);
+                    VariableReferenceExpression elem = p.variable("elem", BIGINT);
+                    VariableReferenceExpression kOut = p.variable("k_out", BIGINT);
+                    VariableReferenceExpression elemOut = p.variable("elem_out", BIGINT);
+                    return p.exchange(e -> e
+                            .type(REPARTITION)
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder().put(k, k).put(elem, elem).build(),
+                                            p.unnest(
+                                                    p.values(k, arr),
+                                                    ImmutableList.of(k),
+                                                    ImmutableMap.of(arr, ImmutableList.of(elem)),
+                                                    Optional.empty())))
+                            .addInputsSet(k, elem)
+                            .fixedHashDistributionPartitioningScheme(ImmutableList.of(kOut, elemOut), ImmutableList.of(kOut)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
     public void testDoesNotFireWhenNoUnnestInChain()
     {
         tester().assertThat(new PullRowLocalChainAboveExchange(getFunctionManager()))


### PR DESCRIPTION
## Summary

Follow-up to #28079 addressing a review comment on the identity-layout guard in `PullRowLocalChainAboveExchange` (["can add a project to rename output?"](https://github.com/prestodb/presto/pull/28079#discussion_r3515128411)).

The rule only rewrites **single-source** exchanges (it returns early when `getSources().size() != 1`) whose output layout equals their input (identity mapping). A single-source repartition exchange never renames its columns in practice: `ExchangeNode.partitionedExchange` sets the output layout to the child's output variables, so `inputs[0] == outputLayout`. Column renaming only happens on **multi-source** UNION exchanges, which are already excluded. So the identity-layout guard is not reachable for a single-source exchange, and adding a rename `ProjectNode` would be dead code.

Rather than add a never-exercised path, this adds a unit test that **force-constructs a single-source renaming exchange** (`inputs = [k, elem]` but output layout `[k_out, elem_out]`) via `PlanBuilder` and asserts the rule correctly **does not fire**, locking in that defensive guard.

## Tests

- `TestPullRowLocalChainAboveExchange.testDoesNotFireWhenExchangeRenamesOutput` — new negative unit test for the renaming-exchange guard.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Add a negative unit test verifying PullRowLocalChainAboveExchange does not apply to single-source repartition exchanges that rename their output layout.