### PR TITLE
feat: Add configurable JDBC fetch size support in BaseJdbcClient

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -47,6 +47,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -123,6 +124,7 @@ public class BaseJdbcClient
     protected final Cache<RemoteTableNameCacheKey, Map<String, String>> remoteTableNames;
     protected final Set<String> listSchemasIgnoredSchemas;
     protected final boolean caseSensitiveNameMatchingEnabled;
+    protected final int fetchSize;
 
     public BaseJdbcClient(JdbcConnectorId connectorId, BaseJdbcConfig config, String identifierQuote, ConnectionFactory connectionFactory)
     {
@@ -138,6 +140,7 @@ public class BaseJdbcClient
         this.remoteTableNames = remoteNamesCacheBuilder.build();
         this.listSchemasIgnoredSchemas = config.getlistSchemasIgnoredSchemas();
         this.caseSensitiveNameMatchingEnabled = config.isCaseSensitiveNameMatching();
+        this.fetchSize = config.getFetchSize();
     }
 
     @PreDestroy
@@ -630,7 +633,9 @@ public class BaseJdbcClient
     public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        return connection.prepareStatement(sql);
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
     }
 
     @Override
@@ -644,11 +649,18 @@ public class BaseJdbcClient
     {
         DatabaseMetaData metadata = connection.getMetaData();
         Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
-        return metadata.getTables(
+        ResultSet resultSet = metadata.getTables(
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, escape).orElse(null),
                 escapeNamePattern(tableName, escape).orElse(null),
                 new String[] {"TABLE", "VIEW"});
+        try {
+            resultSet.setFetchSize(fetchSize);
+        }
+        catch (SQLFeatureNotSupportedException e) {
+            // safeguard
+        }
+        return resultSet;
     }
 
     protected String getTableSchemaName(ResultSet resultSet)

--- a/presto-hana/src/main/java/com/facebook/presto/plugin/hana/HanaClient.java
+++ b/presto-hana/src/main/java/com/facebook/presto/plugin/hana/HanaClient.java
@@ -91,6 +91,7 @@ public class HanaClient
         if (statement.isWrapperFor(Statement.class)) {
             statement.unwrap(Statement.class);
         }
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -47,6 +47,7 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +84,6 @@ public class OracleClient
         extends BaseJdbcClient
 {
     private static final Logger LOG = Logger.get(OracleClient.class);
-    private final int fetchSize;
 
     private final boolean synonymsEnabled;
     private final int numberDefaultScale;
@@ -100,7 +100,6 @@ public class OracleClient
         requireNonNull(oracleConfig, "oracle config is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
         this.numberDefaultScale = oracleConfig.getNumberDefaultScale();
-        this.fetchSize = config.getFetchSize();
     }
 
     private String[] getTableTypes()
@@ -122,17 +121,13 @@ public class OracleClient
                 escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
                 escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
                 getTableTypes());
-        resultSet.setFetchSize(fetchSize);
+        try {
+            resultSet.setFetchSize(fetchSize);
+        }
+        catch (SQLFeatureNotSupportedException e) {
+            // safeguard
+        }
         return resultSet;
-    }
-
-    @Override
-    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
-            throws SQLException
-    {
-        PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(fetchSize);
-        return statement;
     }
 
     @Override

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -99,7 +99,7 @@ public class PostgreSqlClient
     {
         connection.setAutoCommit(false);
         PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(1000);
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -51,7 +51,7 @@ public class RedshiftClient
     {
         connection.setAutoCommit(false);
         PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(1000);
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 


### PR DESCRIPTION
## Description
Move fetch size application from individual connector overrides into `BaseJdbcClient` so all JDBC connectors inherit consistent fetch size behavior automatically.

Connectors with driver-specific overrides (e.g. Oracle with SYNONYM support) retain their getTables() override but can reference the inherited fetchSize field directly.

## Motivation and Context
https://github.com/prestodb/presto/pull/27690#discussion_r3292654574

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add configurable JDBC fetch size support 

```