### PR TITLE
fix: Return no-op for LazyOutputBuffer.acknowledge() before buffer init (#28121)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution.buffer;
 
 import com.facebook.airlift.concurrent.ExtendedSettableFuture;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
@@ -48,6 +49,8 @@ import static java.util.Objects.requireNonNull;
 public class LazyOutputBuffer
         implements OutputBuffer
 {
+    private static final Logger log = Logger.get(LazyOutputBuffer.class);
+
     private final StateMachine<BufferState> state;
     private final TaskId taskId;
     private final String taskInstanceId;
@@ -219,7 +222,22 @@ public class LazyOutputBuffer
     @Override
     public void acknowledge(OutputBufferId bufferId, long token)
     {
-        OutputBuffer outputBuffer = getDelegateOutputBufferOrFail();
+        OutputBuffer outputBuffer = delegate;
+        if (outputBuffer == null) {
+            synchronized (this) {
+                if (delegate == null) {
+                    // The delegate output buffer has not been created yet (setOutputBuffers has
+                    // not run). An acknowledge for a not-yet-initialized buffer is a no-op: there
+                    // are no pages to release, and the client will re-issue the request once the
+                    // buffer exists. Mirrors the null-tolerant behavior of get() and abort();
+                    // failing hard here (as the previous getDelegateOutputBufferOrFail did)
+                    // turned an early acknowledge/HEAD get-data-size probe into a 500.
+                    log.debug("acknowledge(%s, %s) before output buffer initialized for task %s; treating as no-op", bufferId, token, taskId);
+                    return;
+                }
+                outputBuffer = delegate;
+            }
+        }
         outputBuffer.acknowledge(bufferId, token);
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestLazyOutputBuffer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestLazyOutputBuffer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertFalse;
+
+public class TestLazyOutputBuffer
+{
+    private static final String TASK_INSTANCE_ID = "task-instance-id";
+    private static final OutputBufferId BUFFER_ID = new OutputBufferId(0);
+
+    private ScheduledExecutorService executor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        executor = newScheduledThreadPool(2, daemonThreadsNamed("test-%s"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    private LazyOutputBuffer createLazyOutputBuffer()
+    {
+        return new LazyOutputBuffer(
+                new TaskId("query", 0, 0, 0, 0),
+                TASK_INSTANCE_ID,
+                executor,
+                1024L,
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
+                new SpoolingOutputBufferFactory(new FeaturesConfig()));
+    }
+
+    // Before the delegate output buffer is created (setOutputBuffers has not run),
+    // an acknowledge must be a no-op rather than throwing. A native worker's HEAD
+    // get-data-size probe routes to acknowledge; failing hard turned it into a 500
+    // and stalled the consumer. Mirrors the null-tolerant get()/abort() behavior.
+    @Test
+    public void testAcknowledgeBeforeInitializationIsNoOp()
+    {
+        LazyOutputBuffer buffer = createLazyOutputBuffer();
+        buffer.acknowledge(BUFFER_ID, 0);
+    }
+
+    // Control: get() and abort() already tolerate a null delegate; verify they do
+    // not throw either, so the acknowledge fix matches sibling behavior.
+    @Test
+    public void testGetAndAbortBeforeInitializationDoNotThrow()
+    {
+        LazyOutputBuffer buffer = createLazyOutputBuffer();
+        assertFalse(buffer.get(BUFFER_ID, 0, 1024L).isDone());
+        buffer.abort(BUFFER_ID);
+    }
+}

--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -25,6 +25,7 @@ std::string announcementBody(
     const std::string& address,
     bool useHttps,
     int port,
+    const std::optional<int>& httpPort,
     const std::string& nodeVersion,
     const std::string& environment,
     const std::string& nodeLocation,
@@ -36,21 +37,27 @@ std::string announcementBody(
 
   const auto uriScheme = useHttps ? "https" : "http";
 
+  auto properties = nlohmann::json{
+      {"node_version", nodeVersion},
+      {"coordinator", false},
+      {"sidecar", sidecar},
+      {"connectorIds", folly::join(',', connectorIds)},
+      {"pool_type", nodePoolType},
+      {uriScheme, fmt::format("{}://{}:{}", uriScheme, address, port)}};
+
+  // Always announce both http and https URIs when both ports are available,
+  // so the node is discoverable regardless of the coordinator's
+  // internal-communication.https.required setting.
+  if (useHttps && httpPort.has_value()) {
+    properties["http"] = fmt::format("http://{}:{}", address, httpPort.value());
+  }
+
   nlohmann::json body = {
       {"environment", environment},
       {"pool", "general"},
       {"location", nodeLocation},
       {"services",
-       {{{"id", id},
-         {"type", "presto"},
-         {"properties",
-          {{"node_version", nodeVersion},
-           {"coordinator", false},
-           {"sidecar", sidecar},
-           {"connectorIds", folly::join(',', connectorIds)},
-           {"pool_type", nodePoolType},
-           {uriScheme,
-            fmt::format("{}://{}:{}", uriScheme, address, port)}}}}}}};
+       {{{"id", id}, {"type", "presto"}, {"properties", properties}}}}};
   return body.dump();
 }
 
@@ -76,6 +83,7 @@ Announcer::Announcer(
     const std::string& address,
     bool useHttps,
     int port,
+    const std::optional<int>& httpPort,
     const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
     const std::string& nodeVersion,
     const std::string& environment,
@@ -97,6 +105,7 @@ Announcer::Announcer(
           address,
           useHttps,
           port,
+          httpPort,
           nodeVersion,
           environment,
           nodeLocation,

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -18,6 +18,8 @@
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicServiceInventoryManager.h"
 
+#include <optional>
+
 namespace facebook::presto {
 
 class Announcer : public PeriodicServiceInventoryManager {
@@ -26,6 +28,7 @@ class Announcer : public PeriodicServiceInventoryManager {
       const std::string& address,
       bool useHttps,
       int port,
+      const std::optional<int>& httpPort,
       const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
       const std::string& nodeVersion,
       const std::string& environment,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -409,18 +409,28 @@ void PrestoServer::initializeConfigs() {
       }
       keyPath_ = optionalKeyPath.value();
 
-      auto optionalClientCertPath = systemConfig->httpsClientCertAndKeyPath();
-      if (!optionalClientCertPath.has_value()) {
-        // This config is not used in server but validated here, otherwise, it
-        // will fail later in the HttpClient during query execution.
-        VELOX_USER_FAIL(
-            "Https Client Certificates are not configured correctly");
-      }
+      // The internal client SSL context is only needed when intra-cluster
+      // communication requires HTTPS. When
+      // internal-communication.https.required is false the coordinator hands
+      // out plaintext http:// peer URIs, and the announcer/heartbeat/exchange
+      // clients must speak plaintext to match -- leaving sslContext_ null
+      // selects HTTP for all internal clients. The HTTPS server listener
+      // (certPath_/keyPath_) is independent and stays up for external client
+      // connections regardless.
+      if (systemConfig->internalCommunicationHttpsRequired()) {
+        auto optionalClientCertPath = systemConfig->httpsClientCertAndKeyPath();
+        if (!optionalClientCertPath.has_value()) {
+          // This config is not used in server but validated here, otherwise, it
+          // will fail later in the HttpClient during query execution.
+          VELOX_USER_FAIL(
+              "Https Client Certificates are not configured correctly");
+        }
 
-      sslContext_ = util::createSSLContext(
-          optionalClientCertPath.value(),
-          ciphers_,
-          systemConfig->httpClientHttp2Enabled());
+        sslContext_ = util::createSSLContext(
+            optionalClientCertPath.value(),
+            ciphers_,
+            systemConfig->httpClientHttp2Enabled());
+      }
     }
 
     if (systemConfig->internalCommunicationJwtEnabled()) {
@@ -729,6 +739,8 @@ void PrestoServer::startServer(const std::vector<std::string>& catalogNames) {
                 address_,
                 httpsPort_.has_value(),
                 address.address.getPort(),
+                httpsPort_.has_value() ? std::optional<int>(httpPort_)
+                                       : std::nullopt,
                 coordinatorDiscoverer_,
                 nodeVersion_,
                 environment_,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -768,13 +768,19 @@ void PrestoServer::startServer(const std::vector<std::string>& catalogNames) {
             }
           }
 
+          // The task base URI (TaskStatus.self) must use the internal
+          // communication scheme, not merely whichever listener exists. When
+          // internal-communication.https.required is false, sslContext_ is null
+          // and internal peers speak plaintext; advertising an https:// self
+          // URI here would make the coordinator attempt a TLS handshake against
+          // the worker for task status/results and fail (PKIX/handshake error)
+          // even though the HTTPS listener is up for external clients.
           std::string taskUri;
-          if (httpsPort_.has_value()) {
+          if (sslContext_ != nullptr) {
             taskUri = fmt::format(
                 kTaskUriFormat, kHttps, address_, address.address.getPort());
           } else {
-            taskUri = fmt::format(
-                kTaskUriFormat, kHttp, address_, address.address.getPort());
+            taskUri = fmt::format(kTaskUriFormat, kHttp, address_, httpPort_);
           }
           taskManager_->setBaseUri(taskUri);
           break;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -273,6 +273,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kIncludeNodeInSpillPath, false),
           NUM_PROP(kOldTaskCleanUpMs, 60'000),
           BOOL_PROP(kEnableOldTaskCleanUp, true),
+          BOOL_PROP(kInternalCommunicationHttpsRequired, true),
           BOOL_PROP(kInternalCommunicationJwtEnabled, false),
           STR_PROP(kInternalCommunicationSharedSecret, ""),
           NUM_PROP(kInternalCommunicationJwtExpirationSeconds, 300),
@@ -1117,6 +1118,10 @@ int32_t SystemConfig::oldTaskCleanUpMs() const {
 
 bool SystemConfig::enableOldTaskCleanUp() const {
   return optionalProperty<bool>(kEnableOldTaskCleanUp).value();
+}
+
+bool SystemConfig::internalCommunicationHttpsRequired() const noexcept {
+  return optionalProperty<bool>(kInternalCommunicationHttpsRequired).value();
 }
 
 // The next three toggles govern the use of JWT for authentication

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -880,6 +880,15 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kRemoteFunctionServerSerde{
       "remote-function-server.serde"};
 
+  /// When true (default) intra-cluster communication (announcement, heartbeat
+  /// and exchange) uses HTTPS. When false the internal client SSL context is
+  /// not built, so the announcer/heartbeat/exchange clients speak plaintext
+  /// HTTP to match the http:// peer URIs the coordinator hands out. The HTTPS
+  /// server listener (http-server.https.*) is independent and stays up for
+  /// external clients.
+  static constexpr std::string_view kInternalCommunicationHttpsRequired{
+      "internal-communication.https.required"};
+
   /// Options to configure the internal (in-cluster) JWT authentication.
   static constexpr std::string_view kInternalCommunicationJwtEnabled{
       "internal-communication.jwt.enabled"};
@@ -1293,6 +1302,8 @@ class SystemConfig : public ConfigBase {
   int32_t oldTaskCleanUpMs() const;
 
   bool enableOldTaskCleanUp() const;
+
+  bool internalCommunicationHttpsRequired() const noexcept;
 
   bool internalCommunicationJwtEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -77,7 +77,7 @@ static std::unique_ptr<http::HttpServer> createHttpServer(
 }
 
 std::unique_ptr<facebook::presto::test::HttpServerWrapper> makeDiscoveryServer(
-    std::function<void()> onAnnouncement,
+    std::function<void(const std::string&)> onAnnouncement,
     bool useHttps) {
   auto httpServer = createHttpServer(useHttps);
 
@@ -85,9 +85,16 @@ std::unique_ptr<facebook::presto::test::HttpServerWrapper> makeDiscoveryServer(
       R"(/v1/announcement/(.+))",
       [onAnnouncement](
           proxygen::HTTPMessage* /*message*/,
-          const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
           proxygen::ResponseHandler* downstream) mutable {
-        onAnnouncement();
+        std::string announcement;
+        for (const auto& buf : body) {
+          if (buf != nullptr) {
+            announcement +=
+                std::string((const char*)buf->data(), buf->length());
+          }
+        }
+        onAnnouncement(announcement);
         proxygen::ResponseBuilder(downstream)
             .status(http::kHttpAccepted, "Accepted")
             .sendWithEOM();
@@ -117,13 +124,15 @@ class TestCoordinatorDiscoverer : public CoordinatorDiscoverer {
       folly::Promise<bool> announcementPromise,
       bool useHttps)
       : announcementCnt(0), addressLookupCnt(0), useHttps(useHttps) {
-    onAnnouncement = [this,
-                      promiseHolder = std::make_shared<PromiseHolder<bool>>(
-                          std::move(announcementPromise))]() {
-      if (++announcementCnt == 5) {
-        promiseHolder->get().setValue(true);
-      }
-    };
+    onAnnouncement =
+        [this,
+         promiseHolder = std::make_shared<PromiseHolder<bool>>(
+             std::move(announcementPromise))](const std::string& body) {
+          lastAnnouncementBody = body;
+          if (++announcementCnt == 5) {
+            promiseHolder->get().setValue(true);
+          }
+        };
     discoveryServer = makeDiscoveryServer(onAnnouncement, useHttps);
     serverAddress = discoveryServer->start().get();
   }
@@ -151,7 +160,8 @@ class TestCoordinatorDiscoverer : public CoordinatorDiscoverer {
 
   std::unique_ptr<test::HttpServerWrapper> discoveryServer;
   folly::SocketAddress serverAddress;
-  std::function<void()> onAnnouncement;
+  std::function<void(const std::string&)> onAnnouncement;
+  std::string lastAnnouncementBody;
   std::atomic_int announcementCnt;
   std::atomic_int addressLookupCnt;
   bool useHttps;
@@ -164,10 +174,16 @@ TEST_P(AnnouncerTestSuite, basic) {
   auto coordinatorDiscoverer =
       std::make_shared<TestCoordinatorDiscoverer>(std::move(promise), useHttps);
 
+  // When HTTPS is enabled the main announcement port is the HTTPS port and a
+  // separate plaintext HTTP port is also advertised; when disabled only the
+  // HTTP port exists.
+  constexpr int kMainPort = 1234;
+  constexpr int kHttpPort = 5678;
   Announcer announcer(
       "127.0.0.1",
       useHttps,
-      1234,
+      kMainPort,
+      useHttps ? std::optional<int>(kHttpPort) : std::nullopt,
       coordinatorDiscoverer,
       "testversion",
       "testing",
@@ -182,6 +198,27 @@ TEST_P(AnnouncerTestSuite, basic) {
   announcer.start();
   ASSERT_TRUE(std::move(future).getTry().hasValue());
   ASSERT_GE(coordinatorDiscoverer->addressLookupCnt, 8);
+
+  // Verify the announced URI properties. A node must advertise the "http"
+  // property whenever a plaintext port exists so it stays discoverable when the
+  // coordinator has internal-communication.https.required=false; when HTTPS is
+  // enabled it advertises both "http" and "https".
+  const auto properties = nlohmann::json::parse(
+      coordinatorDiscoverer->lastAnnouncementBody)["services"][0]["properties"];
+  if (useHttps) {
+    EXPECT_EQ(
+        properties.value("https", ""),
+        fmt::format("https://127.0.0.1:{}", kMainPort));
+    EXPECT_EQ(
+        properties.value("http", ""),
+        fmt::format("http://127.0.0.1:{}", kHttpPort));
+  } else {
+    EXPECT_EQ(
+        properties.value("http", ""),
+        fmt::format("http://127.0.0.1:{}", kMainPort));
+    EXPECT_FALSE(properties.contains("https"));
+  }
+
   announcer.stop();
 }
 


### PR DESCRIPTION
Summary:

LazyOutputBuffer.acknowledge() called getDelegateOutputBufferOrFail(), which
threw when the delegate was not yet set, turning an early acknowledge / HEAD
get-data-size probe into an HTTP 500. Match the null-tolerant behavior of
get() and abort() and treat pre-initialization acknowledge as a no-op: there
are no pages to release, and the client re-issues once the buffer exists.

== RELEASE NOTES ==

General Changes
* Fix intermittent HTTP 500 errors when a client acknowledges or probes task
  results before the output buffer is initialized.

Differential Revision: D111179038


