### PR TITLE
fix(plugin-iceberg): Fix NULL reads after partition evolution and snapshot resolution in rewrite_data_files

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -597,12 +597,15 @@ public class IcebergPageSourceProvider
                     columnReferences.add(new TupleDomainOrcPredicate.ColumnReference<>(columnHandle, columnHandle.getHiveColumnIndex(), typeManager.getType(columnHandle.getTypeSignature())));
                 }
                 else {
+                    // Missing columns are treated as REGULAR at the physical ORC-reader level.
+                    // PARTITION_KEY is an Iceberg metadata concept handled upstream by
+                    // IcebergPartitionInsertingPageSource; OrcBatchPageSource requires REGULAR.
                     physicalColumnHandles.add(new HiveColumnHandle(
                             column.getName(),
                             toHiveType(column.getType()),
                             column.getType().getTypeSignature(),
                             nextMissingColumnIndex++,
-                            column.getColumnType(),
+                            REGULAR,
                             column.getComment(),
                             column.getRequiredSubfields(),
                             Optional.empty()));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionInsertingPageSource.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.Utils.nativeValueToBlock;
-import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.isMetadataColumnId;
 import static com.facebook.presto.iceberg.IcebergUtil.deserializeIcebergValue;
@@ -46,6 +45,12 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * When a new page is requested, this class inserts the partition fields as
  * RLE-encoded blocks to save memory and IO cost at runtime.
+ * <p>
+ * After partition evolution, a column that is an identity partition field in the
+ * current spec may be absent from the partition metadata of files written under an
+ * older spec. Those old files still contain the column value in the Parquet row data
+ * (because at write time the column was REGULAR, not PARTITION_KEY). Skipping it here
+ * would cause Presto to return NULL instead of reading the real value from the file.
  */
 public class IcebergPartitionInsertingPageSource
         implements ConnectorPageSource
@@ -84,10 +89,12 @@ public class IcebergPartitionInsertingPageSource
         // generate array of non-partition column indexes
         for (int i = 0; i < fullColumnList.size(); i++) {
             IcebergColumnHandle handle = fullColumnList.get(i);
-            if (handle.getColumnType() == PARTITION_KEY ||
-                    partitionKeys.containsKey(handle.getId()) ||
+            // Skip only when the value is already available from partition metadata or is an
+            // Iceberg metadata field. Do NOT skip on PARTITION_KEY column type alone: after
+            // partition evolution, old files have no partition metadata entry for the new field
+            // but do contain the value in the Parquet row data — it must be read from the file.
+            if (partitionKeys.containsKey(handle.getId()) ||
                     isMetadataColumnId(handle.getId())) {
-                // is partition key, don't include for delegate supplier
                 continue;
             }
             nonPartitionColumnIndexes[i] = handle;
@@ -112,14 +119,6 @@ public class IcebergPartitionInsertingPageSource
                     if (partitionKeys.containsKey(column.getId())) {
                         HivePartitionKey icebergPartition = partitionKeys.get(column.getId());
                         Object prefilledValue = deserializeIcebergValue(type, icebergPartition.getValue().orElse(null), column.getName());
-                        return nativeValueToBlock(type, prefilledValue);
-                    }
-                    else if (column.getColumnType() == PARTITION_KEY) {
-                        // Partition key with no value. This can happen after partition evolution
-                        Object prefilledValue = null;
-                        if (column.getDefaultValue().isPresent()) {
-                            prefilledValue = deserializeIcebergValue(type, column.getDefaultValue().get(), column.getName());
-                        }
                         return nativeValueToBlock(type, prefilledValue);
                     }
                     else if (isMetadataColumnId(column.getId())) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -249,15 +249,18 @@ public class RewriteDataFilesProcedure
             final Set<DataFile> scannedDataFiles = new HashSet<>();
             final Set<DeleteFile> fullyAppliedDeleteFiles = new HashSet<>();
 
-            // Resolve the snapshot to scan: use the explicitly specified snapshot if present,
-            // otherwise fall back to the current snapshot. This ensures that scannedDataFiles
-            // is always populated so the Iceberg RewriteFiles operation correctly retires the
-            // old files from the manifest (not just appends new ones).
-            Snapshot scanSnapshot = tableHandle.getIcebergTableName().getSnapshotId()
-                    .map(icebergTable::snapshot)
-                    .orElse(icebergTable.currentSnapshot());
+            // The snapshot ID was resolved at analysis/planning time in getTableHandle() via
+            // resolveSnapshotIdByName(), which stores currentSnapshot().snapshotId() into
+            // IcebergTableName for any non-empty table. Using that resolved ID here ensures
+            // finishCallDistributedProcedure operates on the same snapshot that was used when
+            // reading data in beginCallDistributedProcedure, and scannedDataFiles is correctly
+            // populated so the Iceberg RewriteFiles operation retires old files from the manifest
+            // (rather than just appending new ones alongside them).
+            Optional<Snapshot> scanSnapshotOpt = tableHandle.getIcebergTableName().getSnapshotId()
+                    .map(icebergTable::snapshot);
 
-            if (scanSnapshot != null) {
+            if (scanSnapshotOpt.isPresent()) {
+                Snapshot scanSnapshot = scanSnapshotOpt.get();
                 TupleDomain<IcebergColumnHandle> predicate = layoutHandle.getValidPredicate();
 
                 TableScan tableScan = procedureContext.getTable().newScan()
@@ -299,9 +302,7 @@ public class RewriteDataFilesProcedure
             RewriteFiles rewriteFiles = icebergTable.newRewrite()
                     .rewriteFiles(scannedDataFiles, fullyAppliedDeleteFiles, newFiles, ImmutableSet.of());
 
-            if (scanSnapshot != null) {
-                rewriteFiles.validateFromSnapshot(scanSnapshot.snapshotId());
-            }
+            scanSnapshotOpt.ifPresent(snapshot -> rewriteFiles.validateFromSnapshot(snapshot.snapshotId()));
             rewriteFiles.commit();
         }
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -248,13 +248,22 @@ public class RewriteDataFilesProcedure
             IcebergTableHandle tableHandle = layoutHandle.getTable();
             final Set<DataFile> scannedDataFiles = new HashSet<>();
             final Set<DeleteFile> fullyAppliedDeleteFiles = new HashSet<>();
-            if (tableHandle.getIcebergTableName().getSnapshotId().isPresent()) {
+
+            // Resolve the snapshot to scan: use the explicitly specified snapshot if present,
+            // otherwise fall back to the current snapshot. This ensures that scannedDataFiles
+            // is always populated so the Iceberg RewriteFiles operation correctly retires the
+            // old files from the manifest (not just appends new ones).
+            Snapshot scanSnapshot = tableHandle.getIcebergTableName().getSnapshotId()
+                    .map(icebergTable::snapshot)
+                    .orElse(icebergTable.currentSnapshot());
+
+            if (scanSnapshot != null) {
                 TupleDomain<IcebergColumnHandle> predicate = layoutHandle.getValidPredicate();
 
                 TableScan tableScan = procedureContext.getTable().newScan()
                         .metricsReporter(new RuntimeStatsMetricsReporter(session.getRuntimeStats()))
                         .filter(toIcebergExpression(predicate))
-                        .useSnapshot(tableHandle.getIcebergTableName().getSnapshotId().get());
+                        .useSnapshot(scanSnapshot.snapshotId());
 
                 Map<String, String> options = procedureContext.getOptions();
                 // Apply filtering using options
@@ -290,15 +299,8 @@ public class RewriteDataFilesProcedure
             RewriteFiles rewriteFiles = icebergTable.newRewrite()
                     .rewriteFiles(scannedDataFiles, fullyAppliedDeleteFiles, newFiles, ImmutableSet.of());
 
-            // Table.snapshot method returns null if there is no matching snapshot
-            Snapshot snapshot = requireNonNull(
-                    handle.getTableName()
-                            .getSnapshotId()
-                            .map(icebergTable::snapshot)
-                            .orElse(null),
-                    "snapshot is null");
-            if (icebergTable.currentSnapshot() != null) {
-                rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
+            if (scanSnapshot != null) {
+                rewriteFiles.validateFromSnapshot(scanSnapshot.snapshotId());
             }
             rewriteFiles.commit();
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -302,7 +302,8 @@ public class RewriteDataFilesProcedure
             RewriteFiles rewriteFiles = icebergTable.newRewrite()
                     .rewriteFiles(scannedDataFiles, fullyAppliedDeleteFiles, newFiles, ImmutableSet.of());
 
-            scanSnapshotOpt.ifPresent(snapshot -> rewriteFiles.validateFromSnapshot(snapshot.snapshotId()));
+            checkArgument(scanSnapshotOpt.isPresent(), "snapshot is null");
+            rewriteFiles.validateFromSnapshot(scanSnapshotOpt.get().snapshotId());
             rewriteFiles.commit();
         }
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestRewriteDataFilesProcedure.java
@@ -1479,6 +1479,92 @@ public class TestRewriteDataFilesProcedure
                 .build();
     }
 
+    /**
+     * CASE: partition evolution NULL bug
+     *
+     * The scenario:
+     *   - Table created partitioned by day(int_load_ts) only.
+     *   - Rows inserted -> old files whose partition metadata has no rec_source entry.
+     *   - rec_source identity partition field added via Iceberg API (equivalent to Spark's
+     *     ALTER TABLE ... ADD PARTITION FIELD, which Presto SQL does not support in its grammar).
+     *   - New rows inserted → new files whose partition metadata includes rec_source.
+     *
+     * This test verifies the SELECT query results are correct at each stage.
+     */
+    @Test
+    public void testPartitionEvolutionQueryBehaviour()
+    {
+        String tableName = "test_partition_evolution_query";
+        try {
+            // Step 1: create table partitioned only by day(int_load_ts)
+            assertUpdate("CREATE TABLE " + tableName + " (" +
+                    "id INTEGER, rec_source VARCHAR, int_load_ts TIMESTAMP" +
+                    ") WITH (partitioning = ARRAY['day(int_load_ts)'])");
+
+            // Step 2: insert old rows (spec-0 files: only day partition in metadata)
+            assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                    "(1, 'WF360', TIMESTAMP '2026-01-18 10:00:00'), " +
+                    "(2, 'WF360', TIMESTAMP '2026-01-18 11:00:00')", 2);
+
+            Table table = loadTable(tableName);
+            // Both rows land in one file under int_load_ts_day=2026-01-18/
+            assertHasDataFiles(table.currentSnapshot(), 1);
+
+            // Step 3: evolve the partition spec via the Iceberg Java API
+            // This is equivalent to Spark's: ALTER TABLE ... ADD PARTITION FIELD rec_source
+            // Presto's SQL grammar does not have ADD PARTITION FIELD syntax for existing columns
+            table.updateSpec()
+                    .addField("rec_source")
+                    .commit();
+            table.refresh();
+
+            // The table now has two specs: spec-0 (day only) and spec-1 (day + rec_source)
+            assertEquals(table.specs().size(), 2);
+
+            // Step 4: insert new rows (spec-1 files: day + rec_source in metadata)
+            assertUpdate("INSERT INTO " + tableName + " VALUES " +
+                    "(3, 'WF360', TIMESTAMP '2026-06-18 10:00:00'), " +
+                    "(4, 'WF360', TIMESTAMP '2026-06-18 11:00:00')", 2);
+
+            table.refresh();
+            assertHasDataFiles(table.currentSnapshot(), 2);
+
+            // Step 5: query before any rewrite
+            // Old files (spec-0) have rec_source physically inside the Parquet data —
+            // Presto must read it from the file, not from partition metadata
+            // Expected: WF360 → 4  (no NULLs, value is read from the file body)
+            assertQuery(
+                    "SELECT rec_source, COUNT(*) FROM " + tableName + " GROUP BY rec_source",
+                    "VALUES ('WF360', 4)");
+
+            assertQuery(
+                    "SELECT id, rec_source FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'WF360'), (2, 'WF360'), (3, 'WF360'), (4, 'WF360')");
+
+            // Step 6: rewrite_data_files and verify
+            // This also exercises commit d94fa39 (TIMESTAMP_MICROSECONDS in transforms)
+            // and commit 21162cc (correct snapshot resolution so old files are retired)
+            assertUpdate(format(
+                    "CALL system.rewrite_data_files(table_name => '%s', schema => '%s', " +
+                    "options => map(array['rewrite-all'], array['true']))",
+                    tableName, TEST_SCHEMA), 4);
+
+            table.refresh();
+
+            // Results must be identical after rewrite : no new NULLs introduced
+            assertQuery(
+                    "SELECT rec_source, COUNT(*) FROM " + tableName + " GROUP BY rec_source",
+                    "VALUES ('WF360', 4)");
+
+            assertQuery(
+                    "SELECT id, rec_source FROM " + tableName + " ORDER BY id",
+                    "VALUES (1, 'WF360'), (2, 'WF360'), (3, 'WF360'), (4, 'WF360')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
     private Table loadTable(String tableName)
     {
         Catalog catalog = CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), ICEBERG_CATALOG, getProperties(), new Configuration());


### PR DESCRIPTION
## Description
Fixes three related bugs that cause Presto to return `NULL` for identity partition columns on Iceberg tables that have undergone partition evolution, and prevent `rewrite_data_files` from working correctly on Spark-created tables.

## Motivation and Context

When a Spark-created Iceberg table has a new identity partition field added after initial data has been written (partition evolution), the table ends up with two partition specs:

- **Spec-0 (old)**: partitioned by `day(int_load_ts)` only — files written before the `ALTER`
- **Spec-1 (new)**: partitioned by `day(int_load_ts)` + `rec_source` (identity) : files written after

Old files have `rec_source` in their Parquet row data (it was a regular column at write time) but have **no `rec_source` entry in their Iceberg partition metadata** (it did not exist in the partition spec when they were written).

Presto was returning `NULL` for `rec_source` on all rows from old files because it was skipping those columns at the read layer before they could be read from the Parquet file. Running `rewrite_data_files` to repair this was also broken: it crashed with `Unsupported type for 'day'` on `TIMESTAMP_MICROSECONDS` columns (Spark's `timestamp_ntz` type), and even when that error was bypassed, old files were never retired from the manifest, new and old files coexisted, producing double data.

## Impact

- **Query results**: Presto now returns correct values (not `NULL`) for identity partition columns on files written before a partition spec evolution. No query changes required.
- **`rewrite_data_files`**: The procedure now runs correctly on Spark-created tables with `TIMESTAMP_MICROSECONDS` columns and properly retires old files after rewriting.
- **No behavior change** for tables that have not undergone partition evolution : the `partitionKeys.containsKey()` check is equivalent to the old guard for all files where partition metadata is fully populated.

## Test Plan

`TestPartitionTransforms`: four new unit tests assert that `year`, `month`, `day`, and `hour` transforms produce correct output for `TIMESTAMP_MICROSECONDS` values (microseconds since epoch), including boundary values and negative epochs.
`testPartitionEvolutionQueryBehaviour` in `TestRewriteDataFilesProcedure`: an end-to-end integration test that runs against a real embedded Presto engine with real Parquet files on disk

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
