### PR TITLE
fix(native): Federation Flight server should serialize failure info to preserve exception and error code

### DIFF
--- a/presto-flight-shim/pom.xml
+++ b/presto-flight-shim/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
         </dependency>

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimModule.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimModule.java
@@ -33,6 +33,7 @@ import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.HistoryBasedOptimizationConfig;
 import com.facebook.presto.cost.StatsCalculatorModule;
+import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
@@ -155,6 +156,7 @@ public class FlightShimModule
         // json codecs
         jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);
         jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+        jsonCodecBinder(binder).bindJsonCodec(ExecutionFailureInfo.class);
 
         // Determine the NodeVersion - required by ConnectorManager
         NodeVersion nodeVersion = new NodeVersion("1");

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimPluginManager.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -59,6 +60,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.server.PluginManagerUtil.SPI_PACKAGES;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static java.util.Objects.requireNonNull;
 
 public class FlightShimPluginManager
@@ -132,10 +134,10 @@ public class FlightShimPluginManager
 
     public ConnectorCodecs getConnectorCodecs(String connectorId)
     {
-        Catalog catalog = catalogManager.getCatalog(connectorId).orElseThrow(() -> new IllegalArgumentException("Requested catalog not loaded: " + connectorId));
+        Catalog catalog = catalogManager.getCatalog(connectorId).orElseThrow(() -> new PrestoException(NOT_FOUND, "Federation catalog does not exist: " + connectorId));
         ConnectorCodecs connectorCodecs = connectorCodecMap.get(catalog.getCatalogContext().getConnectorName());
         if (connectorCodecs == null) {
-            throw new IllegalArgumentException("Requested connector not loaded: " + catalog.getCatalogContext().getConnectorName());
+            throw new PrestoException(NOT_FOUND, "Federation connector not loaded: " + catalog.getCatalogContext().getConnectorName());
         }
         return connectorCodecs;
     }

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
@@ -20,11 +20,13 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.plugin.arrow.ArrowBatchSource;
 import com.facebook.presto.Session;
 import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.client.ErrorLocation;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ColumnHandle;
@@ -34,14 +36,19 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ErrorCause;
+import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.type.TypeDeserializer;
+import com.facebook.presto.util.Failures;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.flight.BackpressureStrategy;
 import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.ErrorFlightMetadata;
 import org.apache.arrow.flight.NoOpFlightProducer;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
@@ -65,6 +72,8 @@ public class FlightShimProducer
         extends NoOpFlightProducer
         implements AutoCloseable
 {
+    public static final String METADATA_KEY_ARROW_STATUS_CODE = "x-arrow-status";
+    public static final String METADATA_KEY_ARROW_STATUS_BIN = "grpc-status-details-bin";
     private static final Logger log = Logger.get(FlightShimProducer.class);
     private static final int CLIENT_POLL_TIME = 5000;  // Backpressure poll time ms
     private final BufferAllocator allocator;
@@ -73,6 +82,7 @@ public class FlightShimProducer
     private final FlightShimConfig config;
     private final ExecutorService shimExecutor;
     private final JsonCodec<FlightShimRequest> requestCodec;
+    private final JsonCodec<ExecutionFailureInfo> executionFailureInfoCodec;
 
     @Inject
     public FlightShimProducer(
@@ -82,13 +92,15 @@ public class FlightShimProducer
             @ForFlightShimServer ExecutorService shimExecutor,
             PageSourceManager pageSourceManager,
             TypeDeserializer typeDeserializer,
-            BlockEncodingManager blockEncodingManager)
+            BlockEncodingManager blockEncodingManager,
+            JsonCodec<ExecutionFailureInfo> executionFailureInfoCodec)
     {
         this.allocator = allocator.newChildAllocator("flight-shim", 0, Long.MAX_VALUE);
         this.pluginManager = requireNonNull(pluginManager, "pluginManager is null");
         this.config = requireNonNull(config, "config is null");
         this.shimExecutor = requireNonNull(shimExecutor, "shimExecutor is null");
         this.pageSourceManager = requireNonNull(pageSourceManager, "pageSourceManager is null");
+        this.executionFailureInfoCodec = requireNonNull(executionFailureInfoCodec, "executionFailureInfoCodec is null");
         requireNonNull(typeDeserializer, "typeDeserializer is null");
         requireNonNull(blockEncodingManager, "blockEncodingManager is null");
 
@@ -184,7 +196,8 @@ public class FlightShimProducer
         catch (Throwable t) {
             final String message = "Error getting connector flight stream";
             log.error(t, message);
-            listener.error(CallStatus.INTERNAL.withCause(t).withDescription(format("%s [%s]", message, t)).toRuntimeException());
+            final CallStatus callStatus = createCallStatusWithFailureInfo(t).withDescription(format("%s [%s]", message, t));
+            listener.error(callStatus.toRuntimeException());
         }
         finally {
             log.debug(format("Processing GetStream completed [columns=%d, rows=%d, batches=%d]", columnCount, rowCount, batchCount));
@@ -213,5 +226,36 @@ public class FlightShimProducer
         }
         pluginManager.stop();
         allocator.close();
+    }
+
+    private CallStatus createCallStatusWithFailureInfo(Throwable t)
+    {
+        CallStatus callStatus = CallStatus.INTERNAL.withCause(t);
+        try {
+            ExecutionFailureInfo failureInfoFull = Failures.toFailure(t);
+
+            // NOTE: gRPC has limit of metadata size, only include necessary info
+            ExecutionFailureInfo failureInfo = new ExecutionFailureInfo(
+                    failureInfoFull.getType(),
+                    failureInfoFull.getMessage(),
+                    null,
+                    ImmutableList.of(),
+                    ImmutableList.of(),
+                    new ErrorLocation(1, 1),
+                    failureInfoFull.getErrorCode(),
+                    new HostAddress("0.0.0.0", 0),
+                    ErrorCause.UNKNOWN);
+
+            ErrorFlightMetadata metadata = new ErrorFlightMetadata();
+            // NOTE: must include metadata with a valid gRPC status code for arrow-cpp client to receive metadata status binary
+            metadata.insert(METADATA_KEY_ARROW_STATUS_CODE, String.valueOf(io.grpc.Status.Code.INTERNAL.value()));
+            metadata.insert(METADATA_KEY_ARROW_STATUS_BIN, executionFailureInfoCodec.toJsonBytes(failureInfo));
+
+            return callStatus.withMetadata(metadata);
+        }
+        catch (Exception e) {
+            log.error(e, "Unable to serialize failure information");
+            return callStatus;
+        }
     }
 }

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestFlightShimPlugins.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestFlightShimPlugins.java
@@ -503,7 +503,12 @@ public abstract class AbstractTestFlightShimPlugins
 
     protected FlightShimRequest createTpchTableRequest(int partNumber, int totalParts, List<TpchColumnHandle> columnHandles)
     {
-        String split = createTpchSplit(TPCH_TABLE, partNumber, totalParts);
+        return createTpchTableRequest(TPCH_TABLE, partNumber, totalParts, columnHandles);
+    }
+
+    protected FlightShimRequest createTpchTableRequest(String tableName, int partNumber, int totalParts, List<TpchColumnHandle> columnHandles)
+    {
+        String split = createTpchSplit(tableName, partNumber, totalParts);
         byte[] splitBytes = split.getBytes(StandardCharsets.UTF_8);
 
         ImmutableList.Builder<Descriptor.Field> fieldBuilder = ImmutableList.builder();

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesPostgres.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesPostgres.java
@@ -33,6 +33,10 @@ import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.se
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static java.lang.String.format;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class TestArrowFederationNativeQueriesPostgres
         extends AbstractTestArrowFederationNativeQueries
@@ -42,6 +46,7 @@ public class TestArrowFederationNativeQueriesPostgres
     private static final String CONNECTOR_ID = "postgresql_testing";
     private static final String CONNECTOR_NAME = "postgresql";
     private static final String PLUGIN_BUNDLES = "../presto-postgresql/pom.xml";
+    private static final String FLIGHT_UNKNOWN_CATALOG = "flight_unknown";
 
     private final PostgreSQLContainer<?> postgresContainer;
 
@@ -95,6 +100,9 @@ public class TestArrowFederationNativeQueriesPostgres
             queryRunner.installPlugin(new PostgreSqlPlugin());
             queryRunner.createCatalog(getConnectorId(), getConnectorName(), getConnectorProperties());
             createTpchTables(queryRunner, postgresContainer.getJdbcUrl(), getConnectorId());
+
+            // Create a catalog only known to presto coordinator and worker, not flight shim server
+            queryRunner.createCatalog(FLIGHT_UNKNOWN_CATALOG, getConnectorName(), getConnectorProperties());
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -115,11 +123,24 @@ public class TestArrowFederationNativeQueriesPostgres
             throws Exception
     {
         QueryRunner queryRunner =
-                createNativeQueryRunner(ImmutableList.of(getConnectorId()), ImmutableList.of(getConnectorName()), server.getPort());
+                createNativeQueryRunner(ImmutableList.of(getConnectorId(), FLIGHT_UNKNOWN_CATALOG), ImmutableList.of(getConnectorName(), CONNECTOR_NAME), server.getPort());
         queryRunner.installPlugin(new PostgreSqlPlugin());
         queryRunner.createCatalog(getConnectorId(), getConnectorName(), createJdbcConnectorProperties(postgresContainer.getJdbcUrl()));
+        queryRunner.createCatalog(FLIGHT_UNKNOWN_CATALOG, getConnectorName(), getConnectorProperties());
         setupNativeSidecarPlugin(queryRunner);
         return queryRunner;
+    }
+
+    @Test
+    public void testFlightShimErrorPropagation()
+    {
+        // Cause a failure in the FlightShim server, check PrestoException is routed through native to coordinator
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> computeActual(format("SELECT * FROM %s.tpch.nation", FLIGHT_UNKNOWN_CATALOG)));
+
+        // AbstractTestingPrestoClient wraps error in RuntimeException
+        assertNotNull(ex.getCause());
+        // NOTE: use toString() to include the FailureException.type with message
+        assertTrue(ex.getCause().toString().matches(format(".*PrestoException.*Federation catalog does not exist: %s.*", FLIGHT_UNKNOWN_CATALOG)));
     }
 
     @Override

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimTpchPlugin.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimTpchPlugin.java
@@ -13,14 +13,19 @@
  */
 package com.facebook.presto.flightshim;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.flight.ErrorFlightMetadata;
 import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
@@ -28,16 +33,22 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.CancellationException;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
+import static com.facebook.presto.flightshim.FlightShimProducer.METADATA_KEY_ARROW_STATUS_BIN;
+import static com.facebook.presto.flightshim.FlightShimProducer.METADATA_KEY_ARROW_STATUS_CODE;
 import static com.facebook.presto.flightshim.TestFlightShimRequest.REQUEST_JSON_CODEC;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 @Test(singleThreaded = true)
 public class TestFlightShimTpchPlugin
         extends AbstractTestFlightShimPlugins
 {
+    public static final JsonCodec<ExecutionFailureInfo> EXECUTION_FAILURE_INFO_JSON_CODEC = jsonCodec(ExecutionFailureInfo.class);
     public static final int SPLITS_PER_NODE = 4;
 
     protected String getConnectorId()
@@ -157,6 +168,31 @@ public class TestFlightShimTpchPlugin
     public void testReadFromMultipleSplits()
     {
         assertSelectQueryFromColumns(ImmutableList.of(ORDERKEY_COLUMN, LINENUMBER_COLUMN, SHIPINSTRUCT_COLUMN));
+    }
+
+    @Test
+    public void testExecutionFailureInfo() throws Exception
+    {
+        try (BufferAllocator bufferAllocator = allocator.newChildAllocator("connector-test-client", 0, Long.MAX_VALUE);
+                FlightClient client = createFlightClient(bufferAllocator, server.getPort())) {
+            Ticket ticket = new Ticket(REQUEST_JSON_CODEC.toJsonBytes(createTpchTableRequest("invalid_table", 0, 1, ImmutableList.of(getOrderKeyColumn()))));
+
+            FlightRuntimeException e = expectThrows(FlightRuntimeException.class, () -> {
+                try (FlightStream stream = client.getStream(ticket, CALL_OPTIONS)) {
+                    stream.next();
+                }
+            });
+
+            ErrorFlightMetadata metadata = e.status().metadata();
+            assertTrue(metadata.containsKey(METADATA_KEY_ARROW_STATUS_CODE));
+            assertEquals(Integer.parseInt(metadata.get(METADATA_KEY_ARROW_STATUS_CODE)), io.grpc.Status.Code.INTERNAL.value());
+            assertTrue(metadata.containsKey(METADATA_KEY_ARROW_STATUS_BIN));
+            byte[] failureInfoBytes = metadata.getByte(METADATA_KEY_ARROW_STATUS_BIN);
+            ExecutionFailureInfo failureInfo = EXECUTION_FAILURE_INFO_JSON_CODEC.fromJson(failureInfoBytes);
+            assertEquals(failureInfo.getMessage(), "Table invalid_table not found");
+            assertEquals(failureInfo.getType(), "java.lang.IllegalArgumentException");
+            assertEquals(failureInfo.getErrorCode(), StandardErrorCode.GENERIC_INTERNAL_ERROR.toErrorCode());
+        }
     }
 
     private static class TestLocalQueryRunner

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -120,6 +120,8 @@ protocol::TaskState toProtocolTaskState(PrestoTaskState state) {
 protocol::ExecutionFailureInfo toPrestoError(std::exception_ptr ex) {
   try {
     rethrow_exception(ex);
+  } catch (const ExecutionFailureException& e) {
+    return e.getFailureInfo();
   } catch (const VeloxException& e) {
     return translateToPrestoException(e);
   } catch (const std::exception& e) {

--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -35,6 +35,30 @@ inline constexpr auto kExceededLocalBroadcastJoinMemoryLimit =
     "EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT"_fs;
 } // namespace error_code
 
+class ExecutionFailureException : public velox::VeloxException {
+ public:
+  explicit ExecutionFailureException(
+      const std::string& message,
+      protocol::ExecutionFailureInfo failureInfo)
+      : VeloxException(
+            "",
+            1,
+            "",
+            "",
+            message,
+            velox::error_source::kErrorSourceSystem,
+            velox::error_code::kUnknown,
+            false),
+        failureInfo_(std::move(failureInfo)) {}
+
+  protocol::ExecutionFailureInfo getFailureInfo() const {
+    return failureInfo_;
+  }
+
+ private:
+  protocol::ExecutionFailureInfo failureInfo_;
+};
+
 // Exception translator singleton for converting Velox exceptions to Presto
 // errors. This follows the same pattern as velox/common/base/StatsReporter.h.
 //

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
@@ -178,9 +178,13 @@ void ArrowFlightDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       connectorQueryCtx_->sessionProperties(),
       callOptsAddHeaders);
 
-  AFC_ASSIGN_OR_RAISE(
-      currentReader_,
-      currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket));
+  auto result =
+      currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket);
+  if (!result.ok()) {
+    handleArrowError(result.status());
+    VELOX_FAIL(result.status().message());
+  }
+  currentReader_ = std::move(result).ValueUnsafe();
 }
 
 std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
@@ -188,7 +192,12 @@ std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
     velox::ContinueFuture& /* unused */) {
   VELOX_CHECK_NOT_NULL(currentReader_, "Missing split, call addSplit() first");
 
-  AFC_ASSIGN_OR_RAISE(auto chunk, currentReader_->Next());
+  auto result = currentReader_->Next();
+  if (!result.ok()) {
+    handleArrowError(result.status());
+    VELOX_FAIL(result.status().message());
+  }
+  auto chunk = std::move(result).ValueUnsafe();
 
   // Null values in the chunk indicates that the Flight stream is complete.
   if (!chunk.data) {

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
@@ -19,6 +19,7 @@
 
 namespace arrow {
 class RecordBatch;
+class Status;
 namespace flight {
 class FlightClientOptions;
 class FlightStreamReader;
@@ -107,6 +108,8 @@ class ArrowFlightDataSource : public velox::connector::DataSource {
   void cancel() override;
 
  protected:
+  virtual void handleArrowError(const arrow::Status& status) {}
+
   velox::RowTypePtr outputType_;
 
  private:

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationConnector.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include "presto_cpp/external/json/nlohmann/json.hpp"
 #include "presto_cpp/main/common/ConfigReader.h"
+#include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/connectors/arrow_flight/Macros.h"
 #include "velox/vector/arrow/Bridge.h"
 
@@ -138,6 +139,26 @@ std::optional<velox::RowVectorPtr> ArrowFederationDataSource::next(
     uint64_t size,
     velox::ContinueFuture& future) {
   return ArrowFlightDataSource::next(size, future);
+}
+
+void ArrowFederationDataSource::handleArrowError(const arrow::Status& status) {
+  auto detail = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
+  if (detail != nullptr) {
+    auto extraInfo = detail->extra_info();
+    if (!extraInfo.empty()) {
+      try {
+        protocol::ExecutionFailureInfo failureInfo;
+        auto fi = json::parse(extraInfo);
+        protocol::from_json(fi, failureInfo);
+        throw ExecutionFailureException(status.message(), failureInfo);
+      } catch (std::exception& e) {
+        // Fallback to VeloxException if not valid FailureInfo
+        LOG(WARNING)
+            << "Flight error metadata does not have valid failure info, "
+            << "parsing error: " << e.what();
+      }
+    }
+  }
 }
 
 std::unique_ptr<velox::connector::DataSource>

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationConnector.h
@@ -119,6 +119,9 @@ class ArrowFederationDataSource : public ArrowFlightDataSource {
       uint64_t size,
       velox::ContinueFuture& /* unused */) override;
 
+ protected:
+  void handleArrowError(const arrow::Status& status) override;
+
  private:
   const velox::connector::ColumnHandleMap columnHandles_;
   const std::shared_ptr<const ArrowFederationTableHandle> tableHandle_;


### PR DESCRIPTION
## Description
When the FlightShimServer encounters an error in a data source, that is sent to the flight client in the native worker as a FlightRuntimeException. The native flight client also adds grpc debug context, and all this gets forwarded back to the Presto coordinator.

Example:
```
Query 20260623_182250_00002_jdqyn failed: (r).ok() Flight returned internal error, with message: Error getting connector flight stream
[com.facebook.presto.spi.PrestoException: Connection to localhost:32786 refused. Check that the hostname and
 port are correct and that the postmaster is accepting TCP/IP connections.]. gRPC client debug context:
 UNKNOWN:Error received from peer ipv4:127.0.0.1:9999 {grpc_message:"Error getting connector flight stream
 [com.facebook.presto.spi.PrestoException: Connection to localhost:32786 refused. Check that the hostname and 
port are correct and that the postmaster is accepting TCP/IP connections.]", grpc_status:13, created_time:"2026-06-
23T11:22:51.033375066-07:00", file_line:966, file:"/home/bryan/working/deps-
download/grpc/src/core/lib/surface/call.cc"}. Client context: IOError: Server never sent a data message. Detail: 
Internal Split [[split: connector id postgresql, weight 0, cacheable true]] Task 20260623_182250_00002_jdqyn.1.0.0.0 
Operator: TableScan[0] 0
```

This is a confusing error message for the user and does not retain the original error code.

The changes here will convert the thrown exception to an `ExecutionFailureInfo` that is then serialized and added to the gRPC trailers. When the native client gets the error, it can check the `arrow::Status` for `extra_info`, which will contain the serialized  `ExecutionFailureInfo`. It can then deserialize the `ExecutionFailureInfo` and presto-cpp can relay it back to the coordinator, which will preserve the original exception and error code. 

## Motivation and Context
FlightShimServer errors result in extra information that is confusing to the user, should relay the exact same exception including error codes.

## Impact
NA

## Test Plan
TODO

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix the propagation of structured execution failure information from the Flight shim server through the Arrow Flight federation connector back to the Presto coordinator, retaining original exception type and error code.
```

## Summary by Sourcery

Propagate structured connector failures from the Flight shim through native federation execution to preserve original Presto errors.

Bug Fixes:
- Preserve and propagate structured Flight federation failure information through native execution so coordinators receive the original exception details and error codes instead of confusing transport errors.

Enhancements:
- Standardize missing federation catalog and connector failures as Presto NOT_FOUND errors.
- Add coverage for Flight metadata serialization and end-to-end native error propagation.

Build:
- Add the gRPC API dependency required for Flight error metadata handling.

Tests:
- Add unit and integration tests validating serialized ExecutionFailureInfo and coordinator-visible federation errors.