### PR TITLE
fix: Flight shim server not correctly loading connector from connector id

### DIFF
--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
@@ -23,6 +23,8 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.metadata.Catalog;
+import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.server.PluginInstaller;
@@ -65,6 +67,7 @@ public class FlightShimPluginManager
     private static final Logger log = Logger.get(FlightShimPluginManager.class);
     private static final String SERVICES_FILE = "META-INF/services/" + Plugin.class.getName();
     private final ConnectorManager connectorManager;
+    private final CatalogManager catalogManager;
     private final Map<String, ConnectorCodecs> connectorCodecMap = new ConcurrentHashMap<>();
     private final File installedPluginsDir;
     private final List<String> plugins;
@@ -79,6 +82,7 @@ public class FlightShimPluginManager
     @Inject
     public FlightShimPluginManager(
             ConnectorManager connectorManager,
+            CatalogManager catalogManager,
             StaticCatalogStore staticCatalogStore,
             PluginManagerConfig pluginManagerConfig,
             StaticCatalogStoreConfig catalogStoreConfig,
@@ -86,6 +90,7 @@ public class FlightShimPluginManager
             BlockEncodingManager blockEncodingManager)
     {
         this.connectorManager = requireNonNull(connectorManager, "connectorManager is null");
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
         this.staticCatalogStore = requireNonNull(staticCatalogStore, "staticCatalogStore is null");
         requireNonNull(pluginManagerConfig, "pluginManagerConfig is null");
         requireNonNull(catalogStoreConfig, "catalogStoreConfig is null");
@@ -127,7 +132,12 @@ public class FlightShimPluginManager
 
     public ConnectorCodecs getConnectorCodecs(String connectorId)
     {
-        return connectorCodecMap.get(connectorId);
+        Catalog catalog = catalogManager.getCatalog(connectorId).orElseThrow(() -> new IllegalArgumentException("Requested catalog not loaded: " + connectorId));
+        ConnectorCodecs connectorCodecs = connectorCodecMap.get(catalog.getCatalogContext().getConnectorName());
+        if (connectorCodecs == null) {
+            throw new IllegalArgumentException("Requested connector not loaded: " + catalog.getCatalogContext().getConnectorName());
+        }
+        return connectorCodecs;
     }
 
     @Override

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
@@ -124,7 +124,6 @@ public class FlightShimProducer
             log.debug("Request for connector: %s", request.getConnectorId());
 
             FlightShimPluginManager.ConnectorCodecs connectorCodecs = pluginManager.getConnectorCodecs(request.getConnectorId());
-            requireNonNull(connectorCodecs, format("Requested connector not loaded: %s", request.getConnectorId()));
 
             ConnectorSplit connectorSplit = connectorCodecs.getCodecSplit().fromJson(request.getSplitBytes());
 

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.memory.BufferAllocator;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 import static com.facebook.presto.SystemSessionProperties.MERGE_AGGREGATIONS_WITH_AND_WITHOUT_FILTER;
 import static com.facebook.presto.SystemSessionProperties.REMOVE_MAP_CAST;
-import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.buildCatalogsMap;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.getFlightServerShimConfig;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 
@@ -51,7 +51,9 @@ public abstract class AbstractTestArrowFederationNativeQueries
             throws Exception
     {
         Injector injector = FlightShimServer.initialize(getFlightServerShimConfig(getPluginBundles()));
-        server = FlightShimServer.start(injector, FlightServer.builder(), buildCatalogsMap(getCatalogPropertiesMap()));
+        ImmutableMap.Builder<String, String> propertyBuilder = ImmutableMap.builder();
+        propertyBuilder.put("connector.name", getConnectorName()).putAll(getConnectorProperties());
+        server = FlightShimServer.start(injector, FlightServer.builder(), ImmutableMap.of(getConnectorId(), propertyBuilder.build()));
         allocator = injector.getInstance(BufferAllocator.class);
         producer = injector.getInstance(FlightShimProducer.class);
         super.init();
@@ -81,9 +83,19 @@ public abstract class AbstractTestArrowFederationNativeQueries
         super.close();
     }
 
-    protected abstract String getPluginBundles();
+    protected abstract String getConnectorId();
 
-    protected abstract Map<String, Map<String, String>> getCatalogPropertiesMap();
+    protected String getConnectorName()
+    {
+        return getConnectorId();
+    }
+
+    protected Map<String, String> getConnectorProperties()
+    {
+        return ImmutableMap.of();
+    }
+
+    protected abstract String getPluginBundles();
 
     @Override
     protected FeaturesConfig createFeaturesConfig()

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestFlightShimPlugins.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestFlightShimPlugins.java
@@ -108,6 +108,11 @@ public abstract class AbstractTestFlightShimPlugins
 
     protected abstract String getConnectorId();
 
+    protected String getConnectorName()
+    {
+        return getConnectorId();
+    }
+
     protected abstract String getPluginBundles();
 
     @BeforeClass
@@ -126,7 +131,7 @@ public abstract class AbstractTestFlightShimPlugins
 
         // Create the catalog for the test connector, avoid loading other catalogs
         ImmutableMap.Builder<String, String> propertyBuilder = ImmutableMap.builder();
-        propertyBuilder.put("connector.name", getConnectorId()).putAll(getConnectorProperties());
+        propertyBuilder.put("connector.name", getConnectorName()).putAll(getConnectorProperties());
         configBuilder.put("catalog.config-dir", "src/test/resources/etc/catalog");
 
         Injector injector = FlightShimServer.initialize(configBuilder.build());

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/NativeArrowFederationConnectorUtils.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/NativeArrowFederationConnectorUtils.java
@@ -81,8 +81,10 @@ public class NativeArrowFederationConnectorUtils
                 .build();
     }
 
-    public static Optional<BiFunction<Integer, URI, Process>> getExternalWorkerLauncher(String prestoServerPath, int flightServerPort, List<String> connectorIds)
+    public static Optional<BiFunction<Integer, URI, Process>> getExternalWorkerLauncher(String prestoServerPath, int flightServerPort, List<String> connectorIds, List<String> connectorNames)
     {
+        checkArgument(connectorIds.size() == connectorNames.size(), "connectorId and connectorNames must be the same size");
+
         return Optional.of((workerIndex, discoveryUri) -> {
             try {
                 Path dir = Paths.get("/tmp", NativeArrowFederationConnectorUtils.class.getSimpleName());
@@ -110,7 +112,8 @@ public class NativeArrowFederationConnectorUtils
                 String clientCertPath = Paths.get("src/test/resources/certs/client.crt").toAbsolutePath().toString();
                 String clientKeyPath = Paths.get("src/test/resources/certs/client.key").toAbsolutePath().toString();
 
-                for (String connectorId : connectorIds) {
+                for (int i = 0; i < connectorIds.size(); i++) {
+                    String connectorName = connectorNames.get(i);
                     String catalogBuilder = format(
                             "connector.name=%s\n" +
                                     "protocol-connector.id=%s\n" +
@@ -121,9 +124,9 @@ public class NativeArrowFederationConnectorUtils
                                     "arrow-flight.server-ssl-certificate=%s\n" +
                                     "arrow-flight.client-ssl-certificate=%s\n" +
                                     "arrow-flight.client-ssl-key=%s\n",
-                            ARROW_FEDERATION_CONNECTOR, connectorId, flightServerPort, caCertPath, clientCertPath, clientKeyPath);
+                            ARROW_FEDERATION_CONNECTOR, connectorName, flightServerPort, caCertPath, clientCertPath, clientKeyPath);
                     Files.write(
-                            catalogDirectoryPath.resolve(format("%s.properties", connectorId)),
+                            catalogDirectoryPath.resolve(format("%s.properties", connectorIds.get(i))),
                             catalogBuilder.getBytes());
                 }
 
@@ -150,6 +153,12 @@ public class NativeArrowFederationConnectorUtils
     public static QueryRunner createNativeQueryRunner(List<String> connectorIds, int port)
             throws Exception
     {
+        return createNativeQueryRunner(connectorIds, connectorIds, port);
+    }
+
+    public static QueryRunner createNativeQueryRunner(List<String> connectorIds, List<String> connectorNames, int port)
+            throws Exception
+    {
         Path prestoServerPath = Paths.get(getProperty("PRESTO_SERVER")
                         .orElse("_build/debug/presto_cpp/main/presto_server"))
                 .toAbsolutePath();
@@ -169,7 +178,7 @@ public class NativeArrowFederationConnectorUtils
         DistributedQueryRunner queryRunner = queryRunnerBuilder
                 .setExtraProperties(getNativeWorkerSystemProperties())
                 .setExternalWorkerLauncher(
-                        getExternalWorkerLauncher(prestoServerPath.toString(), port, connectorIds))
+                        getExternalWorkerLauncher(prestoServerPath.toString(), port, connectorIds, connectorNames))
                 .build();
 
         try {
@@ -205,7 +214,7 @@ public class NativeArrowFederationConnectorUtils
         }
     }
 
-    public static Map<String, String> getConnectorProperties(String jdbcUrl)
+    public static Map<String, String> createJdbcConnectorProperties(String jdbcUrl)
     {
         Map<String, String> connectorProperties = new HashMap<>();
         connectorProperties.putIfAbsent("connection-url", jdbcUrl);

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesCassandra.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesCassandra.java
@@ -69,9 +69,15 @@ public class TestArrowFederationNativeQueriesCassandra
     }
 
     @Override
-    protected Map<String, Map<String, String>> getCatalogPropertiesMap()
+    protected String getConnectorId()
     {
-        return ImmutableMap.of(CONNECTOR_ID, getConnectorProperties(cassandraServer));
+        return CONNECTOR_ID;
+    }
+
+    @Override
+    protected Map<String, String> getConnectorProperties()
+    {
+        return createCassandraConnectorProperties(cassandraServer);
     }
 
     @Override
@@ -81,7 +87,7 @@ public class TestArrowFederationNativeQueriesCassandra
         try {
             QueryRunner queryRunner = createJavaQueryRunner();
             queryRunner.installPlugin(new CassandraPlugin());
-            queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(cassandraServer));
+            queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties());
             createTpchTables(getSession(), cassandraServer, queryRunner);
             queryRunner.close();
         }
@@ -106,7 +112,7 @@ public class TestArrowFederationNativeQueriesCassandra
         QueryRunner queryRunner =
                 createNativeQueryRunner(ImmutableList.of(CONNECTOR_ID), server.getPort());
         queryRunner.installPlugin(new CassandraPlugin());
-        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(cassandraServer));
+        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties());
         return queryRunner;
     }
 
@@ -298,7 +304,7 @@ public class TestArrowFederationNativeQueriesCassandra
         return "cast(" + columnExpression + " as DATE)";
     }
 
-    static Map<String, String> getConnectorProperties(CassandraServer server)
+    static Map<String, String> createCassandraConnectorProperties(CassandraServer server)
     {
         Map<String, String> connectorProperties = new HashMap<>();
         connectorProperties.putIfAbsent("cassandra.contact-points", server.getHost());

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMixedConnectors.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMixedConnectors.java
@@ -37,15 +37,14 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.buildCatalogsMap;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJavaQueryRunner;
+import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJdbcConnectorProperties;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createNativeQueryRunner;
-import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.getConnectorProperties;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.getFlightServerShimConfig;
-import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesMongo.getMongoConnectorProperties;
+import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesMongo.createMongoConnectorProperties;
 import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesMongo.getMongoDbSeeds;
 import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesMySql.getConnectionUrl;
-import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesRedis.getConnectorProperties;
+import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesRedis.createRedisConnectorProperties;
 import static com.facebook.presto.flightshim.TestArrowFederationNativeQueriesRedis.installRedisPlugin;
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
 import static com.facebook.presto.redis.RedisQueryRunner.createTpchTableDescriptions;
@@ -104,7 +103,7 @@ public class TestArrowFederationNativeQueriesMixedConnectors
             throws Exception
     {
         Injector injector = FlightShimServer.initialize(getFlightServerShimConfig(PLUGIN_BUNDLES));
-        server = FlightShimServer.start(injector, FlightServer.builder(), buildCatalogsMap(getCatalogPropertiesMap()));
+        server = FlightShimServer.start(injector, FlightServer.builder(), getCatalogPropertiesMap());
         allocator = injector.getInstance(BufferAllocator.class);
         producer = injector.getInstance(FlightShimProducer.class);
         super.init();
@@ -170,10 +169,10 @@ public class TestArrowFederationNativeQueriesMixedConnectors
     private Map<String, Map<String, String>> getCatalogPropertiesMap()
     {
         return ImmutableMap.of(
-                MYSQL_CONNECTOR_ID, getConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl())),
-                POSTGRES_CONNECTOR_ID, getConnectorProperties(postgresContainer.getJdbcUrl()),
-                REDIS_CONNECTOR_ID, getConnectorProperties(embeddedRedis, createEmptyTableDescriptions()),
-                MONGO_CONNECTOR_ID, getMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner)));
+                MYSQL_CONNECTOR_ID, createConnectorCatalog(MYSQL_CONNECTOR_ID, createJdbcConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl()))),
+                POSTGRES_CONNECTOR_ID, createConnectorCatalog(POSTGRES_CONNECTOR_ID, createJdbcConnectorProperties(postgresContainer.getJdbcUrl())),
+                REDIS_CONNECTOR_ID, createConnectorCatalog(REDIS_CONNECTOR_ID, createRedisConnectorProperties(embeddedRedis, createEmptyTableDescriptions())),
+                MONGO_CONNECTOR_ID, createConnectorCatalog(MONGO_CONNECTOR_ID, createMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner))));
     }
 
     @Override
@@ -355,10 +354,10 @@ public class TestArrowFederationNativeQueriesMixedConnectors
             throws Exception
     {
         queryRunner.installPlugin(new PostgreSqlPlugin());
-        queryRunner.createCatalog(POSTGRES_CONNECTOR_ID, POSTGRES_CONNECTOR_ID, getConnectorProperties(postgresJdbcUrl));
+        queryRunner.createCatalog(POSTGRES_CONNECTOR_ID, POSTGRES_CONNECTOR_ID, createJdbcConnectorProperties(postgresJdbcUrl));
 
         queryRunner.installPlugin(new MySqlPlugin());
-        queryRunner.createCatalog(MYSQL_CONNECTOR_ID, MYSQL_CONNECTOR_ID, getConnectorProperties(getConnectionUrl(mySqlJdbcUrl)));
+        queryRunner.createCatalog(MYSQL_CONNECTOR_ID, MYSQL_CONNECTOR_ID, createJdbcConnectorProperties(getConnectionUrl(mySqlJdbcUrl)));
 
         installRedisPlugin(
                 embeddedRedis,
@@ -366,13 +365,20 @@ public class TestArrowFederationNativeQueriesMixedConnectors
                 createTpchTableDescriptions(((DistributedQueryRunner) queryRunner).getCoordinator().getMetadata(), TpchTable.getTables(), "string"));
 
         queryRunner.installPlugin(new MongoPlugin());
-        queryRunner.createCatalog(MONGO_CONNECTOR_ID, MONGO_CONNECTOR_ID, getMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner)));
+        queryRunner.createCatalog(MONGO_CONNECTOR_ID, MONGO_CONNECTOR_ID, createMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner)));
     }
 
     private static void createTables(QueryRunner queryRunner, String postgresJdbcUrl, EmbeddedRedis embeddedRedis)
     {
-        TestArrowFederationNativeQueriesPostgres.createTpchTables(queryRunner, postgresJdbcUrl);
+        TestArrowFederationNativeQueriesPostgres.createTpchTables(queryRunner, postgresJdbcUrl, POSTGRES_CONNECTOR_ID);
         TestArrowFederationNativeQueriesMySql.createTpchTables(queryRunner);
         TestArrowFederationNativeQueriesRedis.createTpchTables(embeddedRedis, queryRunner);
+    }
+
+    private static Map<String, String> createConnectorCatalog(String connectorName, Map<String, String> connectorProperties)
+    {
+        ImmutableMap.Builder<String, String> propertyBuilder = ImmutableMap.builder();
+        propertyBuilder.put("connector.name", connectorName).putAll(connectorProperties);
+        return propertyBuilder.build();
     }
 }

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMongo.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMongo.java
@@ -63,9 +63,15 @@ public class TestArrowFederationNativeQueriesMongo
     }
 
     @Override
-    protected Map<String, Map<String, String>> getCatalogPropertiesMap()
+    protected String getConnectorId()
     {
-        return ImmutableMap.of(CONNECTOR_ID, getMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner)));
+        return CONNECTOR_ID;
+    }
+
+    @Override
+    protected Map<String, String> getConnectorProperties()
+    {
+        return createMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner));
     }
 
     @Override
@@ -84,7 +90,7 @@ public class TestArrowFederationNativeQueriesMongo
         QueryRunner queryRunner =
                 createNativeQueryRunner(ImmutableList.of(CONNECTOR_ID), server.getPort());
         queryRunner.installPlugin(new MongoPlugin());
-        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getMongoConnectorProperties(getMongoDbSeeds(mongoQueryRunner)));
+        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties());
         return queryRunner;
     }
 
@@ -159,7 +165,7 @@ public class TestArrowFederationNativeQueriesMongo
         return mongoQueryRunner.getAddress().getHostString() + ":" + mongoQueryRunner.getAddress().getPort();
     }
 
-    static Map<String, String> getMongoConnectorProperties(String seeds)
+    static Map<String, String> createMongoConnectorProperties(String seeds)
     {
         Map<String, String> connectorProperties = new HashMap<>();
         connectorProperties.putIfAbsent("mongodb.seeds", seeds);

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMySql.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesMySql.java
@@ -18,7 +18,6 @@ import com.facebook.presto.plugin.mysql.MySqlPlugin;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import org.testcontainers.containers.MySQLContainer;
 import org.testng.annotations.AfterClass;
@@ -32,8 +31,8 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.flightshim.AbstractTestFlightShimJdbcPlugins.addDatabaseCredentialsToJdbcUrl;
 import static com.facebook.presto.flightshim.AbstractTestFlightShimJdbcPlugins.removeDatabaseFromJdbcUrl;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJavaQueryRunner;
+import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJdbcConnectorProperties;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createNativeQueryRunner;
-import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.getConnectorProperties;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -76,9 +75,15 @@ public class TestArrowFederationNativeQueriesMySql
     }
 
     @Override
-    protected Map<String, Map<String, String>> getCatalogPropertiesMap()
+    protected String getConnectorId()
     {
-        return ImmutableMap.of(CONNECTOR_ID, getConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl())));
+        return CONNECTOR_ID;
+    }
+
+    @Override
+    protected Map<String, String> getConnectorProperties()
+    {
+        return createJdbcConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl()));
     }
 
     @Override
@@ -88,7 +93,7 @@ public class TestArrowFederationNativeQueriesMySql
         try {
             QueryRunner queryRunner = createJavaQueryRunner();
             queryRunner.installPlugin(new MySqlPlugin());
-            queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl())));
+            queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties());
             createTpchTables(queryRunner);
             createTestTimestampColumnTables(getSession(), queryRunner);
         }
@@ -113,7 +118,7 @@ public class TestArrowFederationNativeQueriesMySql
         QueryRunner queryRunner =
                 createNativeQueryRunner(ImmutableList.of(CONNECTOR_ID), server.getPort());
         queryRunner.installPlugin(new MySqlPlugin());
-        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(getConnectionUrl(mysqlContainer.getJdbcUrl())));
+        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties());
         return queryRunner;
     }
 

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesPostgres.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesPostgres.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.plugin.postgresql.PostgreSqlPlugin;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
@@ -27,8 +26,8 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJavaQueryRunner;
+import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createJdbcConnectorProperties;
 import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.createNativeQueryRunner;
-import static com.facebook.presto.flightshim.NativeArrowFederationConnectorUtils.getConnectorProperties;
 import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.createSchema;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
@@ -39,7 +38,8 @@ public class TestArrowFederationNativeQueriesPostgres
 {
     private static final String TEST_USER = "testuser";
     private static final String TEST_PASSWORD = "testpass";
-    private static final String CONNECTOR_ID = "postgresql";
+    private static final String CONNECTOR_ID = "postgresql_testing";
+    private static final String CONNECTOR_NAME = "postgresql";
     private static final String PLUGIN_BUNDLES = "../presto-postgresql/pom.xml";
 
     private final PostgreSQLContainer<?> postgresContainer;
@@ -68,9 +68,21 @@ public class TestArrowFederationNativeQueriesPostgres
     }
 
     @Override
-    protected Map<String, Map<String, String>> getCatalogPropertiesMap()
+    protected String getConnectorId()
     {
-        return ImmutableMap.of(CONNECTOR_ID, getConnectorProperties(postgresContainer.getJdbcUrl()));
+        return CONNECTOR_ID;
+    }
+
+    @Override
+    protected String getConnectorName()
+    {
+        return CONNECTOR_NAME;
+    }
+
+    @Override
+    protected Map<String, String> getConnectorProperties()
+    {
+        return createJdbcConnectorProperties(postgresContainer.getJdbcUrl());
     }
 
     @Override
@@ -80,8 +92,8 @@ public class TestArrowFederationNativeQueriesPostgres
         try {
             QueryRunner queryRunner = createJavaQueryRunner();
             queryRunner.installPlugin(new PostgreSqlPlugin());
-            queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(postgresContainer.getJdbcUrl()));
-            createTpchTables(queryRunner, postgresContainer.getJdbcUrl());
+            queryRunner.createCatalog(getConnectorId(), getConnectorName(), getConnectorProperties());
+            createTpchTables(queryRunner, postgresContainer.getJdbcUrl(), getConnectorId());
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -92,7 +104,7 @@ public class TestArrowFederationNativeQueriesPostgres
     public Session getSession()
     {
         return testSessionBuilder()
-                .setCatalog("postgresql")
+                .setCatalog(getConnectorId())
                 .setSchema("tpch")
                 .build();
     }
@@ -102,9 +114,9 @@ public class TestArrowFederationNativeQueriesPostgres
             throws Exception
     {
         QueryRunner queryRunner =
-                createNativeQueryRunner(ImmutableList.of(CONNECTOR_ID), server.getPort());
+                createNativeQueryRunner(ImmutableList.of(getConnectorId()), ImmutableList.of(getConnectorName()), server.getPort());
         queryRunner.installPlugin(new PostgreSqlPlugin());
-        queryRunner.createCatalog(CONNECTOR_ID, CONNECTOR_ID, getConnectorProperties(postgresContainer.getJdbcUrl()));
+        queryRunner.createCatalog(getConnectorId(), getConnectorName(), createJdbcConnectorProperties(postgresContainer.getJdbcUrl()));
         return queryRunner;
     }
 
@@ -179,7 +191,7 @@ public class TestArrowFederationNativeQueriesPostgres
         // PostgreSQL does not support ROW type
     }
 
-    static void createTpchTables(QueryRunner queryRunner, String postgresJdbcUrl)
+    static void createTpchTables(QueryRunner queryRunner, String postgresJdbcUrl, String catalogName)
     {
         // create schema for postgresQuery Runner
         try {
@@ -194,7 +206,7 @@ public class TestArrowFederationNativeQueriesPostgres
                 "tpch",
                 TINY_SCHEMA_NAME,
                 testSessionBuilder()
-                        .setCatalog("postgresql")
+                        .setCatalog(catalogName)
                         .setSchema("tpch")
                         .build(),
                 TpchTable.getTables());

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
@@ -77,9 +77,15 @@ public class TestArrowFederationNativeQueriesRedis
     }
 
     @Override
-    protected Map<String, Map<String, String>> getCatalogPropertiesMap()
+    protected String getConnectorId()
     {
-        return ImmutableMap.of(CONNECTOR_ID, getConnectorProperties(embeddedRedis, createEmptyTableDescriptions()));
+        return CONNECTOR_ID;
+    }
+
+    @Override
+    protected Map<String, String> getConnectorProperties()
+    {
+        return createRedisConnectorProperties(embeddedRedis, createEmptyTableDescriptions());
     }
 
     @Override
@@ -215,10 +221,10 @@ public class TestArrowFederationNativeQueriesRedis
         redisPlugin.setTableDescriptionSupplier(() -> tableDescriptions);
         queryRunner.installPlugin(redisPlugin);
         queryRunner.createCatalog("redis", "redis",
-                getConnectorProperties(embeddedRedis, tableDescriptions));
+                createRedisConnectorProperties(embeddedRedis, tableDescriptions));
     }
 
-    static Map<String, String> getConnectorProperties(EmbeddedRedis embeddedRedis, Map<SchemaTableName, RedisTableDescription> tableDescriptions)
+    static Map<String, String> createRedisConnectorProperties(EmbeddedRedis embeddedRedis, Map<SchemaTableName, RedisTableDescription> tableDescriptions)
     {
         Map<String, String> connectorProperties = new HashMap<>();
         connectorProperties.putIfAbsent("redis.nodes", embeddedRedis.getConnectString() + ":" + embeddedRedis.getPort());

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimTpchPlugin.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimTpchPlugin.java
@@ -42,6 +42,11 @@ public class TestFlightShimTpchPlugin
 
     protected String getConnectorId()
     {
+        return "tpch_testing";
+    }
+
+    protected String getConnectorName()
+    {
         return "tpch";
     }
 


### PR DESCRIPTION
## Description
Summary:
The provided connector id passed in the `FlightShimRequest` is a string based on the catalog used in the query. The Flight server was incorrectly using this string to lookup the connector, causing an error unless the catalog name was the same as the connector name.  This fixes the lookup done in the Flight server to get the correct connector name from the  CatalogManager, given the connector id.

## Motivation and Context
This corrects the lookup of the connector, which failed if the catalog was named differently than the connector.

## Impact
NA

## Test Plan
An existing test was changed so that the connector id, or catalog name, is different than the connector name.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix connector lookup in the Flight shim server so connectors are resolved via the catalog manager rather than assuming the catalog name matches the connector name.

Bug Fixes:
- Correct connector codecs retrieval in FlightShimPluginManager when catalog and connector names differ.

Tests:
- Adjust Flight shim plugin tests to use distinct connector IDs and names and validate the corrected lookup behavior.