### PR TITLE
feat: Parameterize TimestampWithTimeZoneType by precision

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/TimestampConstants.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/TimestampConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+public final class TimestampConstants
+{
+    private static final int MAX_PICOS_OF_MICRO = 999_999;
+
+    private TimestampConstants() {}
+
+    public static void checkPicosOfMicro(int picosOfMicro)
+    {
+        if (picosOfMicro < 0 || picosOfMicro > MAX_PICOS_OF_MICRO) {
+            throw new IllegalArgumentException(
+                    "picosOfMicro must be in [0, " + MAX_PICOS_OF_MICRO + "]: " + picosOfMicro);
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -158,6 +158,9 @@ public interface Block
 
     /**
      * Appends the value at {@code position} to {@code blockBuilder} and closes the entry.
+     * Implementations do not check {@link #isNull(int)}: a null position is written as a
+     * zeroed non-null entry. Callers must check {@code isNull} first and call
+     * {@link BlockBuilder#appendNull()} themselves when the position is null.
      */
     void writePositionTo(int position, BlockBuilder blockBuilder);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
@@ -40,6 +40,7 @@ public final class BlockEncodingManager
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
+import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
+import static com.facebook.presto.common.array.Arrays.ensureCapacity;
+import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+
+/** Storage layout: {@code getLong(position, 0)} -> epochMicros; {@code getInt(position)} -> picosOfMicro. */
+public class Fixed12ArrayBlock
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlock.class).instanceSize();
+    public static final int FIXED12_BYTES = Integer.BYTES * 3;
+    public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
+
+    static final int INTS_PER_POSITION = 3;
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long retainedSizeInBytes;
+
+    public Fixed12ArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values);
+    }
+
+    Fixed12ArrayBlock(int positionOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - (positionOffset * INTS_PER_POSITION) < positionCount * INTS_PER_POSITION) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position)
+    {
+        return getLong(position, 0);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position + positionOffset);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return getPicosOfMicro(position + positionOffset);
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && isNullUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        blockBuilder.writeLong(getEpochMicros(internalPosition))
+                .writeInt(getPicosOfMicro(internalPosition))
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            int internalPosition = position + positionOffset;
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(internalPosition));
+            output.writeInt(getPicosOfMicro(internalPosition));
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                new int[] {
+                        values[internalPosition * INTS_PER_POSITION],
+                        values[internalPosition * INTS_PER_POSITION + 1],
+                        values[internalPosition * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            int internalPosition = position + positionOffset;
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[internalPosition];
+            }
+            newValues[i * INTS_PER_POSITION] = values[internalPosition * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[internalPosition * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[internalPosition * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+        return new Fixed12ArrayBlock(positionOffset + this.positionOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlock(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    // WARNING: returns only epochMicros; call getIntUnchecked separately for picosOfMicro. See #27934 Phase 3.
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getPicosOfMicro(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return positionOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public Block appendNull()
+    {
+        boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
+        int[] newValues = ensureCapacity(values, (positionOffset + positionCount + 1) * INTS_PER_POSITION, SMALL, PRESERVE);
+        return new Fixed12ArrayBlock(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    private long getEpochMicros(int internalPosition)
+    {
+        return unpackEpochMicros(values, internalPosition * INTS_PER_POSITION);
+    }
+
+    private int getPicosOfMicro(int internalPosition)
+    {
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    static long unpackEpochMicros(int[] values, int base)
+    {
+        // & 0xFFFFFFFFL prevents sign extension of the low 32-bit word.
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    static void packEpochMicros(int[] values, int base, long epochMicros)
+    {
+        values[base] = (int) (epochMicros >>> 32);
+        values[base + 1] = (int) epochMicros;
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    // Same equals/hashCode shape as LongArrayBlock, IntArrayBlock, and Int128ArrayBlock.
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Fixed12ArrayBlock other = (Fixed12ArrayBlock) obj;
+        return this.positionOffset == other.positionOffset &&
+                this.positionCount == other.positionCount &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                this.retainedSizeInBytes == other.retainedSizeInBytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                retainedSizeInBytes);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.TimestampConstants;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.Fixed12ArrayBlock.FIXED12_BYTES;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+/**
+ * Each non-null entry requires writeLong(epochMicros) -> writeInt(picosOfMicro) -> closeEntry() in order.
+ * Null entries use appendNull() alone. Violations throw IllegalStateException immediately.
+ */
+public class Fixed12ArrayBlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlockBuilder.class).instanceSize();
+    private static final Block NULL_VALUE_BLOCK = new Fixed12ArrayBlock(0, 1, new boolean[] {true}, new int[3]);
+
+    private static final int INTS_PER_POSITION = Fixed12ArrayBlock.INTS_PER_POSITION;
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+
+    private boolean[] valueIsNull = new boolean[0];
+    private int[] values = new int[0];
+
+    private long retainedSizeInBytes;
+
+    private int entryFieldCount;
+
+    public Fixed12ArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        updateDataSize();
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("writeLong must be the first write for each entry");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        Fixed12ArrayBlock.packEpochMicros(values, positionCount * INTS_PER_POSITION, value);
+        entryFieldCount = 1;
+        hasNonNullValue = true;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        if (entryFieldCount != 1) {
+            throw new IllegalStateException("writeInt must follow writeLong for each entry");
+        }
+        TimestampConstants.checkPicosOfMicro(value);
+        values[positionCount * INTS_PER_POSITION + 2] = value;
+        entryFieldCount = 2;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (entryFieldCount != 2) {
+            throw new IllegalStateException(
+                    "Each entry requires writeLong(epochMicros) then writeInt(picosOfMicro) before closeEntry()");
+        }
+        positionCount++;
+        entryFieldCount = 0;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        valueIsNull[positionCount] = true;
+        hasNullValue = true;
+        positionCount++;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("Current entry is not complete — call writeInt and closeEntry before building");
+        }
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
+        return new Fixed12ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * INTS_PER_POSITION);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position)
+    {
+        return getLong(position, 0);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return values[position * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        blockBuilder.writeLong(getEpochMicros(position))
+                .writeInt(values[position * INTS_PER_POSITION + 2])
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(position));
+            output.writeInt(values[position * INTS_PER_POSITION + 2]);
+        }
+    }
+
+    @Override
+    public BlockBuilder readPositionFrom(SliceInput input)
+    {
+        boolean isNull = input.readByte() == 0;
+        if (isNull) {
+            appendNull();
+        }
+        else {
+            writeLong(input.readLong());
+            writeInt(input.readInt());
+            closeEntry();
+        }
+        return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                valueIsNull[position] ? new boolean[] {true} : null,
+                new int[] {
+                        values[position * INTS_PER_POSITION],
+                        values[position * INTS_PER_POSITION + 1],
+                        values[position * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (hasNullValue) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            newValues[i * INTS_PER_POSITION] = values[position * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[position * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[position * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        return new Fixed12ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlockBuilder(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    private long getEpochMicros(int position)
+    {
+        return Fixed12ArrayBlock.unpackEpochMicros(values, position * INTS_PER_POSITION);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.TimestampConstants;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
+import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
+
+public class Fixed12ArrayBlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "FIXED12_ARRAY";
+    private static final int INTS_PER_POSITION = Fixed12ArrayBlock.INTS_PER_POSITION;
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        boolean mayHaveNull = block.mayHaveNull();
+        for (int position = 0; position < positionCount; position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        int[] values = new int[positionCount * INTS_PER_POSITION];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull == null || !valueIsNull[position]) {
+                long epochMicros = sliceInput.readLong();
+                int picosOfMicro = sliceInput.readInt();
+                TimestampConstants.checkPicosOfMicro(picosOfMicro);
+                int base = position * INTS_PER_POSITION;
+                Fixed12ArrayBlock.packEpochMicros(values, base, epochMicros);
+                values[base + 2] = picosOfMicro;
+            }
+        }
+
+        return new Fixed12ArrayBlock(0, positionCount, valueIsNull, values);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MethodHandleUtil.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MethodHandleUtil.java
@@ -129,6 +129,7 @@ public final class MethodHandleUtil
         Class<?> javaType = type.getJavaType();
 
         MethodHandle methodHandle;
+        // TODO(#27934 Phase 2): GET_LONG binds to Type.getLong(Block, int), which throws for TimestampType p=7–12.
         if (javaType == long.class) {
             methodHandle = GET_LONG;
         }
@@ -156,6 +157,7 @@ public final class MethodHandleUtil
         Class<?> javaType = type.getJavaType();
 
         MethodHandle methodHandle;
+        // TODO(#27934 Phase 2): WRITE_LONG binds to Type.writeLong(BlockBuilder, long), which throws for TimestampType p=7–12.
         if (javaType == long.class) {
             methodHandle = WRITE_LONG;
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -23,6 +23,21 @@ import io.airlift.slice.Slice;
 
 import static java.lang.Long.rotateLeft;
 
+/**
+ * Base class for fixed-width types whose SPI Java type ({@link #getJavaType()}) is {@code long.class}.
+ * The physical block layout may still be wider (e.g. {@code TimestampType} p=7–12 uses a 12-byte
+ * Fixed12ArrayBlock); such subclasses may override these non-final methods:
+ * <ul>
+ *   <li>{@link #getFixedSize()}, {@link #getLong(Block, int)}, {@link #writeLong(BlockBuilder, long)}</li>
+ *   <li>{@link #appendTo(Block, int, BlockBuilder)}</li>
+ *   <li>{@link #createBlockBuilder} / {@link #createFixedSizeBlockBuilder}</li>
+ * </ul>
+ *
+ * <p>{@link #getLongUnchecked} stays {@code final} and reads only the first {@code long} word;
+ * do not rely on it for wider storage.
+ * TODO(#27934 Phase 2): {@code TypeUtils.readNativeValue} must check {@code isShort()} before
+ * dispatching {@code getJavaType() == long.class} to {@code getLong()} for p=7–12.
+ */
 public abstract class AbstractLongType
         extends AbstractPrimitiveType
         implements FixedWidthType
@@ -33,7 +48,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return Long.BYTES;
     }
@@ -51,11 +66,12 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final long getLong(Block block, int position)
+    public long getLong(Block block, int position)
     {
         return block.getLong(position);
     }
 
+    // TODO(#27934 Phase 3): returns only epochMicros for Fixed12ArrayBlock; fix vectorized operators before p=7–12 is SQL-reachable.
     @Override
     public final long getLongUnchecked(UncheckedBlock block, int internalPosition)
     {
@@ -69,13 +85,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final void writeLong(BlockBuilder blockBuilder, long value)
+    public void writeLong(BlockBuilder blockBuilder, long value)
     {
         blockBuilder.writeLong(value).closeEntry();
     }
 
     @Override
-    public final void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
     {
         if (block.isNull(position)) {
             blockBuilder.appendNull();
@@ -108,7 +124,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
@@ -123,13 +139,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, Long.BYTES);
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(null, positionCount);
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.TimestampConstants;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public final class LongTimestamp
+{
+    private final long epochMicros;
+    private final int picosOfMicro;
+
+    public LongTimestamp(long epochMicros, int picosOfMicro)
+    {
+        TimestampConstants.checkPicosOfMicro(picosOfMicro);
+        this.epochMicros = epochMicros;
+        this.picosOfMicro = picosOfMicro;
+    }
+
+    public long getEpochMicros()
+    {
+        return epochMicros;
+    }
+
+    public int getPicosOfMicro()
+    {
+        return picosOfMicro;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongTimestamp that = (LongTimestamp) o;
+        return epochMicros == that.epochMicros && picosOfMicro == that.picosOfMicro;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(epochMicros, picosOfMicro);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("LongTimestamp{epochMicros=%d, picosOfMicro=%d}", epochMicros, picosOfMicro);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -14,6 +14,11 @@
 package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
+import com.facebook.presto.common.block.Fixed12ArrayBlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.concurrent.TimeUnit;
@@ -21,18 +26,16 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
+import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-// Short precisions (p=0–6) are stored as a single epoch-scaled long. The stored value equals the
-// number of units elapsed since 1970-01-01T00:00:00 UTC — e.g. p=3 stores epoch-milliseconds and
-// p=6 stores epoch-microseconds.
-//
-// Long precisions (p=7–12) will use a two-field LongTimestamp representation (epochMicros + picosOfMicro)
-// once that type is introduced in a follow-up change (see github.com/prestodb/presto/issues/27934).
-// Instances for p=7–12 are pre-allocated here but their arithmetic helpers throw
-// UnsupportedOperationException until the LongTimestamp path is wired in.
+// Short precisions (p=0–6) store a single epoch-scaled long (e.g. p=3 = epoch-millis, p=6 = epoch-micros).
+// Long precisions (p=7–12) store (epochMicros, picosOfMicro) in a Fixed12ArrayBlock. getJavaType()
+// returns long.class for all precisions; callers must check isShort() before treating the value as
+// a single long. SQL grammar, operator registration, and connector I/O for p=7–12 are tracked in #27934.
+// TODO(#27934 Phase 2): callers dispatching on getJavaType() == long.class must also check isShort().
 public final class TimestampType
         extends AbstractLongType
 {
@@ -40,6 +43,7 @@ public final class TimestampType
     public static final int MAX_SHORT_PRECISION = 6;
     public static final int DEFAULT_PRECISION = 3;
 
+    // TODO(#27934 Phase 3): p=7–12 entries unused until getEpochSecond/getNanos gain LongTimestamp overloads.
     private static final long[] PRECISION_SCALE = {
             1L,                     // p=0  (seconds)
             10L,                    // p=1
@@ -72,9 +76,13 @@ public final class TimestampType
 
     private final int precision;
 
-    // Returns the interned instance for p=0..MAX_PRECISION. Only p=3 and p=6 are registered in
-    // the type manager; all other precisions are arithmetic-only until a follow-up change wires
-    // full type-system support (see github.com/prestodb/presto/issues/27934).
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    // Only p=3 and p=6 are registered in the type manager; other precisions tracked in #27934.
     public static TimestampType createTimestampType(int precision)
     {
         if (precision < 0 || precision > MAX_PRECISION) {
@@ -82,12 +90,6 @@ public final class TimestampType
                     "TIMESTAMP precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
         }
         return INSTANCES[precision];
-    }
-
-    private TimestampType(int precision)
-    {
-        super(buildTypeSignature(precision));
-        this.precision = precision;
     }
 
     private static TypeSignature buildTypeSignature(int precision)
@@ -100,13 +102,11 @@ public final class TimestampType
             // Preserve "timestamp microseconds" for the same reason.
             return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
         }
-        // Other precisions use a numeric parameter; the type registry does not yet recognize the
-        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        // TODO(#27934 Phase 2): Register TimestampParametricType for type-registry round-trip.
         return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
     }
 
-    // Only p=3 and p=6 are supported; all other precisions throw UnsupportedOperationException.
-    // Support for p=0–2, p=4–5, and p=7–12 is planned for a follow-up change.
+    // TODO(#27934 Phase 2): Implement for all precisions; p=7–12 needs SqlTimestamp from getLongTimestamp().
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
@@ -124,23 +124,18 @@ public final class TimestampType
         return new SqlTimestamp(block.getLong(position), unit);
     }
 
-    // True when the value fits in a single long (p <= MAX_SHORT_PRECISION). Storage concept only —
-    // short precisions other than p=3 and p=6 are not yet registered in the type manager.
     public boolean isShort()
     {
         return precision <= MAX_SHORT_PRECISION;
     }
 
-    // Used to distinguish millisecond-precision timestamps (e.g. PartitionTable Iceberg partition
-    // value conversion, and future JDBC/ORC paths).
+    // Used by Iceberg partition value conversion.
     public boolean isMillisPrecision()
     {
         return precision == DEFAULT_PRECISION;
     }
 
-    // Instances are interned (one per precision, 0–MAX_PRECISION), so reference equality is correct.
-    // Both methods are overridden solely to satisfy the checkstyle EqualsHashCode rule; the default
-    // Object implementations would behave identically.
+    // Instances are interned, so reference equality is correct; overridden only for checkstyle's EqualsHashCode rule.
     @Override
     public boolean equals(Object other)
     {
@@ -153,27 +148,161 @@ public final class TimestampType
         return System.identityHashCode(this);
     }
 
+    // Guards against silently truncating long-precision timestamps to epochMicros.
+    @Override
+    public long getLong(Block block, int position)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getLong is not supported for TIMESTAMP(" + precision + "); use getLongTimestamp or read epochMicros/picosOfMicro from the block directly");
+        }
+        return super.getLong(block, position);
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return isShort() ? Long.BYTES : Fixed12ArrayBlock.FIXED12_BYTES;
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        if (!isShort()) {
+            return new Fixed12ArrayBlockBuilder(null, positionCount);
+        }
+        return super.createFixedSizeBlockBuilder(positionCount);
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "writeLong is not supported for TIMESTAMP(" + precision + "); use writeLongTimestamp");
+        }
+        super.writeLong(blockBuilder, value);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else if (isShort()) {
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
+        }
+        else {
+            blockBuilder.writeLong(block.getLong(position, 0))
+                    .writeInt(block.getInt(position))
+                    .closeEntry();
+        }
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        if (!isShort()) {
+            // expectedBytesPerEntry is ignored: Fixed12ArrayBlock always uses FIXED12_BYTES per position.
+            int maxBlockSizeInBytes = blockBuilderStatus == null
+                    ? PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES
+                    : blockBuilderStatus.getMaxPageSizeInBytes();
+            return new Fixed12ArrayBlockBuilder(
+                    blockBuilderStatus,
+                    min(expectedEntries, maxBlockSizeInBytes / Fixed12ArrayBlock.FIXED12_BYTES));
+        }
+        return super.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+    }
+
+    /**
+     * Not on the {@link com.facebook.presto.common.type.Type} interface to avoid polluting the SPI;
+     * callers must hold a {@code TimestampType} reference and check {@link #isShort()} first.
+     */
+    public void writeLongTimestamp(BlockBuilder blockBuilder, LongTimestamp value)
+    {
+        if (isShort()) {
+            throw new UnsupportedOperationException(
+                    "writeLongTimestamp is not supported for short TIMESTAMP(" + precision + "); use writeLong");
+        }
+        blockBuilder.writeLong(value.getEpochMicros())
+                .writeInt(value.getPicosOfMicro())
+                .closeEntry();
+    }
+
+    /**
+     * Not on the {@link com.facebook.presto.common.type.Type} interface to avoid polluting the SPI;
+     * callers must hold a {@code TimestampType} reference and check {@link #isShort()} first.
+     * Not for scan/projection hot paths — allocates a {@link LongTimestamp} per call.
+     */
+    public LongTimestamp getLongTimestamp(Block block, int position)
+    {
+        if (isShort()) {
+            throw new UnsupportedOperationException(
+                    "getLongTimestamp is not supported for short TIMESTAMP(" + precision + "); use getLong");
+        }
+        return new LongTimestamp(block.getLong(position, 0), block.getInt(position));
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            int epochCompare = Long.compare(leftBlock.getLong(leftPosition, 0), rightBlock.getLong(rightPosition, 0));
+            if (epochCompare != 0) {
+                return epochCompare;
+            }
+            return Integer.compare(leftBlock.getInt(leftPosition), rightBlock.getInt(rightPosition));
+        }
+        return super.compareTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            return leftBlock.getLong(leftPosition, 0) == rightBlock.getLong(rightPosition, 0)
+                    && leftBlock.getInt(leftPosition) == rightBlock.getInt(rightPosition);
+        }
+        return super.equalTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        if (!isShort()) {
+            // int->long widening sign-extends, but picosOfMicro is always non-negative, so this is safe.
+            long epochHash = AbstractLongType.hash(block.getLong(position, 0));
+            return 31 * epochHash + AbstractLongType.hash(block.getInt(position));
+        }
+        return super.hash(block, position);
+    }
+
     // Floor division gives the correct epoch-second for negative (pre-1970) timestamps.
+    // TODO(#27934 Phase 3): Add getEpochSecond(LongTimestamp) for date_trunc/date_add/AT TIME ZONE.
     public long getEpochSecond(long timestamp)
     {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getEpochSecond is not supported for TIMESTAMP(" + precision + "); use getLongTimestamp(block, position) to obtain the LongTimestamp representation");
+        }
         return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
     // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
+    // TODO(#27934 Phase 3): Add getNanos(LongTimestamp) for date_format/date_trunc.
     public int getNanos(long timestamp)
     {
-        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
-        long scale = PRECISION_SCALE[precision];
-        // For p <= 9, scale <= 1e9: multiply up to nanoseconds.
-        // For p > 9, scale > 1e9: dividing avoids integer overflow; scale is always a multiple of 1e9.
-        if (scale <= 1_000_000_000L) {
-            return (int) (fractional * (1_000_000_000L / scale));
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getNanos is not supported for TIMESTAMP(" + precision + "); use getLongTimestamp(block, position) to obtain the LongTimestamp representation");
         }
-        return (int) (fractional / (scale / 1_000_000_000L));
+        // isShort() guarantees scale <= 1_000_000 < 1e9, so the multiply below never overflows.
+        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
+        return (int) (fractional * (1_000_000_000L / PRECISION_SCALE[precision]));
     }
 
-    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
-    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    // TODO(#27934 Phase 4): Add toEpochMillis(LongTimestamp) for Iceberg/ORC/Parquet/JDBC.
     public long toEpochMillis(long timestamp)
     {
         if (!isShort()) {
@@ -183,8 +312,7 @@ public final class TimestampType
         return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
     }
 
-    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
-    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    // TODO(#27934 Phase 4): Add toEpochMicros(LongTimestamp) for ORC/Parquet microsecond writes.
     public long toEpochMicros(long timestamp)
     {
         if (!isShort()) {
@@ -194,6 +322,7 @@ public final class TimestampType
         return getEpochSecond(timestamp) * 1_000_000L + getNanos(timestamp) / 1_000;
     }
 
+    // TODO(#27934 Phase 4): Add fromEpochComponents(epochSecond, nanos) -> LongTimestamp for Parquet/ORC nanosecond reads.
     public long fromEpochComponents(long epochSecond, int nanos)
     {
         if (!isShort()) {
@@ -203,14 +332,14 @@ public final class TimestampType
         if (nanos < 0 || nanos >= 1_000_000_000) {
             throw new IllegalArgumentException("nanos must be in range [0, 999_999_999]: " + nanos);
         }
+        // scale is 10^p, so 1_000_000_000 / scale divides exactly for all short precisions p=0..6.
         long scale = PRECISION_SCALE[precision];
         return epochSecond * scale + nanos / (1_000_000_000L / scale);
     }
 
     private static TimeUnit toTimeUnit(int precision)
     {
-        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
-        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
+        // Only p=3 (millis) and p=6 (micros) map directly to a TimeUnit.
         if (precision == DEFAULT_PRECISION) {
             return MILLISECONDS;
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -18,16 +18,57 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
 
 // TODO(#27934 Phase 1): Add parameterized precision registry (p=0–12), isShort() dispatch, and a LongTimestamp analogue for p=7–12.
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
-    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+    public static final int MAX_PRECISION = 12;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private TimestampWithTimeZoneType()
+    private static final TimestampWithTimeZoneType[] INSTANCES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampWithTimeZoneType(p);
+        }
+    }
+
+    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = INSTANCES[DEFAULT_PRECISION];
+
+    private final int precision;
+
+    // Only p=3 is registered in the type manager; other precisions tracked in #27934.
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampWithTimeZoneType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        }
+        // The type registry does not yet recognize the "timestamp with time zone(p)" string form,
+        // so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+    }
+
+    public int getPrecision()
+    {
+        return precision;
     }
 
     /**
@@ -43,16 +84,23 @@ public final class TimestampWithTimeZoneType
         return false;
     }
 
+    // SqlTimestampWithTimeZone has no sub-millisecond representation yet, so silently accepting other
+    // precisions here would truncate values without any indication.
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
+        if (precision != DEFAULT_PRECISION) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + ") WITH TIME ZONE");
+        }
 
         return new SqlTimestampWithTimeZone(block.getLong(position));
     }
 
+    // TODO(#27934 Phase 2): equalTo/hash/compareTo assume DEFAULT_PRECISION encoding; add precision-aware dispatch.
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
@@ -75,16 +123,16 @@ public final class TimestampWithTimeZoneType
         return Long.compare(leftValue, rightValue);
     }
 
+    // Interned per precision, so reference equality is correct; overridden only for checkstyle.
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == TIMESTAMP_WITH_TIME_ZONE;
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return getClass().hashCode();
+        return System.identityHashCode(this);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 
+// TODO(#27934 Phase 1): Add parameterized precision registry (p=0–12), isShort() dispatch, and a LongTimestamp analogue for p=7–12.
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -106,6 +106,7 @@ public final class TypeUtils
         if (block.isNull(position)) {
             return null;
         }
+        // TODO(#27934 Phase 2): check TimestampType.isShort() and return LongTimestamp for p=7–12; type.getLong() throws for those precisions.
         if (javaType == long.class) {
             return type.getLong(block, position);
         }
@@ -135,6 +136,7 @@ public final class TypeUtils
         else if (type.getJavaType() == double.class) {
             type.writeDouble(blockBuilder, ((Number) value).doubleValue());
         }
+        // TODO(#27934 Phase 2): check TimestampType.isShort() and dispatch to writeLongTimestamp for p=7–12; type.writeLong() throws for those precisions.
         else if (type.getJavaType() == long.class) {
             if (value instanceof BigDecimal) {
                 type.writeLong(blockBuilder, ((BigDecimal) value).unscaledValue().longValue());

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
@@ -1,0 +1,560 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.TimestampType;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestFixed12ArrayBlock
+{
+    @Test
+    public void testSinglePositionRoundTrip()
+    {
+        long epochMicros = 1_000_000_000L;
+        int picosOfMicro = 500_000;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 1);
+        assertEquals(block.getLong(0), epochMicros);
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        long epochMicros = -1_000_000L;
+        int picosOfMicro = 999_999;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testMultiplePositions()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(200L).writeInt(999_999).closeEntry();
+        builder.writeLong(-300L).writeInt(500_000).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getLong(0, 0), 100L);
+        assertEquals(block.getInt(0), 0);
+        assertEquals(block.getLong(1, 0), 200L);
+        assertEquals(block.getInt(1), 999_999);
+        assertEquals(block.getLong(2, 0), -300L);
+        assertEquals(block.getInt(2), 500_000);
+    }
+
+    @Test
+    public void testNullPosition()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 2);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+    }
+
+    @Test
+    public void testSizeInBytes()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 4);
+        for (int i = 0; i < 4; i++) {
+            builder.writeLong((long) i * 1000).writeInt(i).closeEntry();
+        }
+        Block block = builder.build();
+        assertEquals(block.getSizeInBytes(), Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * 4L);
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForLongPrecision()
+    {
+        TimestampType longType = createTimestampType(7);
+        assertFalse(longType.isShort());
+        BlockBuilder builder = longType.createBlockBuilder(null, 10);
+        assertTrue(builder instanceof Fixed12ArrayBlockBuilder,
+                "Expected Fixed12ArrayBlockBuilder for p=7, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForShortPrecision()
+    {
+        TimestampType shortType = createTimestampType(6);
+        assertTrue(shortType.isShort());
+        BlockBuilder builder = shortType.createBlockBuilder(null, 10);
+        assertTrue(builder instanceof LongArrayBlockBuilder,
+                "Expected LongArrayBlockBuilder for p=6, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testEncodingRoundTrip()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000_000L).writeInt(500_000).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999_999L).writeInt(999_999).closeEntry();
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(256);
+        Fixed12ArrayBlockEncoding encoding = new Fixed12ArrayBlockEncoding();
+        encoding.writeBlock(null, sliceOutput, original);
+
+        SliceInput sliceInput = sliceOutput.slice().getInput();
+        Block decoded = encoding.readBlock(null, sliceInput);
+
+        assertEquals(decoded.getPositionCount(), 3);
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertTrue(decoded.isNull(1));
+        assertFalse(decoded.isNull(2));
+        assertEquals(decoded.getLong(2, 0), -999_999L);
+        assertEquals(decoded.getInt(2), 999_999);
+    }
+
+    @Test
+    public void testExtremeNegativeEpoch()
+    {
+        long epochMicros = Long.MIN_VALUE;
+        int picosOfMicro = 0;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testBuilderGetLongNoOffset()
+    {
+        long epochMicros = -999_000L;
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(0).closeEntry();
+
+        assertEquals(builder.getLong(0), epochMicros);
+        assertEquals(builder.getLong(0, 0), epochMicros);
+    }
+
+    @Test
+    public void testEqualTo()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(100L).writeInt(999_999).closeEntry();
+        Block block = builder.build();
+
+        assertTrue(longType.equalTo(block, 0, block, 0), "value must equal itself");
+        assertTrue(longType.equalTo(block, 0, block, 1), "identical values must be equal");
+        assertFalse(longType.equalTo(block, 0, block, 2), "same epochMicros but different picosOfMicro must not be equal");
+    }
+
+    @Test
+    public void testHashEqualsContract()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(42L).writeInt(7).closeEntry();
+        builder.writeLong(42L).writeInt(7).closeEntry();
+        Block block = builder.build();
+
+        assertTrue(longType.equalTo(block, 0, block, 1));
+        assertEquals(longType.hash(block, 0), longType.hash(block, 1),
+                "equal values must have the same hash");
+    }
+
+    @Test
+    public void testHashDifferentiatesByPicosOfMicro()
+    {
+        // Guards against a future bug where hash() ignores the picosOfMicro field.
+        TimestampType nanos = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(100L).writeInt(1).closeEntry();
+        Block block = builder.build();
+
+        assertNotEquals(nanos.hash(block, 0), nanos.hash(block, 1),
+                "same epochMicros but different picosOfMicro must produce different hashes");
+    }
+
+    @Test
+    public void testGetRegionWithNonZeroOffset()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 5);
+        for (int i = 0; i < 5; i++) {
+            builder.writeLong((long) (i + 1) * 100).writeInt(i * 10).closeEntry();
+        }
+        Block block = builder.build();
+
+        Block region1 = block.getRegion(1, 4);
+        assertEquals(region1.getPositionCount(), 4);
+        assertEquals(region1.getLong(0, 0), 200L);
+        assertEquals(region1.getInt(0), 10);
+
+        Block region2 = region1.getRegion(1, 2);
+        assertEquals(region2.getPositionCount(), 2);
+        assertEquals(region2.getLong(0, 0), 300L);
+        assertEquals(region2.getInt(0), 20);
+        assertEquals(region2.getLong(1, 0), 400L);
+        assertEquals(region2.getInt(1), 30);
+    }
+
+    @Test
+    public void testCopyRegionWithNonZeroOffset()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 5);
+        for (int i = 0; i < 5; i++) {
+            builder.writeLong((long) (i + 1) * 100).writeInt(i * 10).closeEntry();
+        }
+        Block block = builder.build();
+
+        Block region = block.getRegion(2, 3);
+        Block copy = region.copyRegion(0, 2);
+
+        assertEquals(copy.getPositionCount(), 2);
+        assertEquals(copy.getLong(0, 0), 300L);
+        assertEquals(copy.getInt(0), 20);
+        assertEquals(copy.getLong(1, 0), 400L);
+        assertEquals(copy.getInt(1), 30);
+        assertEquals(copy.getLong(0, 0), region.getLong(0, 0));
+    }
+
+    @Test
+    public void testEncodingRoundTripViaSerde()
+    {
+        BlockEncodingSerde serde = new TestingBlockEncodingSerde();
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000_000L).writeInt(500_000).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999_999L).writeInt(999_999).closeEntry();
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(256);
+        serde.writeBlock(sliceOutput, original);
+        Block decoded = serde.readBlock(sliceOutput.slice().getInput());
+
+        assertEquals(decoded.getPositionCount(), 3);
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertTrue(decoded.isNull(1));
+        assertFalse(decoded.isNull(2));
+        assertEquals(decoded.getLong(2, 0), -999_999L);
+        assertEquals(decoded.getInt(2), 999_999);
+    }
+
+    @Test
+    public void testWriteProtocolViolations()
+    {
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeInt(0));
+
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).closeEntry());
+
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(1L).closeEntry());
+
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(1L).appendNull());
+
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(1L).writeLong(2L));
+
+        expectThrows(IllegalStateException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(1L).build());
+    }
+
+    @Test
+    public void testWriteIntRejectsPicosOutOfRange()
+    {
+        expectThrows(IllegalArgumentException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(0L).writeInt(-1));
+
+        expectThrows(IllegalArgumentException.class, () ->
+                new Fixed12ArrayBlockBuilder(null, 1).writeLong(0L).writeInt(1_000_000));
+
+        new Fixed12ArrayBlockBuilder(null, 1).writeLong(0L).writeInt(0).closeEntry();
+        new Fixed12ArrayBlockBuilder(null, 1).writeLong(0L).writeInt(999_999).closeEntry();
+    }
+
+    @Test
+    public void testEncodingRoundTripViaBlockEncodingManager()
+    {
+        BlockEncodingSerde serde = new BlockEncodingManager();
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000_000L).writeInt(500_000).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999_999L).writeInt(999_999).closeEntry();
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(256);
+        serde.writeBlock(sliceOutput, original);
+        Block decoded = serde.readBlock(sliceOutput.slice().getInput());
+
+        assertEquals(decoded.getPositionCount(), 3);
+        assertTrue(decoded instanceof Fixed12ArrayBlock, "Expected Fixed12ArrayBlock, got: " + decoded.getClass().getSimpleName());
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertTrue(decoded.isNull(1));
+        assertFalse(decoded.isNull(2));
+        assertEquals(decoded.getLong(2, 0), -999_999L);
+        assertEquals(decoded.getInt(2), 999_999);
+    }
+
+    @Test
+    public void testAppendNullOnBlock()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(200L).writeInt(0).closeEntry();
+        Block base = builder.build();
+
+        Block withNull = base.appendNull();
+        assertEquals(withNull.getPositionCount(), 3);
+        assertFalse(withNull.isNull(0));
+        assertFalse(withNull.isNull(1));
+        assertTrue(withNull.isNull(2));
+        assertEquals(withNull.getLong(0, 0), 100L);
+        assertEquals(withNull.getInt(0), 500_000);
+    }
+
+    @Test
+    public void testEncodingRejectsOutOfRangePicosOfMicro()
+    {
+        // Bypass the builder's validation by writing raw bytes directly.
+        DynamicSliceOutput out = new DynamicSliceOutput(64);
+        out.writeInt(1);          // positionCount
+        out.writeBoolean(false);  // mayHaveNull = false (matches encodeNullsAsBits output)
+        out.writeLong(0L);        // epochMicros
+        out.writeInt(1_000_000);  // invalid picosOfMicro
+
+        Fixed12ArrayBlockEncoding encoding = new Fixed12ArrayBlockEncoding();
+        expectThrows(IllegalArgumentException.class,
+                () -> encoding.readBlock(null, out.slice().getInput()));
+    }
+
+    @Test
+    public void testCompareToNegativeEpochWithNonZeroPicos()
+    {
+        TimestampType nanos = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(-1_000L).writeInt(0).closeEntry();       // earlier
+        builder.writeLong(-1_000L).writeInt(500_000).closeEntry(); // same epoch, higher picos
+        builder.writeLong(-999L).writeInt(0).closeEntry();         // later epoch
+        Block block = builder.build();
+
+        assertEquals(nanos.compareTo(block, 0, block, 0), 0);
+        assertTrue(nanos.compareTo(block, 0, block, 1) < 0, "same negative epoch, lower picos must sort first");
+        assertTrue(nanos.compareTo(block, 1, block, 0) > 0);
+        assertTrue(nanos.compareTo(block, 0, block, 2) < 0, "more negative epoch must sort first");
+        assertTrue(nanos.compareTo(block, 2, block, 0) > 0);
+    }
+
+    @Test
+    public void testWritePositionToBlockBuilderContractForNullPosition()
+    {
+        // Same contract as LongArrayBlock/Int128ArrayBlock: null positions are written as zeroed non-null entries.
+        Fixed12ArrayBlockBuilder source = new Fixed12ArrayBlockBuilder(null, 2);
+        source.writeLong(42L).writeInt(7).closeEntry();
+        source.appendNull();
+        Block sourceBlock = source.build();
+
+        Fixed12ArrayBlockBuilder dest = new Fixed12ArrayBlockBuilder(null, 2);
+        sourceBlock.writePositionTo(0, dest);
+        sourceBlock.writePositionTo(1, dest);
+
+        assertEquals(dest.getPositionCount(), 2);
+        assertFalse(dest.isNull(0));
+        assertEquals(dest.getLong(0, 0), 42L);
+        assertEquals(dest.getInt(0), 7);
+        assertFalse(dest.isNull(1)); // null position written as non-null per contract
+        assertEquals(dest.getLong(1, 0), 0L);
+        assertEquals(dest.getInt(1), 0);
+    }
+
+    @Test
+    public void testWritePositionToSliceOutputRoundTrip()
+    {
+        Fixed12ArrayBlockBuilder source = new Fixed12ArrayBlockBuilder(null, 3);
+        source.writeLong(1_000_000L).writeInt(500_000).closeEntry();
+        source.appendNull();
+        source.writeLong(-999L).writeInt(999_999).closeEntry();
+        Block sourceBlock = source.build();
+
+        DynamicSliceOutput out = new DynamicSliceOutput(256);
+        for (int i = 0; i < sourceBlock.getPositionCount(); i++) {
+            sourceBlock.writePositionTo(i, out);
+        }
+
+        SliceInput in = out.slice().getInput();
+        Fixed12ArrayBlockBuilder dest = new Fixed12ArrayBlockBuilder(null, 3);
+        for (int i = 0; i < sourceBlock.getPositionCount(); i++) {
+            dest.readPositionFrom(in);
+        }
+        Block result = dest.build();
+
+        assertEquals(result.getPositionCount(), 3);
+        assertFalse(result.isNull(0));
+        assertEquals(result.getLong(0, 0), 1_000_000L);
+        assertEquals(result.getInt(0), 500_000);
+        assertTrue(result.isNull(1));
+        assertFalse(result.isNull(2));
+        assertEquals(result.getLong(2, 0), -999L);
+        assertEquals(result.getInt(2), 999_999);
+    }
+
+    @Test
+    public void testGetSingleValueBlock()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(42L).writeInt(7).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999L).writeInt(999_999).closeEntry();
+        Block block = builder.build();
+
+        Block single0 = block.getSingleValueBlock(0);
+        assertEquals(single0.getPositionCount(), 1);
+        assertFalse(single0.isNull(0));
+        assertEquals(single0.getLong(0, 0), 42L);
+        assertEquals(single0.getInt(0), 7);
+
+        Block single1 = block.getSingleValueBlock(1);
+        assertEquals(single1.getPositionCount(), 1);
+        assertTrue(single1.isNull(0));
+
+        Block single2 = block.getSingleValueBlock(2);
+        assertEquals(single2.getPositionCount(), 1);
+        assertFalse(single2.isNull(0));
+        assertEquals(single2.getLong(0, 0), -999L);
+        assertEquals(single2.getInt(0), 999_999);
+    }
+
+    @Test
+    public void testCopyPositions()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 4);
+        builder.writeLong(10L).writeInt(100).closeEntry();
+        builder.writeLong(20L).writeInt(200).closeEntry();
+        builder.appendNull();
+        builder.writeLong(40L).writeInt(400).closeEntry();
+        Block block = builder.build();
+
+        int[] positions = {3, 0, 2};
+        Block copy = block.copyPositions(positions, 0, 3);
+
+        assertEquals(copy.getPositionCount(), 3);
+        assertFalse(copy.isNull(0));
+        assertEquals(copy.getLong(0, 0), 40L);
+        assertEquals(copy.getInt(0), 400);
+        assertFalse(copy.isNull(1));
+        assertEquals(copy.getLong(1, 0), 10L);
+        assertEquals(copy.getInt(1), 100);
+        assertTrue(copy.isNull(2));
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        Fixed12ArrayBlockBuilder builder1 = new Fixed12ArrayBlockBuilder(null, 2);
+        builder1.writeLong(100L).writeInt(500_000).closeEntry();
+        builder1.appendNull();
+        Block block1 = builder1.build();
+
+        Fixed12ArrayBlockBuilder builder2 = new Fixed12ArrayBlockBuilder(null, 2);
+        builder2.writeLong(100L).writeInt(500_000).closeEntry();
+        builder2.appendNull();
+        Block block2 = builder2.build();
+
+        assertEquals(block1, block2);
+        assertEquals(block1.hashCode(), block2.hashCode());
+        assertEquals(block1, block1);
+
+        Fixed12ArrayBlockBuilder builder3 = new Fixed12ArrayBlockBuilder(null, 2);
+        builder3.writeLong(100L).writeInt(500_001).closeEntry();
+        builder3.appendNull();
+        Block block3 = builder3.build();
+
+        assertNotEquals(block1, block3);
+        assertNotEquals(block1, null);
+        assertNotEquals(block1, "not a block");
+    }
+
+    @Test
+    public void testEqualsWithDifferentPositionOffset()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(1).closeEntry();
+        builder.writeLong(100L).writeInt(1).closeEntry();
+        builder.writeLong(200L).writeInt(2).closeEntry();
+        Block block = builder.build();
+
+        Block region1 = block.getRegion(0, 2);
+        Block region2 = block.getRegion(1, 2);
+
+        assertNotEquals(region1, region2);
+    }
+
+    @Test
+    public void testDictionaryBlockDelegatesLongAndInt()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(111).closeEntry();
+        builder.writeLong(200L).writeInt(222).closeEntry();
+        builder.writeLong(300L).writeInt(333).closeEntry();
+        Block dictionary = builder.build();
+
+        int[] ids = {2, 0, 1};
+        Block dict = new DictionaryBlock(dictionary, ids);
+
+        assertEquals(dict.getLong(0, 0), 300L);
+        assertEquals(dict.getInt(0), 333);
+        assertEquals(dict.getLong(1, 0), 100L);
+        assertEquals(dict.getInt(1), 111);
+        assertEquals(dict.getLong(2, 0), 200L);
+        assertEquals(dict.getInt(2), 222);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
@@ -47,6 +47,7 @@ public final class TestingBlockEncodingSerde
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.expectThrows;
+
+public class TestLongTimestamp
+{
+    @Test
+    public void testConstructorStoresFields()
+    {
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 500_000);
+        assertEquals(ts.getEpochMicros(), 1_000_000L);
+        assertEquals(ts.getPicosOfMicro(), 500_000);
+    }
+
+    @Test
+    public void testPicosOfMicroLowerBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test
+    public void testPicosOfMicroUpperBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 999_999);
+        assertEquals(ts.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testPicosOfMicroNegativeThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> new LongTimestamp(0L, -1));
+    }
+
+    @Test
+    public void testPicosOfMicroTooLargeThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> new LongTimestamp(0L, 1_000_000));
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        LongTimestamp ts = new LongTimestamp(-1_000_000L, 0);
+        assertEquals(ts.getEpochMicros(), -1_000_000L);
+    }
+
+    @Test
+    public void testEqualsHashCodeToString()
+    {
+        LongTimestamp a = new LongTimestamp(42L, 100);
+        LongTimestamp b = new LongTimestamp(42L, 100);
+        LongTimestamp c = new LongTimestamp(42L, 101);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+
+        assertEquals(a.toString(), "LongTimestamp{epochMicros=42, picosOfMicro=100}");
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import org.testng.annotations.Test;
 
@@ -23,10 +24,12 @@ import java.util.Locale;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -40,6 +43,14 @@ public class TestTimestampType
             assertSame(createTimestampType(p), createTimestampType(p),
                     "createTimestampType(" + p + ") must return the same reference on repeated calls");
         }
+    }
+
+    @Test
+    public void testConstantsAreNonNull()
+    {
+        // Guards against static initialization order regressions in the INSTANCES array.
+        assertNotNull(TIMESTAMP, "TIMESTAMP constant must not be null");
+        assertNotNull(TIMESTAMP_MICROSECONDS, "TIMESTAMP_MICROSECONDS constant must not be null");
     }
 
     @Test
@@ -233,13 +244,18 @@ public class TestTimestampType
         assertEquals(TIMESTAMP_MICROSECONDS.getObjectValue(nonLegacy, microsBlock, 0), new SqlTimestamp(1_000_000L, MICROSECONDS));
         assertEquals(TIMESTAMP_MICROSECONDS.getObjectValue(legacy, microsBlock, 0), new SqlTimestamp(1_000_000L, TimeZoneKey.UTC_KEY, MICROSECONDS));
 
-        // Build a non-null block so the precision check is reached (null position returns early).
-        BlockBuilder builder = TIMESTAMP.createBlockBuilder(null, 1);
-        TIMESTAMP.writeLong(builder, 1_000L);
-        Block block = builder.build();
-        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(1).getObjectValue(null, block, 0));
-        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(4).getObjectValue(null, block, 0));
-        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).getObjectValue(null, block, 0));
+        // Build short-precision blocks (p=1, p=4) — the precision guard fires before any block read.
+        BlockBuilder shortBuilder = TIMESTAMP.createBlockBuilder(null, 1);
+        TIMESTAMP.writeLong(shortBuilder, 1_000L);
+        Block shortBlock = shortBuilder.build();
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(1).getObjectValue(null, shortBlock, 0));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(4).getObjectValue(null, shortBlock, 0));
+
+        TimestampType p7 = createTimestampType(7);
+        BlockBuilder p7Builder = p7.createBlockBuilder(null, 1);
+        p7.writeLongTimestamp(p7Builder, new LongTimestamp(1_000_000L, 0));
+        Block p7Block = p7Builder.build();
+        expectThrows(UnsupportedOperationException.class, () -> p7.getObjectValue(nonLegacy, p7Block, 0));
     }
 
     @Test
@@ -267,5 +283,206 @@ public class TestTimestampType
             assertEquals(micros.fromEpochComponents(micros.getEpochSecond(v), (int) micros.getNanos(v)), v,
                     "round-trip failed for p=6, v=" + v);
         }
+    }
+
+    @Test
+    public void testGetEpochSecondThrowsForLongPrecision()
+    {
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            TimestampType ts = createTimestampType(p);
+            expectThrows(UnsupportedOperationException.class, () -> ts.getEpochSecond(0L));
+            expectThrows(UnsupportedOperationException.class, () -> ts.getNanos(0L));
+        }
+    }
+
+    @Test
+    public void testGetFixedSize()
+    {
+        for (int p = 0; p <= TimestampType.MAX_SHORT_PRECISION; p++) {
+            assertEquals(createTimestampType(p).getFixedSize(), Long.BYTES,
+                    "short precision p=" + p + " must report Long.BYTES");
+        }
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            assertEquals(createTimestampType(p).getFixedSize(), Fixed12ArrayBlock.FIXED12_BYTES,
+                    "long precision p=" + p + " must report FIXED12_BYTES");
+        }
+    }
+
+    @Test
+    public void testWriteLongThrowsForLongPrecision()
+    {
+        TimestampType longType = createTimestampType(9);
+        BlockBuilder builder = longType.createBlockBuilder(null, 1);
+        expectThrows(UnsupportedOperationException.class, () -> longType.writeLong(builder, 0L));
+    }
+
+    @Test
+    public void testWriteLongWorksForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_500L);
+        Block block = builder.build();
+        assertEquals(block.getLong(0), 1_500L);
+    }
+
+    @Test
+    public void testWriteLongTimestampAndGetLongTimestamp()
+    {
+        TimestampType nanos = createTimestampType(9);
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 999_999);
+
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, ts);
+        Block block = builder.build();
+
+        LongTimestamp read = nanos.getLongTimestamp(block, 0);
+        assertEquals(read.getEpochMicros(), 1_000_000L);
+        assertEquals(read.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testWriteLongTimestampThrowsForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        expectThrows(UnsupportedOperationException.class,
+                () -> millis.writeLongTimestamp(builder, new LongTimestamp(0L, 0)));
+    }
+
+    @Test
+    public void testGetLongTimestampThrowsForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_000L);
+        Block block = builder.build();
+        expectThrows(UnsupportedOperationException.class, () -> millis.getLongTimestamp(block, 0));
+    }
+
+    @Test
+    public void testAppendToLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder source = nanos.createBlockBuilder(null, 2);
+        nanos.writeLongTimestamp(source, new LongTimestamp(5_000_000L, 123_456));
+        source.appendNull();
+        Block sourceBlock = source.build();
+
+        BlockBuilder dest = nanos.createBlockBuilder(null, 2);
+        nanos.appendTo(sourceBlock, 0, dest);
+        nanos.appendTo(sourceBlock, 1, dest);
+        Block destBlock = dest.build();
+
+        assertFalse(destBlock.isNull(0));
+        assertEquals(destBlock.getLong(0, 0), 5_000_000L);
+        assertEquals(destBlock.getInt(0), 123_456);
+        assertTrue(destBlock.isNull(1));
+    }
+
+    @Test
+    public void testCompareToLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 3);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 0));
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 500_000));
+        nanos.writeLongTimestamp(builder, new LongTimestamp(200L, 0));
+        Block block = builder.build();
+
+        assertEquals(nanos.compareTo(block, 0, block, 0), 0);
+        assertTrue(nanos.compareTo(block, 0, block, 1) < 0);
+        assertTrue(nanos.compareTo(block, 1, block, 0) > 0);
+        assertTrue(nanos.compareTo(block, 0, block, 2) < 0);
+        assertTrue(nanos.compareTo(block, 2, block, 0) > 0);
+    }
+
+    @Test
+    public void testHashLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(42L, 7));
+        Block block = builder.build();
+
+        long h1 = nanos.hash(block, 0);
+        long h2 = nanos.hash(block, 0);
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    public void testAppendToRleNullBlock()
+    {
+        // build() returns a RunLengthEncodedBlock when all entries are null; appendTo must handle it.
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder source = nanos.createBlockBuilder(null, 2);
+        source.appendNull();
+        source.appendNull();
+        Block rleBlock = source.build();
+
+        BlockBuilder dest = nanos.createBlockBuilder(null, 2);
+        nanos.appendTo(rleBlock, 0, dest);
+        nanos.appendTo(rleBlock, 1, dest);
+        Block result = dest.build();
+
+        assertEquals(result.getPositionCount(), 2);
+        assertTrue(result.isNull(0));
+        assertTrue(result.isNull(1));
+    }
+
+    @Test
+    public void testGetLongThrowsForLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(1_000_000L, 999_999));
+        Block block = builder.build();
+
+        expectThrows(UnsupportedOperationException.class, () -> nanos.getLong(block, 0));
+    }
+
+    @Test
+    public void testGetLongWorksForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_500L);
+        Block block = builder.build();
+
+        assertEquals(millis.getLong(block, 0), 1_500L);
+    }
+
+    @Test
+    public void testReadNativeValueThrowsForLongPrecision()
+    {
+        // Must not silently return a truncated long; see TODO(#27934 Phase 2) in TypeUtils.readNativeValue.
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(1_000_000L, 999_999));
+        Block block = builder.build();
+
+        expectThrows(UnsupportedOperationException.class, () -> readNativeValue(nanos, block, 0));
+    }
+
+    @Test
+    public void testGetSliceThrowsForLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(1_000_000L, 999_999));
+        Block block = builder.build();
+
+        expectThrows(UnsupportedOperationException.class, () -> nanos.getSlice(block, 0));
+    }
+
+    @Test
+    public void testGetSliceThrowsForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_500L);
+        Block block = builder.build();
+
+        expectThrows(UnsupportedOperationException.class, () -> millis.getSlice(block, 0));
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampWithTimeZoneType
+{
+    @Test
+    public void testInterning()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            assertSame(createTimestampWithTimeZoneType(p), createTimestampWithTimeZoneType(p),
+                    "Expected same instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testPreAllocation()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            TimestampWithTimeZoneType instance = createTimestampWithTimeZoneType(p);
+            assertEquals(instance.getPrecision(), p);
+        }
+    }
+
+    @Test
+    public void testBackwardCompatConstant()
+    {
+        assertSame(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testBackwardCompatTypeSignature()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getBase(), "timestamp with time zone");
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testInvalidPrecisionNegative()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampWithTimeZoneType(-1));
+    }
+
+    @Test
+    public void testInvalidPrecisionTooLarge()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampWithTimeZoneType(TimestampWithTimeZoneType.MAX_PRECISION + 1));
+    }
+
+    @Test
+    public void testDistinctInstances()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            for (int q = p + 1; q <= TimestampWithTimeZoneType.MAX_PRECISION; q++) {
+                TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
+                TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
+                assertNotSame(a, b, "Expected distinct instances for p=" + p + " and q=" + q);
+            }
+        }
+    }
+
+    @Test
+    public void testGetObjectValueSupportedForDefaultPrecision()
+    {
+        BlockBuilder builder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(null, 1);
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(builder, 0L);
+        Block block = builder.build();
+
+        Object value = TIMESTAMP_WITH_TIME_ZONE.getObjectValue(null, block, 0);
+        assertTrue(value instanceof SqlTimestampWithTimeZone, "Expected a SqlTimestampWithTimeZone for the default precision");
+    }
+
+    @Test
+    public void testGetObjectValueUnsupportedForNonDefaultPrecision()
+    {
+        BlockBuilder builder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(null, 1);
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(builder, 0L);
+        Block block = builder.build();
+
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            if (p == TimestampWithTimeZoneType.DEFAULT_PRECISION) {
+                continue;
+            }
+            TimestampWithTimeZoneType type = createTimestampWithTimeZoneType(p);
+            expectThrows(UnsupportedOperationException.class, () -> type.getObjectValue(null, block, 0));
+        }
+    }
+}


### PR DESCRIPTION
## Description
Parameterizes `TimestampWithTimeZoneType` by precision, following the same interning/factory pattern already established for `TimestampType`. `TimestampWithTimeZoneType` moves from a single hardcoded singleton to a static pool of interned instances for precisions `0..MAX_PRECISION` (12), built once in a static initializer.

Adds `createTimestampWithTimeZoneType(int precision)` and `getPrecision()`. The existing `TIMESTAMP_WITH_TIME_ZONE` constant still refers to the same interned p=3 instance, and its `TypeSignature` is unchanged (`"timestamp with time zone"`, no parameter), so existing serialized metadata continues to parse identically. `getObjectValue()` throws `UnsupportedOperationException` for any non-default precision, since `SqlTimestampWithTimeZone` has no sub-millisecond representation yet. `equalTo`/`hash`/`compareTo` are unchanged in behavior (still millis-only); precision-aware dispatch for those is left for a follow-up. `equals`/`hashCode` switch from class-based to reference-identity comparison, which is correct now that instances are interned per precision, with no observable change for the default precision (it was already effectively a singleton).

## Motivation and Context
This is groundwork for full `TIMESTAMP(p) WITH TIME ZONE` type-system support, tracked in #27934. Introducing the interned per-precision instances now — without yet wiring them into the parser/type registry — lets later phases (parsing, function dispatch, connector support) build on a stable `TimestampWithTimeZoneType` API instead of bundling the type-model change with those larger changes.


## Impact
No user-facing or behavioral change for the default precision (`TIMESTAMP WITH TIME ZONE`, p=3): the public constant, its type signature, and its `equals`/`hashCode`/`getObjectValue` behavior are unchanged from a caller's perspective. `createTimestampWithTimeZoneType(p)` for `p != 3` is new API surface, but the resulting instances aren't yet reachable through SQL parsing or the type registry, so they must not be surfaced outside `presto-common` (e.g. returned from a connector's column type) until #27934 lands — instances with `p != 3` will fail to round-trip through `TypeSignature` serialization since the parser doesn't recognize the `"timestamp with time zone(p)"` string form yet.

## Test Plan
Added `TestTimestampWithTimeZoneType` covering:
- Interning: repeated calls to `createTimestampWithTimeZoneType(p)` return the same instance; different precisions return distinct instances.
- Backward compatibility: the `TIMESTAMP_WITH_TIME_ZONE` constant is identical to `createTimestampWithTimeZoneType(3)`, and its type signature has no parameter.
- Invalid precision boundaries (negative, `> MAX_PRECISION`).
- `getObjectValue()` returns a `SqlTimestampWithTimeZone` for the default precision, and throws `UnsupportedOperationException` for every non-default precision.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Parameterize the TIMESTAMP WITH TIME ZONE type by precision while preserving backward compatibility for the default precision and reference semantics.

New Features:
- Introduce precision-specific instances of TimestampWithTimeZoneType with a factory method to obtain types for all supported precisions.

Enhancements:
- Ensure TIMESTAMP WITH TIME ZONE default constant retains legacy unparameterized type signature for serialized metadata compatibility.
- Adjust equality and hashCode semantics of TimestampWithTimeZoneType to rely on instance identity rather than a single global constant.
- Restrict getObjectValue to the default precision to avoid silent truncation until sub-millisecond encodings are supported.

Tests:
- Add unit tests covering interning and pre-allocation of precision-specific instances, backward-compatible constant and type signature behavior, precision validation, reference equality, and getObjectValue behavior for non-default precision.