### PR TITLE
chore: Apply backwards compatibility `AllowLegacyMissingUris` annotation to Thrift files

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
@@ -66,6 +66,8 @@ thrift_library(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/presto_cpp/main/thrift
   ".."
+  THRIFT_INCLUDE_DIRECTORIES
+  ${THRIFT_INCLUDES}
 )
 target_link_libraries(presto_native-cpp2 ${presto_thrift_library_dependencies})
 set(presto_native_INCLUDES ${CMAKE_CURRENT_BINARY_DIR})

--- a/presto-native-execution/presto_cpp/main/thrift/presto_native.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_native.thrift
@@ -12,6 +12,11 @@
  * limitations under the License.
  */
 
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
+
 namespace cpp2 facebook.presto.thrift
 
 struct BroadcastFileFooter {

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -15,6 +15,9 @@
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
+@thrift.AllowLegacyMissingUris
+package;
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {

--- a/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
@@ -15,6 +15,9 @@
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
+@thrift.AllowLegacyMissingUris
+package;
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {


### PR DESCRIPTION
Summary:
Add `AllowLegacyMissingUris` annotation to Presto Thrift IDL files - this is a legacy/backwards compatibility annotation, as fbthrift is moving towards requiring a non-empty `package` statement.

As an intermediate step, we plan to allow files without such a package to compile when annotated with this backwards compatibility opt-in, while new files are encouraged to use a package from the beginning.

```
== NO RELEASE NOTE ==
```

Differential Revision: D110387972

## Summary by Sourcery

Apply backward-compatibility annotations to Presto Thrift IDL files to support missing package URIs and update Thrift build configuration accordingly.

Enhancements:
- Annotate existing Presto Thrift IDL files with AllowLegacyMissingUris to permit compilation without explicit package URIs during migration.
- Update the Thrift CMake configuration to include the shared THRIFT_INCLUDES directory for generated libraries.