### PR TITLE
feat(plugin-iceberg): Enable case-sensitive support for Iceberg Native(Rest, Hadoop, Nessie) catalogs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -448,6 +448,10 @@ Property Name                                           Description             
                                                         ``256MB``, ``1GB``). Supported units are: ``B`` (bytes),
                                                         ``kB`` (kilobytes), ``MB`` (megabytes), ``GB`` (gigabytes),
                                                         ``TB`` (terabytes), ``PB`` (petabytes).
+
+``case-sensitive-name-matching``                        Enable case-sensitive identifier matching for the connector.  ``false``                          Yes
+                                                        ``case-sensitive-name-matching=true`` is not supported for
+                                                        ``iceberg.catalog.type=HIVE``.
 ======================================================= ============================================================= ================================== =================== =============================================
 
 Table Properties

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -21,6 +21,9 @@ import com.facebook.presto.hive.HiveCompressionCodec;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.inject.ConfigurationException;
+import com.google.inject.spi.Message;
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -85,6 +88,7 @@ public class IcebergConfig
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
     private boolean aggregatePushDownEnabled = true;
     private DataSize targetMaxFileSize = succinctDataSize(1, GIGABYTE);
+    private boolean caseSensitiveNameMatching;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -593,5 +597,27 @@ public class IcebergConfig
         }
         this.targetMaxFileSize = targetMaxFileSize;
         return this;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription("Enable case-sensitive identifier matching for the connector. Default: false (identifiers are lower-cased)")
+    public IcebergConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatching)
+    {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
+        return this;
+    }
+
+    @PostConstruct
+    public void validateConfig()
+    {
+        if (caseSensitiveNameMatching && catalogType == HIVE) {
+            throw new ConfigurationException(ImmutableList.of(new Message(
+                    "'case-sensitive-name-matching=true' is not supported for iceberg.catalog.type=HIVE")));
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -94,6 +94,7 @@ import static com.google.common.base.Throwables.getRootCause;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -108,6 +109,7 @@ public class IcebergNativeMetadata
     private final Optional<String> warehouseDataDir;
     private final IcebergNativeCatalogFactory catalogFactory;
     private final CatalogType catalogType;
+    private final boolean caseSensitiveIdentifierMatching;
     private final ConcurrentMap<SchemaTableName, View> icebergViews = new ConcurrentHashMap<>();
 
     public IcebergNativeMetadata(
@@ -125,13 +127,15 @@ public class IcebergNativeMetadata
             StatisticsFileCache statisticsFileCache,
             IcebergTableProperties tableProperties,
             IsolationLevel isolationLevel,
-            boolean autoCommitContext)
+            boolean autoCommitContext,
+            boolean caseSensitiveNameMatching)
     {
         super(typeManager, procedureRegistry, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec,
                 nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
         this.warehouseDataDir = Optional.ofNullable(catalogFactory.getCatalogWarehouseDataDir());
+        this.caseSensitiveIdentifierMatching = caseSensitiveNameMatching;
     }
 
     @Override
@@ -428,7 +432,7 @@ public class IcebergNativeMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()), id -> normalizeIdentifier(session, id));
         FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
 
         try {
@@ -456,7 +460,7 @@ public class IcebergNativeMetadata
 
         Table icebergTable = getIcebergTable(session, schemaTableName);
         ReplaceSortOrder replaceSortOrder = icebergTable.replaceSortOrder();
-        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()), id -> normalizeIdentifier(session, id));
         List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);
         for (SortField sortField : sortFields) {
             if (sortField.getSortOrder().isAscending()) {
@@ -599,5 +603,11 @@ public class IcebergNativeMetadata
         viewBuilder.createOrReplace();
 
         icebergViews.remove(viewName);
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveIdentifierMatching ? identifier : identifier.toLowerCase(ENGLISH);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -48,6 +48,7 @@ public class IcebergNativeMetadataFactory
     final FilterStatsCalculatorService filterStatsCalculatorService;
     final StatisticsFileCache statisticsFileCache;
     final IcebergTableProperties tableProperties;
+    final boolean caseSensitiveNameMatching;
 
     @Inject
     public IcebergNativeMetadataFactory(
@@ -78,6 +79,7 @@ public class IcebergNativeMetadataFactory
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.caseSensitiveNameMatching = config.isCaseSensitiveNameMatching();
     }
 
     public IcebergTransactionMetadata create()
@@ -89,6 +91,7 @@ public class IcebergNativeMetadataFactory
     {
         return new IcebergNativeMetadata(catalogFactory, typeManager, procedureRegistry, functionResolution,
                 rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, catalogType, nodeVersion,
-                filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
+                filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext,
+                caseSensitiveNameMatching);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -26,7 +26,6 @@ import jakarta.inject.Inject;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +39,6 @@ import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -137,9 +135,7 @@ public class IcebergTableProperties
                         List.class,
                         ImmutableList.of(),
                         false,
-                        value -> ((Collection<?>) value).stream()
-                                .map(name -> ((String) name).toLowerCase(ENGLISH))
-                                .collect(toImmutableList()),
+                        value -> (List<?>) value,
                         value -> value))
                 .add(stringProperty(
                         LOCATION_PROPERTY,
@@ -259,9 +255,7 @@ public class IcebergTableProperties
                         List.class,
                         ImmutableList.of(),
                         false,
-                        value -> ((Collection<?>) value).stream()
-                                .map(name -> ((String) name).toLowerCase(ENGLISH))
-                                .collect(toImmutableList()),
+                        value -> (List<?>) value,
                         value -> value)
                         .withAdditionalTypeHandler(VARCHAR, ImmutableList::of));
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,23 +43,26 @@ import static org.apache.iceberg.expressions.Expressions.year;
 
 public final class PartitionFields
 {
-    private static final String NAME = "[a-z_][a-z0-9_]*";
-    private static final String FUNCTION_NAME = "\\((" + NAME + ")\\)";
-    private static final String FUNCTION_NAME_INT = "\\((" + NAME + "), *(\\d+)\\)";
-
+    // Column identifier: unquoted (any case) or double-quoted (e.g. "MyCol")
     private static final String UNQUOTED_IDENTIFIER = "[a-zA-Z_][a-zA-Z0-9_]*";
     private static final String QUOTED_IDENTIFIER = "\"(?:\"\"|[^\"])*\"";
+    // IDENTIFIER is a single capture group matching either form; used by both partition and sort parsing
     public static final String IDENTIFIER = "(" + UNQUOTED_IDENTIFIER + "|" + QUOTED_IDENTIFIER + ")";
     private static final Pattern UNQUOTED_IDENTIFIER_PATTERN = Pattern.compile(UNQUOTED_IDENTIFIER);
     private static final Pattern QUOTED_IDENTIFIER_PATTERN = Pattern.compile(QUOTED_IDENTIFIER);
 
-    private static final Pattern IDENTITY_PATTERN = Pattern.compile(NAME);
-    private static final Pattern YEAR_PATTERN = Pattern.compile("year" + FUNCTION_NAME);
-    private static final Pattern MONTH_PATTERN = Pattern.compile("month" + FUNCTION_NAME);
-    private static final Pattern DAY_PATTERN = Pattern.compile("day" + FUNCTION_NAME);
-    private static final Pattern HOUR_PATTERN = Pattern.compile("hour" + FUNCTION_NAME);
-    private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_NAME_INT);
-    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_NAME_INT);
+    // Transform function patterns: case-insensitive keyword + IDENTIFIER column argument
+    private static final String FUNCTION_NAME = "\\(" + IDENTIFIER + "\\)";
+    private static final String FUNCTION_NAME_INT = "\\(" + IDENTIFIER + ", *(\\d+)\\)";
+
+    // Identity: bare or double-quoted column name; transforms: case-insensitive keyword + column
+    private static final Pattern IDENTITY_PATTERN = Pattern.compile(IDENTIFIER);
+    private static final Pattern YEAR_PATTERN = Pattern.compile("(?i:year)" + FUNCTION_NAME);
+    private static final Pattern MONTH_PATTERN = Pattern.compile("(?i:month)" + FUNCTION_NAME);
+    private static final Pattern DAY_PATTERN = Pattern.compile("(?i:day)" + FUNCTION_NAME);
+    private static final Pattern HOUR_PATTERN = Pattern.compile("(?i:hour)" + FUNCTION_NAME);
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("(?i:bucket)" + FUNCTION_NAME_INT);
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("(?i:truncate)" + FUNCTION_NAME_INT);
 
     private static final Pattern COLUMN_BUCKET_PATTERN = Pattern.compile("bucket\\((\\d+)\\)");
     private static final Pattern COLUMN_TRUNCATE_PATTERN = Pattern.compile("truncate\\((\\d+)\\)");
@@ -69,17 +73,27 @@ public final class PartitionFields
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields)
     {
-        return parsePartitionFields(schema, fields, null);
+        return parsePartitionFields(schema, fields, null, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
+        return parsePartitionFields(schema, fields, null, identifierNormalizer);
     }
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, @Nullable Integer specId)
+    {
+        return parsePartitionFields(schema, fields, specId, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, @Nullable Integer specId, UnaryOperator<String> identifierNormalizer)
     {
         PartitionSpec.Builder builder = Optional.ofNullable(specId)
                 .map(id -> PartitionSpec.builderFor(schema).withSpecId(id))
                 .orElseGet(() -> PartitionSpec.builderFor(schema));
 
         for (String field : fields) {
-            buildPartitionField(builder, field);
+            buildPartitionField(builder, field, identifierNormalizer);
         }
         return builder.build();
     }
@@ -99,15 +113,23 @@ public final class PartitionFields
     @VisibleForTesting
     static void buildPartitionField(PartitionSpec.Builder builder, String field)
     {
+        buildPartitionField(builder, field, s -> s.toLowerCase(ENGLISH));
+    }
+
+    @VisibleForTesting
+    static void buildPartitionField(PartitionSpec.Builder builder, String field, UnaryOperator<String> identifierNormalizer)
+    {
+        // group(1) is the column token which may be a double-quoted identifier like "MyCol";
+        // fromIdentifierToColumn strips the quotes and applies identifierNormalizer to the bare name.
         @SuppressWarnings("PointlessBooleanExpression")
         boolean matched = false ||
-                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(match.group())) ||
-                tryMatch(field, YEAR_PATTERN, match -> builder.year(match.group(1))) ||
-                tryMatch(field, MONTH_PATTERN, match -> builder.month(match.group(1))) ||
-                tryMatch(field, DAY_PATTERN, match -> builder.day(match.group(1))) ||
-                tryMatch(field, HOUR_PATTERN, match -> builder.hour(match.group(1))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2))));
+                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifierToColumn(match.group(1), identifierNormalizer), parseInt(match.group(2)))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifierToColumn(match.group(1), identifierNormalizer), parseInt(match.group(2))));
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }
@@ -287,9 +309,14 @@ public final class PartitionFields
 
     public static String fromIdentifierToColumn(String identifier)
     {
+        return fromIdentifierToColumn(identifier, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static String fromIdentifierToColumn(String identifier, UnaryOperator<String> identifierNormalizer)
+    {
         if (QUOTED_IDENTIFIER_PATTERN.matcher(identifier).matches()) {
-            return identifier.substring(1, identifier.length() - 1).replace("\"\"", "\"").toLowerCase(ENGLISH);
+            return identifierNormalizer.apply(identifier.substring(1, identifier.length() - 1).replace("\"\"", "\""));
         }
-        return identifier.toLowerCase(ENGLISH);
+        return identifierNormalizer.apply(identifier);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortFieldUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortFieldUtils.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.types.Types;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,8 +51,13 @@ public class SortFieldUtils
 
     public static SortOrder parseSortFields(Schema schema, List<String> fields)
     {
+        return parseSortFields(schema, fields, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    public static SortOrder parseSortFields(Schema schema, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
         SortOrder.Builder builder = SortOrder.builderFor(schema);
-        parseSortFields(builder, fields);
+        parseSortFields(builder, fields, identifierNormalizer);
         SortOrder sortOrder;
         try {
             sortOrder = builder.build();
@@ -74,17 +80,22 @@ public class SortFieldUtils
 
     public static void parseSortFields(SortOrderBuilder<?> sortOrderBuilder, List<String> fields)
     {
-        fields.forEach(field -> parseSortField(sortOrderBuilder, field));
+        parseSortFields(sortOrderBuilder, fields, s -> s.toLowerCase(Locale.ENGLISH));
     }
 
-    private static void parseSortField(SortOrderBuilder<?> builder, String field)
+    public static void parseSortFields(SortOrderBuilder<?> sortOrderBuilder, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
+        fields.forEach(field -> parseSortField(sortOrderBuilder, field, identifierNormalizer));
+    }
+
+    private static void parseSortField(SortOrderBuilder<?> builder, String field, UnaryOperator<String> identifierNormalizer)
     {
         Matcher matcher = PATTERN.matcher(field);
         if (!matcher.matches()) {
             throw new IllegalArgumentException(format("Unable to parse sort field: [%s]", field));
         }
 
-        String columnName = fromIdentifierToColumn(matcher.group("identifier"));
+        String columnName = fromIdentifierToColumn(matcher.group("identifier"), identifierNormalizer);
         boolean ascending;
         String ordering = firstNonNull(matcher.group("ordering"), "ASC").toUpperCase(Locale.ENGLISH);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -180,7 +180,8 @@ public class RewriteDataFilesProcedure
                             "Use either zorder function alone or regular column names, but not both.");
                 }
 
-                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields);
+                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields,
+                        id -> procedureContext.getMetadata().normalizeIdentifier(session, id));
                 if (specifiedSortOrder.satisfies(sortOrder)) {
                     // If the specified sort order satisfies the target table's internal sort order, use the specified sort order
                     sortOrder = specifiedSortOrder;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.ConfigurationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergConfig
 {
@@ -82,7 +84,8 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(100)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0)
                 .setAggregatePushDownEnabled(true)
-                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE)));
+                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE))
+                .setCaseSensitiveNameMatching(false));
     }
 
     @Test
@@ -125,6 +128,7 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-view-default-max-snapshots-per-refresh", "10")
                 .put("iceberg.aggregate-push-down-enabled", "false")
                 .put("iceberg.target-max-file-size", "512MB")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -163,8 +167,23 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(2000)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10)
                 .setAggregatePushDownEnabled(false)
-                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE));
+                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE))
+                .setCaseSensitiveNameMatching(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testCaseSensitiveNameMatchingNotSupportedForHiveCatalog()
+    {
+        // case-sensitive-name-matching=true must throw for HIVE catalog type.
+        assertThatThrownBy(() ->
+                new IcebergConfig()
+                        .setCatalogType(HIVE)
+                        .setCaseSensitiveNameMatching(true)
+                        .validateConfig())
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("case-sensitive-name-matching=true")
+                .hasMessageContaining("iceberg.catalog.type=HIVE");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.Session;
+import com.facebook.presto.hive.NodeVersion;
+import com.facebook.presto.hive.azure.HiveAzureConfig;
+import com.facebook.presto.hive.azure.HiveAzureConfigurationInitializer;
+import com.facebook.presto.hive.gcs.HiveGcsConfig;
+import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Table;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.SESSION;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class IcebergRestNameMatchingTestBase
+        extends AbstractTestQueryFramework
+{
+    protected static final String SCHEMA = "tpch";
+
+    protected TestingHttpServer restServer;
+    protected String serverUri;
+    protected File warehouseLocation;
+
+    @BeforeClass
+    public void init()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+        serverUri = restServer.getBaseUrl().toString();
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (restServer != null) {
+            restServer.stop();
+        }
+        if (warehouseLocation != null) {
+            deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    protected Session testSession()
+    {
+        return testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+    }
+
+    /**
+     * Builds the {@link IcebergNativeCatalogFactory} for direct Iceberg metadata access.
+     * Subclasses set {@code setCaseSensitiveNameMatching} as appropriate.
+     */
+    protected abstract IcebergNativeCatalogFactory getCatalogFactory();
+
+    /**
+     * Returns the raw Iceberg {@link Table} from the REST catalog, bypassing Presto's
+     * serialisation layer — allows direct inspection of PartitionSpec, Schema, etc.
+     */
+    protected Table getIcebergTable(String schema, String tableName)
+    {
+        return getNativeIcebergTable(getCatalogFactory(), SESSION, SchemaTableName.valueOf(schema + "." + tableName));
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        assertQuerySucceeds(testSession(), "SHOW SCHEMAS");
+        assertQuery(testSession(), "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'tpch'", "VALUES 'tpch'");
+    }
+
+    /**
+     * Double-quotes allow special characters (hyphens, spaces) and reserved keywords in identifiers.
+     * These names are stored as-is in case-sensitive mode and lowercased in case-insensitive mode.
+     * Since the names used here are already lowercase, the result is identical in both modes.
+     */
+    @Test
+    public void testSpecialCharacterIdentifiersViaDoubleQuotes()
+    {
+        // Columns with hyphen, space, and reserved keyword — all require double-quotes.
+        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharcols (\"first-name\" varchar, \"last name\" varchar, \"order\" bigint)");
+        assertQuerySucceeds(testSession(), "INSERT INTO specialcharcols VALUES ('Alice', 'Smith', 1)");
+        assertQuery(testSession(), "SELECT \"first-name\", \"last name\", \"order\" FROM specialcharcols", "VALUES ('Alice', 'Smith', 1)");
+
+        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM specialcharcols").toString();
+        assertTrue(result.contains("first-name"), "Expected 'first-name' in SHOW COLUMNS output");
+        assertTrue(result.contains("last name"), "Expected 'last name' in SHOW COLUMNS output");
+        assertTrue(result.contains("order"), "Expected 'order' in SHOW COLUMNS output");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE specialcharcols");
+
+        // Partition column with hyphen — must embed double-quotes in the raw array string.
+        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharpart (\"region-id\" bigint, name varchar) WITH (partitioning = ARRAY['\"region-id\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO specialcharpart VALUES (10, 'north'), (20, 'south')");
+        assertQuery(testSession(), "SELECT \"region-id\", name FROM specialcharpart ORDER BY \"region-id\"", "VALUES (10, 'north'), (20, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE specialcharpart");
+
+        // Reserved keyword 'year' as a partition column — quoting required in the array string
+        // so the parser doesn't confuse it with the year() transform function.
+        assertQuerySucceeds(testSession(), "CREATE TABLE keywordpart (\"year\" bigint, name varchar) WITH (partitioning = ARRAY['\"year\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO keywordpart VALUES (2024, 'a'), (2025, 'b')");
+        assertQuery(testSession(), "SELECT \"year\", name FROM keywordpart ORDER BY \"year\"", "VALUES (2024, 'a'), (2025, 'b')");
+        assertQuerySucceeds(testSession(), "DROP TABLE keywordpart");
+    }
+
+    /**
+     * Partition transform keywords (year, month, bucket, truncate …) are accepted in any case
+     * because PartitionFields uses {@code (?i:year)} patterns. The Iceberg library always stores
+     * transforms in lowercase ({@code field.transform().toString()} is hardcoded in the Iceberg
+     * spec), so SHOW CREATE TABLE and the raw metadata both show lowercase regardless of input.
+     */
+    @Test
+    public void testPartitionTransformKeywordCaseInsensitive()
+    {
+        // Uppercase transform keywords accepted
+        assertQuerySucceeds(testSession(), "CREATE TABLE transformcase (ts timestamp, id bigint, val varchar) WITH (partitioning = ARRAY['YEAR(ts)', 'BUCKET(id, 4)'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO transformcase VALUES (TIMESTAMP '2024-03-15 10:00:00', 1, 'a')");
+        assertQuerySucceeds(testSession(), "SELECT val FROM transformcase");
+
+        // 1. SHOW CREATE TABLE serialises transforms in lowercase
+        String showCreate = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcase").toString();
+        assertTrue(showCreate.contains("year(ts)"), "Expected lowercase 'year(ts)' in SHOW CREATE TABLE output, got: " + showCreate);
+        assertTrue(showCreate.contains("bucket(id, 4)"), "Expected lowercase 'bucket(id, 4)' in SHOW CREATE TABLE output, got: " + showCreate);
+
+        // 2. Raw Iceberg catalog metadata also stores transforms in lowercase
+        List<PartitionField> fields = getIcebergTable(SCHEMA, "transformcase").spec().fields();
+        assertEquals(fields.size(), 2);
+        assertEquals(fields.get(0).transform().toString(), "year", "Iceberg must store transform as lowercase 'year'");
+        assertEquals(fields.get(1).transform().toString(), "bucket[4]", "Iceberg must store transform as lowercase 'bucket[4]'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE transformcase");
+
+        // Mixed-case transform keywords accepted
+        assertQuerySucceeds(testSession(), "CREATE TABLE transformcasemixed (ts timestamp, val varchar) WITH (partitioning = ARRAY['Month(ts)', 'Truncate(val, 8)'])");
+
+        String showCreate2 = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcasemixed").toString();
+        assertTrue(showCreate2.contains("month(ts)"), "Expected lowercase 'month(ts)' in SHOW CREATE TABLE output, got: " + showCreate2);
+        assertTrue(showCreate2.contains("truncate(val, 8)"), "Expected lowercase 'truncate(val, 8)' in SHOW CREATE TABLE output, got: " + showCreate2);
+
+        List<PartitionField> fields2 = getIcebergTable(SCHEMA, "transformcasemixed").spec().fields();
+        assertEquals(fields2.size(), 2);
+        assertEquals(fields2.get(0).transform().toString(), "month", "Iceberg must store transform as lowercase 'month'");
+        assertEquals(fields2.get(1).transform().toString(), "truncate[8]", "Iceberg must store transform as lowercase 'truncate[8]'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE transformcasemixed");
+    }
+
+    protected IcebergNativeCatalogFactory buildCatalogFactory(IcebergConfig icebergConfig)
+    {
+        return new IcebergRestCatalogFactory(
+                icebergConfig,
+                new IcebergRestConfig().setServerUri(serverUri),
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                new PrestoS3ConfigurationUpdater(new HiveS3Config()),
+                new HiveGcsConfigurationInitializer(new HiveGcsConfig()),
+                new HiveAzureConfigurationInitializer(new HiveAzureConfig()),
+                new NodeVersion("test_version"));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.FileFormat.ORC;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies the default (case-insensitive) behaviour of the Iceberg REST connector, i.e.
+ * {@code case-sensitive-name-matching} is NOT set (defaults to {@code false}).
+ *
+ * <p>In this mode {@code normalizeIdentifier} lowercases every identifier it receives, so:
+ * <ul>
+ *   <li>Mixed-case table/column names are stored and retrieved in lowercase.</li>
+ *   <li>Double-quoted identifiers with mixed case are also lowercased — quoting only helps
+ *       with special characters or reserved keywords, not with preserving case.</li>
+ * </ul>
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseInsensitiveNameMatching
+        extends IcebergRestNameMatchingTestBase
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        // No case-sensitive-name-matching property — defaults to false (case-insensitive).
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setFormat(ORC)
+                .setExtraConnectorProperties(ImmutableMap.copyOf(restConnectorProperties(serverUri)))
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    @Override
+    protected IcebergNativeCatalogFactory getCatalogFactory()
+    {
+        IcebergConfig icebergConfig = new IcebergConfig()
+                .setCatalogType(REST)
+                .setCatalogWarehouse(warehouseLocation.getAbsolutePath());
+        return buildCatalogFactory(icebergConfig);
+    }
+
+    @Test
+    public void testCreateTableMixedCase()
+    {
+        // normalizeIdentifier lowercases 'MixedCaseTable' → 'mixedcasetable'.
+        // All case variants resolve to the same stored name.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+
+            assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM MIXEDCASETABLE");
+
+            // Creating with a different case input refers to the same table — already exists.
+            assertQueryFails(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)", ".*Table.*already exists.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MixedCaseTable");
+        }
+    }
+
+    @Test
+    public void testCreateTableAsMixedCase()
+    {
+        // 'MyTable' is normalised to 'mytable'; all case variants resolve to the same table.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+
+            assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+            assertQuery(testSession(), "SELECT id, name FROM mytable", "VALUES (1, 'hello')");
+            assertQuery(testSession(), "SELECT id, name FROM MYTABLE", "VALUES (1, 'hello')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MyTable");
+        }
+    }
+
+    @Test
+    public void testMixedCaseColumns()
+    {
+        // normalizeIdentifier lowercases every column name regardless of quoting.
+
+        // Quoted: 'FirstName' → 'firstname'. Any case variant retrieves the same column.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT firstname, lastname FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestquoted");
+        }
+
+        // Unquoted: 'FirstName' → 'firstname'.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+            assertQuery(testSession(), "SELECT firstname, lastname FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestunquoted");
+        }
+    }
+
+    @Test
+    public void testMixedCasePartitionColumn()
+    {
+        // normalizeIdentifier lowercases the resolved column name; column definition and
+        // partition array reference both resolve to the same lowercase name.
+
+        // Quoted in array: '"RegionId"' → 'RegionId' → 'regionid'. Column also → 'regionid'. ✓
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT regionid, name FROM partTestQuoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestQuoted");
+        }
+
+        // Unquoted in array: 'RegionId' → 'regionid'. ✓
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT regionid, name FROM partTestUnquoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestUnquoted");
+        }
+    }
+
+    @Test
+    public void testShowColumnsCaseInsensitive()
+    {
+        // All column names are lowercased regardless of how they were written.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+            String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+            assertTrue(result.contains("mycol"), "Expected lowercase 'mycol' in SHOW COLUMNS output");
+            assertTrue(result.contains("anothercol"), "Expected lowercase 'anothercol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcols");
+        }
+    }
+
+    @Test
+    public void testNormalizeIdentifierLowercases()
+    {
+        String normalized = normalizeIdentifier("MyTable", ICEBERG_CATALOG);
+        assertTrue(normalized.equals("mytable"), "Expected normalizeIdentifier to lowercase 'MyTable', got: " + normalized);
+
+        String normalizedLower = normalizeIdentifier("mytable", ICEBERG_CATALOG);
+        assertTrue(normalizedLower.equals("mytable"), "Expected normalizeIdentifier to return 'mytable' unchanged, got: " + normalizedLower);
+
+        String normalizedUpper = normalizeIdentifier("MYTABLE", ICEBERG_CATALOG);
+        assertTrue(normalizedUpper.equals("mytable"), "Expected normalizeIdentifier to lowercase 'MYTABLE', got: " + normalizedUpper);
+
+        assertFalse(normalized.equals("MyTable"), "normalizeIdentifier must not preserve mixed case in case-insensitive mode");
+        assertFalse(normalizedUpper.equals("MYTABLE"), "normalizeIdentifier must not leave uppercase unchanged in case-insensitive mode");
+    }
+
+    @Test
+    public void testRewriteDataFilesWithSortedByMixedCaseColumn()
+    {
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_ci (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (3, 'c', 30), (1, 'a', 10)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (2, 'b', 20), (4, 'd', 40)");
+
+            // sorted_by 'Id' → normalizeIdentifier → 'id' → matches stored column 'id'
+            assertQuerySucceeds(testSession(), format(
+                    "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_ci', " +
+                            "sorted_by => ARRAY['Id'])",
+                    SCHEMA));
+
+            // Columns are stored and retrieved as lowercase
+            assertQuery(testSession(), "SELECT id, name, val FROM rewrite_sorted_ci ORDER BY id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+
+            List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_ci").schema().columns();
+            assertEquals(columns.get(0).name(), "id", "Column 0 must be stored as lowercase 'id'");
+            assertEquals(columns.get(1).name(), "name", "Column 1 must be stored as lowercase 'name'");
+            assertEquals(columns.get(2).name(), "val", "Column 2 must be stored as lowercase 'val'");
+            assertFalse(columns.get(0).name().equals("Id"), "Column 0 must NOT be stored as mixed-case 'Id'");
+            assertFalse(columns.get(1).name().equals("Name"), "Column 1 must NOT be stored as mixed-case 'Name'");
+            assertFalse(columns.get(2).name().equals("VAL"), "Column 2 must NOT be stored as mixed-case 'VAL'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS rewrite_sorted_ci");
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.FileFormat.ORC;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that when {@code case-sensitive-name-matching=true} identifiers (schema names,
+ * table names, column names) are preserved as-is by {@code normalizeIdentifier}, enabling
+ * case-sensitive access to REST catalogs that preserve identifier case.
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseSensitiveNameMatching
+        extends IcebergRestNameMatchingTestBase
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setFormat(ORC)
+                .setExtraConnectorProperties(ImmutableMap.<String, String>builder()
+                        .putAll(restConnectorProperties(serverUri))
+                        .put("case-sensitive-name-matching", "true")
+                        .build())
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    @Override
+    protected IcebergNativeCatalogFactory getCatalogFactory()
+    {
+        IcebergConfig icebergConfig = new IcebergConfig()
+                .setCatalogType(REST)
+                .setCaseSensitiveNameMatching(true)
+                .setCatalogWarehouse(warehouseLocation.getAbsolutePath());
+        return buildCatalogFactory(icebergConfig);
+    }
+
+    @Test
+    public void testCreateTableMixedCase()
+    {
+        // Both lower-case and upper-case variants can coexist as distinct tables in a
+        // case-sensitive catalog — normalizeIdentifier preserves each name as written.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+            assertQuerySucceeds(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)");
+
+            assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+
+            // MIXEDCASETABLE is a third distinct name — does not exist
+            assertQueryFails(testSession(), "SELECT * FROM MIXEDCASETABLE", ".*Table.*does not exist.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MixedCaseTable");
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS mixedcasetable");
+        }
+    }
+
+    @Test
+    public void testCreateTableAsMixedCase()
+    {
+        // 'MyTable' is stored as-is; 'mytable' is a different (non-existent) table.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+            assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+
+            assertQueryFails(testSession(), "SELECT * FROM mytable", ".*Table.*does not exist.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MyTable");
+        }
+    }
+
+    @Test
+    public void testMixedCaseColumns()
+    {
+        // The Presto parser preserves identifier case exactly as written — it never lowercases.
+        // normalizeIdentifier is the only thing that changes case; with case-sensitive-name-matching=true
+        // it returns identifiers as-is regardless of whether they were quoted or unquoted in SQL.
+
+        // Quoted: double-quotes tell the parser to treat the token as an identifier (not a keyword).
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestquoted");
+
+            // Unquoted mixed-case: same result — normalizeIdentifier preserves as-is.
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+            assertQuery(testSession(), "SELECT FirstName, lastName FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestquoted");
+        }
+    }
+
+    @Test
+    public void testMixedCasePartitionColumn()
+    {
+        // Quoted column in partition array: '"RegionId"' → strips quotes → 'RegionId' preserved.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT \"RegionId\", name FROM partTestQuoted ORDER BY \"RegionId\"", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestQuoted");
+        }
+
+        // Unquoted in partition array: 'RegionId' preserved as-is.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT RegionId, name FROM partTestUnquoted ORDER BY RegionId", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestUnquoted");
+        }
+    }
+
+    @Test
+    public void testShowColumnsCaseSensitive()
+    {
+        // Quoted: normalizeIdentifier preserves mixed case.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+            String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+            assertTrue(result.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+            assertTrue(result.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcols");
+        }
+
+        // Unquoted: same result — normalizeIdentifier preserves as-is.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcolslower (MyCol bigint, anotherCol varchar)");
+            String resultLower = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcolslower").toString();
+            assertTrue(resultLower.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+            assertTrue(resultLower.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcolslower");
+        }
+    }
+
+    @Test
+    public void testNormalizeIdentifierPreservesCase()
+    {
+        String normalized = normalizeIdentifier("MyTable", ICEBERG_CATALOG);
+        assertTrue(normalized.equals("MyTable"), "Expected normalizeIdentifier to preserve case, got: " + normalized);
+        String normalizedLower = normalizeIdentifier("mytable", ICEBERG_CATALOG);
+        assertTrue(normalizedLower.equals("mytable"), "Expected normalizeIdentifier to preserve lowercase, got: " + normalizedLower);
+        assertFalse(normalized.equals("mytable"), "normalizeIdentifier must not lowercase 'MyTable' in case-sensitive mode");
+        assertFalse(normalizedLower.equals("MYTABLE"), "normalizeIdentifier must not uppercase 'mytable' in case-sensitive mode");
+    }
+
+    @Test
+    public void testRewriteDataFilesWithSortedByMixedCaseColumn()
+    {
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_cs (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (3, 'c', 30), (1, 'a', 10)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (2, 'b', 20), (4, 'd', 40)");
+
+            // sorted_by uses the mixed-case column 'Id' exactly as stored — must resolve correctly
+            assertQuerySucceeds(testSession(), format(
+                    "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_cs', " +
+                            "sorted_by => ARRAY['Id'])",
+                    SCHEMA));
+
+            assertQuery(testSession(), "SELECT Id, Name, VAL FROM rewrite_sorted_cs ORDER BY Id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+
+            List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_cs").schema().columns();
+            assertEquals(columns.get(0).name(), "Id", "Column 0 must be stored as 'Id', not lower cased");
+            assertEquals(columns.get(1).name(), "Name", "Column 1 must be stored as 'Name', not lower cased");
+            assertEquals(columns.get(2).name(), "VAL", "Column 2 must be stored as 'VAL', not lower cased");
+            assertFalse(columns.get(0).name().equals("id"), "Column 0 must NOT be stored as lowercase 'id'");
+            assertFalse(columns.get(1).name().equals("name"), "Column 1 must NOT be stored as lowercase 'name'");
+            assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS rewrite_sorted_cs");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Enable case-sensitive support for Iceberg Native(Rest, Hadoop, Nessie) catalogs


## Motivation and Context
Enable case-sensitive support for Iceberg Native(Rest, Hadoop, Nessie) catalogs


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add case-sensitive support for Iceberg Native(Rest, Hadoop, Nessie) catalogs
```


## Summary by Sourcery

Add configurable case-sensitive identifier handling for Iceberg native catalogs and update partition/sort parsing to honor it.

New Features:
- Introduce case-sensitive-name-matching connector property to control identifier case handling for Iceberg native catalogs.
- Support quoted identifiers and case-insensitive transform keywords when parsing Iceberg partition and sort field specifications.

Bug Fixes:
- Ensure partitioning and sort order properties no longer implicitly lowercase identifiers, delegating normalization to connector metadata so catalog-specific case behavior is respected.

Enhancements:
- Add metadata-level identifier normalization hook so Iceberg native connectors can choose case-sensitive or case-insensitive matching.
- Validate Iceberg configuration to prevent enabling case-sensitive name matching for unsupported HIVE catalog type.

Tests:
- Add REST catalog tests covering default case-insensitive identifier behavior.
- Add REST catalog tests covering case-sensitive identifier behavior with case-sensitive-name-matching enabled.

## Summary by Sourcery

Add configurable case-sensitive identifier handling for Iceberg native catalogs and align partition/sort parsing and metadata normalization with this behavior.

New Features:
- Introduce case-sensitive-name-matching connector property to control identifier case handling for Iceberg native catalogs.
- Support quoted identifiers and case-insensitive transform keywords when parsing Iceberg partition and sort field specifications.
- Provide case-sensitive identifier preservation in Iceberg REST catalog when case-sensitive-name-matching is enabled, while retaining default case-insensitive behavior.

Bug Fixes:
- Ensure partitioning and sort order properties no longer implicitly lowercase identifiers so catalog-specific case behavior is respected.
- Fix rewrite_data_files procedure to honor connector-specific identifier normalization when interpreting sorted_by columns.

Enhancements:
- Add metadata-level normalizeIdentifier hook in IcebergNativeMetadata to centralize identifier casing decisions.
- Relax Iceberg table property parsing to avoid forcing identifiers to lowercase, delegating normalization to metadata.
- Validate Iceberg configuration to reject case-sensitive-name-matching for unsupported HIVE catalog type.

Tests:
- Add REST catalog test suite covering default case-insensitive identifier behavior for tables, columns, partitions, and procedures.
- Add REST catalog test suite covering case-sensitive identifier behavior when case-sensitive-name-matching is enabled, including SHOW COLUMNS and rewrite_data_files.
- Extend IcebergConfig tests to cover the new case-sensitive-name-matching property and its validation against HIVE catalog type.