### PR TITLE
fix(native): Announce both HTTP and HTTPS URIs in Prestissimo node discovery (#28119)

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -25,6 +25,7 @@ std::string announcementBody(
     const std::string& address,
     bool useHttps,
     int port,
+    const std::optional<int>& httpPort,
     const std::string& nodeVersion,
     const std::string& environment,
     const std::string& nodeLocation,
@@ -36,21 +37,27 @@ std::string announcementBody(
 
   const auto uriScheme = useHttps ? "https" : "http";
 
+  auto properties = nlohmann::json{
+      {"node_version", nodeVersion},
+      {"coordinator", false},
+      {"sidecar", sidecar},
+      {"connectorIds", folly::join(',', connectorIds)},
+      {"pool_type", nodePoolType},
+      {uriScheme, fmt::format("{}://{}:{}", uriScheme, address, port)}};
+
+  // Always announce both http and https URIs when both ports are available,
+  // so the node is discoverable regardless of the coordinator's
+  // internal-communication.https.required setting.
+  if (useHttps && httpPort.has_value()) {
+    properties["http"] = fmt::format("http://{}:{}", address, httpPort.value());
+  }
+
   nlohmann::json body = {
       {"environment", environment},
       {"pool", "general"},
       {"location", nodeLocation},
       {"services",
-       {{{"id", id},
-         {"type", "presto"},
-         {"properties",
-          {{"node_version", nodeVersion},
-           {"coordinator", false},
-           {"sidecar", sidecar},
-           {"connectorIds", folly::join(',', connectorIds)},
-           {"pool_type", nodePoolType},
-           {uriScheme,
-            fmt::format("{}://{}:{}", uriScheme, address, port)}}}}}}};
+       {{{"id", id}, {"type", "presto"}, {"properties", properties}}}}};
   return body.dump();
 }
 
@@ -76,6 +83,7 @@ Announcer::Announcer(
     const std::string& address,
     bool useHttps,
     int port,
+    const std::optional<int>& httpPort,
     const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
     const std::string& nodeVersion,
     const std::string& environment,
@@ -97,6 +105,7 @@ Announcer::Announcer(
           address,
           useHttps,
           port,
+          httpPort,
           nodeVersion,
           environment,
           nodeLocation,

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -18,6 +18,8 @@
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicServiceInventoryManager.h"
 
+#include <optional>
+
 namespace facebook::presto {
 
 class Announcer : public PeriodicServiceInventoryManager {
@@ -26,6 +28,7 @@ class Announcer : public PeriodicServiceInventoryManager {
       const std::string& address,
       bool useHttps,
       int port,
+      const std::optional<int>& httpPort,
       const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
       const std::string& nodeVersion,
       const std::string& environment,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -409,18 +409,28 @@ void PrestoServer::initializeConfigs() {
       }
       keyPath_ = optionalKeyPath.value();
 
-      auto optionalClientCertPath = systemConfig->httpsClientCertAndKeyPath();
-      if (!optionalClientCertPath.has_value()) {
-        // This config is not used in server but validated here, otherwise, it
-        // will fail later in the HttpClient during query execution.
-        VELOX_USER_FAIL(
-            "Https Client Certificates are not configured correctly");
-      }
+      // The internal client SSL context is only needed when intra-cluster
+      // communication requires HTTPS. When
+      // internal-communication.https.required is false the coordinator hands
+      // out plaintext http:// peer URIs, and the announcer/heartbeat/exchange
+      // clients must speak plaintext to match -- leaving sslContext_ null
+      // selects HTTP for all internal clients. The HTTPS server listener
+      // (certPath_/keyPath_) is independent and stays up for external client
+      // connections regardless.
+      if (systemConfig->internalCommunicationHttpsRequired()) {
+        auto optionalClientCertPath = systemConfig->httpsClientCertAndKeyPath();
+        if (!optionalClientCertPath.has_value()) {
+          // This config is not used in server but validated here, otherwise, it
+          // will fail later in the HttpClient during query execution.
+          VELOX_USER_FAIL(
+              "Https Client Certificates are not configured correctly");
+        }
 
-      sslContext_ = util::createSSLContext(
-          optionalClientCertPath.value(),
-          ciphers_,
-          systemConfig->httpClientHttp2Enabled());
+        sslContext_ = util::createSSLContext(
+            optionalClientCertPath.value(),
+            ciphers_,
+            systemConfig->httpClientHttp2Enabled());
+      }
     }
 
     if (systemConfig->internalCommunicationJwtEnabled()) {
@@ -729,6 +739,8 @@ void PrestoServer::startServer(const std::vector<std::string>& catalogNames) {
                 address_,
                 httpsPort_.has_value(),
                 address.address.getPort(),
+                httpsPort_.has_value() ? std::optional<int>(httpPort_)
+                                       : std::nullopt,
                 coordinatorDiscoverer_,
                 nodeVersion_,
                 environment_,

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -273,6 +273,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kIncludeNodeInSpillPath, false),
           NUM_PROP(kOldTaskCleanUpMs, 60'000),
           BOOL_PROP(kEnableOldTaskCleanUp, true),
+          BOOL_PROP(kInternalCommunicationHttpsRequired, true),
           BOOL_PROP(kInternalCommunicationJwtEnabled, false),
           STR_PROP(kInternalCommunicationSharedSecret, ""),
           NUM_PROP(kInternalCommunicationJwtExpirationSeconds, 300),
@@ -1117,6 +1118,10 @@ int32_t SystemConfig::oldTaskCleanUpMs() const {
 
 bool SystemConfig::enableOldTaskCleanUp() const {
   return optionalProperty<bool>(kEnableOldTaskCleanUp).value();
+}
+
+bool SystemConfig::internalCommunicationHttpsRequired() const noexcept {
+  return optionalProperty<bool>(kInternalCommunicationHttpsRequired).value();
 }
 
 // The next three toggles govern the use of JWT for authentication

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -880,6 +880,15 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kRemoteFunctionServerSerde{
       "remote-function-server.serde"};
 
+  /// When true (default) intra-cluster communication (announcement, heartbeat
+  /// and exchange) uses HTTPS. When false the internal client SSL context is
+  /// not built, so the announcer/heartbeat/exchange clients speak plaintext
+  /// HTTP to match the http:// peer URIs the coordinator hands out. The HTTPS
+  /// server listener (http-server.https.*) is independent and stays up for
+  /// external clients.
+  static constexpr std::string_view kInternalCommunicationHttpsRequired{
+      "internal-communication.https.required"};
+
   /// Options to configure the internal (in-cluster) JWT authentication.
   static constexpr std::string_view kInternalCommunicationJwtEnabled{
       "internal-communication.jwt.enabled"};
@@ -1293,6 +1302,8 @@ class SystemConfig : public ConfigBase {
   int32_t oldTaskCleanUpMs() const;
 
   bool enableOldTaskCleanUp() const;
+
+  bool internalCommunicationHttpsRequired() const noexcept;
 
   bool internalCommunicationJwtEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -77,7 +77,7 @@ static std::unique_ptr<http::HttpServer> createHttpServer(
 }
 
 std::unique_ptr<facebook::presto::test::HttpServerWrapper> makeDiscoveryServer(
-    std::function<void()> onAnnouncement,
+    std::function<void(const std::string&)> onAnnouncement,
     bool useHttps) {
   auto httpServer = createHttpServer(useHttps);
 
@@ -85,9 +85,16 @@ std::unique_ptr<facebook::presto::test::HttpServerWrapper> makeDiscoveryServer(
       R"(/v1/announcement/(.+))",
       [onAnnouncement](
           proxygen::HTTPMessage* /*message*/,
-          const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
           proxygen::ResponseHandler* downstream) mutable {
-        onAnnouncement();
+        std::string announcement;
+        for (const auto& buf : body) {
+          if (buf != nullptr) {
+            announcement +=
+                std::string((const char*)buf->data(), buf->length());
+          }
+        }
+        onAnnouncement(announcement);
         proxygen::ResponseBuilder(downstream)
             .status(http::kHttpAccepted, "Accepted")
             .sendWithEOM();
@@ -117,13 +124,15 @@ class TestCoordinatorDiscoverer : public CoordinatorDiscoverer {
       folly::Promise<bool> announcementPromise,
       bool useHttps)
       : announcementCnt(0), addressLookupCnt(0), useHttps(useHttps) {
-    onAnnouncement = [this,
-                      promiseHolder = std::make_shared<PromiseHolder<bool>>(
-                          std::move(announcementPromise))]() {
-      if (++announcementCnt == 5) {
-        promiseHolder->get().setValue(true);
-      }
-    };
+    onAnnouncement =
+        [this,
+         promiseHolder = std::make_shared<PromiseHolder<bool>>(
+             std::move(announcementPromise))](const std::string& body) {
+          lastAnnouncementBody = body;
+          if (++announcementCnt == 5) {
+            promiseHolder->get().setValue(true);
+          }
+        };
     discoveryServer = makeDiscoveryServer(onAnnouncement, useHttps);
     serverAddress = discoveryServer->start().get();
   }
@@ -151,7 +160,8 @@ class TestCoordinatorDiscoverer : public CoordinatorDiscoverer {
 
   std::unique_ptr<test::HttpServerWrapper> discoveryServer;
   folly::SocketAddress serverAddress;
-  std::function<void()> onAnnouncement;
+  std::function<void(const std::string&)> onAnnouncement;
+  std::string lastAnnouncementBody;
   std::atomic_int announcementCnt;
   std::atomic_int addressLookupCnt;
   bool useHttps;
@@ -164,10 +174,16 @@ TEST_P(AnnouncerTestSuite, basic) {
   auto coordinatorDiscoverer =
       std::make_shared<TestCoordinatorDiscoverer>(std::move(promise), useHttps);
 
+  // When HTTPS is enabled the main announcement port is the HTTPS port and a
+  // separate plaintext HTTP port is also advertised; when disabled only the
+  // HTTP port exists.
+  constexpr int kMainPort = 1234;
+  constexpr int kHttpPort = 5678;
   Announcer announcer(
       "127.0.0.1",
       useHttps,
-      1234,
+      kMainPort,
+      useHttps ? std::optional<int>(kHttpPort) : std::nullopt,
       coordinatorDiscoverer,
       "testversion",
       "testing",
@@ -182,6 +198,27 @@ TEST_P(AnnouncerTestSuite, basic) {
   announcer.start();
   ASSERT_TRUE(std::move(future).getTry().hasValue());
   ASSERT_GE(coordinatorDiscoverer->addressLookupCnt, 8);
+
+  // Verify the announced URI properties. A node must advertise the "http"
+  // property whenever a plaintext port exists so it stays discoverable when the
+  // coordinator has internal-communication.https.required=false; when HTTPS is
+  // enabled it advertises both "http" and "https".
+  const auto properties = nlohmann::json::parse(
+      coordinatorDiscoverer->lastAnnouncementBody)["services"][0]["properties"];
+  if (useHttps) {
+    EXPECT_EQ(
+        properties.value("https", ""),
+        fmt::format("https://127.0.0.1:{}", kMainPort));
+    EXPECT_EQ(
+        properties.value("http", ""),
+        fmt::format("http://127.0.0.1:{}", kHttpPort));
+  } else {
+    EXPECT_EQ(
+        properties.value("http", ""),
+        fmt::format("http://127.0.0.1:{}", kMainPort));
+    EXPECT_FALSE(properties.contains("https"));
+  }
+
   announcer.stop();
 }
 


### PR DESCRIPTION
Summary:

The C++ worker announcer included only one URI property (either "http" or
"https"). When the coordinator's internal-communication.https.required was
false it looked for "http" but the worker announced only "https", making the
worker invisible and crashing the coordinator. Announce both "http" and
"https" when both ports are available, matching Java worker behavior, so
internal-communication.https.required can be toggled without breaking
discovery.

Differential Revision: D94275133


