### PR TITLE
fix(native-pos): Delete native task after completion

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -190,6 +190,26 @@ public class PrestoSparkHttpTaskClient
         return result;
     }
 
+    public void deleteTask(TaskId taskId)
+    {
+        Request request = new Request.Builder()
+                .url(getTaskUri(taskId).toString())
+                .delete()
+                .build();
+
+        RequestErrorTracker errorTracker = new RequestErrorTracker(
+                "NativeExecution",
+                location,
+                NATIVE_EXECUTION_TASK_ERROR,
+                "deleteTask encountered too many errors talking to native process",
+                remoteTaskMaxErrorDuration,
+                scheduledExecutorService,
+                "delete native task");
+        SettableFuture<Void> result = SettableFuture.create();
+        scheduleVoidRequest(request, new BytesResponseHandler(), errorTracker, result);
+        getFutureValue(result);
+    }
+
     public TaskInfo getTaskInfo(TaskId taskId)
     {
         Request request = setContentTypeHeaders(new Request.Builder())

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -179,6 +179,12 @@ public class NativeExecutionTask
         taskInfoFetcher.stop();
         taskResultFetcher.ifPresent(fetcher -> fetcher.stop(success));
         workerClient.abortResultsAsync(taskId);
+        try {
+            workerClient.deleteTask(taskId);
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Failed to delete native task %s", taskId);
+        }
     }
 
     private TaskInfo sendUpdateRequest()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -327,10 +327,16 @@ public class PrestoSparkNativeTaskExecutorFactory
                             .getHandle().equals(FIXED_BROADCAST_DISTRIBUTION));
 
             log.info("Creating task and will wait for remote task completion");
-            TaskInfo taskInfo = task.start();
+            try {
+                TaskInfo taskInfo = task.start();
 
-            // task creation might have failed
-            processTaskInfoForErrorsOrCompletion(taskInfo);
+                // task creation might have failed
+                processTaskInfoForErrorsOrCompletion(taskInfo);
+            }
+            catch (RuntimeException e) {
+                task.stop(false);
+                throw e;
+            }
 
             // 4. return output to spark RDD layer
             return new PrestoSparkNativeTaskOutputIterator<>(
@@ -360,28 +366,31 @@ public class PrestoSparkNativeTaskExecutorFactory
 
     private static void completeTask(boolean success, CollectionAccumulator<SerializedTaskInfo> taskInfoCollector, NativeExecutionTask task, Codec<TaskInfo> taskInfoCodec, CpuTracker cpuTracker)
     {
-        // stop the task
-        task.stop(success);
+        try {
+            OptionalLong processCpuTime = cpuTracker.get();
 
-        OptionalLong processCpuTime = cpuTracker.get();
+            // collect statistics (if available)
+            Optional<TaskInfo> taskInfoOptional = tryGetTaskInfo(task);
+            if (!taskInfoOptional.isPresent()) {
+                log.error("Missing taskInfo. Statistics might be inaccurate");
+                return;
+            }
 
-        // collect statistics (if available)
-        Optional<TaskInfo> taskInfoOptional = tryGetTaskInfo(task);
-        if (!taskInfoOptional.isPresent()) {
-            log.error("Missing taskInfo. Statistics might be inaccurate");
-            return;
+            // Record process-wide CPU time spent while executing this task. Since we run one task at a time,
+            // process-wide CPU time matches task's CPU time.
+            processCpuTime.ifPresent(cpuTime -> taskInfoOptional.get().getStats().getRuntimeStats()
+                    .addMetricValue("javaProcessCpuTime", RuntimeUnit.NANO, cpuTime));
+
+            SerializedTaskInfo serializedTaskInfo = new SerializedTaskInfo(serializeZstdCompressed(taskInfoCodec, taskInfoOptional.get()));
+            taskInfoCollector.add(serializedTaskInfo);
+
+            // Update Spark Accumulators for spark internal metrics
+            PrestoSparkStatsCollectionUtils.collectMetrics(taskInfoOptional.get());
         }
-
-        // Record process-wide CPU time spent while executing this task. Since we run one task at a time,
-        // process-wide CPU time matches task's CPU time.
-        processCpuTime.ifPresent(cpuTime -> taskInfoOptional.get().getStats().getRuntimeStats()
-                .addMetricValue("javaProcessCpuTime", RuntimeUnit.NANO, cpuTime));
-
-        SerializedTaskInfo serializedTaskInfo = new SerializedTaskInfo(serializeZstdCompressed(taskInfoCodec, taskInfoOptional.get()));
-        taskInfoCollector.add(serializedTaskInfo);
-
-        // Update Spark Accumulators for spark internal metrics
-        PrestoSparkStatsCollectionUtils.collectMetrics(taskInfoOptional.get());
+        finally {
+            // Stop after fetching final task info so task cleanup does not race with stats collection.
+            task.stop(success);
+        }
     }
 
     private static Optional<TaskInfo> tryGetTaskInfo(NativeExecutionTask task)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -79,6 +79,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
@@ -235,6 +236,31 @@ public class TestPrestoSparkHttpClient
             e.printStackTrace();
             fail();
         }
+    }
+
+    @Test
+    public void testDeleteTask()
+    {
+        TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
+        AtomicInteger deleteTaskCount = new AtomicInteger();
+        TestingResponseManager responseManager = new TestingResponseManager(taskId.toString())
+        {
+            @Override
+            public Response createDummyResultResponse(Request request)
+            {
+                if (request.method().equalsIgnoreCase("DELETE") &&
+                        request.url().encodedPath().equals(TASK_ROOT_PATH + "/" + taskId)) {
+                    deleteTaskCount.incrementAndGet();
+                }
+                return super.createDummyResultResponse(request);
+            }
+        };
+
+        PrestoSparkHttpTaskClient workerClient = createWorkerClient(
+                new TestingOkHttpClient(scheduledExecutorService, responseManager));
+        workerClient.deleteTask(taskId);
+
+        assertEquals(deleteTaskCount.get(), 1);
     }
 
     @Test
@@ -875,12 +901,25 @@ public class TestPrestoSparkHttpClient
         taskConfig.setInfoUpdateInterval(new Duration(200, TimeUnit.MILLISECONDS));
         queryConfig.setRemoteTaskMaxErrorDuration(new Duration(1, TimeUnit.MINUTES));
         List<TaskSource> sources = new ArrayList<>();
+        AtomicInteger deleteTaskCount = new AtomicInteger();
+        TestingResponseManager responseManager = new TestingResponseManager(taskId.toString(),
+                new TimeoutResponseManager(0, 10, 0))
+        {
+            @Override
+            public Response createDummyResultResponse(Request request)
+            {
+                if (request.method().equalsIgnoreCase("DELETE") &&
+                        request.url().encodedPath().equals(TASK_ROOT_PATH + "/" + taskId)) {
+                    deleteTaskCount.incrementAndGet();
+                }
+                return super.createDummyResultResponse(request);
+            }
+        };
         try {
             NativeExecutionTaskFactory taskFactory = new NativeExecutionTaskFactory(
                     new TestingOkHttpClient(
                             scheduledExecutorService,
-                            new TestingResponseManager(taskId.toString(),
-                                    new TimeoutResponseManager(0, 10, 0))),
+                            responseManager),
                     scheduledExecutorService,
                     scheduledExecutorService,
                     TASK_INFO_JSON_CODEC,
@@ -916,6 +955,7 @@ public class TestPrestoSparkHttpClient
             assertTrue(task.getTaskInfo().isPresent());
 
             task.stop(true);
+            assertEquals(deleteTaskCount.get(), 1);
         }
         catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
Summary: Make the Presto-on-Spark native task lifecycle send task-level cleanup to the native worker after final task info collection. Keep result-buffer aborts, then issue `DELETE /v1/task/{taskId}` so failed or completed native tasks do not leave root pools behind in `presto_cpp`. Also clean up if native task startup returns a failed task info before the output iterator is created.

Differential Revision: D112004639

## Summary by Sourcery

Ensure native Presto-on-Spark tasks are fully cleaned up on the native worker after completion or failure, and add coverage for the new task deletion behavior.

Bug Fixes:
- Prevent native tasks from leaving resources and root pools behind by deleting the native task on the worker after task completion or failure.
- Avoid losing task cleanup when native task startup throws by stopping the task in a finally-like path.

Enhancements:
- Collect final task statistics and CPU usage before stopping the native task to avoid races with task cleanup and stats collection.

Tests:
- Add unit tests to verify that DELETE requests are issued for native task cleanup and that task deletion is invoked when stopping native execution tasks.

```
== NO RELEASE NOTE ==
```