### PR TITLE
fix : load getFunctions() properly

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -136,6 +136,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.stream.Collectors.partitioningBy;
 
 /**
  * TODO: This should not extend from FunctionMetadataManager and TypeManager
@@ -532,7 +533,19 @@ public class FunctionAndTypeManager
 
     public void registerPluginFunctions(List<? extends SqlFunction> functions)
     {
-        builtInPluginFunctionNamespaceManager.registerBuiltInSpecialFunctions(functions);
+        Map<Boolean, List<SqlFunction>> functionsByNamespace = functions.stream()
+                .collect(partitioningBy(function -> function.getSignature().getName().getCatalogSchemaName().equals(JAVA_BUILTIN_NAMESPACE)));
+
+        List<SqlFunction> builtInFunctionList = functionsByNamespace.get(true);
+        List<SqlFunction> pluginFunctionList = functionsByNamespace.get(false);
+
+        if (!builtInFunctionList.isEmpty()) {
+            builtInTypeAndFunctionNamespaceManager.registerBuiltInFunctions(builtInFunctionList);
+        }
+
+        if (!pluginFunctionList.isEmpty()) {
+            builtInPluginFunctionNamespaceManager.registerBuiltInSpecialFunctions(pluginFunctionList);
+        }
     }
 
     public void registerConnectorFunctions(String catalogName, List<? extends SqlFunction> functions)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
@@ -73,8 +73,8 @@ public final class FunctionExtractor
             return ScalarFromAnnotationsParser.parseFunctionDefinition(clazz, defaultNamespace);
         }
         if (clazz.isAnnotationPresent(ScalarOperator.class)) {
-            checkArgument(defaultNamespace.equals(JAVA_BUILTIN_NAMESPACE), format("Connector specific Scalar Operator functions are not supported: Class [%s], Namespace [%s]", clazz.getName(), defaultNamespace));
-            return ScalarFromAnnotationsParser.parseFunctionDefinition(clazz);
+            // Always register @ScalarOperator functions under JAVA_BUILTIN_NAMESPACE.
+            return ScalarFromAnnotationsParser.parseFunctionDefinition(clazz, JAVA_BUILTIN_NAMESPACE);
         }
 
         if (clazz.isAnnotationPresent(SqlInvokedScalarFunction.class)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarFromAnnotationsParser.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarFromAnnotationsParser.java
@@ -43,7 +43,6 @@ import static com.facebook.presto.operator.scalar.annotations.OperatorValidator.
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class ScalarFromAnnotationsParser
@@ -108,7 +107,8 @@ public final class ScalarFromAnnotationsParser
             checkCondition((method.getAnnotation(ScalarFunction.class) != null) || (method.getAnnotation(ScalarOperator.class) != null),
                     FUNCTION_IMPLEMENTATION_ERROR, "Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator", method);
             if (method.getAnnotation(ScalarOperator.class) != null) {
-                checkArgument(functionNamespace.equals(JAVA_BUILTIN_NAMESPACE), format("Connector specific Scalar operator functions are not supported: Class [%s], Namespace [%s]", annotated.getName(), functionNamespace));
+                // Always register @ScalarOperator functions under JAVA_BUILTIN_NAMESPACE.
+                functionNamespace = JAVA_BUILTIN_NAMESPACE;
             }
             for (ScalarImplementationHeader header : ScalarImplementationHeader.fromAnnotatedElement(method, functionNamespace)) {
                 builder.add(new ScalarHeaderAndMethods(header, ImmutableSet.of(method)));

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -231,7 +231,8 @@ public class PluginManager
 
         for (Class<?> functionClass : plugin.getFunctions()) {
             log.info("Registering functions from %s", functionClass.getName());
-            metadata.registerBuiltInFunctions(extractFunctions(functionClass));
+            metadata.getFunctionAndTypeManager().registerPluginFunctions(
+                    extractFunctions(functionClass, metadata.getFunctionAndTypeManager().getDefaultNamespace()));
         }
 
         for (FunctionNamespaceManagerFactory functionNamespaceManagerFactory : plugin.getFunctionNamespaceManagerFactories()) {

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginLoadedTypesAndFunctions.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginLoadedTypesAndFunctions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sidecar;
 
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -20,17 +21,26 @@ import com.facebook.presto.ml.MLPlugin;
 import com.facebook.presto.ml.type.ClassifierParametricType;
 import com.facebook.presto.mongodb.MongoPlugin;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 import static com.facebook.presto.mongodb.ObjectIdType.OBJECT_ID;
 import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class TestNativeSidecarWithPluginLoadedTypes
+public class TestNativeSidecarPluginLoadedTypesAndFunctions
         extends AbstractTestQueryFramework
 {
     @Override
@@ -57,5 +67,30 @@ public class TestNativeSidecarWithPluginLoadedTypes
                 ClassifierParametricType.NAME,
                 TypeSignatureParameter.of(BIGINT.getTypeSignature()));
         assertTrue(functionAndTypeManager.hasType(classifierSignature));
+    }
+
+    @Test
+    public void testFunctionsLoaded()
+    {
+        // ML plugin functions
+        MaterializedResult functions = computeActual("SHOW FUNCTIONS LIKE 'classify'");
+        assertTrue(functions.getMaterializedRows().stream()
+                .anyMatch(row -> row.getField(0).equals("classify") && row.getField(3).equals("scalar")));
+
+        FunctionAndTypeManager functionAndTypeManager = getQueryRunner().getMetadata().getFunctionAndTypeManager();
+
+        Collection<? extends SqlFunction> nativeClassifyFunctions = functionAndTypeManager
+                .getBuiltInPluginFunctionNamespaceManager()
+                .getFunctions(Optional.empty(), QualifiedObjectName.valueOf(functionAndTypeManager.getDefaultNamespace(), "classify"));
+        assertFalse(nativeClassifyFunctions.isEmpty());
+
+        List<? extends SqlFunction> mongoCastOperators = functionAndTypeManager.listOperators().stream()
+                .filter(function -> function.getSignature().getName().getCatalogSchemaName().equals(JAVA_BUILTIN_NAMESPACE))
+                .filter(function -> function.getSignature().getArgumentTypes().size() == 1)
+                .filter(function -> function.getSignature().getArgumentTypes().get(0).equals(OBJECT_ID.getTypeSignature()))
+                .filter(function -> function.getSignature().getReturnType().toString().startsWith("varchar"))
+                .collect(toImmutableList());
+
+        assertFalse(mongoCastOperators.isEmpty());
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure plugin functions and scalar operators are registered under the correct namespaces so sidecar plugins expose both types and functions properly.

Bug Fixes:
- Fix registration of plugin scalar functions and operators so they are visible through the built-in and plugin function namespace managers as intended.

Enhancements:
- Standardize handling of @ScalarOperator-annotated functions to always use the JAVA_BUILTIN_NAMESPACE.
- Adjust plugin installation to use FunctionAndTypeManager.registerPluginFunctions for function classes, separating built-in and plugin functions by namespace.

Tests:
- Extend native sidecar plugin integration tests to verify that ML functions and Mongo ObjectId cast operators are loaded and discoverable via SHOW FUNCTIONS and operator listings.