### PR TITLE
fix(native-pos): Let native subprocess pick its own HTTP port to avoid bind races (#28125)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -18,6 +18,10 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <glog/logging.h>
 #include <proxygen/lib/http/HTTPHeaders.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
 #include "presto_cpp/main/Announcer.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicMemoryChecker.h"
@@ -267,6 +271,37 @@ json::array_t getOptimizedExpressions(
     result.push_back(optimized);
   }
   return result;
+}
+
+// Atomically writes 'boundPort' to '<configDirectoryPath>/http-server.port'
+// via a tmp+rename so readers only ever see a fully-written, current value.
+// Logs and returns on any failure; never throws.
+void writeBoundHttpPortFile(
+    const std::string& configDirectoryPath,
+    uint16_t boundPort) {
+  const std::string portFilePath = configDirectoryPath + "/http-server.port";
+  const std::string tmpPortFilePath = portFilePath + ".tmp";
+  try {
+    {
+      std::ofstream out(tmpPortFilePath);
+      out.exceptions(std::ios::failbit | std::ios::badbit);
+      out << boundPort << std::endl;
+      out.flush();
+    }
+    if (std::rename(tmpPortFilePath.c_str(), portFilePath.c_str()) != 0) {
+      PRESTO_STARTUP_LOG(ERROR)
+          << "Failed to rename port file " << tmpPortFilePath << " -> "
+          << portFilePath << ": " << std::strerror(errno);
+      std::remove(tmpPortFilePath.c_str());
+      return;
+    }
+  } catch (const std::exception& e) {
+    PRESTO_STARTUP_LOG(ERROR)
+        << "Failed to write port file " << portFilePath << ": " << e.what();
+    std::remove(tmpPortFilePath.c_str());
+    return;
+  }
+  PRESTO_STARTUP_LOG(INFO) << "HTTP server bound to port " << boundPort;
 }
 
 } // namespace
@@ -766,6 +801,10 @@ void PrestoServer::startServer(const std::vector<std::string>& catalogNames) {
                 kTaskUriFormat, kHttp, address_, address.address.getPort());
           }
           taskManager_->setBaseUri(taskUri);
+          if (systemConfig->httpServerReportBoundPortToFile()) {
+            writeBoundHttpPortFile(
+                configDirectoryPath_, address.address.getPort());
+          }
           break;
         }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -18,6 +18,10 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <glog/logging.h>
 #include <proxygen/lib/http/HTTPHeaders.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
 #include "presto_cpp/main/Announcer.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicMemoryChecker.h"
@@ -766,6 +770,32 @@ void PrestoServer::startServer(const std::vector<std::string>& catalogNames) {
                 kTaskUriFormat, kHttp, address_, address.address.getPort());
           }
           taskManager_->setBaseUri(taskUri);
+          if (systemConfig->httpServerReportBoundPortToFile()) {
+            const std::string portFilePath =
+                configDirectoryPath_ + "/http-server.port";
+            const std::string tmpPortFilePath = portFilePath + ".tmp";
+            try {
+              {
+                std::ofstream out(tmpPortFilePath);
+                out.exceptions(std::ios::failbit | std::ios::badbit);
+                out << address.address.getPort() << std::endl;
+                out.flush();
+              }
+              if (std::rename(tmpPortFilePath.c_str(), portFilePath.c_str()) !=
+                  0) {
+                PRESTO_STARTUP_LOG(ERROR)
+                    << "Failed to rename port file " << tmpPortFilePath
+                    << " -> " << portFilePath << ": " << std::strerror(errno);
+                std::remove(tmpPortFilePath.c_str());
+              }
+            } catch (const std::exception& e) {
+              PRESTO_STARTUP_LOG(ERROR) << "Failed to write port file "
+                                        << portFilePath << ": " << e.what();
+              std::remove(tmpPortFilePath.c_str());
+            }
+            PRESTO_STARTUP_LOG(INFO)
+                << "HTTP server bound to port " << address.address.getPort();
+          }
           break;
         }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -139,6 +139,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kPrestoVersion),
           NONE_PROP(kHttpServerHttpPort),
           BOOL_PROP(kHttpServerReusePort, false),
+          BOOL_PROP(kHttpServerReportBoundPortToFile, false),
           BOOL_PROP(kHttpServerBindToNodeInternalAddressOnlyEnabled, false),
           NONE_PROP(kDiscoveryUri),
           NUM_PROP(kMaxDriversPerTask, hardwareConcurrency()),
@@ -324,6 +325,10 @@ int SystemConfig::httpServerHttpPort() const {
 
 bool SystemConfig::httpServerReusePort() const {
   return optionalProperty<bool>(kHttpServerReusePort).value();
+}
+
+bool SystemConfig::httpServerReportBoundPortToFile() const {
+  return optionalProperty<bool>(kHttpServerReportBoundPortToFile).value();
 }
 
 bool SystemConfig::httpServerBindToNodeInternalAddressOnlyEnabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -171,6 +171,10 @@ class SystemConfig : public ConfigBase {
   /// startup.
   static constexpr std::string_view kHttpServerReusePort{
       "http-server.reuse-port"};
+  /// If true, write the bound HTTP port to
+  /// `<etc_dir>/http-server.port` after bind.
+  static constexpr std::string_view kHttpServerReportBoundPortToFile{
+      "http-server.report-bound-port-to-file"};
   /// By default the server binds to 0.0.0.0
   /// With this option enabled the server will bind strictly to the
   /// address set in node.internal-address property
@@ -985,6 +989,8 @@ class SystemConfig : public ConfigBase {
   int httpServerHttpPort() const;
 
   bool httpServerReusePort() const;
+
+  bool httpServerReportBoundPortToFile() const;
 
   bool httpServerBindToNodeInternalAddressOnlyEnabled() const;
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
@@ -46,10 +46,12 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -88,17 +90,35 @@ public abstract class AbstractNativeProcess
     private static final String WORKER_CONNECTOR_CONFIG_DIR = "catalog";
     private static final int SIGSYS = 31;
 
+    private static final String PORT_FILE_NAME = "http-server.port";
+    private static final Duration PORT_DISCOVERY_POLL_INTERVAL = Duration.valueOf("200ms");
+
     private final String executablePath;
     private final String programArguments;
-    private final PrestoSparkHttpServerClient serverClient;
-    private final URI location;
-    private final int port;
+    private final String nodeInternalAddress;
+    private final OkHttpClient httpClient;
+    private final JsonCodec<ServerInfo> serverInfoCodec;
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final Duration maxErrorDuration;
     private final Executor executor;
-    private final RequestErrorTracker errorTracker;
+
+    private volatile int port;
+    private volatile URI location;
+    private volatile PrestoSparkHttpServerClient serverClient;
+    private volatile RequestErrorTracker errorTracker;
+
+    private final boolean subprocessSelectsPort;
+    private final String configDirName;
 
     private volatile Process process;
     private volatile ProcessOutputPipe processOutputPipe;
+    private volatile Path configPath;
 
+    /**
+     * Legacy constructor: Java pre-picks the port with {@link #getAvailableTcpPort} and
+     * hands it to the subprocess via configuration. Kept for callers that have not
+     * migrated to the subprocess-selects-port model.
+     */
     protected AbstractNativeProcess(
             String executablePath,
             String programArguments,
@@ -109,29 +129,74 @@ public abstract class AbstractNativeProcess
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration)
     {
+        this(executablePath, programArguments, nodeInternalAddress, httpClient, executor,
+                scheduledExecutorService, serverInfoCodec, maxErrorDuration, false);
+    }
+
+    /**
+     * When {@code subprocessSelectsPort} is true, port, location, and HTTP client
+     * initialization is deferred until {@link #start} reads the bound port from
+     * {@code <etc_dir>/http-server.port}. Subclasses that opt in must configure the
+     * native binary with {@code http-server.http.port=0} and
+     * {@code http-server.report-bound-port-to-file=true}.
+     */
+    protected AbstractNativeProcess(
+            String executablePath,
+            String programArguments,
+            String nodeInternalAddress,
+            OkHttpClient httpClient,
+            Executor executor,
+            ScheduledExecutorService scheduledExecutorService,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            Duration maxErrorDuration,
+            boolean subprocessSelectsPort)
+    {
         this.executablePath = requireNonNull(executablePath, "executablePath is null");
         this.programArguments = requireNonNull(programArguments, "programArguments is null");
-        requireNonNull(nodeInternalAddress, "nodeInternalAddress is null");
-        this.port = getAvailableTcpPort(nodeInternalAddress);
-        this.location = HttpUrl.parse("http://" + nodeInternalAddress + ":" + getPort()).uri();
-        this.serverClient = new PrestoSparkHttpServerClient(
-                requireNonNull(httpClient, "httpClient is null"),
-                location,
-                serverInfoCodec);
+        this.nodeInternalAddress = requireNonNull(nodeInternalAddress, "nodeInternalAddress is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.executor = requireNonNull(executor, "executor is null");
+        this.scheduledExecutorService = requireNonNull(scheduledExecutorService, "scheduledExecutorService is null");
+        this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
+        this.subprocessSelectsPort = subprocessSelectsPort;
+
+        if (subprocessSelectsPort) {
+            // Port, location, serverClient, errorTracker deferred until start().
+            this.configDirName = UUID.randomUUID().toString();
+        }
+        else {
+            this.port = getAvailableTcpPort(nodeInternalAddress);
+            this.configDirName = String.valueOf(this.port);
+            initializePortDependentFields(this.port);
+        }
+    }
+
+    private void initializePortDependentFields(int boundPort)
+    {
+        initializePortDependentFields(boundPort, maxErrorDuration);
+    }
+
+    private void initializePortDependentFields(int boundPort, Duration errorBudget)
+    {
+        this.port = boundPort;
+        this.location = HttpUrl.parse("http://" + nodeInternalAddress + ":" + boundPort).uri();
+        this.serverClient = new PrestoSparkHttpServerClient(httpClient, location, serverInfoCodec);
         this.errorTracker = new RequestErrorTracker(
                 "NativeExecution",
                 location,
                 NATIVE_EXECUTION_TASK_ERROR,
                 NATIVE_EXECUTION_TASK_ERROR_MESSAGE,
-                maxErrorDuration,
+                errorBudget,
                 scheduledExecutorService,
                 "getting native process status");
     }
 
     /**
      * Starts the external native process. Blocks until the process responds at /v1/info
-     * or until the error tracker exhausts its budget.
+     * or until the error tracker exhausts its budget. In subprocess-selects-port mode
+     * this also blocks until the subprocess writes its bound port to
+     * {@code <etc_dir>/http-server.port}.
      */
     public synchronized void start()
             throws ExecutionException, InterruptedException, IOException
@@ -156,12 +221,73 @@ public abstract class AbstractNativeProcess
             throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start %s", processBuilder.command()), e);
         }
 
+        if (subprocessSelectsPort) {
+            try {
+                awaitPortDiscovery();
+            }
+            catch (PrestoException e) {
+                close();
+                throw e;
+            }
+        }
+
         try {
             getServerInfoWithRetry().get();
         }
         catch (Throwable t) {
             close();
             throw propagateStartFailure(t);
+        }
+    }
+
+    private void awaitPortDiscovery()
+    {
+        if (configPath == null) {
+            throw new PrestoException(
+                    NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                    "configPath was not populated before awaitPortDiscovery — likely a getLaunchCommand() bug");
+        }
+        Path portFile = configPath.resolve(PORT_FILE_NAME);
+        long deadlineNanos = System.nanoTime() + maxErrorDuration.roundTo(TimeUnit.NANOSECONDS);
+        long pollMillis = PORT_DISCOVERY_POLL_INTERVAL.roundTo(TimeUnit.MILLISECONDS);
+        while (true) {
+            if (Files.exists(portFile)) {
+                try {
+                    int boundPort = Integer.parseInt(new String(Files.readAllBytes(portFile), UTF_8).trim());
+                    if (boundPort <= 0 || boundPort > 65535) {
+                        throw new PrestoException(
+                                NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                                format("Invalid bound port %s read from %s", boundPort, portFile));
+                    }
+                    Duration remainingBudget = new Duration(Math.max(0L, deadlineNanos - System.nanoTime()), TimeUnit.NANOSECONDS);
+                    log.info("Native subprocess reported bound port %s (via %s)", boundPort, portFile);
+                    initializePortDependentFields(boundPort, remainingBudget);
+                    return;
+                }
+                catch (IOException | NumberFormatException e) {
+                    log.warn(e, "Port file exists but not yet readable — will retry: %s", portFile);
+                }
+            }
+            if (!process.isAlive()) {
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        format("Native subprocess exited before writing port file %s (exit code %s)", portFile, process.exitValue()));
+            }
+            if (System.nanoTime() >= deadlineNanos) {
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        format("Native subprocess did not write port file %s within %s", portFile, maxErrorDuration));
+            }
+            try {
+                Thread.sleep(pollMillis);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        "Interrupted while waiting for native subprocess to write port file",
+                        e);
+            }
         }
     }
 
@@ -409,7 +535,7 @@ public abstract class AbstractNativeProcess
     private List<String> getLaunchCommand()
             throws IOException
     {
-        String configPath = Paths.get(resolveProcessWorkingPath("./"), String.valueOf(port)).toAbsolutePath().toString();
+        String configPathStr = Paths.get(resolveProcessWorkingPath("./"), configDirName).toAbsolutePath().toString();
         ImmutableList.Builder<String> command = ImmutableList.builder();
         List<String> argsList = Arrays.asList(programArguments.split("\\s+"));
         boolean etcDirSet = false;
@@ -417,15 +543,16 @@ public abstract class AbstractNativeProcess
             String arg = argsList.get(i);
             if (arg.equals("--etc_dir")) {
                 etcDirSet = true;
-                configPath = argsList.get(i + 1);
+                configPathStr = argsList.get(i + 1);
                 break;
             }
         }
         command.add(executablePath).addAll(argsList);
         if (!etcDirSet) {
-            command.add("--etc_dir").add(configPath);
-            populateConfigurationFiles(Paths.get(configPath));
+            command.add("--etc_dir").add(configPathStr);
+            populateConfigurationFiles(Paths.get(configPathStr));
         }
+        this.configPath = Paths.get(configPathStr).toAbsolutePath();
         ImmutableList<String> commandList = command.build();
         log.info("Launching native process using command: %s", String.join(" ", commandList));
         return commandList;
@@ -455,7 +582,7 @@ public abstract class AbstractNativeProcess
         return configBasePath.resolve(WORKER_CONNECTOR_CONFIG_DIR);
     }
 
-    private static class ProcessOutputPipe
+    static class ProcessOutputPipe
             implements Runnable
     {
         private final long pid;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
@@ -47,11 +47,13 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -99,17 +101,35 @@ public abstract class AbstractNativeProcess
     // pipe can still be draining while the relaunched worker's pipe starts writing), preventing interleaved lines.
     private static final PrintStream EXECUTOR_STDERR = new PrintStream(new FileOutputStream(FileDescriptor.err), false, UTF_8);
 
+    private static final String PORT_FILE_NAME = "http-server.port";
+    private static final Duration PORT_DISCOVERY_POLL_INTERVAL = Duration.valueOf("200ms");
+
     private final String executablePath;
     private final String programArguments;
-    private final PrestoSparkHttpServerClient serverClient;
-    private final URI location;
-    private final int port;
+    private final String nodeInternalAddress;
+    private final OkHttpClient httpClient;
+    private final JsonCodec<ServerInfo> serverInfoCodec;
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final Duration maxErrorDuration;
     private final Executor executor;
-    private final RequestErrorTracker errorTracker;
+
+    private volatile int port;
+    private volatile URI location;
+    private volatile PrestoSparkHttpServerClient serverClient;
+    private volatile RequestErrorTracker errorTracker;
+
+    private final boolean subprocessSelectsPort;
+    private final String configDirName;
 
     private volatile Process process;
     private volatile ProcessOutputPipe processOutputPipe;
+    private volatile Path configPath;
 
+    /**
+     * Legacy constructor: Java pre-picks the port with {@link #getAvailableTcpPort} and
+     * hands it to the subprocess via configuration. Kept for callers that have not
+     * migrated to the subprocess-selects-port model.
+     */
     protected AbstractNativeProcess(
             String executablePath,
             String programArguments,
@@ -120,29 +140,74 @@ public abstract class AbstractNativeProcess
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration)
     {
+        this(executablePath, programArguments, nodeInternalAddress, httpClient, executor,
+                scheduledExecutorService, serverInfoCodec, maxErrorDuration, false);
+    }
+
+    /**
+     * When {@code subprocessSelectsPort} is true, port, location, and HTTP client
+     * initialization is deferred until {@link #start} reads the bound port from
+     * {@code <etc_dir>/http-server.port}. Subclasses that opt in must configure the
+     * native binary with {@code http-server.http.port=0} and
+     * {@code http-server.report-bound-port-to-file=true}.
+     */
+    protected AbstractNativeProcess(
+            String executablePath,
+            String programArguments,
+            String nodeInternalAddress,
+            OkHttpClient httpClient,
+            Executor executor,
+            ScheduledExecutorService scheduledExecutorService,
+            JsonCodec<ServerInfo> serverInfoCodec,
+            Duration maxErrorDuration,
+            boolean subprocessSelectsPort)
+    {
         this.executablePath = requireNonNull(executablePath, "executablePath is null");
         this.programArguments = requireNonNull(programArguments, "programArguments is null");
-        requireNonNull(nodeInternalAddress, "nodeInternalAddress is null");
-        this.port = getAvailableTcpPort(nodeInternalAddress);
-        this.location = HttpUrl.parse("http://" + nodeInternalAddress + ":" + getPort()).uri();
-        this.serverClient = new PrestoSparkHttpServerClient(
-                requireNonNull(httpClient, "httpClient is null"),
-                location,
-                serverInfoCodec);
+        this.nodeInternalAddress = requireNonNull(nodeInternalAddress, "nodeInternalAddress is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.executor = requireNonNull(executor, "executor is null");
+        this.scheduledExecutorService = requireNonNull(scheduledExecutorService, "scheduledExecutorService is null");
+        this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
+        this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
+        this.subprocessSelectsPort = subprocessSelectsPort;
+
+        if (subprocessSelectsPort) {
+            // Port, location, serverClient, errorTracker deferred until start().
+            this.configDirName = UUID.randomUUID().toString();
+        }
+        else {
+            this.port = getAvailableTcpPort(nodeInternalAddress);
+            this.configDirName = String.valueOf(this.port);
+            initializePortDependentFields(this.port);
+        }
+    }
+
+    private void initializePortDependentFields(int boundPort)
+    {
+        initializePortDependentFields(boundPort, maxErrorDuration);
+    }
+
+    private void initializePortDependentFields(int boundPort, Duration errorBudget)
+    {
+        this.port = boundPort;
+        this.location = HttpUrl.parse("http://" + nodeInternalAddress + ":" + boundPort).uri();
+        this.serverClient = new PrestoSparkHttpServerClient(httpClient, location, serverInfoCodec);
         this.errorTracker = new RequestErrorTracker(
                 "NativeExecution",
                 location,
                 NATIVE_EXECUTION_TASK_ERROR,
                 NATIVE_EXECUTION_TASK_ERROR_MESSAGE,
-                maxErrorDuration,
+                errorBudget,
                 scheduledExecutorService,
                 "getting native process status");
     }
 
     /**
      * Starts the external native process. Blocks until the process responds at /v1/info
-     * or until the error tracker exhausts its budget.
+     * or until the error tracker exhausts its budget. In subprocess-selects-port mode
+     * this also blocks until the subprocess writes its bound port to
+     * {@code <etc_dir>/http-server.port}.
      */
     public synchronized void start()
             throws ExecutionException, InterruptedException, IOException
@@ -167,12 +232,73 @@ public abstract class AbstractNativeProcess
             throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start %s", processBuilder.command()), e);
         }
 
+        if (subprocessSelectsPort) {
+            try {
+                awaitPortDiscovery();
+            }
+            catch (PrestoException e) {
+                close();
+                throw e;
+            }
+        }
+
         try {
             getServerInfoWithRetry().get();
         }
         catch (Throwable t) {
             close();
             throw propagateStartFailure(t);
+        }
+    }
+
+    private void awaitPortDiscovery()
+    {
+        if (configPath == null) {
+            throw new PrestoException(
+                    NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                    "configPath was not populated before awaitPortDiscovery — likely a getLaunchCommand() bug");
+        }
+        Path portFile = configPath.resolve(PORT_FILE_NAME);
+        long deadlineNanos = System.nanoTime() + maxErrorDuration.roundTo(TimeUnit.NANOSECONDS);
+        long pollMillis = PORT_DISCOVERY_POLL_INTERVAL.roundTo(TimeUnit.MILLISECONDS);
+        while (true) {
+            if (Files.exists(portFile)) {
+                try {
+                    int boundPort = Integer.parseInt(new String(Files.readAllBytes(portFile), UTF_8).trim());
+                    if (boundPort <= 0 || boundPort > 65535) {
+                        throw new PrestoException(
+                                NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                                format("Invalid bound port %s read from %s", boundPort, portFile));
+                    }
+                    Duration remainingBudget = new Duration(Math.max(0L, deadlineNanos - System.nanoTime()), TimeUnit.NANOSECONDS);
+                    log.info("Native subprocess reported bound port %s (via %s)", boundPort, portFile);
+                    initializePortDependentFields(boundPort, remainingBudget);
+                    return;
+                }
+                catch (IOException | NumberFormatException e) {
+                    log.warn(e, "Port file exists but not yet readable — will retry: %s", portFile);
+                }
+            }
+            if (!process.isAlive()) {
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        format("Native subprocess exited before writing port file %s (exit code %s)", portFile, process.exitValue()));
+            }
+            if (System.nanoTime() >= deadlineNanos) {
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        format("Native subprocess did not write port file %s within %s", portFile, maxErrorDuration));
+            }
+            try {
+                Thread.sleep(pollMillis);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new PrestoException(
+                        NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR,
+                        "Interrupted while waiting for native subprocess to write port file",
+                        e);
+            }
         }
     }
 
@@ -436,7 +562,7 @@ public abstract class AbstractNativeProcess
     private List<String> getLaunchCommand()
             throws IOException
     {
-        String configPath = Paths.get(resolveProcessWorkingPath("./"), String.valueOf(port)).toAbsolutePath().toString();
+        String configPathStr = Paths.get(resolveProcessWorkingPath("./"), configDirName).toAbsolutePath().toString();
         ImmutableList.Builder<String> command = ImmutableList.builder();
         List<String> argsList = Arrays.asList(programArguments.split("\\s+"));
         boolean etcDirSet = false;
@@ -444,15 +570,16 @@ public abstract class AbstractNativeProcess
             String arg = argsList.get(i);
             if (arg.equals("--etc_dir")) {
                 etcDirSet = true;
-                configPath = argsList.get(i + 1);
+                configPathStr = argsList.get(i + 1);
                 break;
             }
         }
         command.add(executablePath).addAll(argsList);
         if (!etcDirSet) {
-            command.add("--etc_dir").add(configPath);
-            populateConfigurationFiles(Paths.get(configPath));
+            command.add("--etc_dir").add(configPathStr);
+            populateConfigurationFiles(Paths.get(configPathStr));
         }
+        this.configPath = Paths.get(configPathStr).toAbsolutePath();
         ImmutableList<String> commandList = command.build();
         log.info("Launching native process using command: %s", String.join(" ", commandList));
         return commandList;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/MetadataSidecarProcess.java
@@ -23,7 +23,6 @@ import okhttp3.OkHttpClient;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -90,7 +89,8 @@ public class MetadataSidecarProcess
                 executor,
                 scheduledExecutorService,
                 serverInfoCodec,
-                maxErrorDuration);
+                maxErrorDuration,
+                true);
         this.storageOncallName = storageOncallName;
         this.storageUserName = storageUserName;
         this.storageServiceName = storageServiceName;
@@ -109,13 +109,11 @@ public class MetadataSidecarProcess
             throws IOException
     {
         Files.createDirectories(configBasePath);
-        Files.write(workerConfigFile(configBasePath), buildSystemConfigLines());
+        Files.write(workerConfigFile(configBasePath), buildSystemConfigLines(configBasePath));
         Files.write(workerNodeConfigFile(configBasePath), buildNodeConfigLines());
         // The catalog directory is intentionally empty (no connectors) but must exist —
         // PrestoServer iterates it during startup and aborts if it's missing.
         Files.createDirectories(workerCatalogDir(configBasePath));
-        // Remember where we wrote so close() can clean it up; the parent abstract class
-        // computes this path internally and never exposes it to the subclass otherwise.
         this.configBasePath = configBasePath;
     }
 
@@ -126,11 +124,7 @@ public class MetadataSidecarProcess
             super.close();
         }
         finally {
-            // Etc-dir written by populateConfigurationFiles (may be null if start() never ran),
-            // and the spill dir referenced from config.properties (may or may not exist
-            // depending on whether the native process actually spilled).
             deleteQuietly(configBasePath);
-            deleteQuietly(Paths.get(sidecarSpillDirectory(getPort())));
         }
     }
 
@@ -147,28 +141,18 @@ public class MetadataSidecarProcess
         }
     }
 
-    private Iterable<String> buildSystemConfigLines()
+    private Iterable<String> buildSystemConfigLines(Path configBasePath)
     {
-        // The native-sidecar=true flag turns on /v1/functions and friends.
-        // The storage-* triple satisfies FacebookPrestoBase::registerFileSinks, which calls
-        // requiredProperty() for these even though we never use WarmStorage in metadata-only
-        // mode. The experimental.spiller-spill-path setting short-circuits the FB datacenter
-        // detection in FacebookPrestoBase::getBaseSpillDirectory.
         return Arrays.asList(
-                "discovery.uri=http://" + SIDECAR_NODE_INTERNAL_ADDRESS + ":" + getPort(),
                 "presto.version=metadata-sidecar",
-                "http-server.http.port=" + getPort(),
+                "http-server.http.port=0",
+                "http-server.report-bound-port-to-file=true",
                 "shutdown-onset-sec=1",
                 "native-sidecar=true",
                 "storage_oncall_name=" + storageOncallName,
                 "storage_user_name=" + storageUserName,
                 "storage_service_name=" + storageServiceName,
-                "experimental.spiller-spill-path=" + sidecarSpillDirectory(getPort()));
-    }
-
-    private static String sidecarSpillDirectory(int port)
-    {
-        return System.getProperty("java.io.tmpdir") + "/presto-spark-metadata-sidecar-spill-" + port;
+                "experimental.spiller-spill-path=" + configBasePath.resolve("spill").toAbsolutePath());
     }
 
     private Iterable<String> buildNodeConfigLines()


### PR DESCRIPTION
D111320787
## Description

`AbstractNativeProcess.getAvailableTcpPort()` pre-picks an ephemeral TCP port by opening a `ServerSocket` on port 0, reading `getLocalPort()`, closing the socket, and passing the released port to the forked native subprocess via config. The subprocess later calls `bind()` on that port — but by then the port has been released to the OS ephemeral pool, and any other process on the host that grabs an ephemeral port in the meantime wins the race. When that happens, the C++ side aborts at HTTP-server startup with `failed to bind to async server socket: [::]:<port>: Address already in use` and the Java parent reports `Failed to start metadata sidecar` after the 2-minute `/v1/info` startup poll times out.

This diff adds an opt-in mode where the subprocess picks its own port and reports it back via an atomic file write. Java-side changes: the caller passes `subprocessSelectsPort=true` to a new `AbstractNativeProcess` constructor, which defers port-dependent field initialization until `start()` reads the port. Java writes `http-server.http.port=0` and `http-server.report-bound-port-to-file=true` into the subprocess config, then polls `<etc_dir>/http-server.port` for the reported port with a fast-fail on subprocess exit. C++-side changes (in `PrestoServer.cpp`): when the new config flag is set, the server writes its bound port to `<configDirectoryPath>/http-server.port` atomically (write to `.tmp` then `rename`) inside the `httpServer_->start()` callback after `taskManager_->setBaseUri` runs, so any reader that sees the file gets a complete, up-to-date value. The check and the use of the port now happen inside the same process, eliminating the TOCTOU race by construction.

Changes:

1. `common/Configs.{h,cpp}`: new `http-server.report-bound-port-to-file` bool config, default `false`. When true, the server writes its bound port to a file inside its etc-dir after bind.
2. `PrestoServer.cpp`: in `startServer`, inside the address-bind callback and gated on the new config, atomically write `<configDirectoryPath>/http-server.port` via `tmp+rename`. Off by default so existing consumers (native workers, standalone metadata sidecars, executor subprocesses) are byte-identical in behavior.
3. `AbstractNativeProcess`:
   - New constructor overload accepting `subprocessSelectsPort=true` that defers `port` / `location` / `serverClient` / `errorTracker` until `start()` learns the port.
   - `start()` in the new mode calls `awaitPortDiscovery()` which polls `<etc_dir>/http-server.port` at 200ms intervals, fast-fails if the subprocess exits before writing (surfacing the actual exit code instead of waiting out the full timeout), and shares the existing `maxErrorDuration` budget with the `/v1/info` health poll.
   - The etc-dir path (previously `String.valueOf(port)`) becomes a UUID in the new mode since the port is not known at etc-dir-creation time. Legacy mode still uses the port for backward-compatible on-disk layout.
4. `MetadataSidecarProcess`: opts into the new mode; sets `http-server.http.port=0` and `http-server.report-bound-port-to-file=true` in its config; spill directory moves under the etc-dir so `close()` cleanup is a single recursive delete that also removes the port file.

The executor path (a different subclass of `AbstractNativeProcess` used for query tasks, not the metadata sidecar) uses the same base class and has the same latent race but is unchanged in this diff — it launches lazily on first task in a quieter container context than the sidecar's driver-init context, so it hits the race far less often, and the migration is deferred to a follow-up to keep this change reviewable.

## Motivation and Context

Textbook TOCTOU: the resource (port) is checked, released, then reused later, opening a race window in which any concurrent ephemeral-port allocator can grab the port. The bug has been latent in this base class since the subprocess model was introduced but has only started causing hard failures with the metadata sidecar rollout, because the sidecar launches during the driver JVM's initialization storm — the noisiest possible moment for ephemeral port allocation in the driver's container (Spark driver RPC, storage clients, thrift clients, Netty selectors all racing for ephemeral ports at exactly the moment the sidecar Java code pre-picks). The subprocess-selects-port pattern makes the check and the bind happen inside the same process, so no window exists for another allocator to intervene.

## Impact

- Metadata sidecar startup becomes race-free. Failures of the form `Failed to start metadata sidecar at http://127.0.0.1:<port>/` caused by the port being taken between pre-pick and subprocess bind are eliminated.
- The executor path is unchanged — same code, same latent race, same observed behavior. A follow-up will migrate it to the new mode after the sidecar path has soaked in production.
- The new `http-server.report-bound-port-to-file` config defaults to `false`, so C++ servers that are not launched by the new Java code path (regular native workers, standalone metadata sidecars, executor subprocesses) get zero behavior change — no extra file write, no extra log line, no risk on read-only etc-dirs.
- The legacy constructor (`subprocessSelectsPort` unset) is preserved; existing subclasses keep working unchanged.

## Test Plan

I0710 12:04:28.685112 3079733 PrestoServer.cpp:719] Server listening at :::33961 - https false
I0710 12:04:28.685228 3079733 PrestoServer.cpp:791] HTTP server bound to port 33961

## Release Notes

```
== NO RELEASE NOTE ==
```


