### PR TITLE
feat(native): Add support to apply GFlags as configs

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -739,3 +739,185 @@ Once decrypted the preloaded library sets the ``AWS_S3_ACCESS_KEY``
 environment variable which then can be accessed by providing it in the catalog properties:
 
 ``hive.s3.aws-access-key=${AWS_S3_ACCESS_KEY}``
+
+GFlag Properties
+----------------
+
+Velox gflags can be set via ``config.properties`` using the ``gflag.`` prefix.
+The property name after the prefix uses hyphens in place of underscores in the
+original flag name. For example, the gflag ``velox_memory_num_shared_leaf_pools``
+is set as ``gflag.velox-memory-num-shared-leaf-pools``.
+
+Command-line flags always take precedence over values set in config.properties.
+
+``gflag.velox-memory-num-shared-leaf-pools``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_memory_num_shared_leaf_pools``
+* **Default value:** ``32``
+
+Number of shared leaf memory pools per process.
+
+``gflag.velox-time-allocations``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_time_allocations``
+* **Default value:** ``false``
+
+Record time and volume for large allocation/free.
+
+``gflag.velox-exception-user-stacktrace-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_exception_user_stacktrace_enabled``
+* **Default value:** ``false``
+
+Enable the stacktrace for user type of VeloxException.
+
+``gflag.velox-exception-system-stacktrace-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_exception_system_stacktrace_enabled``
+* **Default value:** ``true``
+
+Enable the stacktrace for system type of VeloxException.
+
+``gflag.velox-exception-user-stacktrace-rate-limit-ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_exception_user_stacktrace_rate_limit_ms``
+* **Default value:** ``0``
+
+Min time interval in milliseconds between stack traces captured in user type of
+VeloxException. Off when set to 0.
+
+``gflag.velox-exception-system-stacktrace-rate-limit-ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_exception_system_stacktrace_rate_limit_ms``
+* **Default value:** ``0``
+
+Min time interval in milliseconds between stack traces captured in system type of
+VeloxException. Off when set to 0.
+
+``gflag.avx2``
+^^^^^^^^^^^^^^
+
+* **GFlag:** ``avx2``
+* **Default value:** ``true``
+
+Enables use of AVX2 when available.
+
+``gflag.bmi2``
+^^^^^^^^^^^^^^
+
+* **GFlag:** ``bmi2``
+* **Default value:** ``true``
+
+Enables use of BMI2 when available.
+
+``gflag.velox-save-input-on-expression-any-failure-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_save_input_on_expression_any_failure_path``
+* **Default value:** ``""``
+
+Enable saving input vector and expression SQL on any failure during expression
+evaluation. Specifies the directory to use for storing the vectors and expression
+SQL strings.
+
+``gflag.velox-save-input-on-expression-system-failure-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_save_input_on_expression_system_failure_path``
+* **Default value:** ``""``
+
+Enable saving input vector and expression SQL on system failure during expression
+evaluation. Specifies the directory to use for storing the vectors and expression
+SQL strings. This flag is ignored if
+``velox_save_input_on_expression_any_failure_path`` is set.
+
+``gflag.force-eval-simplified``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``force_eval_simplified``
+* **Default value:** ``false``
+
+Whether to overwrite queryCtx and force the use of simplified expression
+evaluation path.
+
+``gflag.velox-experimental-save-input-on-fatal-signal``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_experimental_save_input_on_fatal_signal``
+* **Default value:** ``false``
+
+Experimental. If set to true, serializes the input vector data and all the SQL
+expressions in the ExprSet that is currently executing, whenever a fatal signal
+is encountered.
+
+``gflag.velox-memory-leak-check-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_memory_leak_check_enabled``
+* **Default value:** ``false``
+
+If true, check fails on any memory leaks in memory pool and memory manager.
+
+``gflag.velox-enable-memory-usage-track-in-default-memory-pool``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_enable_memory_usage_track_in_default_memory_pool``
+* **Default value:** ``false``
+
+If true, enable memory usage tracking in the default memory pool.
+
+``gflag.velox-suppress-memory-capacity-exceeding-error-message``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_suppress_memory_capacity_exceeding_error_message``
+* **Default value:** ``false``
+
+If true, suppress the verbose error message in memory capacity exceeded
+exception.
+
+``gflag.velox-memory-use-hugepages``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_memory_use_hugepages``
+* **Default value:** ``true``
+
+Use explicit huge pages.
+
+``gflag.cache-prefetch-min-pct``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``cache_prefetch_min_pct``
+* **Default value:** ``80``
+
+Minimum percentage of actual uses over references to a column for prefetching.
+No prefetch if > 100.
+
+``gflag.velox-ssd-odirect``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_ssd_odirect``
+* **Default value:** ``true``
+
+Use O_DIRECT for SSD cache IO.
+
+``gflag.velox-ssd-verify-write``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_ssd_verify_write``
+* **Default value:** ``false``
+
+Read back data after writing to SSD.
+
+``gflag.velox-tpch-text-pool-size-mb``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **GFlag:** ``velox_tpch_text_pool_size_mb``
+* **Default value:** ``300``
+
+TPC-H DBGen text pool size in MB.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -514,7 +514,7 @@ The configuration properties of AsyncDataCache and SSD cache are described here.
 * **Type:** ``integer``
 * **Default value:** ``16777216``
 
-  Min SSD savable (in-memory) cache space to start writing SSD savable cache entries into SSD cache.
+  Minimum SSD savable (in-memory) cache space to start writing SSD savable cache entries into SSD cache.
 
   The default value ``16777216`` is 16 MB.
 
@@ -743,7 +743,7 @@ environment variable which then can be accessed by providing it in the catalog p
 GFlag Properties
 ----------------
 
-Velox gflags can be set via ``config.properties`` using the ``gflag.`` prefix.
+Velox gflags can be set in ``config.properties`` using the ``gflag.`` prefix.
 The property name after the prefix uses hyphens in place of underscores in the
 original flag name. For example, the gflag ``velox_memory_num_shared_leaf_pools``
 is set as ``gflag.velox-memory-num-shared-leaf-pools``.
@@ -788,7 +788,7 @@ Enable the stacktrace for system type of VeloxException.
 * **GFlag:** ``velox_exception_user_stacktrace_rate_limit_ms``
 * **Default value:** ``0``
 
-Min time interval in milliseconds between stack traces captured in user type of
+Minimum time interval in milliseconds between stack traces captured in user type of
 VeloxException. Off when set to 0.
 
 ``gflag.velox-exception-system-stacktrace-rate-limit-ms``
@@ -797,7 +797,7 @@ VeloxException. Off when set to 0.
 * **GFlag:** ``velox_exception_system_stacktrace_rate_limit_ms``
 * **Default value:** ``0``
 
-Min time interval in milliseconds between stack traces captured in system type of
+Minimum time interval in milliseconds between stack traces captured in system type of
 VeloxException. Off when set to 0.
 
 ``gflag.avx2``

--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -16,6 +16,8 @@
 #include <gflags/gflags_declare.h>
 #include <glog/logging.h>
 #include "presto_cpp/main/PrestoServer.h"
+#include "presto_cpp/main/common/ConfigReader.h"
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/StatsReporter.h"
@@ -25,6 +27,12 @@ DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
 int main(int argc, char* argv[]) {
   facebook::presto::util::installSignalHandler();
   folly::Init init{&argc, &argv};
+
+  // Apply gflag.* properties from config.properties to Velox gflags.
+  // Must be after folly::Init (which parses command-line flags) so that
+  // SET_FLAG_IF_DEFAULT respects command-line overrides.
+  facebook::presto::applyGFlags(
+      facebook::presto::util::readConfig(FLAGS_etc_dir + "/config.properties"));
 
   PRESTO_STARTUP_LOG(INFO) << "Entering main()";
   facebook::presto::PrestoServer presto(FLAGS_etc_dir);

--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -28,14 +28,15 @@ int main(int argc, char* argv[]) {
   facebook::presto::util::installSignalHandler();
   folly::Init init{&argc, &argv};
 
+  PRESTO_STARTUP_LOG(INFO) << "Entering main()";
+  facebook::presto::PrestoServer presto(FLAGS_etc_dir);
+
   // Apply gflag.* properties from config.properties to Velox gflags.
   // Must be after folly::Init (which parses command-line flags) so that
   // SET_FLAG_IF_DEFAULT respects command-line overrides.
   facebook::presto::applyGFlags(
       facebook::presto::util::readConfig(FLAGS_etc_dir + "/config.properties"));
 
-  PRESTO_STARTUP_LOG(INFO) << "Entering main()";
-  facebook::presto::PrestoServer presto(FLAGS_etc_dir);
   presto.run();
   PRESTO_SHUTDOWN_LOG(INFO) << "Exiting main()";
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -390,7 +390,7 @@ void PrestoServer::initializeConfigs() {
     // Velox GFlags inside 'velox/flag_definitions/flags.cpp' can be set via config.
     // Each GFlag name can mapped to the config by replacing the '_' with a '-' and
     // adding a 'gflag.*' prefix.
-    // Example: FLAGS_velox_ssd_odirect -> gflags.velox-ssd-odirect 
+    // Example: FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect
     // Apply gflag.* properties from config.properties to Velox gflags.
     GFlagConfig::applyFlags(
         util::readConfig(fmt::format("{}/config.properties", configDirectoryPath_)));

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -387,14 +387,6 @@ void PrestoServer::initializeConfigs() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
-    // GFlags in 'velox/flag_definitions/flags.cpp' can be set via config.
-    // Each GFlag name can be mapped to a config property by replacing '_' with
-    // '-' and prefixing with "gflag.".
-    // Example: FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect
-    // Apply gflag.* properties from config.properties to gflags.
-    applyGFlags(
-        util::readConfig(
-            fmt::format("{}/config.properties", configDirectoryPath_)));
 
     httpPort_ = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -387,6 +387,13 @@ void PrestoServer::initializeConfigs() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
+    // Velox GFlags inside 'velox/flag_definitions/flags.cpp' can be set via config.
+    // Each GFlag name can mapped to the config by replacing the '_' with a '-' and
+    // adding a 'gflag.*' prefix.
+    // Example: FLAGS_velox_ssd_odirect -> gflags.velox-ssd-odirect 
+    // Apply gflag.* properties from config.properties to Velox gflags.
+    GFlagConfig::applyFlags(
+        util::readConfig(fmt::format("{}/config.properties", configDirectoryPath_)));
 
     httpPort_ = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -387,11 +387,11 @@ void PrestoServer::initializeConfigs() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
-    // Velox GFlags inside 'velox/flag_definitions/flags.cpp' can be set via
-    // config. Each GFlag name can mapped to the config by replacing the '_'
-    // with a '-' and adding a 'gflag.*' prefix. Example:
-    // FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect Apply gflag.*
-    // properties from config.properties to Velox gflags.
+    // GFlags in 'velox/flag_definitions/flags.cpp' can be set via config.
+    // Each GFlag name can be mapped to a config property by replacing '_' with
+    // '-' and prefixing with "gflag.".
+    // Example: FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect
+    // Apply gflag.* properties from config.properties to gflags.
     applyGFlags(
         util::readConfig(
             fmt::format("{}/config.properties", configDirectoryPath_)));

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -387,13 +387,14 @@ void PrestoServer::initializeConfigs() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
-    // Velox GFlags inside 'velox/flag_definitions/flags.cpp' can be set via config.
-    // Each GFlag name can mapped to the config by replacing the '_' with a '-' and
-    // adding a 'gflag.*' prefix.
-    // Example: FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect
-    // Apply gflag.* properties from config.properties to Velox gflags.
-    GFlagConfig::applyFlags(
-        util::readConfig(fmt::format("{}/config.properties", configDirectoryPath_)));
+    // Velox GFlags inside 'velox/flag_definitions/flags.cpp' can be set via
+    // config. Each GFlag name can mapped to the config by replacing the '_'
+    // with a '-' and adding a 'gflag.*' prefix. Example:
+    // FLAGS_velox_ssd_odirect -> gflag.velox-ssd-odirect Apply gflag.*
+    // properties from config.properties to Velox gflags.
+    applyGFlags(
+        util::readConfig(
+            fmt::format("{}/config.properties", configDirectoryPath_)));
 
     httpPort_ = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -19,10 +19,10 @@
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/core/QueryConfig.h"
 
-#include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <algorithm>
 #include <limits>
 #if __has_include("filesystem")
 #include <filesystem>
@@ -1291,8 +1291,8 @@ std::string NodeConfig::nodeInternalAddress(
   }
 }
 
-void GFlagConfig::applyFlags(
-    const std::unordered_map<std::string, std::string>& configs) {
+void applyGFlags(const std::unordered_map<std::string, std::string>& configs) {
+  static constexpr std::string_view kGflagPrefix{"gflag."};
   static constexpr size_t kPrefixLen = kGflagPrefix.size();
   for (const auto& [key, value] : configs) {
     if (key.rfind(kGflagPrefix, 0) != 0) {
@@ -1308,13 +1308,11 @@ void GFlagConfig::applyFlags(
         flagName.c_str(), value.c_str(), gflags::SET_FLAG_IF_DEFAULT);
     if (result.empty()) {
       PRESTO_STARTUP_LOG(WARNING)
-          << "Failed to set gflag '" << flagName
-          << "' from config property '" << key << "' with value '" << value
-          << "'";
+          << "Failed to set gflag '" << flagName << "' from config property '"
+          << key << "' with value '" << value << "'";
     } else {
-      PRESTO_STARTUP_LOG(INFO)
-          << "Set gflag '" << flagName << "' = '" << value
-          << "' from config.properties";
+      PRESTO_STARTUP_LOG(INFO) << "Set gflag '" << flagName << "' = '" << value
+                               << "' from config.properties";
     }
   }
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -14,10 +14,12 @@
 
 #include "presto_cpp/main/common/Configs.h"
 #include <folly/system/HardwareConcurrency.h>
+#include <gflags/gflags.h>
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/core/QueryConfig.h"
 
+#include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -1286,6 +1288,34 @@ std::string NodeConfig::nodeInternalAddress(
     VELOX_FAIL(
         "Node Internal Address or IP was not found in NodeConfigs. Default IP was not provided "
         "either.");
+  }
+}
+
+void GFlagConfig::applyFlags(
+    const std::unordered_map<std::string, std::string>& configs) {
+  static constexpr size_t kPrefixLen = kGflagPrefix.size();
+  for (const auto& [key, value] : configs) {
+    if (key.substr(0, kPrefixLen) != kGflagPrefix) {
+      continue;
+    }
+    // Strip "gflag." prefix and convert hyphens to underscores to get the
+    // flag name. e.g., "gflag.velox-memory-num-shared-leaf-pools" becomes
+    // "velox_memory_num_shared_leaf_pools".
+    auto flagName = key.substr(kPrefixLen);
+    std::replace(flagName.begin(), flagName.end(), '-', '_');
+
+    auto result = gflags::SetCommandLineOptionWithMode(
+        flagName.c_str(), value.c_str(), gflags::SET_FLAG_IF_DEFAULT);
+    if (result.empty()) {
+      PRESTO_STARTUP_LOG(WARNING)
+          << "Failed to set gflag '" << flagName
+          << "' from config property '" << key << "' with value '" << value
+          << "'";
+    } else {
+      PRESTO_STARTUP_LOG(INFO)
+          << "Set gflag '" << flagName << "' = '" << value
+          << "' from config.properties";
+    }
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -1295,7 +1295,7 @@ void GFlagConfig::applyFlags(
     const std::unordered_map<std::string, std::string>& configs) {
   static constexpr size_t kPrefixLen = kGflagPrefix.size();
   for (const auto& [key, value] : configs) {
-    if (key.substr(0, kPrefixLen) != kGflagPrefix) {
+    if (key.rfind(kGflagPrefix, 0) != 0) {
       continue;
     }
     // Strip "gflag." prefix and convert hyphens to underscores to get the

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -1307,12 +1307,11 @@ void applyGFlags(const std::unordered_map<std::string, std::string>& configs) {
     auto result = gflags::SetCommandLineOptionWithMode(
         flagName.c_str(), value.c_str(), gflags::SET_FLAG_IF_DEFAULT);
     if (result.empty()) {
-      PRESTO_STARTUP_LOG(WARNING)
-          << "Failed to set gflag '" << flagName << "' from config property '"
-          << key << "' with value '" << value << "'";
+      PRESTO_STARTUP_LOG(WARNING) << "Failed to set gflag '" << flagName
+                                  << "' from config property '" << key << "'";
     } else {
-      PRESTO_STARTUP_LOG(INFO) << "Set gflag '" << flagName << "' = '" << value
-                               << "' from config.properties";
+      PRESTO_STARTUP_LOG(INFO)
+          << "Set gflag '" << flagName << "' from config.properties";
     }
   }
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1394,4 +1394,16 @@ class NodeConfig : public ConfigBase {
   std::string nodeLocation() const;
 };
 
+/// Applies gflag.* properties from a config file to Velox gflags.
+/// Strips the "gflag." prefix and converts hyphens to underscores to derive
+/// the flag name. Uses SET_FLAG_IF_DEFAULT so command-line flags take
+/// precedence.
+class GFlagConfig {
+ public:
+  static constexpr std::string_view kGflagPrefix{"gflag."};
+
+  static void applyFlags(
+      const std::unordered_map<std::string, std::string>& configs);
+};
+
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1394,7 +1394,7 @@ class NodeConfig : public ConfigBase {
   std::string nodeLocation() const;
 };
 
-/// Applies gflag.* properties from a config map to Velox gflags.
+/// Applies gflag.* properties from a config map to gflags.
 /// Strips the "gflag." prefix and converts hyphens to underscores to derive
 /// the flag name. Uses SET_FLAG_IF_DEFAULT so command-line flags take
 /// precedence.

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1394,16 +1394,10 @@ class NodeConfig : public ConfigBase {
   std::string nodeLocation() const;
 };
 
-/// Applies gflag.* properties from a config file to Velox gflags.
+/// Applies gflag.* properties from a config map to Velox gflags.
 /// Strips the "gflag." prefix and converts hyphens to underscores to derive
 /// the flag name. Uses SET_FLAG_IF_DEFAULT so command-line flags take
 /// precedence.
-class GFlagConfig {
- public:
-  static constexpr std::string_view kGflagPrefix{"gflag."};
-
-  static void applyFlags(
-      const std::unordered_map<std::string, std::string>& configs);
-};
+void applyGFlags(const std::unordered_map<std::string, std::string>& configs);
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -418,14 +418,43 @@ TEST_F(ConfigTest, prestoDefaultNamespacePrefix) {
   ASSERT_TRUE(validateDefaultNamespacePrefix(
       windowFunctions, prestoBuiltinFunctionPrefix));
 }
+} // namespace facebook::presto::test
+
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_ssd_odirect);
 DECLARE_bool(avx2);
 
-TEST_F(ConfigTest, applyGFlags) {
-  auto origPools = FLAGS_velox_memory_num_shared_leaf_pools;
-  auto origSsd = FLAGS_velox_ssd_odirect;
+namespace facebook::presto::test {
 
+class GFlagConfigTest : public ConfigTest {
+ protected:
+  void SetUp() override {
+    ConfigTest::SetUp();
+    saveFlagState("velox_memory_num_shared_leaf_pools");
+    saveFlagState("velox_ssd_odirect");
+    saveFlagState("avx2");
+  }
+
+  void TearDown() override {
+    for (const auto& [name, value] : savedFlags_) {
+      gflags::SetCommandLineOptionWithMode(
+          name.c_str(), value.c_str(), gflags::SET_FLAGS_DEFAULT);
+    }
+    ConfigTest::TearDown();
+  }
+
+ private:
+  void saveFlagState(const char* name) {
+    gflags::CommandLineFlagInfo info;
+    if (gflags::GetCommandLineFlagInfo(name, &info)) {
+      savedFlags_.emplace_back(name, info.current_value);
+    }
+  }
+
+  std::vector<std::pair<std::string, std::string>> savedFlags_;
+};
+
+TEST_F(GFlagConfigTest, applyGFlags) {
   applyGFlags({
       {"gflag.velox-memory-num-shared-leaf-pools", "64"},
       {"gflag.velox-ssd-odirect", "false"},
@@ -434,12 +463,9 @@ TEST_F(ConfigTest, applyGFlags) {
 
   EXPECT_EQ(FLAGS_velox_memory_num_shared_leaf_pools, 64);
   EXPECT_FALSE(FLAGS_velox_ssd_odirect);
-
-  FLAGS_velox_memory_num_shared_leaf_pools = origPools;
-  FLAGS_velox_ssd_odirect = origSsd;
 }
 
-TEST_F(ConfigTest, applyGFlagsIgnoresNonGflagKeys) {
+TEST_F(GFlagConfigTest, applyGFlagsIgnoresNonGflagKeys) {
   auto origPools = FLAGS_velox_memory_num_shared_leaf_pools;
 
   applyGFlags({{"velox-memory-num-shared-leaf-pools", "99"}});
@@ -447,9 +473,7 @@ TEST_F(ConfigTest, applyGFlagsIgnoresNonGflagKeys) {
   EXPECT_EQ(FLAGS_velox_memory_num_shared_leaf_pools, origPools);
 }
 
-TEST_F(ConfigTest, applyGFlagsCommandLineTakesPrecedence) {
-  auto origAvx2 = FLAGS_avx2;
-
+TEST_F(GFlagConfigTest, applyGFlagsCommandLineTakesPrecedence) {
   gflags::SetCommandLineOptionWithMode(
       "avx2", "false", gflags::SET_FLAGS_VALUE);
 
@@ -457,8 +481,6 @@ TEST_F(ConfigTest, applyGFlagsCommandLineTakesPrecedence) {
 
   // SET_FLAG_IF_DEFAULT won't override a non-default flag.
   EXPECT_FALSE(FLAGS_avx2);
-
-  FLAGS_avx2 = origAvx2;
 }
 
 } // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -16,6 +16,7 @@
 #include <unordered_set>
 
 #include <folly/system/HardwareConcurrency.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include "presto_cpp/main/common/ConfigReader.h"
@@ -417,4 +418,47 @@ TEST_F(ConfigTest, prestoDefaultNamespacePrefix) {
   ASSERT_TRUE(validateDefaultNamespacePrefix(
       windowFunctions, prestoBuiltinFunctionPrefix));
 }
+DECLARE_int32(velox_memory_num_shared_leaf_pools);
+DECLARE_bool(velox_ssd_odirect);
+DECLARE_bool(avx2);
+
+TEST_F(ConfigTest, applyGFlags) {
+  auto origPools = FLAGS_velox_memory_num_shared_leaf_pools;
+  auto origSsd = FLAGS_velox_ssd_odirect;
+
+  applyGFlags({
+      {"gflag.velox-memory-num-shared-leaf-pools", "64"},
+      {"gflag.velox-ssd-odirect", "false"},
+      {"unrelated.property", "ignored"},
+  });
+
+  EXPECT_EQ(FLAGS_velox_memory_num_shared_leaf_pools, 64);
+  EXPECT_FALSE(FLAGS_velox_ssd_odirect);
+
+  FLAGS_velox_memory_num_shared_leaf_pools = origPools;
+  FLAGS_velox_ssd_odirect = origSsd;
+}
+
+TEST_F(ConfigTest, applyGFlagsIgnoresNonGflagKeys) {
+  auto origPools = FLAGS_velox_memory_num_shared_leaf_pools;
+
+  applyGFlags({{"velox-memory-num-shared-leaf-pools", "99"}});
+
+  EXPECT_EQ(FLAGS_velox_memory_num_shared_leaf_pools, origPools);
+}
+
+TEST_F(ConfigTest, applyGFlagsCommandLineTakesPrecedence) {
+  auto origAvx2 = FLAGS_avx2;
+
+  gflags::SetCommandLineOptionWithMode(
+      "avx2", "false", gflags::SET_FLAGS_VALUE);
+
+  applyGFlags({{"gflag.avx2", "true"}});
+
+  // SET_FLAG_IF_DEFAULT won't override a non-default flag.
+  EXPECT_FALSE(FLAGS_avx2);
+
+  FLAGS_avx2 = origAvx2;
+}
+
 } // namespace facebook::presto::test


### PR DESCRIPTION
Velox GFlags inside 'velox/flag_definitions/flags.cpp' and Presto C++ GFlags, if any, can now be set via config.
Each GFlag name can mapped to the config by replacing the '_' with a '-' and adding a 'gflag.*' prefix.
Example: FLAGS_velox_ssd_odirect can be set via gflags.velox-ssd-odirect

Command-line flags always take precedence over values set in config.properties.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
 * Add support for setting gflags via ``config.properties`` using the ``gflag.`` prefix. Property names use hyphens in place of underscores (e.g.,
  ``gflag.velox-memory-num-shared-leaf-pools=64``). Command-line flags take precedence over config values. See :doc:`/presto_cpp/properties` for the
  full list of supported gflag properties.

```