### PR TITLE
perf(optimizer): Randomize outer-join null keys in their native type

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketedRandomizeNullKeyOuterJoin.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketedRandomizeNullKeyOuterJoin.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import io.airlift.tpch.TpchTable;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies {@code RandomizeNullKeyInOuterJoin} over BUCKETED Hive tables joined on the bucket column.
+ * This is the one path that routes the randomized key through the connector's bucket partition function
+ * (the TPC-H-based tests deliberately join on non-bucket columns and so only exercise the system-hash
+ * exchange). It confirms the rewrite fires, does not overflow/crash a real (hash-based) bucket function,
+ * and returns results identical to the un-optimized plan.
+ */
+public class TestHiveBucketedRandomizeNullKeyOuterJoin
+        extends AbstractTestQueryFramework
+{
+    private static final String RANDOMIZE_MARKER = "RandomizeNullKeyInOuterJoin";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(ImmutableList.<TpchTable<?>>of());
+    }
+
+    private Session randomizeEnabled()
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, "true")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .build();
+    }
+
+    private boolean rewriteFires(Session session, String sql)
+    {
+        return ((String) computeActual(session, "EXPLAIN (TYPE DISTRIBUTED) " + sql).getOnlyValue()).contains(RANDOMIZE_MARKER);
+    }
+
+    @Test
+    public void testBucketedBigintKey()
+    {
+        assertUpdate("CREATE TABLE rz_probe_bigint (k bigint, v bigint) WITH (bucketed_by = ARRAY['k'], bucket_count = 4)");
+        assertUpdate("INSERT INTO rz_probe_bigint VALUES (1, 10), (2, 20), (3, 30), (4, 40), (cast(null as bigint), 50), (cast(null as bigint), 60)", 6);
+        assertUpdate("CREATE TABLE rz_build_bigint (k bigint, w bigint) WITH (bucketed_by = ARRAY['k'], bucket_count = 4)");
+        assertUpdate("INSERT INTO rz_build_bigint VALUES (1, 100), (2, 200), (4, 400), (cast(null as bigint), 500)", 4);
+        try {
+            Session enabled = randomizeEnabled();
+            for (String joinType : ImmutableList.of("left join", "right join", "full join")) {
+                String sql = format("SELECT p.k, p.v, b.w FROM rz_probe_bigint p %s rz_build_bigint b ON p.k = b.k", joinType);
+                // The rewrite fires on the bucket-column join, so the randomized key flows through the Hive bucket function.
+                assertTrue(rewriteFires(enabled, sql), "expected randomization to fire for BIGINT " + joinType);
+                // Spreading null keys must not change results versus the un-optimized plan.
+                assertQueryWithSameQueryRunner(enabled, sql, getSession());
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS rz_probe_bigint");
+            assertUpdate("DROP TABLE IF EXISTS rz_build_bigint");
+        }
+    }
+
+    @Test
+    public void testBucketedVarcharKey()
+    {
+        assertUpdate("CREATE TABLE rz_probe_varchar (k varchar, v bigint) WITH (bucketed_by = ARRAY['k'], bucket_count = 4)");
+        assertUpdate("INSERT INTO rz_probe_varchar VALUES ('1', 10), ('2', 20), ('3', 30), ('4', 40), (cast(null as varchar), 50), (cast(null as varchar), 60)", 6);
+        assertUpdate("CREATE TABLE rz_build_varchar (k varchar, w bigint) WITH (bucketed_by = ARRAY['k'], bucket_count = 4)");
+        assertUpdate("INSERT INTO rz_build_varchar VALUES ('1', 100), ('2', 200), ('4', 400), (cast(null as varchar), 500)", 4);
+        try {
+            Session enabled = randomizeEnabled();
+            for (String joinType : ImmutableList.of("left join", "right join", "full join")) {
+                String sql = format("SELECT p.k, p.v, b.w FROM rz_probe_varchar p %s rz_build_varchar b ON p.k = b.k", joinType);
+                // The right key is cast to VARCHAR so both sides share a type; the rewrite fires for all outer
+                // join types, including FULL.
+                assertTrue(rewriteFires(enabled, sql), "expected randomization to fire for VARCHAR " + joinType);
+                assertQueryWithSameQueryRunner(enabled, sql, getSession());
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS rz_probe_varchar");
+            assertUpdate("DROP TABLE IF EXISTS rz_build_varchar");
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -803,6 +803,67 @@ public class PlannerUtils
         return new SpecialFormExpression(COALESCE, VARCHAR, ImmutableList.of(castToVarchar, concatExpression));
     }
 
+    /**
+     * Randomizes a null join key in its own native type: {@code COALESCE(key, randomDefault)}, where the
+     * default is a random value drawn from the hash-partition-count range so null keys spread across
+     * partitions instead of colliding on one. The key itself is never cast to VARCHAR.
+     * <p>
+     * The default is chosen to rarely collide with a real key (which only saves wasted work, not
+     * correctness): for BIGINT it is {@code -random(N)} (a negative value real ids almost never take),
+     * for DATE a pre-epoch date, and for VARCHAR the textual form of a small random number (e.g.
+     * {@code "53"}). Correctness does not depend on this: callers compare the coalesced key against the RAW
+     * other-side key and guard the join with {@code key IS NOT NULL} (as
+     * {@link com.facebook.presto.sql.planner.optimizations.RandomizeNullKeyInOuterJoin} does), so a
+     * randomized null can never match a real key or a null regardless of the random value.
+     * <p>
+     * For BIGINT/DATE the randomized key is produced in the key's own type, so it stays identical to the raw
+     * other-side key type. For VARCHAR the small random number is cast to unbounded VARCHAR (which never
+     * throws, unlike a cast to a bounded {@code varchar(n)}); the resulting key is unbounded VARCHAR, so the
+     * caller must NOT randomize VARCHAR keys in FULL joins -- FULL-join partitioning property derivation
+     * ({@code COALESCE(probe, build)}) requires the randomized key type to match the raw build key exactly.
+     *
+     * @param keyExpression the original join key expression (BIGINT, DATE, or VARCHAR)
+     * @return {@code COALESCE(key, randomDefault)} in the key's native type (unbounded VARCHAR for VARCHAR keys)
+     */
+    public static RowExpression randomizeJoinKeyNative(Session session, FunctionAndTypeManager functionAndTypeManager, RowExpression keyExpression)
+    {
+        int partitionCount = getHashPartitionCount(session);
+        RowExpression randomNumber = call(
+                functionAndTypeManager,
+                "random",
+                BIGINT,
+                constant((long) partitionCount, BIGINT));
+        // Negate so the fill is negative, which real keys rarely are -> fewer (harmless) hash collisions.
+        RowExpression negativeRandom = callOperator(functionAndTypeManager.getFunctionAndTypeResolver(), OperatorType.NEGATION, BIGINT, randomNumber);
+
+        Type keyType = keyExpression.getType();
+        RowExpression randomDefault;
+        if (keyType.equals(BIGINT)) {
+            randomDefault = negativeRandom;
+        }
+        else if (keyType.equals(DATE)) {
+            // date_add('day', -random(N), DATE '1970-01-01') -> a pre-epoch date, rarely a real key
+            randomDefault = call(
+                    functionAndTypeManager,
+                    "date_add",
+                    DATE,
+                    constant(Slices.utf8Slice("day"), VARCHAR),
+                    negativeRandom,
+                    constant(0L, DATE));
+        }
+        else if (keyType instanceof VarcharType) {
+            // Cast only the small random number to unbounded VARCHAR (e.g. "53"), never the (potentially
+            // large) key itself. Unbounded VARCHAR never overflows on cast; the caller excludes VARCHAR keys
+            // from FULL joins so the unbounded randomized key never needs to match a bounded build key.
+            randomDefault = call("CAST", functionAndTypeManager.lookupCast(CAST, BIGINT, VARCHAR), VARCHAR, randomNumber);
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported key type for native null-key randomization: " + keyType);
+        }
+        // BIGINT/DATE keep their native type; a VARCHAR key's randomized key is unbounded VARCHAR.
+        return new SpecialFormExpression(COALESCE, keyType instanceof VarcharType ? VARCHAR : keyType, ImmutableList.of(keyExpression, randomDefault));
+    }
+
     public static RowExpression getVariableHash(List<VariableReferenceExpression> inputVariables, FunctionAndTypeManager functionAndTypeManager)
     {
         checkArgument(!inputVariables.isEmpty());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -19,6 +19,7 @@ import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.JoinNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -52,6 +54,8 @@ import static com.facebook.presto.SystemSessionProperties.getRandomizeOuterJoinN
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.CastType.CAST;
 import static com.facebook.presto.spi.plan.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.spi.plan.JoinType.FULL;
 import static com.facebook.presto.spi.plan.JoinType.LEFT;
@@ -63,6 +67,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoin
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy.DISABLED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.RandomizeOuterJoinNullKeyStrategy.KEY_FROM_OUTER_JOIN;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -189,7 +194,6 @@ public class RandomizeNullKeyInOuterJoin
         private static final double NULL_BUILD_KEY_COUNT_THRESHOLD = 100_000;
         private static final double NULL_PROBE_KEY_COUNT_THRESHOLD = 100_000;
         private static final String LEFT_PREFIX = "l";
-        private static final String RIGHT_PREFIX = "r";
         private final Session session;
         private final FunctionAndTypeManager functionAndTypeManager;
         private final PlanNodeIdAllocator planNodeIdAllocator;
@@ -301,16 +305,29 @@ public class RandomizeNullKeyInOuterJoin
                     .collect(toImmutableList());
             Map<VariableReferenceExpression, RowExpression> leftKeyRandomVariableMap = generateRandomKeyMap(leftJoinKeys, LEFT_PREFIX);
 
-            List<VariableReferenceExpression> rightJoinKeys = candidateEquiJoinClauses.stream()
-                    .map(x -> x.getRight())
-                    .filter(x -> !isAlreadyRandomized(rewrittenRight, x, RIGHT_PREFIX))
-                    .collect(toImmutableList());
-            Map<VariableReferenceExpression, RowExpression> rightKeyRandomVariableMap = generateRandomKeyMap(rightJoinKeys, RIGHT_PREFIX);
+            // A VARCHAR key is randomized into an unbounded VARCHAR, so cast the raw right key to unbounded
+            // VARCHAR as well: the two join-key sides must share the exact same type for FULL-join and
+            // materialized-exchange partitioning property derivation. BIGINT/DATE keys already match natively
+            // and keep the right key raw.
+            Map<VariableReferenceExpression, VariableReferenceExpression> rightVarcharCastMap = new HashMap<>();
+            Map<VariableReferenceExpression, RowExpression> rightCastAssignments = new HashMap<>();
+            candidateEquiJoinClauses.stream()
+                    .map(EquiJoinClause::getRight)
+                    .filter(x -> x.getType() instanceof VarcharType)
+                    .distinct()
+                    .forEach(rightKey -> {
+                        RowExpression castExpression = call("CAST", functionAndTypeManager.lookupCast(CAST, rightKey.getType(), VARCHAR), VARCHAR, rightKey);
+                        VariableReferenceExpression castVariable = planVariableAllocator.newVariable(castExpression, RandomizeNullKeyInOuterJoin.class.getSimpleName());
+                        rightVarcharCastMap.put(rightKey, castVariable);
+                        rightCastAssignments.put(castVariable, castExpression);
+                    });
 
             ImmutableList.Builder<EquiJoinClause> joinClauseBuilder = ImmutableList.builder();
-            // Rewrite supported join clauses
+            // Rewrite supported clauses to `COALESCE(l.key, random) = r.key` (right key cast to VARCHAR for
+            // VARCHAR keys). Only the left key's nulls are spread; the `l.key IS NOT NULL` guard below keeps a
+            // randomized null on the left from ever matching a real or null right key.
             List<EquiJoinClause> rewrittenJoinClauses = candidateEquiJoinClauses.stream()
-                    .map(x -> new EquiJoinClause(keyToRandomKeyMap.get(LEFT_PREFIX).get(x.getLeft()), keyToRandomKeyMap.get(RIGHT_PREFIX).get(x.getRight())))
+                    .map(x -> new EquiJoinClause(keyToRandomKeyMap.get(LEFT_PREFIX).get(x.getLeft()), rightVarcharCastMap.getOrDefault(x.getRight(), x.getRight())))
                     .collect(toImmutableList());
             joinClauseBuilder.addAll(rewrittenJoinClauses);
             // Add the join clauses which are not supported back
@@ -319,38 +336,38 @@ public class RandomizeNullKeyInOuterJoin
                     .collect(toImmutableList());
             joinClauseBuilder.addAll(unchangedJoinClauses);
 
-            // If the join key is varchar, add additional null check
-            Map<VariableReferenceExpression, RowExpression> leftIsNullCheckExpression = candidateEquiJoinClauses.stream()
-                    .filter(x -> x.getLeft().getType() instanceof VarcharType).map(x -> x.getLeft()).distinct().collect(toImmutableMap(identity(), x -> specialForm(IS_NULL, BOOLEAN, x)));
-            Map<RowExpression, VariableReferenceExpression> leftIsNullCheckAssignment = leftIsNullCheckExpression.values().stream().collect(toImmutableMap(identity(), x -> planVariableAllocator.newVariable(x)));
-            Map<VariableReferenceExpression, RowExpression> rightIsNullCheckExpression = candidateEquiJoinClauses.stream()
-                    .filter(x -> x.getRight().getType() instanceof VarcharType).map(x -> x.getRight()).distinct().collect(toImmutableMap(identity(), x -> specialForm(IS_NULL, BOOLEAN, x)));
-            Map<RowExpression, VariableReferenceExpression> rightIsNullCheckAssignment = rightIsNullCheckExpression.values().stream().collect(toImmutableMap(identity(), x -> planVariableAllocator.newVariable(x)));
-
-            List<EquiJoinClause> isNullCheck = candidateEquiJoinClauses.stream()
-                    .filter(x -> x.getLeft().getType() instanceof VarcharType && x.getRight().getType() instanceof VarcharType)
-                    .map(x -> new EquiJoinClause(leftIsNullCheckAssignment.get(leftIsNullCheckExpression.get(x.getLeft())), rightIsNullCheckAssignment.get(rightIsNullCheckExpression.get(x.getRight()))))
-                    .collect(toImmutableList());
-            joinClauseBuilder.addAll(isNullCheck);
+            // Guard: `l.key IS NOT NULL`. With this guard, `COALESCE(l.key, random) = r.key` blocks a null
+            // left key from matching a null right key (random != null), a real left key from matching a null
+            // right key (l.key != null), and a randomized null on the left from colliding with a real right
+            // key -- so correctness is independent of the random value, which only spreads the left null keys
+            // across partitions.
+            ImmutableList.Builder<RowExpression> filterConjuncts = ImmutableList.builder();
+            joinNode.getFilter().ifPresent(filterConjuncts::add);
+            candidateEquiJoinClauses.stream()
+                    .map(EquiJoinClause::getLeft)
+                    .distinct()
+                    .forEach(leftKey -> filterConjuncts.add(call(functionAndTypeManager, "not", BOOLEAN, specialForm(IS_NULL, BOOLEAN, leftKey))));
+            Optional<RowExpression> newFilter = Optional.of(LogicalRowExpressions.and(filterConjuncts.build()));
 
             Assignments.Builder leftAssignments = Assignments.builder();
             leftAssignments.putAll(leftKeyRandomVariableMap);
             leftAssignments.putAll(rewrittenLeft.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
-            leftAssignments.putAll(leftIsNullCheckAssignment.entrySet().stream().collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey)));
-
-            Assignments.Builder rightAssignments = Assignments.builder();
-            rightAssignments.putAll(rightKeyRandomVariableMap);
-            rightAssignments.putAll(rewrittenRight.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
-            rightAssignments.putAll(rightIsNullCheckAssignment.entrySet().stream().collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey)));
-
             ProjectNode newLeft = new ProjectNode(rewrittenLeft.getSourceLocation(), planNodeIdAllocator.getNextId(), joinNode.getLeft().getStatsEquivalentPlanNode(), rewrittenLeft, leftAssignments.build(), LOCAL);
-            ProjectNode newRight = new ProjectNode(rewrittenRight.getSourceLocation(), planNodeIdAllocator.getNextId(), joinNode.getRight().getStatsEquivalentPlanNode(), rewrittenRight, rightAssignments.build(), LOCAL);
+
+            // Only add a right projection when a VARCHAR right key needs casting; otherwise keep the right raw.
+            PlanNode newRight = rewrittenRight;
+            if (!rightCastAssignments.isEmpty()) {
+                Assignments.Builder rightAssignments = Assignments.builder();
+                rightAssignments.putAll(rewrittenRight.getOutputVariables().stream().collect(toImmutableMap(identity(), identity())));
+                rightCastAssignments.forEach(rightAssignments::put);
+                newRight = new ProjectNode(rewrittenRight.getSourceLocation(), planNodeIdAllocator.getNextId(), joinNode.getRight().getStatsEquivalentPlanNode(), rewrittenRight, rightAssignments.build(), LOCAL);
+            }
+
             ImmutableList.Builder<VariableReferenceExpression> joinOutputBuilder = ImmutableList.builder();
             joinOutputBuilder.addAll(leftKeyRandomVariableMap.keySet());
             // Input from left side should be before input from right side in join output
             joinOutputBuilder.addAll(joinNode.getOutputVariables().stream().filter(x -> newLeft.getOutputVariables().contains(x)).collect(toImmutableList()));
-            joinOutputBuilder.addAll(rightKeyRandomVariableMap.keySet());
-            joinOutputBuilder.addAll(joinNode.getOutputVariables().stream().filter(x -> newRight.getOutputVariables().contains(x)).collect(toImmutableList()));
+            joinOutputBuilder.addAll(joinNode.getOutputVariables().stream().filter(x -> rewrittenRight.getOutputVariables().contains(x)).collect(toImmutableList()));
 
             planChanged = true;
             JoinNode newJoinNode = new JoinNode(
@@ -362,7 +379,7 @@ public class RandomizeNullKeyInOuterJoin
                     newRight,
                     joinClauseBuilder.build(),
                     joinOutputBuilder.build(),
-                    joinNode.getFilter(),
+                    newFilter,
                     joinNode.getLeftHashVariable(),
                     joinNode.getRightHashVariable(),
                     joinNode.getDistributionType(),
@@ -396,7 +413,7 @@ public class RandomizeNullKeyInOuterJoin
 
         private Map<VariableReferenceExpression, RowExpression> generateRandomKeyMap(List<VariableReferenceExpression> joinKeys, String prefix)
         {
-            List<RowExpression> randomExpressions = joinKeys.stream().map(x -> PlannerUtils.randomizeJoinKey(session, functionAndTypeManager, x, prefix)).collect(toImmutableList());
+            List<RowExpression> randomExpressions = joinKeys.stream().map(x -> PlannerUtils.randomizeJoinKeyNative(session, functionAndTypeManager, x)).collect(toImmutableList());
             List<VariableReferenceExpression> randomVariable = randomExpressions.stream()
                     .map(x -> planVariableAllocator.newVariable(x, RandomizeNullKeyInOuterJoin.class.getSimpleName()))
                     .collect(toImmutableList());

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.LiteralInterpreter;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.ArrayConstructor;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.BetweenPredicate;
@@ -395,6 +396,23 @@ public final class RowExpressionVerifier
             OperatorType expectedOperatorType = getOperatorType(expected.getOperator());
             if (expectedOperatorType.equals(actualOperatorType)) {
                 return process(expected.getLeft(), ((CallExpression) actual).getArguments().get(0)) && process(expected.getRight(), ((CallExpression) actual).getArguments().get(1));
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitArithmeticUnary(ArithmeticUnaryExpression expected, RowExpression actual)
+    {
+        // A positive sign is a no-op in the plan (e.g. +x is stored as x), so match against the operand directly.
+        if (expected.getSign() == ArithmeticUnaryExpression.Sign.PLUS) {
+            return process(expected.getValue(), actual);
+        }
+        // A negative sign is represented as a call to the NEGATION operator over the operand.
+        if (actual instanceof CallExpression) {
+            FunctionMetadata functionMetadata = metadata.getFunctionAndTypeManager().getFunctionMetadata(((CallExpression) actual).getFunctionHandle());
+            if (functionMetadata.getOperatorType().isPresent() && functionMetadata.getOperatorType().get().equals(OperatorType.NEGATION)) {
+                return process(expected.getValue(), ((CallExpression) actual).getArguments().get(0));
             }
         }
         return false;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRandomizeNullKeyInOuterJoin.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
@@ -29,6 +31,7 @@ import static com.facebook.presto.spi.plan.JoinType.RIGHT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -62,15 +65,14 @@ public class TestRandomizeNullKeyInOuterJoin
                 anyTree(
                         join(
                                 LEFT,
-                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom")),
+                                ImmutableList.of(equiJoinClause("leftRandom", "rightCol")),
+                                Optional.of("NOT (leftCol IS NULL)"),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(cast(leftCol as varchar), 'l' || cast(random(100) as varchar))")),
+                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(leftCol, -random(100))")),
                                                 tableScan("orders", ImmutableMap.of("leftCol", "orderkey")))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("rightCol", expression("rightCol"), "rightRandom", expression("coalesce(cast(rightCol as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey")))))),
+                                        tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey"))))),
                 false);
     }
 
@@ -82,14 +84,15 @@ public class TestRandomizeNullKeyInOuterJoin
                 anyTree(
                         join(
                                 LEFT,
-                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom"), equiJoinClause("leftIsNull", "rightIsNull")),
+                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom")),
+                                Optional.of("NOT (leftCol IS NULL)"),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(leftCol, 'l' || cast(random(100) as varchar))"), "leftIsNull", expression("leftCol is NULL")),
+                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(leftCol, cast(random(100) as varchar))")),
                                                 values("leftCol"))),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("rightCol", expression("rightCol"), "rightRandom", expression("coalesce(rightCol, 'r' || cast(random(100) as varchar))"), "rightIsNull", expression("rightCol is NULL")),
+                                                ImmutableMap.of("rightRandom", expression("cast(rightCol as varchar)")),
                                                 values("rightCol"))))),
                 false);
     }
@@ -103,19 +106,16 @@ public class TestRandomizeNullKeyInOuterJoin
                         join(
                                 LEFT,
                                 ImmutableList.of(equiJoinClause("leftVarcharRandom", "rightVarcharRandom"),
-                                        equiJoinClause("leftVarcharIsNull", "rightVarcharIsNull"),
-                                        equiJoinClause("leftBigIntRandom", "rightBigIntRandom")),
+                                        equiJoinClause("leftBigIntRandom", "rightColBigInt")),
+                                Optional.of("(NOT (leftColVarchar IS NULL)) AND (NOT (leftColBigInt IS NULL))"),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("leftVarcharRandom", expression("coalesce(leftColVarchar, 'l' || cast(random(100) as varchar))"),
-                                                        "leftVarcharIsNull", expression("leftColVarchar is NULL"),
-                                                        "leftBigIntRandom", expression("coalesce(cast(leftColBigInt as varchar), 'l' || cast(random(100) as varchar))")),
+                                                ImmutableMap.of("leftVarcharRandom", expression("coalesce(leftColVarchar, cast(random(100) as varchar))"),
+                                                        "leftBigIntRandom", expression("coalesce(leftColBigInt, -random(100))")),
                                                 values("leftColVarchar", "leftColBigInt"))),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("rightVarcharRandom", expression("coalesce(rightColVarchar, 'r' || cast(random(100) as varchar))"),
-                                                        "rightVarcharIsNull", expression("rightColVarchar is NULL"),
-                                                        "rightBigIntRandom", expression("coalesce(cast(rightColBigInt as varchar), 'r' || cast(random(100) as varchar))")),
+                                                ImmutableMap.of("rightVarcharRandom", expression("cast(rightColVarchar as varchar)")),
                                                 values("rightColVarchar", "rightColBigInt"))))),
                 false);
     }
@@ -123,47 +123,49 @@ public class TestRandomizeNullKeyInOuterJoin
     @Test
     public void testRightJoin()
     {
+        // For a RIGHT join the left (non-preserved) side's `leftCol IS NOT NULL` guard is pushed below the
+        // join into a filter over the left scan, so the join itself carries no extra filter.
         assertPlan("SELECT * FROM orders RIGHT JOIN lineitem ON orders.orderkey = lineitem.orderkey ",
                 getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 RIGHT,
-                                ImmutableList.of(equiJoinClause("leftRandom", "rightRandom")),
+                                ImmutableList.of(equiJoinClause("leftRandom", "rightCol")),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("leftCol", expression("leftCol"), "leftRandom", expression("coalesce(cast(leftCol as varchar), 'l' || cast(random(100) as varchar))")),
-                                                tableScan("orders", ImmutableMap.of("leftCol", "orderkey")))),
+                                                ImmutableMap.of("leftRandom", expression("coalesce(leftCol, -random(100))")),
+                                                filter(
+                                                        "NOT (leftCol IS NULL)",
+                                                        tableScan("orders", ImmutableMap.of("leftCol", "orderkey"))))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("rightCol", expression("rightCol"), "rightRandom", expression("coalesce(cast(rightCol as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey")))))),
+                                        tableScan("lineitem", ImmutableMap.of("rightCol", "orderkey"))))),
                 false);
     }
 
     @Test
     public void testLeftJoinOnSameKey()
     {
+        // Same left key (ps.partkey) feeds both joins, so both reuse the one randomized variable and only the
+        // right keys (p.partkey, l.partkey) stay raw. Each join is guarded by `ps.partkey IS NOT NULL`.
         assertPlan("select * from partsupp ps left join part p on ps.partkey = p.partkey left join lineitem l on ps.partkey = l.partkey",
                 getSessionAlwaysEnabled(),
                 anyTree(
                         join(
                                 LEFT,
-                                ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey_random")),
+                                ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey")),
+                                Optional.of("NOT (ps_partkey IS NULL)"),
                                 join(
                                         LEFT,
-                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey")),
+                                        Optional.of("NOT (ps_partkey IS NULL)"),
                                         anyTree(
                                                 project(
-                                                        ImmutableMap.of("ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                        ImmutableMap.of("ps_partkey_random", expression("coalesce(ps_partkey, -random(100))")),
                                                         tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
                                         anyTree(
-                                                project(
-                                                        ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                                tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey")))))),
+                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey"))))),
                 false);
     }
 
@@ -175,23 +177,23 @@ public class TestRandomizeNullKeyInOuterJoin
                 anyTree(
                         join(
                                 LEFT,
-                                ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey_random")),
+                                ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey")),
+                                Optional.of("NOT (ps_partkey IS NULL)"),
                                 anyTree(
                                         project(
-                                                ImmutableMap.of("ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                ImmutableMap.of("ps_partkey_random", expression("coalesce(ps_partkey, -random(100))")),
                                                 tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
                                 anyTree(
                                         join(
                                                 LEFT,
-                                                ImmutableList.of(equiJoinClause("p_partkey_random", "l_partkey_random")),
+                                                ImmutableList.of(equiJoinClause("p_partkey_random", "l_partkey")),
+                                                Optional.of("NOT (p_partkey IS NULL)"),
                                                 anyTree(
                                                         project(
-                                                                ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                                ImmutableMap.of("p_partkey_random", expression("coalesce(p_partkey, -random(100))")),
                                                                 tableScan("part", ImmutableMap.of("p_partkey", "partkey", "name", "name")))),
                                                 anyTree(
-                                                        project(
-                                                                ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "orderkey", "orderkey")))))))),
+                                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "orderkey", "orderkey"))))))),
                 false);
     }
 
@@ -203,24 +205,22 @@ public class TestRandomizeNullKeyInOuterJoin
                 anyTree(
                         join(
                                 LEFT,
-                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey")),
+                                Optional.of("NOT (l_orderkey IS NULL)"),
                                 anyTree(
-                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(l_orderkey, -random(100))")),
                                                 join(
                                                         LEFT,
-                                                        ImmutableList.of(equiJoinClause("p_partkey_random", "l_partkey_random")),
+                                                        ImmutableList.of(equiJoinClause("p_partkey_random", "l_partkey")),
+                                                        Optional.of("NOT (p_partkey IS NULL)"),
                                                         anyTree(
                                                                 project(
-                                                                        ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                                        ImmutableMap.of("p_partkey_random", expression("coalesce(p_partkey, -random(100))")),
                                                                         tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
                                                         anyTree(
-                                                                project(
-                                                                        ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey"))))))),
+                                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey")))))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                                        tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey"))))),
                 false);
     }
 
@@ -231,31 +231,28 @@ public class TestRandomizeNullKeyInOuterJoin
                 getSessionAlwaysEnabled(),
                 anyTree(
                         join(LEFT,
-                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey")),
+                                Optional.of("NOT (l_orderkey IS NULL)"),
                                 anyTree(
-                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(l_orderkey, -random(100))")),
                                                 join(
                                                         LEFT,
-                                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey_random")),
+                                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "l_partkey")),
+                                                        Optional.of("NOT (ps_partkey IS NULL)"),
                                                         join(
                                                                 LEFT,
-                                                                ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                                                ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey")),
+                                                                Optional.of("NOT (ps_partkey IS NULL)"),
                                                                 anyTree(
                                                                         project(
-                                                                                ImmutableMap.of("ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                                                ImmutableMap.of("ps_partkey_random", expression("coalesce(ps_partkey, -random(100))")),
                                                                                 tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
                                                                 anyTree(
-                                                                        project(
-                                                                                ImmutableMap.of("p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                                                tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
                                                         anyTree(
-                                                                project(
-                                                                        ImmutableMap.of("l_partkey_random", expression("coalesce(cast(l_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                                        tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey"))))))),
+                                                                tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey")))))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                                        tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey"))))),
                 false);
     }
 
@@ -266,9 +263,10 @@ public class TestRandomizeNullKeyInOuterJoin
                 getSessionEnabledWhenJoinKeyFromOuterJoin(),
                 anyTree(
                         join(LEFT,
-                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey_random")),
+                                ImmutableList.of(equiJoinClause("l_orderkey_random", "o_orderkey")),
+                                Optional.of("NOT (l_orderkey IS NULL)"),
                                 anyTree(
-                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(cast(l_orderkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                        project(ImmutableMap.of("l_orderkey_random", expression("coalesce(l_orderkey, -random(100))")),
                                                 join(
                                                         LEFT,
                                                         ImmutableList.of(equiJoinClause("ps_partkey", "l_partkey")),
@@ -282,9 +280,7 @@ public class TestRandomizeNullKeyInOuterJoin
                                                         anyTree(
                                                                 tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey", "l_orderkey", "orderkey")))))),
                                 anyTree(
-                                        project(
-                                                ImmutableMap.of("o_orderkey_random", expression("coalesce(cast(o_orderkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey")))))),
+                                        tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey"))))),
                 false);
     }
 
@@ -314,15 +310,14 @@ public class TestRandomizeNullKeyInOuterJoin
                                 ImmutableList.of(),
                                 join(
                                         LEFT,
-                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey_random")),
+                                        ImmutableList.of(equiJoinClause("ps_partkey_random", "p_partkey")),
+                                        Optional.of("NOT (ps_partkey IS NULL)"),
                                         anyTree(
                                                 project(
-                                                        ImmutableMap.of("ps_partkey", expression("ps_partkey"), "ps_partkey_random", expression("coalesce(cast(ps_partkey as varchar), 'l' || cast(random(100) as varchar))")),
+                                                        ImmutableMap.of("ps_partkey", expression("ps_partkey"), "ps_partkey_random", expression("coalesce(ps_partkey, -random(100))")),
                                                         tableScan("partsupp", ImmutableMap.of("ps_partkey", "partkey")))),
                                         anyTree(
-                                                project(
-                                                        ImmutableMap.of("p_partkey", expression("p_partkey"), "p_partkey_random", expression("coalesce(cast(p_partkey as varchar), 'r' || cast(random(100) as varchar))")),
-                                                        tableScan("part", ImmutableMap.of("p_partkey", "partkey"))))),
+                                                tableScan("part", ImmutableMap.of("p_partkey", "partkey")))),
                                 anyTree(
                                         tableScan("lineitem", ImmutableMap.of("l_partkey", "partkey"))))),
                 false);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6938,6 +6938,39 @@ public abstract class AbstractTestQueries
                 .build();
         String varcharJoinKey = "select t.k, t2.k, t2.v from (values 'r0', 'r1', 'r2', 'r3') t(k) left join (values (null, 1), (null, 2), (null, 3), (null, 4)) t2(k, v) on t.k = t2.k";
         assertQueryWithSameQueryRunner(enableRandomizeFourPartition, varcharJoinKey, "values ('r0', null, null), ('r1', null, null), ('r2', null, null), ('r3', null, null)");
+
+        // Native randomization correctness: spreading null join keys across partitions must never change
+        // results. Exercise a supported key type (BIGINT, DATE, VARCHAR) and each outer join type (LEFT,
+        // RIGHT, FULL), comparing optimization-enabled vs disabled with the same query runner. The joins are
+        // table-based (so the join is partitioned and the rewrite fires under a distributed runner) and one
+        // in five keys is NULL. The comparison is a GROUP BY (grouped, not global, avoiding the local-runner
+        // "final aggregation not separated" validator) and the group key is cast to VARCHAR so no compared
+        // column is a DATE (assertQueryWithSameQueryRunner cannot compare DATE-typed result columns). The
+        // join keys are non-bucket columns (custkey/orderdate/clerk, not the orderkey the TPC-H connector
+        // buckets on) so the exchange uses a system hash function -- the primary skew scenario this rewrite
+        // targets -- rather than the connector bucket function.
+        Session enableRandomizePartitioned = Session.builder(getSession())
+                .setSystemProperty(RANDOMIZE_OUTER_JOIN_NULL_KEY, "true")
+                .setSystemProperty(HASH_PARTITION_COUNT, "4")
+                .setSystemProperty("join_distribution_type", "PARTITIONED")
+                .build();
+        String[] nullableKeyByType = {
+                "case when mod(orderkey, 5) = 0 then null else custkey end",    // BIGINT
+                "case when mod(orderkey, 5) = 0 then null else orderdate end",  // DATE
+                "case when mod(orderkey, 5) = 0 then null else clerk end",      // VARCHAR
+        };
+        String[] probeKeyByType = {"custkey", "orderdate", "clerk"};
+        for (int i = 0; i < nullableKeyByType.length; i++) {
+            for (String joinType : ImmutableList.of("left join", "right join", "full join")) {
+                String randomizeCorrectness = format(
+                        "select cast(t.k as varchar) gk, count(*) c, count(t2.k) m " +
+                                "from (select %s k from orders) t " +
+                                "%s (select %s k from orders) t2 on t.k = t2.k " +
+                                "group by cast(t.k as varchar)",
+                        nullableKeyByType[i], joinType, probeKeyByType[i]);
+                assertQueryWithSameQueryRunner(enableRandomizePartitioned, randomizeCorrectness, getSession());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description
Reworks `RandomizeNullKeyInOuterJoin` so it spreads skewed NULL join keys without casting the join key to `VARCHAR`. The left join key is randomized in its own type and the right key is left raw:

- BIGINT: `COALESCE(k, -random(N))`
- DATE: `COALESCE(k, date_add('day', -random(N), DATE '1970-01-01'))`
- VARCHAR: `COALESCE(k, cast(random(N) as varchar))`

where `N = hash_partition_count`. The join is guarded with `k IS NOT NULL`, so a randomized NULL can never match a real key or another NULL — correctness is independent of the fill value. VARCHAR keys are left raw in FULL joins, because the randomized key is unbounded `VARCHAR` and FULL-join partitioning derivation requires it to match the raw build key's type exactly.

## Motivation and Context
The previous implementation cast both keys to `VARCHAR` and added extra `IS NULL` equi-clauses. Keeping the key in its native type avoids widening (potentially large) keys, keeps the raw other-side key untouched, and lets the randomized key partition through a connector's native (hash-based) bucket function.

Resolves #28152

## Impact
No new session property — gated by the existing `randomize_outer_join_null_key` (default off). When enabled, outer joins with many NULL keys spread those keys across partitions to mitigate skew, with identical results.

## Test Plan
- Unit (plan-shape) tests in `TestRandomizeNullKeyInOuterJoin` for LEFT/RIGHT/FULL, single- and multi-join, and mixed VARCHAR/BIGINT keys.
- e2e in `AbstractTestQueries#testRandomizeNullKeyOuterJoin` comparing enabled vs disabled over BIGINT/DATE/VARCHAR x LEFT/RIGHT/FULL (system-hash joins).
- `TestHiveBucketedRandomizeNullKeyOuterJoin`: bucketed Hive tables joined on the bucket column, verifying the native key routes through a real hash-based bucket function with no overflow and identical results.
- `mvn test -pl presto-main-base -Dtest=TestRandomizeNullKeyInOuterJoin`
- `mvn test -pl presto-tests -Dtest=TestLocalQueries`
- `mvn test -pl presto-hive -Dtest=TestHiveBucketedRandomizeNullKeyOuterJoin`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve outer joins on skewed ``NULL`` join keys by spreading the null keys across partitions in their native type. This is controlled by the existing ``randomize_outer_join_null_key`` session property.
```

## Summary by Sourcery

Randomize outer-join null keys in their native types instead of casting to VARCHAR, updating the planner rewrite, plan assertions, and tests to preserve correctness while improving partitioning behavior on skewed NULL keys.

Enhancements:
- Adjust RandomizeNullKeyInOuterJoin to only randomize left join keys using native-type random defaults and add non-null guards instead of VARCHAR-based rewrites and extra IS NULL equi-clauses.
- Introduce PlannerUtils.randomizeJoinKeyNative to generate COALESCE-based randomization expressions for BIGINT, DATE, and VARCHAR join keys without widening them to VARCHAR.
- Extend RowExpressionVerifier to understand unary arithmetic (negation) expressions used in randomized key generation and filters.

Tests:
- Broaden TestRandomizeNullKeyInOuterJoin plan-shape expectations for LEFT/RIGHT/FULL and mixed-type joins to reflect native-type randomization and new filter guards.
- Add end-to-end queries in AbstractTestQueries to validate correctness of native null-key randomization across BIGINT, DATE, and VARCHAR keys and LEFT/RIGHT/FULL outer joins under partitioned execution.
- Introduce TestHiveBucketedRandomizeNullKeyOuterJoin to verify the optimization over bucketed Hive tables, including ensuring the rewrite fires (or not) appropriately and preserves results when routed through Hive bucket functions.