### PR TITLE
feat: Iceberg V3 field-id protocol + Presto-to-Velox bridge

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.iceberg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.MAP;
@@ -37,18 +39,30 @@ public class ColumnIdentity
     private final String name;
     private final TypeCategory typeCategory;
     private final List<ColumnIdentity> children;
+    private final Optional<IcebergTypeAttributes> typeAttributes;
+
+    public ColumnIdentity(
+            int id,
+            String name,
+            TypeCategory typeCategory,
+            List<ColumnIdentity> children)
+    {
+        this(id, name, typeCategory, children, Optional.empty());
+    }
 
     @JsonCreator
     public ColumnIdentity(
             @JsonProperty("id") int id,
             @JsonProperty("name") String name,
             @JsonProperty("typeCategory") TypeCategory typeCategory,
-            @JsonProperty("children") List<ColumnIdentity> children)
+            @JsonProperty("children") List<ColumnIdentity> children,
+            @JsonProperty("typeAttributes") Optional<IcebergTypeAttributes> typeAttributes)
     {
         this.id = id;
         this.name = requireNonNull(name, "name is null");
         this.typeCategory = requireNonNull(typeCategory, "typeCategory is null");
         this.children = requireNonNull(children, "children is null");
+        this.typeAttributes = requireNonNull(typeAttributes, "typeAttributes is null");
         checkArgument(
                 children.isEmpty() == (typeCategory == PRIMITIVE),
                 "Children should be empty if and only if column type is primitive");
@@ -78,6 +92,20 @@ public class ColumnIdentity
         return children;
     }
 
+    /**
+     * Iceberg V3 type-disambiguation attributes for this node, empty when none
+     * were derived. Modeled as Optional so the C++ protocol codegen emits a
+     * nullable std::shared_ptr field and serialized only when present, so older
+     * coordinators/workers tolerate the JSON shape without upgrade-ordering
+     * constraints.
+     */
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<IcebergTypeAttributes> getTypeAttributes()
+    {
+        return typeAttributes;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -91,19 +119,21 @@ public class ColumnIdentity
         return id == that.id &&
                 name.equals(that.name) &&
                 typeCategory == that.typeCategory &&
-                children.equals(that.children);
+                children.equals(that.children) &&
+                Objects.equals(typeAttributes, that.typeAttributes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(id, name, typeCategory, children);
+        return Objects.hash(id, name, typeCategory, children, typeAttributes);
     }
 
     @Override
     public String toString()
     {
-        return id + ":" + name + ":" + typeCategory + ":" + children;
+        return id + ":" + name + ":" + typeCategory + ":" + children +
+                (typeAttributes.isPresent() ? ":" + typeAttributes.get() : "");
     }
 
     public enum TypeCategory
@@ -126,20 +156,22 @@ public class ColumnIdentity
 
     public static ColumnIdentity createColumnIdentity(String name, int id, org.apache.iceberg.types.Type fieldType)
     {
+        Optional<IcebergTypeAttributes> typeAttributes = deriveTypeAttributes(fieldType);
+
         if (!fieldType.isNestedType()) {
-            return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of());
+            return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of(), typeAttributes);
         }
 
         if (fieldType.isListType()) {
             ColumnIdentity elementColumn = createColumnIdentity(getOnlyElement(fieldType.asListType().fields()));
-            return new ColumnIdentity(id, name, ARRAY, ImmutableList.of(elementColumn));
+            return new ColumnIdentity(id, name, ARRAY, ImmutableList.of(elementColumn), typeAttributes);
         }
 
         if (fieldType.isStructType()) {
             List<ColumnIdentity> fieldColumns = fieldType.asStructType().fields().stream()
                     .map(ColumnIdentity::createColumnIdentity)
                     .collect(toImmutableList());
-            return new ColumnIdentity(id, name, STRUCT, fieldColumns);
+            return new ColumnIdentity(id, name, STRUCT, fieldColumns, typeAttributes);
         }
 
         if (fieldType.isMapType()) {
@@ -147,9 +179,163 @@ public class ColumnIdentity
                     .map(ColumnIdentity::createColumnIdentity)
                     .collect(toImmutableList());
             checkArgument(keyValueColumns.size() == 2, "Expected map type to have two fields");
-            return new ColumnIdentity(id, name, MAP, keyValueColumns);
+            return new ColumnIdentity(id, name, MAP, keyValueColumns, typeAttributes);
         }
 
         throw new UnsupportedOperationException(format("Iceberg column type %s is not supported", fieldType.typeId()));
+    }
+
+    // Derives the Iceberg V3 type-disambiguation attributes (ORC Appendix A
+    // semantics) that the format-erased Presto type cannot represent. Returns
+    // Optional.empty() when nothing is set, so the attribute is omitted from the
+    // serialized handle and column identities are unchanged for the common
+    // case.
+    //
+    // Only UUID and FIXED are derived today: both Iceberg types map to Presto
+    // VARBINARY, so the binary variant and (for FIXED) the length are
+    // genuinely lost without these attributes. Iceberg LONG already maps 1:1
+    // to Presto BIGINT (and INT to INTEGER), so a `long-type` attribute would
+    // be redundant; timestamp unit is always microseconds in the current
+    // Iceberg spec; and `iceberg.required` (nullability) is carried by the ORC
+    // writer path. Those fields remain on IcebergTypeAttributes so the wire
+    // format and the native worker are ready for them, but deriving them here
+    // is deferred to avoid rewriting every column identity.
+    private static Optional<IcebergTypeAttributes> deriveTypeAttributes(org.apache.iceberg.types.Type fieldType)
+    {
+        switch (fieldType.typeId()) {
+            case UUID:
+                return Optional.of(new IcebergTypeAttributes(
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of("UUID"),
+                        Optional.empty(),
+                        Optional.of(16)));
+            case FIXED:
+                return Optional.of(new IcebergTypeAttributes(
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of("FIXED"),
+                        Optional.empty(),
+                        Optional.of(((Types.FixedType) fieldType).length())));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    /**
+     * Iceberg V3 type-disambiguation attributes that the format-erased Presto
+     * type cannot represent (e.g. LONG vs INT widening, FIXED/UUID binary
+     * variants, timestamp unit). Derived from the Iceberg schema during
+     * planning and forwarded to the native worker so NIMBLE/ORC files can be
+     * stamped with the spec-compliant ORC Appendix A attribute keys. Every
+     * field is Optional so the C++ protocol codegen emits nullable
+     * std::shared_ptr fields and each attribute is serialized only when present.
+     */
+    public static class IcebergTypeAttributes
+    {
+        private final Optional<Boolean> required;
+        private final Optional<String> longType;
+        private final Optional<String> timestampUnit;
+        private final Optional<String> binaryType;
+        private final Optional<String> structType;
+        private final Optional<Integer> length;
+
+        @JsonCreator
+        public IcebergTypeAttributes(
+                @JsonProperty("required") Optional<Boolean> required,
+                @JsonProperty("longType") Optional<String> longType,
+                @JsonProperty("timestampUnit") Optional<String> timestampUnit,
+                @JsonProperty("binaryType") Optional<String> binaryType,
+                @JsonProperty("structType") Optional<String> structType,
+                @JsonProperty("length") Optional<Integer> length)
+        {
+            this.required = requireNonNull(required, "required is null");
+            this.longType = requireNonNull(longType, "longType is null");
+            this.timestampUnit = requireNonNull(timestampUnit, "timestampUnit is null");
+            this.binaryType = requireNonNull(binaryType, "binaryType is null");
+            this.structType = requireNonNull(structType, "structType is null");
+            this.length = requireNonNull(length, "length is null");
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<Boolean> getRequired()
+        {
+            return required;
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<String> getLongType()
+        {
+            return longType;
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<String> getTimestampUnit()
+        {
+            return timestampUnit;
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<String> getBinaryType()
+        {
+            return binaryType;
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<String> getStructType()
+        {
+            return structType;
+        }
+
+        @JsonProperty
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public Optional<Integer> getLength()
+        {
+            return length;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            IcebergTypeAttributes that = (IcebergTypeAttributes) o;
+            return Objects.equals(required, that.required) &&
+                    Objects.equals(longType, that.longType) &&
+                    Objects.equals(timestampUnit, that.timestampUnit) &&
+                    Objects.equals(binaryType, that.binaryType) &&
+                    Objects.equals(structType, that.structType) &&
+                    Objects.equals(length, that.length);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(required, longType, timestampUnit, binaryType, structType, length);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IcebergTypeAttributes{" +
+                    "required=" + required +
+                    ", longType=" + longType +
+                    ", timestampUnit=" + timestampUnit +
+                    ", binaryType=" + binaryType +
+                    ", structType=" + structType +
+                    ", length=" + length +
+                    '}';
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileFormat.java
@@ -17,4 +17,5 @@ public enum IcebergFileFormat
 {
     ORC,
     PARQUET,
+    NIMBLE,
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -1393,6 +1393,9 @@ public final class IcebergUtil
                 }
                 propertiesBuilder.put(ORC_COMPRESSION, compressionCodec.getOrcCompressionKind().name());
                 break;
+            case NIMBLE:
+                // Nimble handles compression internally; no table property needed.
+                break;
         }
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
@@ -23,11 +23,13 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.type.TypeDeserializer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
@@ -112,6 +114,55 @@ public class TestIcebergColumnHandle
         assertFalse(buildColumnMetadata(regularColumn).isHidden());
         assertFalse(buildColumnMetadata(ROW_ID_COLUMN_HANDLE).isHidden());
         assertFalse(buildColumnMetadata(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE).isHidden());
+    }
+
+    @Test
+    public void testTypeAttributesRoundTrip()
+    {
+        ColumnIdentity.IcebergTypeAttributes attributes = new ColumnIdentity.IcebergTypeAttributes(
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("UUID"), Optional.empty(), Optional.of(16));
+        ColumnIdentity uuidColumn = new ColumnIdentity(9, "uuid_col", PRIMITIVE, ImmutableList.of(), Optional.of(attributes));
+        IcebergColumnHandle handle = new IcebergColumnHandle(
+                uuidColumn,
+                VARBINARY,
+                Optional.empty(),
+                REGULAR);
+        testRoundTrip(handle);
+        assertEquals(handle.getColumnIdentity().getTypeAttributes(), Optional.of(attributes));
+    }
+
+    @Test
+    public void testCreateColumnIdentityDerivesBinaryAttributes()
+    {
+        ColumnIdentity uuidColumn = ColumnIdentity.createColumnIdentity(
+                Types.NestedField.optional(1, "u", Types.UUIDType.get()));
+        assertEquals(uuidColumn.getTypeAttributes().get().getBinaryType(), Optional.of("UUID"));
+        assertEquals(uuidColumn.getTypeAttributes().get().getLength(), Optional.of(16));
+
+        ColumnIdentity fixedColumn = ColumnIdentity.createColumnIdentity(
+                Types.NestedField.optional(2, "f", Types.FixedType.ofLength(12)));
+        assertEquals(fixedColumn.getTypeAttributes().get().getBinaryType(), Optional.of("FIXED"));
+        assertEquals(fixedColumn.getTypeAttributes().get().getLength(), Optional.of(12));
+
+        // Types that are not ambiguous after conversion to Presto carry no
+        // attributes, leaving the column identity unchanged.
+        ColumnIdentity longColumn = ColumnIdentity.createColumnIdentity(
+                Types.NestedField.optional(3, "l", Types.LongType.get()));
+        assertFalse(longColumn.getTypeAttributes().isPresent());
+    }
+
+    @Test
+    public void testMissingTypeAttributesDeserializesToNull()
+    {
+        // A column with no V3 attributes serializes without the typeAttributes
+        // field, and an old-shape JSON deserializes back to a null attributes.
+        IcebergColumnHandle handle = primitiveIcebergColumnHandle(7, "plain", BIGINT, Optional.empty());
+        ObjectMapperProvider objectMapperProvider = new JsonObjectMapperProvider();
+        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new TypeDeserializer(createTestFunctionAndTypeManager())));
+        JsonCodec<IcebergColumnHandle> codec = new JsonCodecFactory(objectMapperProvider).jsonCodec(IcebergColumnHandle.class);
+        String json = codec.toJson(handle);
+        assertFalse(json.contains("typeAttributes"));
+        assertFalse(codec.fromJson(json).getColumnIdentity().getTypeAttributes().isPresent());
     }
 
     private void testRoundTrip(IcebergColumnHandle expected)

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -315,9 +315,8 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
             .thenError(
                 folly::tag_t<std::exception>{},
                 [downstream, handlerState, taskId](auto&& e) {
-                  LOG(ERROR)
-                      << "Error creating/updating task " << taskId
-                      << ": " << e.what();
+                  LOG(ERROR) << "Error creating/updating task " << taskId
+                             << ": " << e.what();
                   if (!handlerState->requestExpired()) {
                     http::sendErrorResponse(downstream, e.what());
                   }

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/TaskResource.h"
+#include <glog/logging.h>
 #include <presto_cpp/main/common/Exception.h>
 #include <typeinfo>
 #include "presto_cpp/main/common/Configs.h"
@@ -313,7 +314,10 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
             })
             .thenError(
                 folly::tag_t<std::exception>{},
-                [downstream, handlerState](auto&& e) {
+                [downstream, handlerState, taskId](auto&& e) {
+                  LOG(ERROR)
+                      << "Error creating/updating task " << taskId
+                      << ": " << e.what();
                   if (!handlerState->requestExpired()) {
                     http::sendErrorResponse(downstream, e.what());
                   }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -21,6 +21,7 @@
 
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
@@ -271,6 +272,41 @@ std::optional<int32_t> tryParsePartitionSpecId(
   }
 }
 
+// Builds the Velox Iceberg V3 type-attribute tree (IcebergFieldMetadata) from
+// the protocol ColumnIdentity, walked in lockstep with toParquetField(). Each
+// protocol field is nullable; an absent typeAttributes (the common case) yields
+// an empty metadata node. The field id itself is carried separately via
+// toParquetField(), not stamped here.
+velox::connector::hive::iceberg::IcebergFieldMetadata toIcebergFieldMetadata(
+    const protocol::iceberg::ColumnIdentity& column) {
+  velox::connector::hive::iceberg::IcebergFieldMetadata metadata;
+  if (column.typeAttributes != nullptr) {
+    const auto& attributes = *column.typeAttributes;
+    if (attributes.required != nullptr) {
+      metadata.required = *attributes.required;
+    }
+    if (attributes.longType != nullptr) {
+      metadata.longType = *attributes.longType;
+    }
+    if (attributes.timestampUnit != nullptr) {
+      metadata.timestampUnit = *attributes.timestampUnit;
+    }
+    if (attributes.binaryType != nullptr) {
+      metadata.binaryType = *attributes.binaryType;
+    }
+    if (attributes.structType != nullptr) {
+      metadata.structType = *attributes.structType;
+    }
+    if (attributes.length != nullptr) {
+      metadata.length = *attributes.length;
+    }
+  }
+  metadata.children.reserve(column.children.size());
+  for (const auto& child : column.children) {
+    metadata.children.push_back(toIcebergFieldMetadata(child));
+  }
+  return metadata;
+}
 } // namespace
 
 std::unique_ptr<velox::connector::ConnectorSplit>
@@ -407,7 +443,8 @@ IcebergPrestoToVeloxConnector::toVeloxColumnHandle(
       type,
       toParquetField(icebergColumn->columnIdentity),
       toRequiredSubfields(icebergColumn->requiredSubfields),
-      defaultValue);
+      defaultValue,
+      toIcebergFieldMetadata(icebergColumn->columnIdentity));
 }
 
 std::unique_ptr<velox::connector::ConnectorTableHandle>

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -290,8 +290,7 @@ TEST_F(PrestoToVeloxConnectorTest, icebergColumnHandleTypeAttributes) {
   uuidColumn.columnIdentity.typeAttributes = typeAttributes;
 
   IcebergPrestoToVeloxConnector icebergConnector("iceberg");
-  auto handle =
-      icebergConnector.toVeloxColumnHandle(&uuidColumn, *typeParser_);
+  auto handle = icebergConnector.toVeloxColumnHandle(&uuidColumn, *typeParser_);
   auto* icebergHandle =
       dynamic_cast<connector::hive::iceberg::IcebergColumnHandle*>(
           handle.get());

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -275,6 +275,44 @@ TEST_F(PrestoToVeloxConnectorTest, icebergColumnHandleSimple) {
   EXPECT_TRUE(icebergHandle->field().children.empty());
 }
 
+// The protocol ColumnIdentity.typeAttributes (populated by the Java planner)
+// must be converted into the Velox IcebergColumnHandle's IcebergFieldMetadata
+// by toVeloxColumnHandle. Asserts a UUID column round-trips
+// required/binary-type/length, and that a column without typeAttributes yields
+// empty metadata.
+TEST_F(PrestoToVeloxConnectorTest, icebergColumnHandleTypeAttributes) {
+  auto uuidColumn = createIcebergColumnHandle("u", 5, "varbinary");
+  auto typeAttributes =
+      std::make_shared<protocol::iceberg::IcebergTypeAttributes>();
+  typeAttributes->required = std::make_shared<bool>(true);
+  typeAttributes->binaryType = std::make_shared<std::string>("UUID");
+  typeAttributes->length = std::make_shared<int>(16);
+  uuidColumn.columnIdentity.typeAttributes = typeAttributes;
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto handle =
+      icebergConnector.toVeloxColumnHandle(&uuidColumn, *typeParser_);
+  auto* icebergHandle =
+      dynamic_cast<connector::hive::iceberg::IcebergColumnHandle*>(
+          handle.get());
+  ASSERT_NE(icebergHandle, nullptr);
+
+  const auto& metadata = icebergHandle->icebergMetadata();
+  EXPECT_EQ(metadata.required, true);
+  EXPECT_EQ(metadata.binaryType, "UUID");
+  EXPECT_EQ(metadata.length, 16);
+
+  // A column without typeAttributes maps to empty metadata.
+  auto plainColumn = createIcebergColumnHandle("a", 1, "bigint");
+  auto plainHandle =
+      icebergConnector.toVeloxColumnHandle(&plainColumn, *typeParser_);
+  auto* plainIcebergHandle =
+      dynamic_cast<connector::hive::iceberg::IcebergColumnHandle*>(
+          plainHandle.get());
+  ASSERT_NE(plainIcebergHandle, nullptr);
+  EXPECT_TRUE(plainIcebergHandle->icebergMetadata().empty());
+}
+
 TEST_F(PrestoToVeloxConnectorTest, icebergColumnHandleNested) {
   protocol::iceberg::ColumnIdentity child1;
   child1.name = "child1";

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -104,21 +104,63 @@ void from_json(const json& j, TypeCategory& e) {
 namespace facebook::presto::protocol::iceberg {
 void to_json(json& j, const IcebergTypeAttributes& p) {
   j = json::object();
-  to_json_key(j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
-  to_json_key(j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
-  to_json_key(j, "timestampUnit", p.timestampUnit, "IcebergTypeAttributes", "String", "timestampUnit");
-  to_json_key(j, "binaryType", p.binaryType, "IcebergTypeAttributes", "String", "binaryType");
-  to_json_key(j, "structType", p.structType, "IcebergTypeAttributes", "String", "structType");
-  to_json_key(j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
+  to_json_key(
+      j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
+  to_json_key(
+      j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
+  to_json_key(
+      j,
+      "timestampUnit",
+      p.timestampUnit,
+      "IcebergTypeAttributes",
+      "String",
+      "timestampUnit");
+  to_json_key(
+      j,
+      "binaryType",
+      p.binaryType,
+      "IcebergTypeAttributes",
+      "String",
+      "binaryType");
+  to_json_key(
+      j,
+      "structType",
+      p.structType,
+      "IcebergTypeAttributes",
+      "String",
+      "structType");
+  to_json_key(
+      j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
 }
 
 void from_json(const json& j, IcebergTypeAttributes& p) {
-  from_json_key(j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
-  from_json_key(j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
-  from_json_key(j, "timestampUnit", p.timestampUnit, "IcebergTypeAttributes", "String", "timestampUnit");
-  from_json_key(j, "binaryType", p.binaryType, "IcebergTypeAttributes", "String", "binaryType");
-  from_json_key(j, "structType", p.structType, "IcebergTypeAttributes", "String", "structType");
-  from_json_key(j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
+  from_json_key(
+      j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
+  from_json_key(
+      j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
+  from_json_key(
+      j,
+      "timestampUnit",
+      p.timestampUnit,
+      "IcebergTypeAttributes",
+      "String",
+      "timestampUnit");
+  from_json_key(
+      j,
+      "binaryType",
+      p.binaryType,
+      "IcebergTypeAttributes",
+      "String",
+      "binaryType");
+  from_json_key(
+      j,
+      "structType",
+      p.structType,
+      "IcebergTypeAttributes",
+      "String",
+      "structType");
+  from_json_key(
+      j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -2178,12 +2220,7 @@ void from_json(const json& j, IcebergSplit& p) {
   }
   if (j.count("firstRowId")) {
     from_json_key(
-        j,
-        "firstRowId",
-        p.firstRowId,
-        "IcebergSplit",
-        "int64_t",
-        "firstRowId");
+        j, "firstRowId", p.firstRowId, "IcebergSplit", "int64_t", "firstRowId");
   }
   if (j.count("affinitySchedulingSectionSize")) {
     from_json_key(

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -102,6 +102,26 @@ void from_json(const json& j, TypeCategory& e) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+void to_json(json& j, const IcebergTypeAttributes& p) {
+  j = json::object();
+  to_json_key(j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
+  to_json_key(j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
+  to_json_key(j, "timestampUnit", p.timestampUnit, "IcebergTypeAttributes", "String", "timestampUnit");
+  to_json_key(j, "binaryType", p.binaryType, "IcebergTypeAttributes", "String", "binaryType");
+  to_json_key(j, "structType", p.structType, "IcebergTypeAttributes", "String", "structType");
+  to_json_key(j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
+}
+
+void from_json(const json& j, IcebergTypeAttributes& p) {
+  from_json_key(j, "required", p.required, "IcebergTypeAttributes", "bool", "required");
+  from_json_key(j, "longType", p.longType, "IcebergTypeAttributes", "String", "longType");
+  from_json_key(j, "timestampUnit", p.timestampUnit, "IcebergTypeAttributes", "String", "timestampUnit");
+  from_json_key(j, "binaryType", p.binaryType, "IcebergTypeAttributes", "String", "binaryType");
+  from_json_key(j, "structType", p.structType, "IcebergTypeAttributes", "String", "structType");
+  from_json_key(j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 
 void to_json(json& j, const ColumnIdentity& p) {
   j = json::object();
@@ -121,6 +141,13 @@ void to_json(json& j, const ColumnIdentity& p) {
       "ColumnIdentity",
       "List<ColumnIdentity>",
       "children");
+  to_json_key(
+      j,
+      "typeAttributes",
+      p.typeAttributes,
+      "ColumnIdentity",
+      "IcebergTypeAttributes",
+      "typeAttributes");
 }
 
 void from_json(const json& j, ColumnIdentity& p) {
@@ -140,6 +167,13 @@ void from_json(const json& j, ColumnIdentity& p) {
       "ColumnIdentity",
       "List<ColumnIdentity>",
       "children");
+  from_json_key(
+      j,
+      "typeAttributes",
+      p.typeAttributes,
+      "ColumnIdentity",
+      "IcebergTypeAttributes",
+      "typeAttributes");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -2133,21 +2167,32 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "ChangelogSplitInfo",
       "changelogSplitInfo");
-  from_json_key(
-      j,
-      "dataSequenceNumber",
-      p.dataSequenceNumber,
-      "IcebergSplit",
-      "int64_t",
-      "dataSequenceNumber");
-  from_json_key(
-      j, "firstRowId", p.firstRowId, "IcebergSplit", "int64_t", "firstRowId");
-  from_json_key(
-      j,
-      "affinitySchedulingSectionSize",
-      p.affinitySchedulingSectionSize,
-      "IcebergSplit",
-      "int64_t",
-      "affinitySchedulingSectionSize");
+  if (j.count("dataSequenceNumber")) {
+    from_json_key(
+        j,
+        "dataSequenceNumber",
+        p.dataSequenceNumber,
+        "IcebergSplit",
+        "int64_t",
+        "dataSequenceNumber");
+  }
+  if (j.count("firstRowId")) {
+    from_json_key(
+        j,
+        "firstRowId",
+        p.firstRowId,
+        "IcebergSplit",
+        "int64_t",
+        "firstRowId");
+  }
+  if (j.count("affinitySchedulingSectionSize")) {
+    from_json_key(
+        j,
+        "affinitySchedulingSectionSize",
+        p.affinitySchedulingSectionSize,
+        "IcebergSplit",
+        "int64_t",
+        "affinitySchedulingSectionSize");
+  }
 }
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -34,11 +34,24 @@ extern void to_json(json& j, const TypeCategory& e);
 extern void from_json(const json& j, TypeCategory& e);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+struct IcebergTypeAttributes {
+  std::shared_ptr<bool> required = {};
+  std::shared_ptr<String> longType = {};
+  std::shared_ptr<String> timestampUnit = {};
+  std::shared_ptr<String> binaryType = {};
+  std::shared_ptr<String> structType = {};
+  std::shared_ptr<Integer> length = {};
+};
+void to_json(json& j, const IcebergTypeAttributes& p);
+void from_json(const json& j, IcebergTypeAttributes& p);
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 struct ColumnIdentity {
   int id = {};
   String name = {};
   TypeCategory typeCategory = {};
   List<ColumnIdentity> children = {};
+  std::shared_ptr<IcebergTypeAttributes> typeAttributes = {};
 };
 void to_json(json& j, const ColumnIdentity& p);
 void from_json(const json& j, ColumnIdentity& p);
@@ -303,7 +316,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   Map<String, String> storageProperties = {};
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
-  bool fullRefreshRequired = {};
+  std::shared_ptr<bool> fullRefreshRequired = {};
   List<String> insertedColumns = {};
 
   IcebergInsertTableHandle() noexcept;

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -65,6 +65,13 @@ AbstractClasses:
 UpdateFields:
   IcebergTableLayoutHandle:
     std::shared_ptr<RowExpression>: remainingPredicate
+  IcebergTypeAttributes:
+    bool: required
+  IcebergInsertTableHandle:
+    # FB-fork coordinator's IcebergInsertTableHandle omits this field (only
+    # presto-trunk's POJO has it, and the C++ worker never reads it). Model it
+    # as nullable so from_json tolerates its absence instead of throwing.
+    std::shared_ptr<bool>: fullRefreshRequired
 
 JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.cpp.inc
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol::iceberg {
+IcebergSplit::IcebergSplit() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergSplit& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "path", p.path, "IcebergSplit", "String", "path");
+  to_json_key(j, "start", p.start, "IcebergSplit", "int64_t", "start");
+  to_json_key(j, "length", p.length, "IcebergSplit", "int64_t", "length");
+  to_json_key(
+      j, "fileFormat", p.fileFormat, "IcebergSplit", "FileFormat", "fileFormat");
+  to_json_key(
+      j,
+      "addresses",
+      p.addresses,
+      "IcebergSplit",
+      "List<HostAddress>",
+      "addresses");
+  to_json_key(
+      j,
+      "partitionKeys",
+      p.partitionKeys,
+      "IcebergSplit",
+      "Map<Integer, HivePartitionKey>",
+      "partitionKeys");
+  to_json_key(
+      j,
+      "partitionSpecAsJson",
+      p.partitionSpecAsJson,
+      "IcebergSplit",
+      "String",
+      "partitionSpecAsJson");
+  to_json_key(
+      j,
+      "partitionDataJson",
+      p.partitionDataJson,
+      "IcebergSplit",
+      "String",
+      "partitionDataJson");
+  to_json_key(
+      j,
+      "nodeSelectionStrategy",
+      p.nodeSelectionStrategy,
+      "IcebergSplit",
+      "NodeSelectionStrategy",
+      "nodeSelectionStrategy");
+  to_json_key(
+      j,
+      "splitWeight",
+      p.splitWeight,
+      "IcebergSplit",
+      "SplitWeight",
+      "splitWeight");
+  to_json_key(
+      j, "deletes", p.deletes, "IcebergSplit", "List<DeleteFile>", "deletes");
+  to_json_key(
+      j,
+      "changelogSplitInfo",
+      p.changelogSplitInfo,
+      "IcebergSplit",
+      "ChangelogSplitInfo",
+      "changelogSplitInfo");
+  to_json_key(
+      j,
+      "dataSequenceNumber",
+      p.dataSequenceNumber,
+      "IcebergSplit",
+      "int64_t",
+      "dataSequenceNumber");
+  to_json_key(
+      j, "firstRowId", p.firstRowId, "IcebergSplit", "int64_t", "firstRowId");
+  to_json_key(
+      j,
+      "affinitySchedulingSectionSize",
+      p.affinitySchedulingSectionSize,
+      "IcebergSplit",
+      "int64_t",
+      "affinitySchedulingSectionSize");
+}
+
+void from_json(const json& j, IcebergSplit& p) {
+  p._type = j["@type"];
+  from_json_key(j, "path", p.path, "IcebergSplit", "String", "path");
+  from_json_key(j, "start", p.start, "IcebergSplit", "int64_t", "start");
+  from_json_key(j, "length", p.length, "IcebergSplit", "int64_t", "length");
+  from_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergSplit",
+      "FileFormat",
+      "fileFormat");
+  from_json_key(
+      j,
+      "addresses",
+      p.addresses,
+      "IcebergSplit",
+      "List<HostAddress>",
+      "addresses");
+  from_json_key(
+      j,
+      "partitionKeys",
+      p.partitionKeys,
+      "IcebergSplit",
+      "Map<Integer, HivePartitionKey>",
+      "partitionKeys");
+  from_json_key(
+      j,
+      "partitionSpecAsJson",
+      p.partitionSpecAsJson,
+      "IcebergSplit",
+      "String",
+      "partitionSpecAsJson");
+  from_json_key(
+      j,
+      "partitionDataJson",
+      p.partitionDataJson,
+      "IcebergSplit",
+      "String",
+      "partitionDataJson");
+  from_json_key(
+      j,
+      "nodeSelectionStrategy",
+      p.nodeSelectionStrategy,
+      "IcebergSplit",
+      "NodeSelectionStrategy",
+      "nodeSelectionStrategy");
+  from_json_key(
+      j,
+      "splitWeight",
+      p.splitWeight,
+      "IcebergSplit",
+      "SplitWeight",
+      "splitWeight");
+  from_json_key(
+      j, "deletes", p.deletes, "IcebergSplit", "List<DeleteFile>", "deletes");
+  from_json_key(
+      j,
+      "changelogSplitInfo",
+      p.changelogSplitInfo,
+      "IcebergSplit",
+      "ChangelogSplitInfo",
+      "changelogSplitInfo");
+  // V3 fields: optional for backward compatibility with coordinators that
+  // do not yet send them. Default values from the struct definition apply.
+  if (j.count("dataSequenceNumber")) {
+    from_json_key(
+        j,
+        "dataSequenceNumber",
+        p.dataSequenceNumber,
+        "IcebergSplit",
+        "int64_t",
+        "dataSequenceNumber");
+  }
+  if (j.count("firstRowId")) {
+    from_json_key(
+        j,
+        "firstRowId",
+        p.firstRowId,
+        "IcebergSplit",
+        "int64_t",
+        "firstRowId");
+  }
+  if (j.count("affinitySchedulingSectionSize")) {
+    from_json_key(
+        j,
+        "affinitySchedulingSectionSize",
+        p.affinitySchedulingSectionSize,
+        "IcebergSplit",
+        "int64_t",
+        "affinitySchedulingSectionSize");
+  }
+}
+} // namespace facebook::presto::protocol::iceberg


### PR DESCRIPTION
Summary:
Prestissimo (presto_cpp native) support for Iceberg V3 field-ids / type-attributes:
the Iceberg presto_protocol additions and the Presto-to-Velox connector bridge.

- presto_protocol/connector/iceberg: presto_protocol_iceberg.{h,cpp,yml} and
  special/IcebergSplit.cpp.inc for the new field-id / type-attribute fields.
- main/connectors/IcebergPrestoToVeloxConnector.cpp: translate the protocol fields
  into the velox Iceberg connector handles.
- main/TaskResource.cpp and types/tests/PrestoToVeloxConnectorTest.cpp.

All OSS (presto-trunk/presto-native-execution). Replaces the prestissimo portions of
D108325318 and D108474295.

=== NO RELEASE NOTES ===

Reviewed By: srsuryadev

Differential Revision: D108699500


