### PR TITLE
fix: Flaky access-control race in Presto-on-Spark tests

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -573,6 +573,7 @@ public class PrestoSparkQueryRunner
     @Override
     public MaterializedResult execute(Session session, String sql)
     {
+        lock.readLock().lock();
         try {
             return executeWithStrategies(session, sql, getExecutionStrategies(session));
         }
@@ -582,6 +583,9 @@ public class PrestoSparkQueryRunner
             }
 
             throw failure;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 


### PR DESCRIPTION
## Description
Fix flaky ConcurrentModificationException / access-control race in Presto-on-Spark tests 

## Motivation and Context
 https://github.com/prestodb/presto/issues/28099

TestPrestoQueries.testAddDistinctForSemiJoinBuild is flaky

`TestPrestoQueries.testAddDistinctForSemiJoinBuild[PARQUET]` (and potentially
other tests sharing the same query runner) intermittently fails with:

```
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode
	at com.facebook.presto.testing.TestingAccessControlManager.shouldDenyPrivilege
	at com.facebook.presto.testing.TestingAccessControlManager.checkCanSelectFromColumns
	at com.facebook.presto.util.AnalyzerUtil...
	at com.facebook.presto.spark.planner.PrestoSparkQueryPlanner.createQueryPlan
	at com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.create
	at com.facebook.presto.spark.PrestoSparkQueryRunner.createPrestoSparkQueryExecution
	at com.facebook.presto.spark.PrestoSparkQueryRunner.executeWithStrategies
	at com.facebook.presto.spark.PrestoSparkQueryRunner.execute
```

## Root cause
 **`PrestoSparkQueryRunner` doesn't honor the `QueryRunner` locking contract**

`AbstractTestQueryFramework.assertAccessDenied()` / `assertAccessAllowed()` run their `deny() → execute() → reset()` sequence inside `executeExclusively()`, which acquires `queryRunner.getExclusiveLock()`
(the write side of a `ReentrantReadWriteLock`). The expectation is that ordinary query execution acquires the corresponding **read** lock, so it can run concurrently with other plain queries but is correctly blocked while a writer is mutating access-control state.

`DistributedQueryRunner`, `LocalQueryRunner`, and `StandaloneQueryRunner`all do this. `PrestoSparkQueryRunner.execute()` does not - it never acquires the read lock, so a plain query (e.g.`assertQuery(...)`) can run in the middle of another test's `assertAccessDenied(...)` window and observe a `deny()` rule it was never meant to see, or vice versa.

## Fix

Based on discussion https://github.com/prestodb/presto/issues/28099#issuecomment-4947426755

Acquire read lock in `PrestoSparkQueryRunner.execute()`

PrestoSparkQueryRunner did not participate in the read/write lock protocol that `AbstractTestQueryFramework.executeExclusively()` relies on to serialize assertAccessDenied()/assertAccessAllowed() against concurrent query execution. `DistributedQueryRunner`, `LocalQueryRunner`, and `StandaloneQueryRunner` all acquire the read lock in execute(); this brings `PrestoSparkQueryRunner` in line with them, closing the semantic race where a plain query could observe a deny() rule set by an unrelated, concurrently-running test.

The lock spans the full `execute()` body, including the retry branch, so a failed first attempt and its retry are treated as one atomic unit rather than reopening the race window between them.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Fix ConcurrentModificationException-based flakiness in Presto-on-Spark tests by serializing access-control checks with concurrent query execution via the query runner read lock.

## Summary by Sourcery

Bug Fixes:
- Fix flaky ConcurrentModificationException in Presto-on-Spark access-control tests by guarding execute() with the shared read lock.