### PR TITLE
fix(native): Support LIKE and regexp on materialized (RPC-result) patterns

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -460,7 +460,29 @@ std::optional<TypedExprPtr> VeloxExprConverter::tryConvertLike(
   auto likePatternExpr =
       std::dynamic_pointer_cast<const protocol::CallExpression>(
           pexpr.arguments[1]);
-  VELOX_CHECK_NOT_NULL(likePatternExpr);
+  if (likePatternExpr == nullptr) {
+    // The pattern is not an inline cast('<pattern>' as LikePattern) /
+    // like_pattern(...) call — it was materialized into a column/variable
+    // upstream. This happens when an RPC function result feeds a LIKE: the
+    // optimizer hoists the constant pattern into a projection below the
+    // RPCNode, so the pattern arrives here as a (constant-valued) column
+    // reference rather than an inline cast. Convert it directly and pass it as
+    // the pattern argument. Velox's like() supports a non-literal pattern via
+    // its per-row path, so this is correct (it only forgoes the
+    // compiled-constant-pattern fast path).
+    //
+    // Scope: this covers a materialized cast(... as LikePattern) (plain LIKE).
+    // A materialized `LIKE ... ESCAPE` pattern is a like_pattern(pattern,
+    // escape) column; Velox has no like_pattern function, so that projection
+    // fails to compile upstream (a hard, non-silent failure) — the escape
+    // cannot be recovered from the column reference here. Materialized LIKE ...
+    // ESCAPE is therefore unsupported; plain materialized LIKE is the supported
+    // path.
+    args.emplace_back(toVeloxExpr(pexpr.arguments[1]));
+    auto returnType = typeParser_->parse(pexpr.returnType);
+    return std::make_shared<CallTypedExpr>(
+        returnType, args, getFunctionName(signature));
+  }
   auto likePatternBuiltin =
       std::static_pointer_cast<protocol::BuiltInFunctionHandle>(
           likePatternExpr->functionHandle);

--- a/presto-native-execution/presto_cpp/main/types/TypeParser.cpp
+++ b/presto-native-execution/presto_cpp/main/types/TypeParser.cpp
@@ -30,6 +30,18 @@ velox::TypePtr TypeParser::parse(const std::string& text) const {
       VELOX_UNSUPPORTED("Unsupported type: {}", text);
     }
   }
+  // Varchar-backed Presto logical types that have no Velox type. Native
+  // normally never parses these: PrestoToVeloxExpr unwraps the inline cast(...
+  // as <T>) (or, for LIKE, the cast(... as LikePattern)) down to the inner
+  // varchar. But when such a value is materialized into a projection column —
+  // e.g. a remote (RPC) function result feeding LIKE, regexp, or json_extract,
+  // where the optimizer hoists the constant pattern below the RPC node — the
+  // column's declared type and references to it reach this parser. Their
+  // runtime value is the varchar pattern/path, so resolve them to varchar.
+  if (text == "LikePattern" || text == "Re2JRegExp" || text == "JsonPath" ||
+      text == "CodePoints") {
+    return velox::VARCHAR();
+  }
   auto it = cache_.find(text);
   if (it != cache_.end()) {
     return it->second;

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -1262,6 +1262,52 @@ TEST_F(RowExpressionTest, likeWithEscape) {
   ASSERT_EQ(callExpr->toString(), "presto.default.like(\"type\",%BRASS,#)");
 }
 
+TEST_F(RowExpressionTest, likeMaterializedPattern) {
+  // When a constant LIKE pattern is materialized into a projection column (e.g.
+  // an RPC function result feeding LIKE), the second argument arrives as a
+  // LikePattern-typed variable rather than an inline cast(... as LikePattern).
+  // This previously failed conversion; it must now resolve to a plain
+  // like(input, patternColumn) with the LikePattern column typed as varchar.
+  std::string str = R"##(
+      {
+         "@type" : "call",
+            "displayName" : "LIKE",
+            "functionHandle" : {
+              "@type" : "$static",
+              "signature" : {
+                "name" : "presto.default.like",
+                "kind" : "SCALAR",
+                "typeVariableConstraints" : [ ],
+                "longVariableConstraints" : [ ],
+                "returnType" : "boolean",
+                "argumentTypes" : [ "varchar", "LikePattern" ],
+                "variableArity" : false
+              },
+              "builtInFunctionKind": "ENGINE"
+            },
+            "returnType" : "boolean",
+            "arguments" : [ {
+              "@type" : "variable",
+              "name" : "type",
+              "type" : "varchar(25)"
+            }, {
+              "@type" : "variable",
+              "name" : "pattern",
+              "type" : "LikePattern"
+            } ]
+      }
+    )##";
+
+  json j = json::parse(str);
+  std::shared_ptr<protocol::RowExpression> p = j;
+
+  auto expr = converter_->toVeloxExpr(p);
+
+  auto callExpr = std::dynamic_pointer_cast<const CallTypedExpr>(expr);
+  ASSERT_NE(callExpr, nullptr);
+  ASSERT_EQ(callExpr->toString(), "presto.default.like(\"type\",\"pattern\")");
+}
+
 TEST_F(RowExpressionTest, dereference) {
   std::string str = R"##(
     {

--- a/presto-native-execution/presto_cpp/main/types/tests/TypeParserTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/TypeParserTest.cpp
@@ -67,3 +67,17 @@ TEST_F(TypeParserTest, parseEnumTypes) {
           "test.enum.mood:VarcharEnum(test.enum.mood{\"CURIOUS\":\"ONXW2ZKWMFWHKZI=\", \"HAPPY\":\"ONXW2ZJAOZQWY5LF\" , \"SAD\":\"KNHU2RJAKZAUYVKF\"})"),
       "Unsupported type: test.enum.mood:VarcharEnum(test.enum.mood{\"CURIOUS\":\"ONXW2ZKWMFWHKZI=\", \"HAPPY\":\"ONXW2ZJAOZQWY5LF\" , \"SAD\":\"KNHU2RJAKZAUYVKF\"})");
 }
+
+TEST_F(TypeParserTest, materializedLogicalTypesAliasToVarchar) {
+  // Varchar-backed Presto logical types have no Velox type. When materialized
+  // into a projection column (e.g. an RPC result feeding
+  // LIKE/regexp/json_extract), their type string reaches the parser and must
+  // resolve to varchar rather than throw "Failed to parse type ... Type not
+  // registered".
+  TypeParser typeParser = TypeParser();
+  for (const auto* name :
+       {"LikePattern", "Re2JRegExp", "JsonPath", "CodePoints"}) {
+    EXPECT_EQ(typeParser.parse(name)->toString(), "VARCHAR")
+        << "type: " << name;
+  }
+}


### PR DESCRIPTION
Summary:
Native plan conversion hard-failed when a LIKE or regexp pattern was a compile-time constant that got materialized into a projection column instead of staying inline. This happens when the pattern operand sits next to a remote/RPC function call: the optimizer splits the projection around the RPC node and hoists the constant pattern into a column below it.

Two failures resulted. First, tryConvertLike required the LIKE pattern argument to be an inline cast(... as LikePattern) (which it unwraps to varchar, since Velox has no LikePattern type); a materialized pattern arrived as a LikePattern-typed column reference and tripped VELOX_CHECK_NOT_NULL. Second, even past that, the LikePattern / Re2JRegExp / JsonPath column type reached the type parser, which has no such Velox type, throwing "Failed to parse type [X]. Type not registered.".

Fix: (1) tryConvertLike accepts a materialized (column/variable) pattern by passing it through to Velox like(), which matches per-row via its LikeGeneric path -- correct, only forgoing the compiled-constant-pattern fast path. (2) TypeParser aliases the varchar-backed Presto logical types that have no Velox type -- LikePattern, Re2JRegExp, JsonPath, CodePoints -- to VARCHAR, so both the cast expression and the column type resolve. These types are always unwrapped to their inner varchar elsewhere in the converter, so aliasing the declared type string is consistent and safe.

regexp (regexp_like / regexp_extract / regexp_replace) and json_extract need only the type alias -- they take a plain varchar pattern/path argument and the Velox re2/json functions accept a non-constant argument, so once the type resolves the generic call path binds directly.

Limitation: LIKE ... ESCAPE with a materialized pattern is unsupported. It compiles to like_pattern(pattern, escape), which Velox has no function for, so the projection fails to compile (a hard, non-silent failure) -- the escape cannot be recovered from the column reference. Plain materialized LIKE and escape-less patterns are supported.

== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix LIKE, regexp, and json_extract queries applied to the result of a remote function (for example meta.ai.* outputs), which previously failed native query plan conversion. :pr:`28118`

Differential Revision:
D111108566

D111108566

Reviewed By: sebastianopeluso


