### PR TITLE
feat: Merge-handle deser fix + existing-DV protocol/bridge (#28131)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -14,11 +14,13 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HiveCompressionCodec;
+import com.facebook.presto.iceberg.delete.DeleteFile;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,9 @@ public class IcebergInsertTableHandle
         implements ConnectorInsertTableHandle
 {
     private final List<String> insertedColumns;
+    // V3 deletion vectors keyed by the data file they reference; empty for plain INSERT/CREATE.
+    // Always serialized so the native worker's deserializer (which treats it as required) finds the key.
+    private final Map<String, DeleteFile> existingDeletionVectors;
 
     public IcebergInsertTableHandle(
             String schemaName,
@@ -46,7 +51,7 @@ public class IcebergInsertTableHandle
             Optional<SchemaTableName> materializedViewName)
     {
         this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
-                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, List.of());
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, List.of(), ImmutableMap.of());
     }
 
     public IcebergInsertTableHandle(
@@ -64,7 +69,7 @@ public class IcebergInsertTableHandle
             List<String> insertedColumns)
     {
         this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
-                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, insertedColumns);
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false, insertedColumns, ImmutableMap.of());
     }
 
     public IcebergInsertTableHandle(
@@ -82,7 +87,7 @@ public class IcebergInsertTableHandle
             boolean fullRefreshRequired)
     {
         this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
-                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, fullRefreshRequired, List.of());
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, fullRefreshRequired, List.of(), ImmutableMap.of());
     }
 
     @JsonCreator
@@ -99,7 +104,8 @@ public class IcebergInsertTableHandle
             @JsonProperty("sortOrder") List<SortField> sortOrder,
             @JsonProperty("materializedViewName") Optional<SchemaTableName> materializedViewName,
             @JsonProperty("fullRefreshRequired") boolean fullRefreshRequired,
-            @JsonProperty("insertedColumns") List<String> insertedColumns)
+            @JsonProperty("insertedColumns") List<String> insertedColumns,
+            @JsonProperty("existingDeletionVectors") Map<String, DeleteFile> existingDeletionVectors)
     {
         super(
                 schemaName,
@@ -115,11 +121,20 @@ public class IcebergInsertTableHandle
                 materializedViewName,
                 fullRefreshRequired);
         this.insertedColumns = ImmutableList.copyOf(requireNonNull(insertedColumns, "insertedColumns is null"));
+        this.existingDeletionVectors = existingDeletionVectors == null
+                ? ImmutableMap.of()
+                : ImmutableMap.copyOf(existingDeletionVectors);
     }
 
     @JsonProperty
     public List<String> getInsertedColumns()
     {
         return insertedColumns;
+    }
+
+    @JsonProperty
+    public Map<String, DeleteFile> getExistingDeletionVectors()
+    {
+        return existingDeletionVectors;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergInsertTableHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergInsertTableHandle.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.hive.HiveCompressionCodec;
+import com.facebook.presto.iceberg.delete.DeleteFile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+import static com.facebook.presto.iceberg.FileFormat.PUFFIN;
+import static com.facebook.presto.iceberg.IcebergTableType.DATA;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergInsertTableHandle
+{
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
+
+    @Test
+    public void testLegacyConstructorDefaultsExistingDeletionVectorsToEmptyMap()
+    {
+        // Exercise the legacy constructor (no existingDeletionVectors parameter) directly, so
+        // this actually covers the defaulting rather than passing an empty map explicitly.
+        IcebergInsertTableHandle handle = new IcebergInsertTableHandle(
+                "schema",
+                new IcebergTableName("table", DATA, Optional.empty(), Optional.empty(), Optional.empty()),
+                emptySchema(),
+                new PrestoIcebergPartitionSpec(1, emptySchema(), ImmutableList.of()),
+                ImmutableList.of(),
+                "file:/tmp/output",
+                PARQUET,
+                HiveCompressionCodec.NONE,
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                ImmutableList.of("id"));
+        assertTrue(handle.getExistingDeletionVectors().isEmpty());
+    }
+
+    @Test
+    public void testExistingDeletionVectorsJsonRoundTrip()
+            throws Exception
+    {
+        DeleteFile deleteFile = new DeleteFile(
+                POSITION_DELETES,
+                "file:/tmp/table/delete-vector.puffin",
+                PUFFIN,
+                10,
+                1024,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                Optional.of(12L),
+                Optional.of(34L),
+                Optional.of("file:/tmp/table/data.parquet"),
+                56L);
+
+        IcebergInsertTableHandle handle = newInsertTableHandle(ImmutableMap.of("file:/tmp/table/data.parquet", deleteFile));
+
+        String json = OBJECT_MAPPER.writeValueAsString(handle);
+        IcebergInsertTableHandle copy = OBJECT_MAPPER.readValue(json, IcebergInsertTableHandle.class);
+
+        assertEquals(copy.getExistingDeletionVectors().size(), 1);
+        DeleteFile copyDeleteFile = copy.getExistingDeletionVectors().get("file:/tmp/table/data.parquet");
+        assertEquals(copyDeleteFile.path(), "file:/tmp/table/delete-vector.puffin");
+        assertEquals(copyDeleteFile.format(), PUFFIN);
+        assertEquals(copyDeleteFile.getContentOffset(), Optional.of(12L));
+        assertEquals(copyDeleteFile.getContentSizeInBytes(), Optional.of(34L));
+        assertEquals(copyDeleteFile.getReferencedDataFile(), Optional.of("file:/tmp/table/data.parquet"));
+        assertEquals(copyDeleteFile.getDataSequenceNumber(), 56L);
+        assertEquals(copy.getInsertedColumns(), ImmutableList.of("id"));
+    }
+
+    private static IcebergInsertTableHandle newInsertTableHandle(ImmutableMap<String, DeleteFile> existingDeletionVectors)
+    {
+        return new IcebergInsertTableHandle(
+                "schema",
+                new IcebergTableName("table", DATA, Optional.empty(), Optional.empty(), Optional.empty()),
+                emptySchema(),
+                new PrestoIcebergPartitionSpec(1, emptySchema(), ImmutableList.of()),
+                ImmutableList.of(),
+                "file:/tmp/output",
+                PARQUET,
+                HiveCompressionCodec.NONE,
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                false,
+                ImmutableList.of("id"),
+                existingDeletionVectors);
+    }
+
+    private static PrestoIcebergSchema emptySchema()
+    {
+        return new PrestoIcebergSchema(1, ImmutableList.of(), ImmutableMap.of(), null, ImmutableSet.of());
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergInsertTableHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergInsertTableHandle.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.hive.HiveCompressionCodec;
+import com.facebook.presto.iceberg.delete.DeleteFile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+import static com.facebook.presto.iceberg.FileFormat.PUFFIN;
+import static com.facebook.presto.iceberg.IcebergTableType.DATA;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergInsertTableHandle
+{
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
+
+    @Test
+    public void testLegacyConstructorDefaultsExistingDeletionVectorsToEmptyMap()
+    {
+        IcebergInsertTableHandle handle = newInsertTableHandle(ImmutableMap.of());
+
+        assertTrue(handle.getExistingDeletionVectors().isEmpty());
+    }
+
+    @Test
+    public void testExistingDeletionVectorsJsonRoundTrip()
+            throws Exception
+    {
+        DeleteFile deleteFile = new DeleteFile(
+                POSITION_DELETES,
+                "file:/tmp/table/delete-vector.puffin",
+                PUFFIN,
+                10,
+                1024,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                Optional.of(12L),
+                Optional.of(34L),
+                Optional.of("file:/tmp/table/data.parquet"),
+                56L);
+        IcebergInsertTableHandle handle = newInsertTableHandle(ImmutableMap.of("file:/tmp/table/data.parquet", deleteFile));
+
+        String json = OBJECT_MAPPER.writeValueAsString(handle);
+        IcebergInsertTableHandle copy = OBJECT_MAPPER.readValue(json, IcebergInsertTableHandle.class);
+
+        assertEquals(copy.getExistingDeletionVectors().size(), 1);
+        DeleteFile copyDeleteFile = copy.getExistingDeletionVectors().get("file:/tmp/table/data.parquet");
+        assertEquals(copyDeleteFile.path(), "file:/tmp/table/delete-vector.puffin");
+        assertEquals(copyDeleteFile.format(), PUFFIN);
+        assertEquals(copyDeleteFile.getContentOffset(), Optional.of(12L));
+        assertEquals(copyDeleteFile.getContentSizeInBytes(), Optional.of(34L));
+        assertEquals(copyDeleteFile.getReferencedDataFile(), Optional.of("file:/tmp/table/data.parquet"));
+        assertEquals(copyDeleteFile.getDataSequenceNumber(), 56L);
+        assertEquals(copy.getInsertedColumns(), ImmutableList.of("id"));
+    }
+
+    private static IcebergInsertTableHandle newInsertTableHandle(ImmutableMap<String, DeleteFile> existingDeletionVectors)
+    {
+        return new IcebergInsertTableHandle(
+                "schema",
+                new IcebergTableName("table", DATA, Optional.empty(), Optional.empty(), Optional.empty()),
+                emptySchema(),
+                new PrestoIcebergPartitionSpec(1, emptySchema(), ImmutableList.of()),
+                ImmutableList.of(),
+                "file:/tmp/output",
+                PARQUET,
+                HiveCompressionCodec.NONE,
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                false,
+                ImmutableList.of("id"),
+                existingDeletionVectors);
+    }
+
+    private static PrestoIcebergSchema emptySchema()
+    {
+        return new PrestoIcebergSchema(1, ImmutableList.of(), ImmutableMap.of(), null, ImmutableSet.of());
+    }
+}

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -680,7 +680,9 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
       writeKind,
       toExistingDeletionVectors(
-          icebergDeleteTableHandle->existingDeletionVectors));
+          icebergDeleteTableHandle->existingDeletionVectors
+              ? *icebergDeleteTableHandle->existingDeletionVectors
+              : std::map<std::string, protocol::iceberg::DeleteFile>{}));
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -307,6 +307,38 @@ velox::connector::hive::iceberg::IcebergFieldMetadata toIcebergFieldMetadata(
   }
   return metadata;
 }
+
+// Converts the protocol's existing-deletion-vector map (data-file path -> DV
+// descriptor) into the Velox handle's ExistingDeletionVector map so the
+// deletion-vector sink can seed a new DV with the prior DV's positions on a
+// repeated V3 mutation. Empty for INSERT and first-time mutations.
+std::unordered_map<
+    std::string,
+    velox::connector::hive::iceberg::IcebergInsertTableHandle::
+        ExistingDeletionVector>
+toExistingDeletionVectors(
+    const std::map<std::string, protocol::iceberg::DeleteFile>&
+        protocolDeletionVectors) {
+  std::unordered_map<
+      std::string,
+      velox::connector::hive::iceberg::IcebergInsertTableHandle::
+          ExistingDeletionVector>
+      result;
+  result.reserve(protocolDeletionVectors.size());
+  for (const auto& [dataFile, deleteFile] : protocolDeletionVectors) {
+    velox::connector::hive::iceberg::IcebergInsertTableHandle::
+        ExistingDeletionVector descriptor;
+    descriptor.puffinPath = deleteFile.path;
+    descriptor.contentOffset =
+        deleteFile.contentOffset ? *deleteFile.contentOffset : 0;
+    descriptor.contentLength =
+        deleteFile.contentSizeInBytes ? *deleteFile.contentSizeInBytes : 0;
+    descriptor.recordCount = deleteFile.recordCount;
+    descriptor.fileSizeInBytes = deleteFile.fileSizeInBytes;
+    result.emplace(dataFile, std::move(descriptor));
+  }
+  return result;
+}
 } // namespace
 
 std::unique_ptr<velox::connector::ConnectorSplit>
@@ -646,7 +678,11 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       std::optional(
           toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
       /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
-      writeKind);
+      writeKind,
+      toExistingDeletionVectors(
+          icebergDeleteTableHandle->existingDeletionVectors
+              ? *icebergDeleteTableHandle->existingDeletionVectors
+              : std::map<std::string, protocol::iceberg::DeleteFile>{}));
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
@@ -700,7 +736,8 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       std::optional(toFileCompressionKind(innerInsert.compressionCodec)),
       std::unordered_map<std::string, std::string>{},
       velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-          kMerge);
+          kMerge,
+      toExistingDeletionVectors(innerInsert.existingDeletionVectors));
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -307,6 +307,38 @@ velox::connector::hive::iceberg::IcebergFieldMetadata toIcebergFieldMetadata(
   }
   return metadata;
 }
+
+// Converts the protocol's existing-deletion-vector map (data-file path -> DV
+// descriptor) into the Velox handle's ExistingDeletionVector map so the
+// deletion-vector sink can seed a new DV with the prior DV's positions on a
+// repeated V3 mutation. Empty for INSERT and first-time mutations.
+std::unordered_map<
+    std::string,
+    velox::connector::hive::iceberg::IcebergInsertTableHandle::
+        ExistingDeletionVector>
+toExistingDeletionVectors(
+    const std::map<std::string, protocol::iceberg::DeleteFile>&
+        protocolDeletionVectors) {
+  std::unordered_map<
+      std::string,
+      velox::connector::hive::iceberg::IcebergInsertTableHandle::
+          ExistingDeletionVector>
+      result;
+  result.reserve(protocolDeletionVectors.size());
+  for (const auto& [dataFile, deleteFile] : protocolDeletionVectors) {
+    velox::connector::hive::iceberg::IcebergInsertTableHandle::
+        ExistingDeletionVector descriptor;
+    descriptor.puffinPath = deleteFile.path;
+    descriptor.contentOffset =
+        deleteFile.contentOffset ? *deleteFile.contentOffset : 0;
+    descriptor.contentLength =
+        deleteFile.contentSizeInBytes ? *deleteFile.contentSizeInBytes : 0;
+    descriptor.recordCount = deleteFile.recordCount;
+    descriptor.fileSizeInBytes = deleteFile.fileSizeInBytes;
+    result.emplace(dataFile, std::move(descriptor));
+  }
+  return result;
+}
 } // namespace
 
 std::unique_ptr<velox::connector::ConnectorSplit>
@@ -646,7 +678,9 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       std::optional(
           toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
       /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
-      writeKind);
+      writeKind,
+      toExistingDeletionVectors(
+          icebergDeleteTableHandle->existingDeletionVectors));
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
@@ -700,7 +734,8 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       std::optional(toFileCompressionKind(innerInsert.compressionCodec)),
       std::unordered_map<std::string, std::string>{},
       velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-          kMerge);
+          kMerge,
+      toExistingDeletionVectors(innerInsert.existingDeletionVectors));
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -63,45 +63,7 @@ void from_json(const json& j, ChangelogOperation& e) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<TypeCategory, json> TypeCategory_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {TypeCategory::PRIMITIVE, "PRIMITIVE"},
-        {TypeCategory::STRUCT, "STRUCT"},
-        {TypeCategory::ARRAY, "ARRAY"},
-        {TypeCategory::MAP, "MAP"}};
-void to_json(json& j, const TypeCategory& e) {
-  static_assert(
-      std::is_enum<TypeCategory>::value, "TypeCategory must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(TypeCategory_enum_table),
-      std::end(TypeCategory_enum_table),
-      [e](const std::pair<TypeCategory, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(TypeCategory_enum_table))
-           ? it
-           : std::begin(TypeCategory_enum_table))
-          ->second;
-}
-void from_json(const json& j, TypeCategory& e) {
-  static_assert(
-      std::is_enum<TypeCategory>::value, "TypeCategory must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(TypeCategory_enum_table),
-      std::end(TypeCategory_enum_table),
-      [&j](const std::pair<TypeCategory, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(TypeCategory_enum_table))
-           ? it
-           : std::begin(TypeCategory_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol::iceberg
-namespace facebook::presto::protocol::iceberg {
 void to_json(json& j, const IcebergTypeAttributes& p) {
   j = json::object();
   to_json_key(
@@ -161,6 +123,45 @@ void from_json(const json& j, IcebergTypeAttributes& p) {
       "structType");
   from_json_key(
       j, "length", p.length, "IcebergTypeAttributes", "Integer", "length");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<TypeCategory, json> TypeCategory_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {TypeCategory::PRIMITIVE, "PRIMITIVE"},
+        {TypeCategory::STRUCT, "STRUCT"},
+        {TypeCategory::ARRAY, "ARRAY"},
+        {TypeCategory::MAP, "MAP"}};
+void to_json(json& j, const TypeCategory& e) {
+  static_assert(
+      std::is_enum<TypeCategory>::value, "TypeCategory must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(TypeCategory_enum_table),
+      std::end(TypeCategory_enum_table),
+      [e](const std::pair<TypeCategory, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(TypeCategory_enum_table))
+           ? it
+           : std::begin(TypeCategory_enum_table))
+          ->second;
+}
+void from_json(const json& j, TypeCategory& e) {
+  static_assert(
+      std::is_enum<TypeCategory>::value, "TypeCategory must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(TypeCategory_enum_table),
+      std::end(TypeCategory_enum_table),
+      [&j](const std::pair<TypeCategory, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(TypeCategory_enum_table))
+           ? it
+           : std::begin(TypeCategory_enum_table))
+          ->first;
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -947,6 +948,7 @@ void from_json(const json& j, SortField& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+
 IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
   _type = "hive-iceberg";
 }
@@ -1038,6 +1040,13 @@ void to_json(json& j, const IcebergDeleteTableHandle& p) {
       "IcebergDeleteTableHandle",
       "FileContent",
       "fileContent");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 
 void from_json(const json& j, IcebergDeleteTableHandle& p) {
@@ -1126,7 +1135,15 @@ void from_json(const json& j, IcebergDeleteTableHandle& p) {
       "IcebergDeleteTableHandle",
       "FileContent",
       "fileContent");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
+
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
 void to_json(json& j, const std::shared_ptr<ColumnHandle>& p) {
@@ -1743,7 +1760,7 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "fullRefreshRequired",
       p.fullRefreshRequired,
       "IcebergInsertTableHandle",
-      "bool",
+      "std::shared_ptr<bool>",
       "fullRefreshRequired");
   to_json_key(
       j,
@@ -1752,6 +1769,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "List<String>",
       "insertedColumns");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergInsertTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -1838,7 +1862,7 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "fullRefreshRequired",
       p.fullRefreshRequired,
       "IcebergInsertTableHandle",
-      "bool",
+      "std::shared_ptr<bool>",
       "fullRefreshRequired");
   from_json_key(
       j,
@@ -1847,6 +1871,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "List<String>",
       "insertedColumns");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergInsertTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -2209,6 +2240,8 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "ChangelogSplitInfo",
       "changelogSplitInfo");
+  // V3 fields: optional for backward compatibility with coordinators that
+  // do not yet send them. Default values from the struct definition apply.
   if (j.count("dataSequenceNumber")) {
     from_json_key(
         j,

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1038,6 +1038,13 @@ void to_json(json& j, const IcebergDeleteTableHandle& p) {
       "IcebergDeleteTableHandle",
       "FileContent",
       "fileContent");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 
 void from_json(const json& j, IcebergDeleteTableHandle& p) {
@@ -1126,6 +1133,13 @@ void from_json(const json& j, IcebergDeleteTableHandle& p) {
       "IcebergDeleteTableHandle",
       "FileContent",
       "fileContent");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -1752,6 +1766,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "List<String>",
       "insertedColumns");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergInsertTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -1847,6 +1868,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "List<String>",
       "insertedColumns");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergInsertTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -234,6 +234,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };
@@ -318,6 +319,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   std::shared_ptr<bool> fullRefreshRequired = {};
   List<String> insertedColumns = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -29,11 +29,6 @@ extern void to_json(json& j, const ChangelogOperation& e);
 extern void from_json(const json& j, ChangelogOperation& e);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class TypeCategory { PRIMITIVE, STRUCT, ARRAY, MAP };
-extern void to_json(json& j, const TypeCategory& e);
-extern void from_json(const json& j, TypeCategory& e);
-} // namespace facebook::presto::protocol::iceberg
-namespace facebook::presto::protocol::iceberg {
 struct IcebergTypeAttributes {
   std::shared_ptr<bool> required = {};
   std::shared_ptr<String> longType = {};
@@ -44,6 +39,11 @@ struct IcebergTypeAttributes {
 };
 void to_json(json& j, const IcebergTypeAttributes& p);
 void from_json(const json& j, IcebergTypeAttributes& p);
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+enum class TypeCategory { PRIMITIVE, STRUCT, ARRAY, MAP };
+extern void to_json(json& j, const TypeCategory& e);
+extern void from_json(const json& j, TypeCategory& e);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
 struct ColumnIdentity {
@@ -234,6 +234,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
+  std::shared_ptr<Map<String, DeleteFile>> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };
@@ -318,6 +319,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   std::shared_ptr<bool> fullRefreshRequired = {};
   List<String> insertedColumns = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -234,7 +234,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
-  Map<String, DeleteFile> existingDeletionVectors = {};
+  std::shared_ptr<Map<String, DeleteFile>> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -72,6 +72,12 @@ UpdateFields:
     # presto-trunk's POJO has it, and the C++ worker never reads it). Model it
     # as nullable so from_json tolerates its absence instead of throwing.
     std::shared_ptr<bool>: fullRefreshRequired
+  IcebergDeleteTableHandle:
+    # OSS presto-iceberg's IcebergDeleteTableHandle POJO does not serialize this
+    # field (only the FB-fork handle does), so an OSS coordinator's DELETE handle
+    # JSON omits it. Model it as nullable so from_json tolerates its absence
+    # instead of throwing json::out_of_range on the native worker.
+    std::shared_ptr<Map<String, DeleteFile>>: existingDeletionVectors
 
 JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.cpp.inc
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol::iceberg {
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergDeleteTableHandle",
+      "String",
+      "schemaName");
+  to_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergDeleteTableHandle",
+      "IcebergTableName",
+      "tableName");
+  to_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  to_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  to_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergDeleteTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  to_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergDeleteTableHandle",
+      "String",
+      "outputPath");
+  to_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergDeleteTableHandle",
+      "FileFormat",
+      "fileFormat");
+  to_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergDeleteTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  to_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergDeleteTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergDeleteTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  to_json_key(
+      j,
+      "materializedViewName",
+      p.materializedViewName,
+      "IcebergDeleteTableHandle",
+      "SchemaTableName",
+      "materializedViewName");
+  to_json_key(
+      j,
+      "fileContent",
+      p.fileContent,
+      "IcebergDeleteTableHandle",
+      "FileContent",
+      "fileContent");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergDeleteTableHandle",
+      "String",
+      "schemaName");
+  from_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergDeleteTableHandle",
+      "IcebergTableName",
+      "tableName");
+  from_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  from_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  from_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergDeleteTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  from_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergDeleteTableHandle",
+      "String",
+      "outputPath");
+  from_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergDeleteTableHandle",
+      "FileFormat",
+      "fileFormat");
+  from_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergDeleteTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  from_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergDeleteTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergDeleteTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  from_json_key(
+      j,
+      "materializedViewName",
+      p.materializedViewName,
+      "IcebergDeleteTableHandle",
+      "SchemaTableName",
+      "materializedViewName");
+  from_json_key(
+      j,
+      "fileContent",
+      p.fileContent,
+      "IcebergDeleteTableHandle",
+      "FileContent",
+      "fileContent");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
+}
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.cpp.inc
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol::iceberg {
+
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergDeleteTableHandle",
+      "String",
+      "schemaName");
+  to_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergDeleteTableHandle",
+      "IcebergTableName",
+      "tableName");
+  to_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  to_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  to_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergDeleteTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  to_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergDeleteTableHandle",
+      "String",
+      "outputPath");
+  to_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergDeleteTableHandle",
+      "FileFormat",
+      "fileFormat");
+  to_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergDeleteTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  to_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergDeleteTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergDeleteTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  to_json_key(
+      j,
+      "materializedViewName",
+      p.materializedViewName,
+      "IcebergDeleteTableHandle",
+      "SchemaTableName",
+      "materializedViewName");
+  to_json_key(
+      j,
+      "fileContent",
+      p.fileContent,
+      "IcebergDeleteTableHandle",
+      "FileContent",
+      "fileContent");
+  to_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergDeleteTableHandle",
+      "String",
+      "schemaName");
+  from_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergDeleteTableHandle",
+      "IcebergTableName",
+      "tableName");
+  from_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  from_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergDeleteTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  from_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergDeleteTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  from_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergDeleteTableHandle",
+      "String",
+      "outputPath");
+  from_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergDeleteTableHandle",
+      "FileFormat",
+      "fileFormat");
+  from_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergDeleteTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  from_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergDeleteTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergDeleteTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  from_json_key(
+      j,
+      "materializedViewName",
+      p.materializedViewName,
+      "IcebergDeleteTableHandle",
+      "SchemaTableName",
+      "materializedViewName");
+  from_json_key(
+      j,
+      "fileContent",
+      p.fileContent,
+      "IcebergDeleteTableHandle",
+      "FileContent",
+      "fileContent");
+  from_json_key(
+      j,
+      "existingDeletionVectors",
+      p.existingDeletionVectors,
+      "IcebergDeleteTableHandle",
+      "Map<String, DeleteFile>",
+      "existingDeletionVectors");
+}
+
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -29,6 +29,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
+  std::shared_ptr<Map<String, DeleteFile>> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -29,6 +29,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -29,7 +29,7 @@ struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   FileContent fileContent = {};
-  Map<String, DeleteFile> existingDeletionVectors = {};
+  std::shared_ptr<Map<String, DeleteFile>> existingDeletionVectors = {};
 
   IcebergDeleteTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
@@ -30,6 +30,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   std::shared_ptr<SchemaTableName> materializedViewName = {};
   bool fullRefreshRequired = {};
   List<String> insertedColumns = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
@@ -28,8 +28,9 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   Map<String, String> storageProperties = {};
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
-  bool fullRefreshRequired = {};
+  std::shared_ptr<bool> fullRefreshRequired = {};
   List<String> insertedColumns = {};
+  Map<String, DeleteFile> existingDeletionVectors = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7554,26 +7554,33 @@ void from_json(const json& j, MemoryInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Route ConnectorMergeTableHandle through the registered connector protocol
+// (mirrors ConnectorDeleteTableHandle). Without this the default codegen
+// hard-throws "no abstract type ConnectorMergeTableHandle", which breaks
+// UPDATE/MERGE deserialization on the worker (MergeHandle.from_json ->
+// from_json_key(connectorMergeTableHandle) reaches here). Unlike the Delete/
+// Insert handles there is no deserialize(ConnectorMergeTableHandle) overload
+// on ConnectorProtocol, so the customSerializedValue branch is omitted.
 void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p) {
   if (p == nullptr) {
     return;
   }
   String type = p->_type;
-
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).to_json(j, p);
 }
 
 void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
   String type;
   try {
-    type = p->getSubclassKey(j);
+    JsonEncodedSubclass keyReader;
+    type = keyReader.getSubclassKey(j);
   } catch (json::parse_error& e) {
     throw ParseError(
         std::string(e.what()) +
         " ConnectorMergeTableHandle  ConnectorMergeTableHandle");
   }
 
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).from_json(j, p);
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -7601,7 +7608,16 @@ void to_json(json& j, const MergeHandle& p) {
 }
 
 void from_json(const json& j, MergeHandle& p) {
-  p._type = j["@type"];
+  // The concrete com.facebook.presto.spi.MergeHandle (held by MergeTarget) is a
+  // non-polymorphic data class serialized without an "@type" key, whereas the
+  // polymorphic ExecutionWriterTarget.MergeHandle carries one. Protocol codegen
+  // conflates both into this single struct, so tolerate a missing "@type": the
+  // constructor already defaults _type to "MergeHandle". Without this, an
+  // UPDATE/MERGE fails on the worker with json type_error.302 (the missing-key
+  // read surfaces as "type must be string, but is number").
+  if (j.contains("@type")) {
+    p._type = j["@type"];
+  }
   from_json_key(
       j,
       "tableHandle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7554,13 +7554,19 @@ void from_json(const json& j, MemoryInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Route ConnectorMergeTableHandle through the registered connector protocol
+// (mirrors ConnectorDeleteTableHandle). Without this the default codegen
+// hard-throws "no abstract type ConnectorMergeTableHandle", which breaks
+// UPDATE/MERGE deserialization on the worker (MergeHandle.from_json ->
+// from_json_key(connectorMergeTableHandle) reaches here). Unlike the Delete/
+// Insert handles there is no deserialize(ConnectorMergeTableHandle) overload
+// on ConnectorProtocol, so the customSerializedValue branch is omitted.
 void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p) {
   if (p == nullptr) {
     return;
   }
   String type = p->_type;
-
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).to_json(j, p);
 }
 
 void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
@@ -7573,7 +7579,7 @@ void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
         " ConnectorMergeTableHandle  ConnectorMergeTableHandle");
   }
 
-  throw TypeError(type + " no abstract type ConnectorMergeTableHandle ");
+  getConnectorProtocol(type).from_json(j, p);
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -7601,7 +7607,16 @@ void to_json(json& j, const MergeHandle& p) {
 }
 
 void from_json(const json& j, MergeHandle& p) {
-  p._type = j["@type"];
+  // The concrete com.facebook.presto.spi.MergeHandle (held by MergeTarget) is a
+  // non-polymorphic data class serialized without an "@type" key, whereas the
+  // polymorphic ExecutionWriterTarget.MergeHandle carries one. Protocol codegen
+  // conflates both into this single struct, so tolerate a missing "@type": the
+  // constructor already defaults _type to "MergeHandle". Without this, an
+  // UPDATE/MERGE fails on the worker with json type_error.302 (the missing-key
+  // read surfaces as "type must be string, but is number").
+  if (j.contains("@type")) {
+    p._type = j["@type"];
+  }
   from_json_key(
       j,
       "tableHandle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorMergeTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorMergeTableHandle.cpp.inc
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+// Route ConnectorMergeTableHandle through the registered connector protocol
+// (mirrors ConnectorDeleteTableHandle). Without this the default codegen
+// hard-throws "no abstract type ConnectorMergeTableHandle", which breaks
+// UPDATE/MERGE deserialization on the worker (MergeHandle.from_json ->
+// from_json_key(connectorMergeTableHandle) reaches here). Unlike the Delete/
+// Insert handles there is no deserialize(ConnectorMergeTableHandle) overload
+// on ConnectorProtocol, so the customSerializedValue branch is omitted.
+void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+  getConnectorProtocol(type).to_json(j, p);
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
+  String type;
+  try {
+    JsonEncodedSubclass keyReader;
+    type = keyReader.getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorMergeTableHandle  ConnectorMergeTableHandle");
+  }
+
+  getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorMergeTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorMergeTableHandle.cpp.inc
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+// Route ConnectorMergeTableHandle through the registered connector protocol
+// (mirrors ConnectorDeleteTableHandle). Without this the default codegen
+// hard-throws "no abstract type ConnectorMergeTableHandle", which breaks
+// UPDATE/MERGE deserialization on the worker (MergeHandle.from_json ->
+// from_json_key(connectorMergeTableHandle) reaches here). Unlike the Delete/
+// Insert handles there is no deserialize(ConnectorMergeTableHandle) overload
+// on ConnectorProtocol, so the customSerializedValue branch is omitted.
+void to_json(json& j, const std::shared_ptr<ConnectorMergeTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+  getConnectorProtocol(type).to_json(j, p);
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorMergeTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorMergeTableHandle  ConnectorMergeTableHandle");
+  }
+
+  getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/MergeHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/MergeHandle.cpp.inc
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+MergeHandle::MergeHandle() noexcept {
+  _type = "MergeHandle";
+}
+
+void to_json(json& j, const MergeHandle& p) {
+  j = json::object();
+  j["@type"] = "MergeHandle";
+  to_json_key(
+      j,
+      "tableHandle",
+      p.tableHandle,
+      "MergeHandle",
+      "TableHandle",
+      "tableHandle");
+  to_json_key(
+      j,
+      "connectorMergeTableHandle",
+      p.connectorMergeTableHandle,
+      "MergeHandle",
+      "ConnectorMergeTableHandle",
+      "connectorMergeTableHandle");
+}
+
+void from_json(const json& j, MergeHandle& p) {
+  // The concrete com.facebook.presto.spi.MergeHandle (held by MergeTarget) is a
+  // non-polymorphic data class serialized without an "@type" key, whereas the
+  // polymorphic ExecutionWriterTarget.MergeHandle carries one. Protocol codegen
+  // conflates both into this single struct, so tolerate a missing "@type": the
+  // constructor already defaults _type to "MergeHandle". Without this, an
+  // UPDATE/MERGE fails on the worker with json type_error.302 (the missing-key
+  // read surfaces as "type must be string, but is number").
+  if (j.contains("@type")) {
+    p._type = j["@type"];
+  }
+  from_json_key(
+      j,
+      "tableHandle",
+      p.tableHandle,
+      "MergeHandle",
+      "TableHandle",
+      "tableHandle");
+  from_json_key(
+      j,
+      "connectorMergeTableHandle",
+      p.connectorMergeTableHandle,
+      "MergeHandle",
+      "ConnectorMergeTableHandle",
+      "connectorMergeTableHandle");
+}
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   DurationTest.cpp
   LifespanTest.cpp
   MapWithIntegerKeysTest.cpp
+  MergeHandleTest.cpp
   OptionalTest.cpp
   RowExpressionTest.cpp
   TaskUpdateRequestTest.cpp

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "presto_cpp/presto_protocol/core/ConnectorProtocol.h"
+
+using namespace facebook::presto::protocol;
+
+namespace {
+
+struct TestConnectorTableHandle : ConnectorTableHandle {
+  std::string table;
+};
+
+struct TestConnectorTransactionHandle : ConnectorTransactionHandle {
+  std::string transaction;
+};
+
+struct TestConnectorMergeTableHandle : ConnectorMergeTableHandle {
+  std::string marker;
+};
+
+void to_json(json& j, const TestConnectorTableHandle& p) {
+  j = json{{"@type", p._type}, {"table", p.table}};
+}
+
+void from_json(const json& j, TestConnectorTableHandle& p) {
+  p._type = j.at("@type");
+  p.table = j.at("table");
+}
+
+void to_json(json& j, const TestConnectorTransactionHandle& p) {
+  j = json{{"@type", p._type}, {"transaction", p.transaction}};
+}
+
+void from_json(const json& j, TestConnectorTransactionHandle& p) {
+  p._type = j.at("@type");
+  p.transaction = j.at("transaction");
+}
+
+void to_json(json& j, const TestConnectorMergeTableHandle& p) {
+  j = json{{"@type", p._type}, {"marker", p.marker}};
+}
+
+void from_json(const json& j, TestConnectorMergeTableHandle& p) {
+  p._type = j.at("@type");
+  p.marker = j.at("marker");
+}
+
+using TestConnectorProtocol = ConnectorProtocolTemplate<
+    TestConnectorTableHandle,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    TestConnectorTransactionHandle,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    TestConnectorMergeTableHandle>;
+
+constexpr const char* kTestConnector = "test-merge-connector";
+
+class MergeHandleTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    registerConnectorProtocol(
+        kTestConnector, std::make_unique<TestConnectorProtocol>());
+  }
+
+  void TearDown() override {
+    unregisterConnectorProtocol(kTestConnector);
+  }
+};
+
+json makeMergeHandleJson(bool includeType) {
+  json j = {
+      {"tableHandle",
+       {{"connectorId", kTestConnector},
+        {"connectorHandle", {{"@type", kTestConnector}, {"table", "orders"}}},
+        {"transaction", {{"@type", kTestConnector}, {"transaction", "txn-1"}}},
+        {"connectorTableLayout", nullptr}}},
+      {"connectorMergeTableHandle",
+       {{"@type", kTestConnector}, {"marker", "merge-marker"}}}};
+  if (includeType) {
+    j["@type"] = "MergeHandle";
+  }
+  return j;
+}
+
+} // namespace
+
+TEST_F(MergeHandleTest, missingTypeDefaultsToMergeHandle) {
+  MergeHandle handle = makeMergeHandleJson(false);
+
+  ASSERT_EQ(handle._type, "MergeHandle");
+  ASSERT_EQ(handle.tableHandle.connectorId, kTestConnector);
+  auto tableHandle = std::dynamic_pointer_cast<TestConnectorTableHandle>(
+      handle.tableHandle.connectorHandle);
+  ASSERT_NE(tableHandle, nullptr);
+  ASSERT_EQ(tableHandle->table, "orders");
+  auto transactionHandle =
+      std::dynamic_pointer_cast<TestConnectorTransactionHandle>(
+          handle.tableHandle.transaction);
+  ASSERT_NE(transactionHandle, nullptr);
+  ASSERT_EQ(transactionHandle->transaction, "txn-1");
+}
+
+TEST_F(
+    MergeHandleTest,
+    connectorMergeTableHandleRoutesThroughConnectorProtocol) {
+  MergeHandle handle = makeMergeHandleJson(true);
+
+  auto mergeHandle = std::dynamic_pointer_cast<TestConnectorMergeTableHandle>(
+      handle.connectorMergeTableHandle);
+  ASSERT_NE(mergeHandle, nullptr);
+  ASSERT_EQ(mergeHandle->_type, kTestConnector);
+  ASSERT_EQ(mergeHandle->marker, "merge-marker");
+}

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "presto_cpp/presto_protocol/core/ConnectorProtocol.h"
+
+using namespace facebook::presto::protocol;
+
+namespace {
+
+struct TestConnectorTableHandle : ConnectorTableHandle {
+  std::string table;
+};
+
+struct TestConnectorTransactionHandle : ConnectorTransactionHandle {
+  std::string transaction;
+};
+
+struct TestConnectorMergeTableHandle : ConnectorMergeTableHandle {
+  std::string marker;
+};
+
+void to_json(json& j, const TestConnectorTableHandle& p) {
+  j = json{{"@type", p._type}, {"table", p.table}};
+}
+
+void from_json(const json& j, TestConnectorTableHandle& p) {
+  p._type = j.at("@type");
+  p.table = j.at("table");
+}
+
+void to_json(json& j, const TestConnectorTransactionHandle& p) {
+  j = json{{"@type", p._type}, {"transaction", p.transaction}};
+}
+
+void from_json(const json& j, TestConnectorTransactionHandle& p) {
+  p._type = j.at("@type");
+  p.transaction = j.at("transaction");
+}
+
+void to_json(json& j, const TestConnectorMergeTableHandle& p) {
+  j = json{{"@type", p._type}, {"marker", p.marker}};
+}
+
+void from_json(const json& j, TestConnectorMergeTableHandle& p) {
+  p._type = j.at("@type");
+  p.marker = j.at("marker");
+}
+
+using TestConnectorProtocol = ConnectorProtocolTemplate<
+    TestConnectorTableHandle,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    TestConnectorTransactionHandle,
+    NotImplemented,
+    NotImplemented,
+    NotImplemented,
+    TestConnectorMergeTableHandle>;
+
+constexpr const char* kTestConnector = "test-merge-connector";
+
+class MergeHandleTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    registerConnectorProtocol(
+        kTestConnector, std::make_unique<TestConnectorProtocol>());
+  }
+
+  void TearDown() override {
+    unregisterConnectorProtocol(kTestConnector);
+  }
+};
+
+json makeMergeHandleJson(bool includeType) {
+  // connectorTableLayout is deliberately omitted rather than set to null:
+  // TableHandle::from_json deserializes the key unconditionally, so an explicit
+  // null throws json type_error.305 instead of being treated as absent.
+  json j = {
+      {"tableHandle",
+       {{"connectorId", kTestConnector},
+        {"connectorHandle", {{"@type", kTestConnector}, {"table", "orders"}}},
+        {"transaction",
+         {{"@type", kTestConnector}, {"transaction", "txn-1"}}}}},
+      {"connectorMergeTableHandle",
+       {{"@type", kTestConnector}, {"marker", "merge-marker"}}}};
+  if (includeType) {
+    j["@type"] = "MergeHandle";
+  }
+  return j;
+}
+
+} // namespace
+
+TEST_F(MergeHandleTest, missingTypeDefaultsToMergeHandle) {
+  MergeHandle handle = makeMergeHandleJson(false);
+
+  ASSERT_EQ(handle._type, "MergeHandle");
+  ASSERT_EQ(handle.tableHandle.connectorId, kTestConnector);
+
+  auto tableHandle = std::dynamic_pointer_cast<TestConnectorTableHandle>(
+      handle.tableHandle.connectorHandle);
+  ASSERT_NE(tableHandle, nullptr);
+  ASSERT_EQ(tableHandle->table, "orders");
+
+  auto transactionHandle =
+      std::dynamic_pointer_cast<TestConnectorTransactionHandle>(
+          handle.tableHandle.transaction);
+  ASSERT_NE(transactionHandle, nullptr);
+  ASSERT_EQ(transactionHandle->transaction, "txn-1");
+}
+
+TEST_F(
+    MergeHandleTest,
+    connectorMergeTableHandleRoutesThroughConnectorProtocol) {
+  MergeHandle handle = makeMergeHandleJson(true);
+
+  auto mergeHandle = std::dynamic_pointer_cast<TestConnectorMergeTableHandle>(
+      handle.connectorMergeTableHandle);
+  ASSERT_NE(mergeHandle, nullptr);
+  ASSERT_EQ(mergeHandle->_type, kTestConnector);
+  ASSERT_EQ(mergeHandle->marker, "merge-marker");
+}


### PR DESCRIPTION
Summary:

presto-trunk (Prestissimo) protocol + bridge changes for Iceberg V3
deletion-vector replacement, stacked on the velox worker diff below and beneath
the presto-facebook coordinator diff. All files are presto-trunk (presto_cpp),
so this exports to prestodb/presto as one unit.

Related protocol/bridge changes, folded together:

1. Merge-handle deserialization fix (presto_protocol/core): correct
   ConnectorMergeTableHandle / MergeHandle deserialization so the V3 MERGE path
   round-trips the merge handle to the native worker.

2. Existing-DV threading (presto_protocol/connector/iceberg + bridge): the
   iceberg protocol structs gain an existingDeletionVectors field
   (special/*.inc overrides + regenerated presto_protocol_iceberg.{h,cpp}),
   and IcebergPrestoToVeloxConnector converts that map into the Velox
   IcebergInsertTableHandle::ExistingDeletionVector descriptors (defaulting
   contentOffset/contentSizeInBytes to 0 per the OSS split-path convention) for
   both the delete-handle and merge-handle conversion paths.

3. IcebergDeleteTableHandle.existingDeletionVectors is modelled as nullable.
   OSS presto-iceberg's IcebergDeleteTableHandle POJO does not serialize this
   field (only the FB-fork handle does), so an OSS coordinator's DELETE handle
   JSON omits it and a non-nullable field threw json::out_of_range on the
   native worker. Covers the .hpp.inc, a new UpdateFields entry in
   presto_protocol_iceberg.yml, the regenerated .h/.cpp, and a null check at
   the IcebergPrestoToVeloxConnector call site.

4. Tests and hand-written serde: IcebergDeleteTableHandle.cpp.inc (the Java
   POJO has no existingDeletionVectors field, so protocol codegen cannot derive
   the serde and it must be supplied by hand), MergeHandleTest.cpp plus its
   CMakeLists entry, and TestIcebergInsertTableHandle.java.

Also aligns IcebergInsertTableHandle.hpp.inc's fullRefreshRequired with the
std::shared_ptr<bool> already declared in presto_protocol_iceberg.yml. The .inc
and the yml disagreed, so a regen would silently revert the checked-in nullable
type back to plain bool and reintroduce the throw-on-absent-field bug. Making
the two sources agree keeps the type stable across future regens; behavior is
unchanged from the checked-in generated header.

== NO RELEASE NOTE ==

Reviewed By: srsuryadev

Differential Revision: D111464673


