### PR TITLE
Skip invalid bigint ranges at INT64_MAX boundary

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -118,6 +118,12 @@ std::unique_ptr<common::Filter> bigintRangeToFilter(
     }
     high--;
   }
+  if (low > high) {
+    return nullAllowed
+        ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+        : std::unique_ptr<common::Filter>(
+              std::make_unique<common::AlwaysFalse>());
+  }
   return std::make_unique<common::BigintRange>(low, high, nullAllowed);
 }
 

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <limits>
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
@@ -249,6 +250,20 @@ protocol::Domain createSingleRangeDomain(
   auto rangeSet = std::make_shared<protocol::SortedRangeSet>();
   rangeSet->type = typeStr;
   rangeSet->ranges = {range};
+
+  protocol::Domain domain;
+  domain.values = rangeSet;
+  domain.nullAllowed = nullAllowed;
+  return domain;
+}
+
+protocol::Domain createMultiRangeDomain(
+    const std::string& typeStr,
+    protocol::List<protocol::Range> ranges,
+    bool nullAllowed) {
+  auto rangeSet = std::make_shared<protocol::SortedRangeSet>();
+  rangeSet->type = typeStr;
+  rangeSet->ranges = std::move(ranges);
 
   protocol::Domain domain;
   domain.values = rangeSet;
@@ -592,6 +607,44 @@ TEST_F(PrestoToVeloxConnectorTest, bigintOverflowWithNullAllowed) {
   EXPECT_FALSE(filter->testInt64(0));
   EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
   EXPECT_TRUE(filter->testNull());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, bigintSkipsEmptyRangeAboveMax) {
+  auto lowBlock = serializeToBlock(
+      BaseVector::createConstant(BIGINT(), variant(14'400), 1, pool_.get()),
+      pool_.get());
+  auto maxBlock = serializeToBlock(
+      BaseVector::createConstant(
+          BIGINT(),
+          variant(std::numeric_limits<int64_t>::max()),
+          1,
+          pool_.get()),
+      pool_.get());
+
+  protocol::Range validRange;
+  validRange.low.type = "bigint";
+  validRange.low.valueBlock = lowBlock;
+  validRange.low.bound = protocol::Bound::EXACTLY;
+  validRange.high.type = "bigint";
+  validRange.high.valueBlock = maxBlock;
+  validRange.high.bound = protocol::Bound::BELOW;
+
+  protocol::Range emptyRange;
+  emptyRange.low.type = "bigint";
+  emptyRange.low.valueBlock = maxBlock;
+  emptyRange.low.bound = protocol::Bound::ABOVE;
+  emptyRange.high.type = "bigint";
+  emptyRange.high.valueBlock = nullptr;
+  emptyRange.high.bound = protocol::Bound::BELOW;
+
+  auto domain = createMultiRangeDomain("bigint", {validRange, emptyRange});
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  auto* range = dynamic_cast<common::BigintRange*>(filter.get());
+  ASSERT_NE(range, nullptr);
+  EXPECT_EQ(range->lower(), 14'400);
+  EXPECT_EQ(range->upper(), std::numeric_limits<int64_t>::max() - 1);
+  EXPECT_TRUE(range->testInt64(std::numeric_limits<int64_t>::max() - 1));
+  EXPECT_FALSE(range->testInt64(std::numeric_limits<int64_t>::max()));
 }
 
 TEST_F(PrestoToVeloxConnectorTest, dateOverflowLowAboveMax) {


### PR DESCRIPTION
Adds a low > high guard in bigintRangeToFilter and a unit test for multi-range bigint domains where an invalid range at INT64_MAX is skipped.

When converting Presto connector tuple domains to Velox filters, exclusive bounds are adjusted to inclusive (ABOVE → low++, BELOW → high--). At INT64_MAX/INT64_MIN, that adjustment can overflow and produce invalid or overlapping ranges. #27600 already guards the boundary increment/decrement and returns AlwaysFalse/IsNull for single empty ranges.

This change adds the remaining gap: return an empty filter when low > high after adjustment, and verify that multi-range domains correctly skip invalid ranges above INT64_MAX while preserving the valid clipped range.

Motivation and Context
Fixes incorrect filter generation for bigint domains touching INT64_MAX, which can surface as overlapping bigint range errors during native execution. Example failing query: msg.lagtimesec != 9223372036854775807.

The domain for that predicate includes:

A valid range [14400, INT64_MAX)
An empty range (INT64_MAX, +∞) — > INT64_MAX overflows when converted
Without skipping the invalid range, the combined filter can be wrong or fail validation. This complements:

#27600 (boundary overflow guards in PrestoToVeloxConnectorUtils)
The corresponding Velox expression filter fix (notEqual for integer !=)
Impact
Native execution only. No SQL syntax, connector configuration, or public API changes.

When a bigint domain range becomes empty after bound adjustment (including low > high), the connector now returns AlwaysFalse or IsNull (if nulls are allowed) instead of constructing an invalid BigintRange. Multi-range domains with one invalid range at INT64_MAX now correctly reduce to the remaining valid range.

Test Plan

Added bigintSkipsEmptyRangeAboveMax in PrestoToVeloxConnectorTest.cpp
Builds a two-range bigint domain: [14400, INT64_MAX) plus (INT64_MAX, +∞)
Asserts the resulting filter is a single BigintRange with bounds [14400, INT64_MAX - 1]
Verifies INT64_MAX - 1 matches and INT64_MAX does not
Existing overflow tests from #27600 (bigintOverflowLowAboveMax, bigintOverflowHighBelowMin, bigintOverflowWithNullAllowed) cover single-range empty cases
cd presto-native-execution/_build/debug && \
  ./presto_cpp/main/types/tests/presto_types_test \
    --gtest_filter='PrestoToVeloxConnectorTest.bigintSkipsEmptyRangeAboveMax'
Contributor checklist

 Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).

 PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.

 Documented new properties (with its default value), SQL syntax, functions, or other functionality.

 If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).

 Adequate tests were added if applicable.

 CI passed.

 If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).
Release Notes

== NO RELEASE NOTE ==

## Summary by Sourcery

Handle empty bigint ranges produced during bound adjustment and ensure filters skip invalid ranges at the INT64_MAX boundary.

Bug Fixes:
- Return an empty (AlwaysFalse or IsNull) filter when bigint range adjustment results in low > high, preventing construction of invalid BigintRange filters at INT64_MAX.

Tests:
- Add a unit test verifying that multi-range bigint domains skip an empty range above INT64_MAX and produce a single valid clipped BigintRange.