### PR TITLE
refactor(native): Replace inline external worker launcher lambda with ExternalWorkerLauncherBuilder

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -728,7 +728,6 @@ public class PrestoNativeQueryRunnerUtils
         private String prestoServerPath;
         private int cacheMaxSize;
         private Optional<String> remoteFunctionServerUds = Optional.empty();
-        private Optional<String> remoteFunctionServerRestUrl = Optional.empty();
         private Optional<String> pluginDirectory = Optional.empty();
         private boolean failOnNestedLoopJoin;
         private boolean coordinatorSidecarEnabled;
@@ -737,14 +736,8 @@ public class PrestoNativeQueryRunnerUtils
         private boolean enableSsdCache;
         private boolean implicitCastCharNToVarchar;
         private boolean enableCudf;
-        private Optional<HttpsClientConfig> httpsClientConfig = Optional.empty();
 
         private ExternalWorkerLauncherBuilder() {}
-
-        public static ExternalWorkerLauncherBuilder builder()
-        {
-            return new ExternalWorkerLauncherBuilder();
-        }
 
         public ExternalWorkerLauncherBuilder setCatalogName(String catalogName)
         {
@@ -773,12 +766,6 @@ public class PrestoNativeQueryRunnerUtils
         public ExternalWorkerLauncherBuilder setRemoteFunctionServerUds(Optional<String> remoteFunctionServerUds)
         {
             this.remoteFunctionServerUds = requireNonNull(remoteFunctionServerUds, "remoteFunctionServerUds is null");
-            return this;
-        }
-
-        public ExternalWorkerLauncherBuilder setRemoteFunctionServerRestUrl(String remoteFunctionServerRestUrl)
-        {
-            this.remoteFunctionServerRestUrl = Optional.of(requireNonNull(remoteFunctionServerRestUrl, "remoteFunctionServerRestUrl is null"));
             return this;
         }
 
@@ -830,12 +817,6 @@ public class PrestoNativeQueryRunnerUtils
             return this;
         }
 
-        public ExternalWorkerLauncherBuilder setHttpsClientConfig(HttpsClientConfig httpsClientConfig)
-        {
-            this.httpsClientConfig = Optional.of(requireNonNull(httpsClientConfig, "httpsClientConfig is null"));
-            return this;
-        }
-
         public Optional<BiFunction<Integer, URI, Process>> build()
         {
             requireNonNull(prestoServerPath, "prestoServerPath must be set");
@@ -883,36 +864,6 @@ public class PrestoNativeQueryRunnerUtils
                                         "remote-function-server.serde=presto_page%n" +
                                         "remote-function-server.signature.files.directory.path=%s%n",
                                 configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
-                    }
-
-                    if (remoteFunctionServerRestUrl.isPresent()) {
-                        configProperties = format("%s%n" +
-                                        "remote-function-server.rest.url=%s%n",
-                                configProperties, remoteFunctionServerRestUrl.get());
-                    }
-
-                    if (httpsClientConfig.isPresent()) {
-                        HttpsClientConfig https = httpsClientConfig.get();
-                        configProperties = format("%s%n" +
-                                        "http-server.https.enabled=true%n" +
-                                        "http-server.http2.enabled=false%n" +
-                                        "http-server.https.port=0%n" +
-                                        "https-cert-path=%s%n" +
-                                        "https-key-path=%s%n" +
-                                        "https-client-cert-key-path=%s%n" +
-                                        "https-client-ca-file=%s%n",
-                                configProperties,
-                                https.getCertPath(),
-                                https.getKeyPath(),
-                                https.getClientCertKeyPath(),
-                                https.getCaCertPath());
-
-                        if (https.getJwtSharedSecret().isPresent()) {
-                            configProperties = format("%s%n" +
-                                            "internal-communication.jwt.enabled=true%n" +
-                                            "internal-communication.shared-secret=%s%n",
-                                    configProperties, https.getJwtSharedSecret().get());
-                        }
                     }
 
                     if (pluginDirectory.isPresent()) {
@@ -981,66 +932,9 @@ public class PrestoNativeQueryRunnerUtils
         }
     }
 
-    /**
-     * HTTPS client certificate configuration for native workers.
-     */
-    public static class HttpsClientConfig
-    {
-        private final String certPath;
-        private final String keyPath;
-        private final String clientCertKeyPath;
-        private final String caCertPath;
-        private final Optional<String> jwtSharedSecret;
-
-        private HttpsClientConfig(
-                String certPath,
-                String keyPath,
-                String clientCertKeyPath,
-                String caCertPath,
-                Optional<String> jwtSharedSecret)
-        {
-            this.certPath = requireNonNull(certPath, "certPath is null");
-            this.keyPath = requireNonNull(keyPath, "keyPath is null");
-            this.clientCertKeyPath = requireNonNull(clientCertKeyPath, "clientCertKeyPath is null");
-            this.caCertPath = requireNonNull(caCertPath, "caCertPath is null");
-            this.jwtSharedSecret = requireNonNull(jwtSharedSecret, "jwtSharedSecret is null");
-        }
-
-        public static HttpsClientConfig of(String certPath, String keyPath, String clientCertKeyPath, String caCertPath)
-        {
-            return new HttpsClientConfig(certPath, keyPath, clientCertKeyPath, caCertPath, Optional.empty());
-        }
-
-        public HttpsClientConfig withJwt(String sharedSecret)
-        {
-            return new HttpsClientConfig(certPath, keyPath, clientCertKeyPath, caCertPath, Optional.of(sharedSecret));
-        }
-
-        public String getCertPath()
-        {
-            return certPath;
-        }
-        public String getKeyPath()
-        {
-            return keyPath;
-        }
-        public String getClientCertKeyPath()
-        {
-            return clientCertKeyPath;
-        }
-        public String getCaCertPath()
-        {
-            return caCertPath;
-        }
-        public Optional<String> getJwtSharedSecret()
-        {
-            return jwtSharedSecret;
-        }
-    }
-
     public static ExternalWorkerLauncherBuilder externalWorkerLauncherBuilder()
     {
-        return ExternalWorkerLauncherBuilder.builder();
+        return new ExternalWorkerLauncherBuilder();
     }
 
     public static void setupJsonFunctionNamespaceManager(QueryRunner queryRunner, String jsonFileName, String catalogName)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -685,116 +685,21 @@ public class PrestoNativeQueryRunnerUtils
             boolean implicitCastCharNToVarchar,
             boolean enableCudf)
     {
-        return
-                Optional.of((workerIndex, discoveryUri) -> {
-                    try {
-                        Path dir = Paths.get("/tmp", PrestoNativeQueryRunnerUtils.class.getSimpleName());
-                        Files.createDirectories(dir);
-                        Path tempDirectoryPath = Files.createTempDirectory(dir, "worker");
-                        log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
-
-                        // Write config file - use an ephemeral port for the worker.
-                        String configProperties = format("discovery.uri=%s%n" +
-                                "presto.version=testversion%n" +
-                                "plan-consistency-check-enabled=true%n" +
-                                "system-memory-gb=4%n" +
-                                "http-server.http.port=0%n", discoveryUri);
-
-                        if (isCoordinatorSidecarEnabled) {
-                            configProperties = format("%s%n" +
-                                    "native-sidecar=true%n" +
-                                    "presto.default-namespace=native.default%n", configProperties);
-                        }
-                        else if (isBuiltInWorkerFunctionsEnabled) {
-                            configProperties = format("%s%n" +
-                                    "native-sidecar=true%n", configProperties);
-                        }
-
-                        if (enableRuntimeMetricsCollection) {
-                            configProperties = format("%s%n" +
-                                    "runtime-metrics-collection-enabled=true%n", configProperties);
-                        }
-
-                        if (enableSsdCache) {
-                            Path ssdCacheDir = Paths.get(tempDirectoryPath + "/velox-ssd-cache");
-                            Files.createDirectories(ssdCacheDir);
-                            configProperties = format("%s%n" +
-                                    "async-cache-ssd-gb=1%n" +
-                                    "async-cache-ssd-path=%s/%n", configProperties, ssdCacheDir);
-                        }
-
-                        if (remoteFunctionServerUds.isPresent()) {
-                            String jsonSignaturesPath = Resources.getResource(REMOTE_FUNCTION_JSON_SIGNATURES).getFile();
-                            configProperties = format("%s%n" +
-                                    "remote-function-server.catalog-name=%s%n" +
-                                    "remote-function-server.thrift.uds-path=%s%n" +
-                                    "remote-function-server.serde=presto_page%n" +
-                                    "remote-function-server.signature.files.directory.path=%s%n", configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
-                        }
-
-                        if (pluginDirectory.isPresent()) {
-                            configProperties = format("%s%n" + "plugin.dir=%s%n", configProperties, pluginDirectory.get());
-                        }
-
-                        if (failOnNestedLoopJoin) {
-                            configProperties = format("%s%n" + "velox-plan-validator-fail-on-nested-loop-join=true%n", configProperties);
-                        }
-
-                        if (implicitCastCharNToVarchar) {
-                            configProperties = format("%s%n" + "char-n-to-varchar-implicit-cast=true%n", configProperties);
-                        }
-
-                        if (enableCudf) {
-                            configProperties = format("%s%n" +
-                                    "cudf.enabled=true%n" +
-                                    "cudf.debug_enabled=true", configProperties);
-                        }
-
-                        Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
-                        Files.write(tempDirectoryPath.resolve("node.properties"),
-                                format("node.id=%s%n" +
-                                        "node.internal-address=127.0.0.1%n" +
-                                        "node.environment=testing%n" +
-                                        "node.location=test-location", UUID.randomUUID()).getBytes());
-
-                        Path catalogDirectoryPath = tempDirectoryPath.resolve("catalog");
-                        Files.createDirectory(catalogDirectoryPath);
-                        if (cacheMaxSize > 0) {
-                            Files.write(catalogDirectoryPath.resolve(format("%s.properties", catalogName)),
-                                    format("connector.name=%s%n" +
-                                            "cache.enabled=true%n" +
-                                            "cache.max-cache-size=%s", connectorName, cacheMaxSize).getBytes());
-                        }
-                        else {
-                            Files.write(catalogDirectoryPath.resolve(format("%s.properties", catalogName)),
-                                    format("connector.name=%s", connectorName).getBytes());
-                        }
-                        // Add catalog with caching always enabled.
-                        Files.write(catalogDirectoryPath.resolve(format("%scached.properties", catalogName)),
-                                format("connector.name=%s%n" +
-                                        "cache.enabled=true%n" +
-                                        "cache.max-cache-size=32", connectorName).getBytes());
-
-                        // Add a tpch catalog.
-                        Files.write(catalogDirectoryPath.resolve("tpchstandard.properties"),
-                                format("connector.name=tpch%n").getBytes());
-
-                        // Add a tpcds catalog.
-                        Files.write(catalogDirectoryPath.resolve("tpcds.properties"),
-                                format("connector.name=tpcds%n").getBytes());
-
-                        // Disable stack trace capturing as some queries (using TRY) generate a lot of exceptions.
-                        return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1", "--velox_ssd_odirect=false")
-                                .directory(tempDirectoryPath.toFile())
-                                .redirectErrorStream(true)
-                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                                .start();
-                    }
-                    catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
+        return externalWorkerLauncherBuilder()
+                .setCatalogName(catalogName)
+                .setConnectorName(connectorName)
+                .setPrestoServerPath(prestoServerPath)
+                .setCacheMaxSize(cacheMaxSize)
+                .setRemoteFunctionServerUds(remoteFunctionServerUds)
+                .setPluginDirectory(pluginDirectory)
+                .setFailOnNestedLoopJoin(failOnNestedLoopJoin)
+                .setCoordinatorSidecarEnabled(isCoordinatorSidecarEnabled)
+                .setBuiltInWorkerFunctionsEnabled(isBuiltInWorkerFunctionsEnabled)
+                .setEnableRuntimeMetricsCollection(enableRuntimeMetricsCollection)
+                .setEnableSsdCache(enableSsdCache)
+                .setImplicitCastCharNToVarchar(implicitCastCharNToVarchar)
+                .setEnableCudf(enableCudf)
+                .build();
     }
 
     public static class NativeQueryRunnerParameters
@@ -811,6 +716,331 @@ public class PrestoNativeQueryRunnerUtils
             this.workerCount = requireNonNull(workerCount, "workerCount is null");
             this.runnerParameters = Collections.unmodifiableMap(new HashMap<>(requireNonNull(runnerParameters, "runnerParameters is null")));
         }
+    }
+
+    /**
+     * Builder for creating native (C++) external worker launchers.
+     */
+    public static class ExternalWorkerLauncherBuilder
+    {
+        private String catalogName = "hive";
+        private String connectorName = "hive";
+        private String prestoServerPath;
+        private int cacheMaxSize;
+        private Optional<String> remoteFunctionServerUds = Optional.empty();
+        private Optional<String> remoteFunctionServerRestUrl = Optional.empty();
+        private Optional<String> pluginDirectory = Optional.empty();
+        private boolean failOnNestedLoopJoin;
+        private boolean coordinatorSidecarEnabled;
+        private boolean builtInWorkerFunctionsEnabled;
+        private boolean enableRuntimeMetricsCollection;
+        private boolean enableSsdCache;
+        private boolean implicitCastCharNToVarchar;
+        private boolean enableCudf;
+        private Optional<HttpsClientConfig> httpsClientConfig = Optional.empty();
+
+        private ExternalWorkerLauncherBuilder() {}
+
+        public static ExternalWorkerLauncherBuilder builder()
+        {
+            return new ExternalWorkerLauncherBuilder();
+        }
+
+        public ExternalWorkerLauncherBuilder setCatalogName(String catalogName)
+        {
+            this.catalogName = requireNonNull(catalogName, "catalogName is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setConnectorName(String connectorName)
+        {
+            this.connectorName = requireNonNull(connectorName, "connectorName is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setPrestoServerPath(String prestoServerPath)
+        {
+            this.prestoServerPath = requireNonNull(prestoServerPath, "prestoServerPath is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setCacheMaxSize(int cacheMaxSize)
+        {
+            this.cacheMaxSize = cacheMaxSize;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setRemoteFunctionServerUds(Optional<String> remoteFunctionServerUds)
+        {
+            this.remoteFunctionServerUds = requireNonNull(remoteFunctionServerUds, "remoteFunctionServerUds is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setRemoteFunctionServerRestUrl(String remoteFunctionServerRestUrl)
+        {
+            this.remoteFunctionServerRestUrl = Optional.of(requireNonNull(remoteFunctionServerRestUrl, "remoteFunctionServerRestUrl is null"));
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setPluginDirectory(Optional<String> pluginDirectory)
+        {
+            this.pluginDirectory = requireNonNull(pluginDirectory, "pluginDirectory is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setFailOnNestedLoopJoin(boolean failOnNestedLoopJoin)
+        {
+            this.failOnNestedLoopJoin = failOnNestedLoopJoin;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setCoordinatorSidecarEnabled(boolean coordinatorSidecarEnabled)
+        {
+            this.coordinatorSidecarEnabled = coordinatorSidecarEnabled;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setBuiltInWorkerFunctionsEnabled(boolean builtInWorkerFunctionsEnabled)
+        {
+            this.builtInWorkerFunctionsEnabled = builtInWorkerFunctionsEnabled;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setEnableRuntimeMetricsCollection(boolean enableRuntimeMetricsCollection)
+        {
+            this.enableRuntimeMetricsCollection = enableRuntimeMetricsCollection;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setEnableSsdCache(boolean enableSsdCache)
+        {
+            this.enableSsdCache = enableSsdCache;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setImplicitCastCharNToVarchar(boolean implicitCastCharNToVarchar)
+        {
+            this.implicitCastCharNToVarchar = implicitCastCharNToVarchar;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setEnableCudf(boolean enableCudf)
+        {
+            this.enableCudf = enableCudf;
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setHttpsClientConfig(HttpsClientConfig httpsClientConfig)
+        {
+            this.httpsClientConfig = Optional.of(requireNonNull(httpsClientConfig, "httpsClientConfig is null"));
+            return this;
+        }
+
+        public Optional<BiFunction<Integer, URI, Process>> build()
+        {
+            requireNonNull(prestoServerPath, "prestoServerPath must be set");
+
+            return Optional.of((workerIndex, discoveryUri) -> {
+                try {
+                    Path dir = Paths.get("/tmp", PrestoNativeQueryRunnerUtils.class.getSimpleName());
+                    Files.createDirectories(dir);
+                    Path tempDirectoryPath = Files.createTempDirectory(dir, "worker");
+                    log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
+
+                    // Write config file - use an ephemeral port for the worker.
+                    String configProperties = format("discovery.uri=%s%n" +
+                            "presto.version=testversion%n" +
+                            "plan-consistency-check-enabled=true%n" +
+                            "system-memory-gb=4%n" +
+                            "http-server.http.port=0%n", discoveryUri);
+
+                    if (coordinatorSidecarEnabled) {
+                        configProperties = format("%s%n" +
+                                "native-sidecar=true%n" +
+                                "presto.default-namespace=native.default%n", configProperties);
+                    }
+                    else if (builtInWorkerFunctionsEnabled) {
+                        configProperties = format("%s%nnative-sidecar=true%n", configProperties);
+                    }
+
+                    if (enableRuntimeMetricsCollection) {
+                        configProperties = format("%s%nruntime-metrics-collection-enabled=true%n", configProperties);
+                    }
+
+                    if (enableSsdCache) {
+                        Path ssdCacheDir = Paths.get(tempDirectoryPath + "/velox-ssd-cache");
+                        Files.createDirectories(ssdCacheDir);
+                        configProperties = format("%s%n" +
+                                "async-cache-ssd-gb=1%n" +
+                                "async-cache-ssd-path=%s/%n", configProperties, ssdCacheDir);
+                    }
+
+                    if (remoteFunctionServerUds.isPresent()) {
+                        String jsonSignaturesPath = Resources.getResource(REMOTE_FUNCTION_JSON_SIGNATURES).getFile();
+                        configProperties = format("%s%n" +
+                                        "remote-function-server.catalog-name=%s%n" +
+                                        "remote-function-server.thrift.uds-path=%s%n" +
+                                        "remote-function-server.serde=presto_page%n" +
+                                        "remote-function-server.signature.files.directory.path=%s%n",
+                                configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
+                    }
+
+                    if (remoteFunctionServerRestUrl.isPresent()) {
+                        configProperties = format("%s%n" +
+                                        "remote-function-server.rest.url=%s%n",
+                                configProperties, remoteFunctionServerRestUrl.get());
+                    }
+
+                    if (httpsClientConfig.isPresent()) {
+                        HttpsClientConfig https = httpsClientConfig.get();
+                        configProperties = format("%s%n" +
+                                        "http-server.https.enabled=true%n" +
+                                        "http-server.http2.enabled=false%n" +
+                                        "http-server.https.port=0%n" +
+                                        "https-cert-path=%s%n" +
+                                        "https-key-path=%s%n" +
+                                        "https-client-cert-key-path=%s%n" +
+                                        "https-client-ca-file=%s%n",
+                                configProperties,
+                                https.getCertPath(),
+                                https.getKeyPath(),
+                                https.getClientCertKeyPath(),
+                                https.getCaCertPath());
+
+                        if (https.getJwtSharedSecret().isPresent()) {
+                            configProperties = format("%s%n" +
+                                            "internal-communication.jwt.enabled=true%n" +
+                                            "internal-communication.shared-secret=%s%n",
+                                    configProperties, https.getJwtSharedSecret().get());
+                        }
+                    }
+
+                    if (pluginDirectory.isPresent()) {
+                        configProperties = format("%s%nplugin.dir=%s%n", configProperties, pluginDirectory.get());
+                    }
+
+                    if (failOnNestedLoopJoin) {
+                        configProperties = format("%s%nvelox-plan-validator-fail-on-nested-loop-join=true%n", configProperties);
+                    }
+
+                    if (implicitCastCharNToVarchar) {
+                        configProperties = format("%s%nchar-n-to-varchar-implicit-cast=true%n", configProperties);
+                    }
+
+                    if (enableCudf) {
+                        configProperties = format("%s%n" +
+                                "cudf.enabled=true%n" +
+                                "cudf.debug_enabled=true", configProperties);
+                    }
+
+                    Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
+                    Files.write(tempDirectoryPath.resolve("node.properties"),
+                            format("node.id=%s%n" +
+                                    "node.internal-address=127.0.0.1%n" +
+                                    "node.environment=testing%n" +
+                                    "node.location=test-location", UUID.randomUUID()).getBytes());
+
+                    Path catalogDirectoryPath = tempDirectoryPath.resolve("catalog");
+                    Files.createDirectory(catalogDirectoryPath);
+                    if (cacheMaxSize > 0) {
+                        Files.write(catalogDirectoryPath.resolve(format("%s.properties", catalogName)),
+                                format("connector.name=%s%n" +
+                                        "cache.enabled=true%n" +
+                                        "cache.max-cache-size=%s", connectorName, cacheMaxSize).getBytes());
+                    }
+                    else {
+                        Files.write(catalogDirectoryPath.resolve(format("%s.properties", catalogName)),
+                                format("connector.name=%s", connectorName).getBytes());
+                    }
+
+                    // Add catalog with caching always enabled.
+                    Files.write(catalogDirectoryPath.resolve(format("%scached.properties", catalogName)),
+                            format("connector.name=%s%n" +
+                                    "cache.enabled=true%n" +
+                                    "cache.max-cache-size=32", connectorName).getBytes());
+
+                    // Add a tpch catalog.
+                    Files.write(catalogDirectoryPath.resolve("tpchstandard.properties"),
+                            format("connector.name=tpch%n").getBytes());
+
+                    // Add a tpcds catalog.
+                    Files.write(catalogDirectoryPath.resolve("tpcds.properties"),
+                            format("connector.name=tpcds%n").getBytes());
+
+                    return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1", "--velox_ssd_odirect=false")
+                            .directory(tempDirectoryPath.toFile())
+                            .redirectErrorStream(true)
+                            .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
+                            .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
+                            .start();
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+    }
+
+    /**
+     * HTTPS client certificate configuration for native workers.
+     */
+    public static class HttpsClientConfig
+    {
+        private final String certPath;
+        private final String keyPath;
+        private final String clientCertKeyPath;
+        private final String caCertPath;
+        private final Optional<String> jwtSharedSecret;
+
+        private HttpsClientConfig(
+                String certPath,
+                String keyPath,
+                String clientCertKeyPath,
+                String caCertPath,
+                Optional<String> jwtSharedSecret)
+        {
+            this.certPath = requireNonNull(certPath, "certPath is null");
+            this.keyPath = requireNonNull(keyPath, "keyPath is null");
+            this.clientCertKeyPath = requireNonNull(clientCertKeyPath, "clientCertKeyPath is null");
+            this.caCertPath = requireNonNull(caCertPath, "caCertPath is null");
+            this.jwtSharedSecret = requireNonNull(jwtSharedSecret, "jwtSharedSecret is null");
+        }
+
+        public static HttpsClientConfig of(String certPath, String keyPath, String clientCertKeyPath, String caCertPath)
+        {
+            return new HttpsClientConfig(certPath, keyPath, clientCertKeyPath, caCertPath, Optional.empty());
+        }
+
+        public HttpsClientConfig withJwt(String sharedSecret)
+        {
+            return new HttpsClientConfig(certPath, keyPath, clientCertKeyPath, caCertPath, Optional.of(sharedSecret));
+        }
+
+        public String getCertPath()
+        {
+            return certPath;
+        }
+        public String getKeyPath()
+        {
+            return keyPath;
+        }
+        public String getClientCertKeyPath()
+        {
+            return clientCertKeyPath;
+        }
+        public String getCaCertPath()
+        {
+            return caCertPath;
+        }
+        public Optional<String> getJwtSharedSecret()
+        {
+            return jwtSharedSecret;
+        }
+    }
+
+    public static ExternalWorkerLauncherBuilder externalWorkerLauncherBuilder()
+    {
+        return ExternalWorkerLauncherBuilder.builder();
     }
 
     public static void setupJsonFunctionNamespaceManager(QueryRunner queryRunner, String jsonFileName, String catalogName)


### PR DESCRIPTION
## Description
Refactors the external worker launcher logic in `PrestoNativeQueryRunnerUtils` into a dedicated `ExternalWorkerLauncherBuilder` class using the builder pattern. The existing inline anonymous lambda for launching native workers is replaced by the builder's `build()` method, improving readability and extensibility.

New additions:

- `ExternalWorkerLauncherBuilder` — a fluent builder for constructing native worker process launchers, supporting remote function server (UDS), SSD cache, plugin directory, and CUDF configuration

- `externalWorkerLauncherBuilder()` — a static factory method on PrestoNativeQueryRunnerUtils for convenience

## Motivation and Context
The existing worker launcher was a large inline lambda directly inside `getExternalWorkerLauncher()`, making it hard to read, extend, and reuse. Introducing a builder pattern cleanly separates construction concerns and makes adding future parameters straightforward without growing an already large parameter list.

## Impact
No user-facing or public API change. This is a test infrastructure refactor only — affects `PrestoNativeQueryRunnerUtils` which is used exclusively in test query runners. No behavioral change to production code.

## Test Plan
Existing native worker tests that exercise `getExternalWorkerLauncher()` continue to pass, validating that the builder produces identical worker process configuration as the previous inline lambda.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```