### PR TITLE
feat: Extend Makefile to accept a list of optional features to build

### DIFF
--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -64,9 +64,8 @@ jobs:
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
           PRESTO_OPTIONAL_FEATURES="s3,gcs,hdfs,remote-functions,jwt" \
-          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
-          make cmake BUILD_DIR=release BUILD_TYPE=Release
-          ninja -C _build/release -j 4
+          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DThrift_ROOT=/usr/local -DMAX_LINK_JOBS=4" \
+          NUM_THREADS=4 make release
 
       - name: Ccache after
         run: ccache -s

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -63,25 +63,9 @@ jobs:
         run: |
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
-          cmake \
-            -B _build/release \
-            -GNinja \
-            -DTREAT_WARNINGS_AS_ERRORS=1 \
-            -DENABLE_ALL_WARNINGS=1 \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPRESTO_ENABLE_S3=ON \
-            -DPRESTO_ENABLE_GCS=ON \
-            -DPRESTO_ENABLE_ABFS=OFF \
-            -DPRESTO_ENABLE_HDFS=ON \
-            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
-            -DPRESTO_ENABLE_JWT=ON \
-            -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
-            -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
-            -DPRESTO_ENABLE_TESTING=OFF \
-            -DCMAKE_PREFIX_PATH=/usr/local \
-            -DThrift_ROOT=/usr/local \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMAX_LINK_JOBS=4
+          PRESTO_OPTIONAL_FEATURES="s3,gcs,hdfs,remote-functions,jwt" \
+          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
+          make cmake BUILD_DIR=release BUILD_TYPE=Release
           ninja -C _build/release -j 4
 
       - name: Ccache after

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -89,20 +89,9 @@ jobs:
         run: |
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
-          cmake \
-            -B _build/release \
-            -GNinja \
-            -DTREAT_WARNINGS_AS_ERRORS=1 \
-            -DENABLE_ALL_WARNINGS=1 \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
-            -DPRESTO_ENABLE_JWT=ON \
-            -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
-            -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
-            -DCMAKE_PREFIX_PATH=/usr/local \
-            -DThrift_ROOT=/usr/local \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMAX_LINK_JOBS=4
+          PRESTO_OPTIONAL_FEATURES="remote-functions,jwt" \
+          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
+          make cmake BUILD_DIR=release BUILD_TYPE=Release
           ninja -C _build/release -j 4
 
       - name: Ccache after

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -90,9 +90,8 @@ jobs:
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
           PRESTO_OPTIONAL_FEATURES="remote-functions,jwt" \
-          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
-          make cmake BUILD_DIR=release BUILD_TYPE=Release
-          ninja -C _build/release -j 4
+          EXTRA_CMAKE_FLAGS="-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DThrift_ROOT=/usr/local -DMAX_LINK_JOBS=4" \
+          NUM_THREADS=4 make release
 
       - name: Ccache after
         if: |

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -49,9 +49,8 @@ jobs:
         source /opt/rh/gcc-toolset-14/enable
         cd presto-native-execution
         PRESTO_OPTIONAL_FEATURES="cudf,s3,gcs,hdfs,remote-functions,jwt" \
-        EXTRA_CMAKE_FLAGS="-DCMAKE_CUDA_ARCHITECTURES=75 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
-        USE_NINJA=1 make cmake BUILD_DIR=release BUILD_TYPE=Release
-        ninja -C _build/release -j 4
+        EXTRA_CMAKE_FLAGS="-DCMAKE_CUDA_ARCHITECTURES=75 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DThrift_ROOT=/usr/local -DMAX_LINK_JOBS=4" \
+        NUM_THREADS=4 make release
 
     steps:
       # We cannot use the github action to free disk space from the runner

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -48,27 +48,9 @@ jobs:
         unset CC && unset CXX
         source /opt/rh/gcc-toolset-14/enable
         cd presto-native-execution
-        cmake \
-          -B _build/release \
-          -GNinja \
-          -DTREAT_WARNINGS_AS_ERRORS=1 \
-          -DENABLE_ALL_WARNINGS=1 \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DPRESTO_ENABLE_S3=ON \
-          -DPRESTO_ENABLE_GCS=ON \
-          -DPRESTO_ENABLE_ABFS=OFF \
-          -DPRESTO_ENABLE_HDFS=ON \
-          -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
-          -DPRESTO_ENABLE_JWT=ON \
-          -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
-          -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
-          -DPRESTO_ENABLE_TESTING=OFF \
-          -DPRESTO_ENABLE_CUDF=ON \
-          -DCMAKE_CUDA_ARCHITECTURES=75 \
-          -DCMAKE_PREFIX_PATH=/usr/local \
-          -DThrift_ROOT=/usr/local \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DMAX_LINK_JOBS=4
+        PRESTO_OPTIONAL_FEATURES="cudf,s3,gcs,hdfs,remote-functions,jwt" \
+        EXTRA_CMAKE_FLAGS="-DCMAKE_CUDA_ARCHITECTURES=75 -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_TESTING=OFF -DCMAKE_PREFIX_PATH=/usr/local -DThrift_ROOT=/usr/local -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMAX_LINK_JOBS=4" \
+        USE_NINJA=1 make cmake BUILD_DIR=release BUILD_TYPE=Release
         ninja -C _build/release -j 4
 
     steps:

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -32,55 +32,57 @@ PRESTO_OPTIONAL_FEATURES ?=
 
 # Process comma-separated features
 ifneq ($(PRESTO_OPTIONAL_FEATURES),)
-  # Convert comma-separated list to space-separated
+  # Convert comma-separated list to space-separated and strip whitespace
   FEATURES_LIST := $(subst $(comma), ,$(PRESTO_OPTIONAL_FEATURES))
-  
+  FEATURES_LIST := $(strip $(FEATURES_LIST))
+  # Further strip whitespace from each individual feature
+  FEATURES_LIST := $(foreach feature,$(FEATURES_LIST),$(strip $(feature)))
+
   # Validate features
   VALID_FEATURES := s3 hdfs gcs abfs parquet cudf remote-functions jwt arrow-flight spatial
   INVALID_FEATURES := $(filter-out $(VALID_FEATURES),$(FEATURES_LIST))
-  
+
   ifneq ($(INVALID_FEATURES),)
-    $(warning Invalid features in PRESTO_OPTIONAL_FEATURES: $(INVALID_FEATURES))
-    $(warning Valid features are: $(VALID_FEATURES))
+    $(error Invalid features in PRESTO_OPTIONAL_FEATURES: $(INVALID_FEATURES). Valid features are: $(VALID_FEATURES))
   endif
-  
+
   # Map features to CMake flags
   ifneq ($(filter s3,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_S3=ON
   endif
-  
+
   ifneq ($(filter hdfs,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_HDFS=ON
   endif
-  
+
   ifneq ($(filter gcs,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_GCS=ON
   endif
-  
+
   ifneq ($(filter abfs,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_ABFS=ON
   endif
-  
+
   ifneq ($(filter parquet,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_PARQUET=ON
   endif
-  
+
   ifneq ($(filter cudf,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_CUDF=ON
   endif
-  
+
   ifneq ($(filter remote-functions,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON
   endif
-  
+
   ifneq ($(filter jwt,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_JWT=ON
   endif
-  
+
   ifneq ($(filter arrow-flight,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON
   endif
-  
+
   ifneq ($(filter spatial,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_SPATIAL=ON
   endif

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -24,6 +24,68 @@ PYTHON_VENV ?= .venv
 
 EXTRA_CMAKE_FLAGS ?= ""
 
+# Define comma for use in substitution
+comma := ,
+
+# New variable for comma-separated optional features
+PRESTO_OPTIONAL_FEATURES ?=
+
+# Process comma-separated features
+ifneq ($(PRESTO_OPTIONAL_FEATURES),)
+  # Convert comma-separated list to space-separated
+  FEATURES_LIST := $(subst $(comma), ,$(PRESTO_OPTIONAL_FEATURES))
+  
+  # Validate features
+  VALID_FEATURES := s3 hdfs gcs abfs parquet cudf remote-functions jwt arrow-flight spatial
+  INVALID_FEATURES := $(filter-out $(VALID_FEATURES),$(FEATURES_LIST))
+  
+  ifneq ($(INVALID_FEATURES),)
+    $(warning Invalid features in PRESTO_OPTIONAL_FEATURES: $(INVALID_FEATURES))
+    $(warning Valid features are: $(VALID_FEATURES))
+  endif
+  
+  # Map features to CMake flags
+  ifneq ($(filter s3,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_S3=ON
+  endif
+  
+  ifneq ($(filter hdfs,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_HDFS=ON
+  endif
+  
+  ifneq ($(filter gcs,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_GCS=ON
+  endif
+  
+  ifneq ($(filter abfs,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_ABFS=ON
+  endif
+  
+  ifneq ($(filter parquet,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_PARQUET=ON
+  endif
+  
+  ifneq ($(filter cudf,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_CUDF=ON
+  endif
+  
+  ifneq ($(filter remote-functions,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON
+  endif
+  
+  ifneq ($(filter jwt,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_JWT=ON
+  endif
+  
+  ifneq ($(filter arrow-flight,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON
+  endif
+  
+  ifneq ($(filter spatial,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_SPATIAL=ON
+  endif
+endif
+
 define deprecate_message
   $(eval $@_VAR_NAME = $(1))
   $(warning ${$@_VAR_NAME} environment variable is deprecated and will be removed in the future. Use EXTRA_CMAKE_FLAGS.)

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -39,11 +39,19 @@ ifneq ($(PRESTO_OPTIONAL_FEATURES),)
   FEATURES_LIST := $(foreach feature,$(FEATURES_LIST),$(strip $(feature)))
 
   # Validate features
-  VALID_FEATURES := s3 hdfs gcs abfs parquet cudf remote-functions jwt arrow-flight spatial
+  VALID_FEATURES := s3 hdfs gcs abfs parquet cudf remote-functions jwt arrow-flight spatial no-parquet no-spatial
   INVALID_FEATURES := $(filter-out $(VALID_FEATURES),$(FEATURES_LIST))
 
   ifneq ($(INVALID_FEATURES),)
     $(error Invalid features in PRESTO_OPTIONAL_FEATURES: $(INVALID_FEATURES). Valid features are: $(VALID_FEATURES))
+  endif
+
+  # Conflict detection
+  ifneq ($(and $(filter parquet,$(FEATURES_LIST)),$(filter no-parquet,$(FEATURES_LIST))),)
+    $(error Conflicting features: both 'parquet' and 'no-parquet' specified in PRESTO_OPTIONAL_FEATURES)
+  endif
+  ifneq ($(and $(filter spatial,$(FEATURES_LIST)),$(filter no-spatial,$(FEATURES_LIST))),)
+    $(error Conflicting features: both 'spatial' and 'no-spatial' specified in PRESTO_OPTIONAL_FEATURES)
   endif
 
   # Map features to CMake flags
@@ -85,6 +93,15 @@ ifneq ($(PRESTO_OPTIONAL_FEATURES),)
 
   ifneq ($(filter spatial,$(FEATURES_LIST)),)
     EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_SPATIAL=ON
+  endif
+
+  # Disable default-ON features
+  ifneq ($(filter no-parquet,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_PARQUET=OFF
+  endif
+
+  ifneq ($(filter no-spatial,$(FEATURES_LIST)),)
+    EXTRA_CMAKE_FLAGS += -DPRESTO_ENABLE_SPATIAL=OFF
   endif
 endif
 

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -27,7 +27,7 @@ EXTRA_CMAKE_FLAGS ?= ""
 # Define comma for use in substitution
 comma := ,
 
-# New variable for comma-separated optional features
+# Comma-separated optional features
 PRESTO_OPTIONAL_FEATURES ?=
 
 # Process comma-separated features

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -81,6 +81,55 @@ Compilers (and versions) not mentioned are known to not work or have not been tr
 
 ### Build Prestissimo
 #### Parquet and S3 Support
+#### Using Comma-Separated Optional Features (Recommended)
+
+You can enable multiple optional features using a single comma-separated list:
+
+```bash
+export PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs,jwt"
+make release
+```
+
+Or inline:
+
+```bash
+PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs" make release
+```
+
+**Available features:**
+- `s3` - S3 support (requires AWS SDK)
+- `hdfs` - HDFS support
+- `gcs` - GCS support
+- `abfs` - ABFS support
+- `parquet` - Parquet support (enabled by default)
+- `cudf` - cuDF GPU support
+- `remote-functions` - Remote function support
+- `jwt` - JWT authentication
+- `arrow-flight` - Arrow Flight connector
+- `spatial` - Spatial support (enabled by default)
+
+**Examples:**
+
+```bash
+# Enable S3, Parquet, and JWT
+PRESTO_OPTIONAL_FEATURES="s3,parquet,jwt" make release
+
+# Enable all storage connectors
+PRESTO_OPTIONAL_FEATURES="s3,hdfs,gcs,abfs" make release
+
+# Enable GPU support with Parquet
+PRESTO_OPTIONAL_FEATURES="cudf,parquet" \
+CUDA_ARCHITECTURES=80 \
+CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+make release
+```
+
+**Note:** Individual flags (e.g., `PRESTO_ENABLE_S3=ON`) are still supported but deprecated. Use `PRESTO_OPTIONAL_FEATURES` for new projects.
+
+#### Parquet and S3 Support (Legacy Method)
+
+**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="s3,parquet"`. The following method is still supported but deprecated.
+
 Parquet support is enabled by default. To disable it, add `-DPRESTO_ENABLE_PARQUET=OFF`
 to the `EXTRA_CMAKE_FLAGS` environment variable.
 
@@ -99,7 +148,10 @@ from the `presto/presto-native-execution` directory.
     Or
 `./velox/scripts/setup-ubuntu.sh install_aws_deps`
 
-#### JWT Authentication
+#### JWT Authentication (Legacy Method)
+
+**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="jwt"`. The following method is still supported but deprecated.
+
 To enable JWT authentication support, add `-DPRESTO_ENABLE_JWT=ON` to the
 `EXTRA_CMAKE_FLAGS` environment variable.
 
@@ -129,7 +181,10 @@ follow these steps:
 * For development, use `make debug` to build a non-optimized debug version.
 * Use `make unittest` to build and run tests.
 
-#### Arrow Flight Connector
+#### Arrow Flight Connector (Legacy Method)
+
+**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="arrow-flight"`. The following method is still supported but deprecated.
+
 To enable Arrow Flight connector support, add to the `EXTRA_CMAKE_FLAGS` environment variable:
 `export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON"`
 
@@ -138,7 +193,9 @@ by running the following script from the `presto/presto-native-execution` direct
 
 `./scripts/setup-adapters.sh arrow_flight`
 
-#### Nvidia cuDF GPU Support
+#### Nvidia cuDF GPU Support (Legacy Method)
+
+**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="cudf"`. The following method is still supported but deprecated.
 
 To enable support with [cuDF](https://github.com/facebookincubator/velox/tree/main/velox/experimental/cudf),
 add to the `EXTRA_CMAKE_FLAGS` environment variable:

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -113,6 +113,15 @@ PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs" make release
 | `jwt`              | JWT authentication      | OFF     |
 | `arrow-flight`     | Arrow Flight connector  | OFF     |
 | `spatial`          | Spatial support         | **ON**  |
+| `no-parquet`       | Disable Parquet support | —       |
+| `no-spatial`       | Disable Spatial support | —       |
+
+To explicitly disable a default-ON feature, use the `no-` prefix:
+
+```bash
+# Disable Parquet and Spatial (both ON by default)
+PRESTO_OPTIONAL_FEATURES="s3,no-parquet,no-spatial" make release
+```
 
 **Examples:**
 

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -80,7 +80,6 @@ Compilers (and versions) not mentioned are known to not work or have not been tr
 | macOS | `clang15 (or later)` |
 
 ### Build Prestissimo
-#### Parquet and S3 Support
 #### Using Comma-Separated Optional Features (Recommended)
 
 You can enable multiple optional features using a single comma-separated list:
@@ -97,16 +96,19 @@ PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs" make release
 ```
 
 **Available features:**
-- `s3` - S3 support (requires AWS SDK)
-- `hdfs` - HDFS support
-- `gcs` - GCS support
-- `abfs` - ABFS support
-- `parquet` - Parquet support (enabled by default)
-- `cudf` - cuDF GPU support
-- `remote-functions` - Remote function support
-- `jwt` - JWT authentication
-- `arrow-flight` - Arrow Flight connector
-- `spatial` - Spatial support (enabled by default)
+
+|    Feature Name    |        Description      | Default |
+|--------------------|-------------------------|---------|
+| `s3`               | S3 support              | OFF     |
+| `hdfs`             | HDFS support            | OFF     |
+| `gcs`              | GCS support             | OFF     |
+| `abfs`             | ABFS support            | OFF     |
+| `parquet`          | Parquet support         | **ON**  |
+| `cudf`             | cuDF GPU support        | OFF     |
+| `remote-functions` | Remote function support | OFF     |
+| `jwt      `        | JWT authentication      | OFF     |
+| `arrow-flight`     | Arrow Flight connector  | OFF     |
+| `spatial`          | Spatial support         | **ON**  |
 
 **Examples:**
 
@@ -126,36 +128,19 @@ make release
 
 **Note:** Individual flags (e.g., `PRESTO_ENABLE_S3=ON`) are still supported but deprecated. Use `PRESTO_OPTIONAL_FEATURES` for new projects.
 
-#### Parquet and S3 Support (Legacy Method)
+#### File System Support
 
-**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="s3,parquet"`. The following method is still supported but deprecated.
-
-Parquet support is enabled by default. To disable it, add `-DPRESTO_ENABLE_PARQUET=OFF`
-to the `EXTRA_CMAKE_FLAGS` environment variable.
-
-`export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS -DPRESTO_ENABLE_PARQUET=OFF"`
-
-To enable S3 support, add `-DPRESTO_ENABLE_S3=ON` to the `EXTRA_CMAKE_FLAGS`
-environment variable.
-
-`export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DPRESTO_ENABLE_S3=ON"`
-
-S3 support needs the [AWS SDK C++](https://github.com/aws/aws-sdk-cpp) library.
+S3, GCS, HDFS, Azure support need their corresponding libraries.
+S3 for example needs the [AWS SDK C++](https://github.com/aws/aws-sdk-cpp) library.
 This dependency can be installed by running the target platform build script
 from the `presto/presto-native-execution` directory.
+For S3 support, run
 
 `./velox/scripts/setup-centos9.sh install_aws_deps`
     Or
 `./velox/scripts/setup-ubuntu.sh install_aws_deps`
 
-#### JWT Authentication (Legacy Method)
-
-**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="jwt"`. The following method is still supported but deprecated.
-
-To enable JWT authentication support, add `-DPRESTO_ENABLE_JWT=ON` to the
-`EXTRA_CMAKE_FLAGS` environment variable.
-
-`export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DPRESTO_ENABLE_JWT=ON"`
+#### JWT Authentication
 
 JWT authentication support needs the [JWT CPP](https://github.com/Thalhammer/jwt-cpp) library.
 This dependency can be installed by running the script below from the
@@ -181,30 +166,19 @@ follow these steps:
 * For development, use `make debug` to build a non-optimized debug version.
 * Use `make unittest` to build and run tests.
 
-#### Arrow Flight Connector (Legacy Method)
-
-**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="arrow-flight"`. The following method is still supported but deprecated.
-
-To enable Arrow Flight connector support, add to the `EXTRA_CMAKE_FLAGS` environment variable:
-`export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON"`
+#### Arrow Flight Connector
 
 The Arrow Flight connector requires the Arrow Flight library. You can install this dependency
 by running the following script from the `presto/presto-native-execution` directory:
 
 `./scripts/setup-adapters.sh arrow_flight`
 
-#### Nvidia cuDF GPU Support (Legacy Method)
-
-**Note:** The recommended way is to use `PRESTO_OPTIONAL_FEATURES="cudf"`. The following method is still supported but deprecated.
-
-To enable support with [cuDF](https://github.com/facebookincubator/velox/tree/main/velox/experimental/cudf),
-add to the `EXTRA_CMAKE_FLAGS` environment variable:
-`export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DPRESTO_ENABLE_CUDF=ON"`
+#### Nvidia cuDF GPU Support
 
 In some environments, the CUDA_ARCHITECTURES and CUDA_COMPILER location must be explicitly set.
 The make command will look like:
 
-`CUDA_ARCHITECTURES=80 CUDA_COMPILER=/usr/local/cuda/bin/nvcc EXTRA_CMAKE_FLAGS=" -DPRESTO_ENABLE_CUDF=ON" make`
+`CUDA_ARCHITECTURES=80 CUDA_COMPILER=/usr/local/cuda/bin/nvcc PRESTO_OPTIONAL_FEATURES="cudf" make`
 
 The required dependencies are bundled from the Velox setup scripts.
 

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -95,6 +95,10 @@ Or inline:
 PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs" make release
 ```
 
+**Note:** Whitespace around commas is automatically handled, so `"s3, parquet, hdfs"` works the same as `"s3,parquet,hdfs"`.
+
+**Important:** Invalid feature names will cause the build to fail immediately with an error message listing valid features. This prevents silent misconfiguration.
+
 **Available features:**
 
 |    Feature Name    |        Description      | Default |
@@ -106,7 +110,7 @@ PRESTO_OPTIONAL_FEATURES="s3,parquet,hdfs" make release
 | `parquet`          | Parquet support         | **ON**  |
 | `cudf`             | cuDF GPU support        | OFF     |
 | `remote-functions` | Remote function support | OFF     |
-| `jwt      `        | JWT authentication      | OFF     |
+| `jwt`              | JWT authentication      | OFF     |
 | `arrow-flight`     | Arrow Flight connector  | OFF     |
 | `spatial`          | Spatial support         | **ON**  |
 
@@ -130,7 +134,7 @@ make release
 
 #### File System Support
 
-S3, GCS, HDFS, Azure support need their corresponding libraries.
+S3, GCS, HDFS,  and Azure support require their corresponding libraries.
 S3 for example needs the [AWS SDK C++](https://github.com/aws/aws-sdk-cpp) library.
 This dependency can be installed by running the target platform build script
 from the `presto/presto-native-execution` directory.
@@ -173,9 +177,9 @@ by running the following script from the `presto/presto-native-execution` direct
 
 `./scripts/setup-adapters.sh arrow_flight`
 
-#### Nvidia cuDF GPU Support
+#### NVIDIA cuDF GPU Support
 
-In some environments, the CUDA_ARCHITECTURES and CUDA_COMPILER location must be explicitly set.
+In some environments, the CUDA_ARCHITECTURES and CUDA_COMPILER must be explicitly set.
 The make command will look like:
 
 `CUDA_ARCHITECTURES=80 CUDA_COMPILER=/usr/local/cuda/bin/nvcc PRESTO_OPTIONAL_FEATURES="cudf" make`

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -146,6 +146,10 @@ For S3 support, run
 
 #### JWT Authentication
 
+To enable JWT authentication support, add to the `PRESTO_OPTIONAL_FEATURES` environment variable:
+
+`export PRESTO_OPTIONAL_FEATURES="${PRESTO_OPTIONAL_FEATURES},jwt"`
+
 JWT authentication support needs the [JWT CPP](https://github.com/Thalhammer/jwt-cpp) library.
 This dependency can be installed by running the script below from the
 `presto/presto-native-execution` directory.
@@ -172,12 +176,21 @@ follow these steps:
 
 #### Arrow Flight Connector
 
+To enable Arrow Flight connector support, add to the `PRESTO_OPTIONAL_FEATURES` environment variable:
+
+`export PRESTO_OPTIONAL_FEATURES="${PRESTO_OPTIONAL_FEATURES},arrow-flight"`
+
 The Arrow Flight connector requires the Arrow Flight library. You can install this dependency
 by running the following script from the `presto/presto-native-execution` directory:
 
 `./scripts/setup-adapters.sh arrow_flight`
 
 #### NVIDIA cuDF GPU Support
+
+To enable support with [cuDF](https://github.com/facebookincubator/velox/tree/main/velox/experimental/cudf),
+add to the `PRESTO_OPTIONAL_FEATURES` environment variable:
+
+`export PRESTO_OPTIONAL_FEATURES="${PRESTO_OPTIONAL_FEATURES},cudf"`
 
 In some environments, the CUDA_ARCHITECTURES and CUDA_COMPILER must be explicitly set.
 The make command will look like:

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -134,7 +134,7 @@ make release
 
 #### File System Support
 
-S3, GCS, HDFS,  and Azure support require their corresponding libraries.
+S3, GCS, HDFS, and Azure support require their corresponding libraries.
 S3 for example needs the [AWS SDK C++](https://github.com/aws/aws-sdk-cpp) library.
 This dependency can be installed by running the target platform build script
 from the `presto/presto-native-execution` directory.

--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -55,6 +55,7 @@ services:
         # A few files in Velox require significant memory to compile and link.
         # Build requires 18GB of memory for 2 threads.
         - NUM_THREADS=2 # default value for NUM_THREADS
-        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_CUDF=${GPU:-OFF}
+        - PRESTO_OPTIONAL_FEATURES=parquet,s3
+        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_CUDF=${GPU:-OFF}
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -28,7 +28,7 @@ ENV BUILD_DIR=""
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
-    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]] || [[ "${PRESTO_OPTIONAL_FEATURES}" =~ cudf ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
+    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]] || [[ ",${PRESTO_OPTIONAL_FEATURES}," =~ ,cudf, ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
     PRESTO_OPTIONAL_FEATURES=${PRESTO_OPTIONAL_FEATURES} \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -16,6 +16,7 @@ FROM ${DEPENDENCY_IMAGE} as prestissimo-image
 
 ARG OSNAME=centos
 ARG BUILD_TYPE=Release
+ARG PRESTO_OPTIONAL_FEATURES=''
 ARG EXTRA_CMAKE_FLAGS=''
 ARG NUM_THREADS=8
 ARG CUDA_ARCHITECTURES=70
@@ -27,7 +28,8 @@ ENV BUILD_DIR=""
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
-    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
+    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]] || [[ "${PRESTO_OPTIONAL_FEATURES}" =~ cudf ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
+    PRESTO_OPTIONAL_FEATURES=${PRESTO_OPTIONAL_FEATURES} \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'


### PR DESCRIPTION
Fixes: https://github.com/prestodb/presto/issues/24822

 Prestissimo now supports a PRESTO_OPTIONAL_FEATURES environment variable that accepts a comma-separated list of features to enable or
  disable during the build. This replaces the need to manually specify individual -DPRESTO_ENABLE_* CMake flags.

  PRESTO_OPTIONAL_FEATURES="s3,hdfs,jwt,no-parquet" make release

  Available features: s3, hdfs, gcs, abfs, parquet, cudf, remote-functions, jwt, arrow-flight, spatial. Default-ON features (parquet, spatial) can be disabled with the no- prefix (no-parquet, no-spatial).

  Invalid feature names cause an immediate build error. Whitespace around commas is handled automatically. The previous per-feature environment variables (e.g., PRESTO_ENABLE_S3=ON) remain supported but are deprecated.

```
== RELEASE NOTES ==

  Prestissimo (Native Execution) Changes
  * Add ``PRESTO_OPTIONAL_FEATURES`` build variable to enable or disable optional
    features using a comma-separated list (e.g.,
    ``PRESTO_OPTIONAL_FEATURES="s3,hdfs,jwt,no-parquet" make release``).
    Default-ON features (``parquet``, ``spatial``) can be disabled with the
    ``no-`` prefix. Invalid feature names cause an immediate build error.
  * Deprecate individual feature environment variables (e.g., ``PRESTO_ENABLE_S3``)
    in favor of ``PRESTO_OPTIONAL_FEATURES``.

```
