### PR TITLE
fix: Avoid state pollution in `DynamicFilterStats` from `copyOf`

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/DynamicFilterStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/DynamicFilterStats.java
@@ -19,7 +19,9 @@ import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -45,10 +47,11 @@ public class DynamicFilterStats
         this.producerNodeIds = requireNonNull(producerNodeIds, "producerNodeIds is null");
     }
 
+    @VisibleForTesting
     public static DynamicFilterStats copyOf(DynamicFilterStats dynamicFilterStats)
     {
         requireNonNull(dynamicFilterStats, "dynamicFilterStats is null");
-        return new DynamicFilterStats(dynamicFilterStats.getProducerNodeIds());
+        return new DynamicFilterStats(new HashSet<>(dynamicFilterStats.getProducerNodeIds()));
     }
 
     public void mergeWith(DynamicFilterStats other)

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -385,7 +385,7 @@ public class TestOperatorStats
 
         DynamicFilterStats expectedDynamicFilterStats = DynamicFilterStats.copyOf(TEST_DYNAMIC_FILTER_STATS_1);
         expectedDynamicFilterStats.mergeWith(TEST_DYNAMIC_FILTER_STATS_2);
-        assertEquals(actual.getDynamicFilterStats().getProducerNodeIds(), TEST_DYNAMIC_FILTER_STATS_1.getProducerNodeIds());
+        assertEquals(actual.getDynamicFilterStats().getProducerNodeIds(), expectedDynamicFilterStats.getProducerNodeIds());
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently, `DynamicFilterStats.copyOf(...)` and `DynamicFilterStats.mergeWith(...)` do not provide isolation from the original `DynamicFilterStats` object. As a result, the following code in the test directly affects the shared object `TEST_DYNAMIC_FILTER_STATS_1`, which is supposed to be immutable:

```
        DynamicFilterStats expectedDynamicFilterStats = DynamicFilterStats.copyOf(TEST_DYNAMIC_FILTER_STATS_1);
        expectedDynamicFilterStats.mergeWith(TEST_DYNAMIC_FILTER_STATS_2);
```

This may cause the flaky issues when test cases are executed concurrently.

This PR introduces a deep copy of the `DynamicFilterStats` state within the `copyOf` method, preventing shared references and state pollution of the source instance.

## Motivation and Context

Closes #28144 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Prevent DynamicFilterStats.copyOf from sharing internal state and align tests with the new behavior.

Bug Fixes:
- Ensure DynamicFilterStats.copyOf creates an independent copy of producer node IDs to avoid shared mutable state and test flakiness.

Tests:
- Update operator stats test to assert against the dynamically computed DynamicFilterStats instead of a shared static instance.