### PR TITLE
fix: Address catalog update failure due to incomplete TVF cleanup on catalog drop

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -356,13 +356,13 @@ public class ConnectorManager
             removeConnectorInternal(connectorId);
             removeConnectorInternal(createInformationSchemaConnectorId(connectorId));
             removeConnectorInternal(createSystemTablesConnectorId(connectorId));
-            metadataManager.getFunctionAndTypeManager().getTableFunctionRegistry().removeTableFunctions(connectorId);
-            metadataManager.getFunctionAndTypeManager().removeTableFunctionProcessorProvider(connectorId);
         });
     }
 
     private synchronized void removeConnectorInternal(ConnectorId connectorId)
     {
+        metadataManager.getFunctionAndTypeManager().getTableFunctionRegistry().removeTableFunctions(connectorId);
+        metadataManager.getFunctionAndTypeManager().removeTableFunctionProcessorProvider(connectorId);
         splitManager.removeConnectorSplitManager(connectorId);
         pageSourceManager.removeConnectorPageSourceProvider(connectorId);
         pageSinkManager.removeConnectorPageSinkProvider(connectorId);


### PR DESCRIPTION
## Description
When a catalog is created in Presto, three internal connectors are registered under the hood:

| Connector ID | Role |
|---|---|
| `tpch_1` | Main connector |
| `$info_schema@tpch_1` | Information schema connector |
| `$system@tpch_1` | System tables connector |

`ConnectorManager.addConnectorInternal()` unconditionally calls both of the following
for **every one of the three connectors**:

```java
getTableFunctionRegistry().addTableFunctions(connectorId, ...);          // TableFunctionRegistry
getFunctionAndTypeManager().addTableFunctionProcessorProvider(connectorId, ...); // ConcurrentHashMap
```

However, the cleanup in `dropConnection()` and the rollback handler in
`addCatalogConnector()` only removed entries for the **main connector**,
leaving stale entries behind for `$info_schema@tpch_1` and `$system@tpch_1`.

On the next CREATE or UPDATE for the same catalog name, both registration
methods throw on the stale entries:

- `TableFunctionRegistry.addTableFunctions()` — strict `checkState(!containsKey(...))`
- `FunctionAndTypeManager.addTableFunctionProcessorProvider()` — strict `putIfAbsent` + throw

This results in an HTTP 500 error for any catalog update (DELETE then re-CREATE, or PUT).

## Motivation and Context

This bug was introduced in commit `c7a444c62a` ("Add SPI support for TableFunctions")
which added `addTableFunctions` / `removeTableFunctions` but only cleaned up the main
connector in `dropConnection`.

It was further compounded by commit `c2b0f5f186` ("feat: TVF Part 7/X Final PR of
adaptation changes #26445") which added `addTableFunctionProcessorProvider` /
`removeTableFunctionProcessorProvider` following the same incomplete cleanup pattern.

The bug affects any Presto deployment that:
1. Uses the catalog management REST API (`PUT /v1/catalog/{name}` or
   `DELETE` followed by `POST /v1/catalog/{name}`)
2. Has the TVF (Table Value Function) feature enabled (post `c7a444c62a`)

## Issue-Creating Scenario

The following sequence reliably reproduces the failure:

```
1. POST  /v1/catalog/mycatalog    → 201 Created   ✓  (registers TVF entries for all 3 connectors)
2. DELETE /v1/catalog/mycatalog   → 204 No Content ✓  (only cleans main connector TVF entries)
                                                       $info_schema@mycatalog entries LEFT BEHIND
3. PUT    /v1/catalog/mycatalog   → 500 Error      ✗  (tries to re-register $info_schema TVF entries,
                                                        finds stale entries, throws)
```

Stack trace:
```
com.facebook.presto.spi.PrestoException:
    TableFuncitonProcessorProvider already exists for connectorId $info_schema@mycatalog.
    Overwriting is not supported.
    at FunctionAndTypeManager.addTableFunctionProcessorProvider(FunctionAndTypeManager.java:794)
    at ConnectorManager.addConnectorInternal(ConnectorManager.java:351)
    at ConnectorManager.addCatalogConnector(ConnectorManager.java:293)
    at ConnectorManager.createConnection(ConnectorManager.java:248)
    ...
```

Or alternatively (depending on execution order):
```
java.lang.IllegalStateException:
    Table functions already registered for catalog: $info_schema@mycatalog
    at TableFunctionRegistry.addTableFunctions(TableFunctionRegistry.java:62)
    at ConnectorManager.addConnectorInternal(ConnectorManager.java:352)
    ...
```

## Impact

Any user or system that calls the Presto catalog management REST API to update
or re-create a catalog will receive an HTTP 500 error after the TVF feature was
introduced. This is a regression introduced by the TVF PRs.

## Fix

Two code paths in `ConnectorManager.java` are fixed to clean up TVF entries for
**all three connectors** (main, info_schema, system):

**1. Exception-handler rollback in `addCatalogConnector()`:**
```java
catch (Throwable e) {
    catalogManager.removeCatalog(catalog.getCatalogName());
    removeConnectorInternal(systemConnector.getConnectorId());
    removeConnectorInternal(informationSchemaConnector.getConnectorId());
    removeConnectorInternal(connector.getConnectorId());
    // ADDED — clean up TVF registrations for all 3 connectors
    getTableFunctionRegistry().removeTableFunctions(systemConnector.getConnectorId());
    getTableFunctionRegistry().removeTableFunctions(informationSchemaConnector.getConnectorId());
    getTableFunctionRegistry().removeTableFunctions(connectorId);
    removeTableFunctionProcessorProvider(systemConnector.getConnectorId());
    removeTableFunctionProcessorProvider(informationSchemaConnector.getConnectorId());
    removeTableFunctionProcessorProvider(connectorId);
    throw e;
}
```

**2. Normal drop path in `dropConnection()`:**
```java
catalogManager.removeCatalog(catalogName).ifPresent(connectorId -> {
    removeConnectorInternal(connectorId);
    removeConnectorInternal(createInformationSchemaConnectorId(connectorId));
    removeConnectorInternal(createSystemTablesConnectorId(connectorId));
    getTableFunctionRegistry().removeTableFunctions(connectorId);
    // ADDED
    getTableFunctionRegistry().removeTableFunctions(createInformationSchemaConnectorId(connectorId));
    getTableFunctionRegistry().removeTableFunctions(createSystemTablesConnectorId(connectorId));
    removeTableFunctionProcessorProvider(connectorId);
    // ADDED
    removeTableFunctionProcessorProvider(createInformationSchemaConnectorId(connectorId));
    removeTableFunctionProcessorProvider(createSystemTablesConnectorId(connectorId));
});
```

Note: `ConcurrentHashMap.remove()` and `TableFunctionRegistry.removeTableFunctions()`
are both safe no-ops for missing keys, so these cleanup calls are harmless even when
info_schema/system connectors registered zero table functions.

## Test Plan

The OSS codebase does not currently have a test covering the catalog UPDATE (PUT) flow
via the REST API. The bug is verified by the following integration test scenario
(available in internal builds):

**Setup:** Start a Presto coordinator with a TPCH catalog pre-registered.

**Steps:**
1. `POST /v1/catalog/tpch_test` with `{"connector.name":"tpch"}` → assert HTTP 201
2. `POST /v1/catalog/tpch_test` again → assert HTTP 409 (already exists)
3. `DELETE /v1/catalog/tpch_test` → assert HTTP 204
4. `DELETE /v1/catalog/tpch_test` again → assert HTTP 409 (already gone)
5. `PUT /v1/catalog/tpch_test` with same properties → assert HTTP 201 ← **FAILS without fix**
6. `PUT /v1/catalog/tpch_test` again → assert HTTP 204 (idempotent update)

**Before fix:** Step 5 returns HTTP 500 with `PrestoException: TableFuncitonProcessorProvider already exists`.
**After fix:** Step 5 returns HTTP 201 as expected.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Fix incomplete removal of table function registry entries and processor providers for information schema and system connectors when adding or dropping catalogs.