### PR TITLE
fix: Resolve case-sensitive nested field names

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaPageSourceProvider.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaPageSourceProvider.java
@@ -99,6 +99,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getSubfieldType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
 import static com.facebook.presto.parquet.ParquetTypeUtils.nestedColumnPath;
 import static com.facebook.presto.parquet.cache.MetadataReader.findFirstNonHiddenColumnId;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
@@ -369,10 +370,10 @@ public class DeltaPageSourceProvider
             if (isPushedDownSubfield(columnHandle)) {
                 Subfield pushedDownSubfield = getPushedDownSubfield(columnHandle);
                 List<String> subfieldPath = columnPathFromSubfield(pushedDownSubfield);
-                descriptor = descriptorsByPath.get(subfieldPath);
+                descriptor = lookupDescriptor(descriptorsByPath, subfieldPath);
             }
             else {
-                descriptor = descriptorsByPath.get(ImmutableList.of(columnHandle.getSourceName()));
+                descriptor = lookupDescriptor(descriptorsByPath, ImmutableList.of(columnHandle.getSourceName()));
             }
 
             if (descriptor != null) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -113,6 +113,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getSubfieldType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
 import static com.facebook.presto.parquet.ParquetTypeUtils.nestedColumnPath;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatches;
@@ -344,10 +345,10 @@ public class ParquetPageSourceFactory
             if (isPushedDownSubfield(columnHandle)) {
                 Subfield pushedDownSubfield = getPushedDownSubfield(columnHandle);
                 List<String> subfieldPath = columnPathFromSubfield(pushedDownSubfield);
-                descriptor = descriptorsByPath.get(subfieldPath);
+                descriptor = lookupDescriptor(descriptorsByPath, subfieldPath);
             }
             else {
-                descriptor = descriptorsByPath.get(ImmutableList.of(columnHandle.getName()));
+                descriptor = lookupDescriptor(descriptorsByPath, ImmutableList.of(columnHandle.getName()));
             }
             if (descriptor != null) {
                 predicate.put(descriptor, entry.getValue());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -108,6 +108,22 @@ public class TestParquetPredicateUtils
     }
 
     @Test
+    public void testParquetTupleDomainPrimitiveCaseInsensitiveFallback()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("mixedcase", HiveType.valueOf("bigint"), parseTypeSignature(StandardTypes.BIGINT), 0, REGULAR, Optional.empty(), Optional.empty());
+        Domain singleValueDomain = Domain.singleValue(BIGINT, 123L);
+        TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, singleValueDomain));
+
+        MessageType fileSchema = new MessageType("hive_schema", new PrimitiveType(OPTIONAL, INT64, "MixedCase"));
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(getDescriptors(fileSchema, fileSchema), domain);
+
+        assertEquals(tupleDomain.getDomains().get().size(), 1);
+        ColumnDescriptor descriptor = tupleDomain.getDomains().get().keySet().iterator().next();
+        assertEquals(descriptor.getPath(), new String[] {"MixedCase"});
+        assertEquals(Iterables.getOnlyElement(tupleDomain.getDomains().get().values()), singleValueDomain);
+    }
+
+    @Test
     public void testParquetTupleDomainStruct()
     {
         HiveColumnHandle columnHandle = new HiveColumnHandle("my_struct", HiveType.valueOf("struct<a:int,b:int>"), parseTypeSignature(StandardTypes.ROW), 0, REGULAR, Optional.empty(), Optional.empty());

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiParquetPageSources.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiParquetPageSources.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimp
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
 import static com.facebook.presto.parquet.cache.MetadataReader.findFirstNonHiddenColumnId;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatches;
@@ -212,7 +213,7 @@ class HudiParquetPageSources
             String baseType = columnHandle.getHiveType().getTypeSignature().getBase();
             // skip looking up predicates for complex types as Parquet only stores stats for primitives
             if (!baseType.equals(StandardTypes.MAP) && !baseType.equals(StandardTypes.ARRAY) && !baseType.equals(StandardTypes.ROW)) {
-                RichColumnDescriptor descriptor = descriptorsByPath.get(ImmutableList.of(columnHandle.getName()));
+                RichColumnDescriptor descriptor = lookupDescriptor(descriptorsByPath, ImmutableList.of(columnHandle.getName()));
                 if (descriptor != null) {
                     predicate.put(descriptor, domain);
                 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -172,6 +172,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getSubfieldType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
 import static com.facebook.presto.parquet.ParquetTypeUtils.nestedColumnPath;
 import static com.facebook.presto.parquet.cache.MetadataReader.findFirstNonHiddenColumnId;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
@@ -472,7 +473,7 @@ public class IcebergPageSourceProvider
             String baseType = columnHandle.getType().getTypeSignature().getBase();
             // skip looking up predicates for complex types as Parquet only stores stats for primitives
             if (!baseType.equals(StandardTypes.MAP) && !baseType.equals(StandardTypes.ARRAY) && !baseType.equals(StandardTypes.ROW)) {
-                RichColumnDescriptor descriptor = descriptorsByPath.get(ImmutableList.of(columnHandle.getName()));
+                RichColumnDescriptor descriptor = lookupDescriptor(descriptorsByPath, ImmutableList.of(columnHandle.getName()));
                 if (descriptor != null) {
                     predicate.put(descriptor, domain);
                 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -93,7 +93,8 @@ public final class TypeConverter
 {
     public static final String ORC_ICEBERG_ID_KEY = "iceberg.id";
     public static final String ORC_ICEBERG_REQUIRED_KEY = "iceberg.required";
-    private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+    // Unquoted SQL identifiers are normalized to lowercase, so mixed-case external names must be delimited.
+    private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z_][a-z0-9_]*");
 
     private TypeConverter() {}
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -93,8 +93,8 @@ public final class TypeConverter
 {
     public static final String ORC_ICEBERG_ID_KEY = "iceberg.id";
     public static final String ORC_ICEBERG_REQUIRED_KEY = "iceberg.required";
-    // Unquoted SQL identifiers are normalized to lowercase, so mixed-case external names must be delimited.
-    private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-z_][a-z0-9_]*");
+    // Unquoted SQL identifiers are normalized to lowercase, so only lowercase names preserve their case.
+    private static final Pattern CASE_PRESERVING_UNQUOTED_IDENTIFIER = Pattern.compile("[a-z_][a-z0-9_]*");
 
     private TypeConverter() {}
 
@@ -151,7 +151,7 @@ public final class TypeConverter
 
     private static boolean needsDelimiting(String name)
     {
-        return !UNQUOTED_IDENTIFIER.matcher(name).matches();
+        return !CASE_PRESERVING_UNQUOTED_IDENTIFIER.matcher(name).matches();
     }
 
     public static org.apache.iceberg.types.Type toIcebergType(

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.facebook.presto.hive.HiveCommonSessionProperties.PARQUET_BATCH_READ_OPTIMIZATION_ENABLED;
+import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -162,9 +163,16 @@ public class TestIcebergTypes
     @Test
     public void testStructWithMixedCaseFieldNames()
     {
-        String tableName = "test_mixed_case_struct";
+        assertStructWithMixedCaseFieldNames("PARQUET");
+        assertStructWithMixedCaseFieldNames("ORC");
+    }
+
+    private void assertStructWithMixedCaseFieldNames(String fileFormat)
+    {
+        String tableName = "test_mixed_case_struct_" + fileFormat.toLowerCase(ENGLISH);
         try {
-            assertUpdate("CREATE TABLE " + tableName + " (x ROW(\"currencyCode\" INTEGER, \"currencycode\" INTEGER))");
+            assertUpdate("CREATE TABLE " + tableName + " (x ROW(\"currencyCode\" INTEGER, \"currencycode\" INTEGER)) " +
+                    "WITH (\"write.format.default\" = '" + fileFormat + "')");
             assertUpdate("INSERT INTO " + tableName + " SELECT ROW(1, 2)", 1);
 
             assertQuery(

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
@@ -159,6 +159,26 @@ public class TestIcebergTypes
         }
     }
 
+    @Test
+    public void testStructWithMixedCaseFieldNames()
+    {
+        String tableName = "test_mixed_case_struct";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (x ROW(\"currencyCode\" INTEGER, \"currencycode\" INTEGER))");
+            assertUpdate("INSERT INTO " + tableName + " SELECT ROW(1, 2)", 1);
+
+            assertQuery(
+                    "SELECT x.\"currencyCode\", x.\"currencycode\" FROM " + tableName,
+                    "VALUES (1, 2)");
+            assertQueryFails(
+                    "SELECT x.\"CURRENCYCODE\" FROM " + tableName,
+                    ".*Ambiguous field 'CURRENCYCODE' in type row\\(\"currencyCode\" integer, \"currencycode\" integer\\).*");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
     /**
      * Test for nested struct with hyphenated field names.
      * Tests deeper nesting levels with special characters.

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -166,6 +166,7 @@ import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessC
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.isTopMostReference;
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.isUnusedArgumentForAccessControl;
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.resolveSubfield;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_ORDER_BY;
@@ -571,13 +572,14 @@ public class ExpressionAnalyzer
             RowType rowType = (RowType) baseType;
             String fieldName = node.getField().getValue();
 
-            Type rowFieldType = null;
-            for (RowType.Field rowField : rowType.getFields()) {
-                if (fieldName.equalsIgnoreCase(rowField.getName().orElse(null))) {
-                    rowFieldType = rowField.getType();
-                    break;
-                }
+            int rowFieldIndex;
+            try {
+                rowFieldIndex = RowFieldNameResolver.resolveFieldIndex(rowType, fieldName);
             }
+            catch (IllegalArgumentException e) {
+                throw new SemanticException(AMBIGUOUS_ATTRIBUTE, node, "%s", e.getMessage());
+            }
+            Type rowFieldType = rowFieldIndex < 0 ? null : rowType.getFields().get(rowFieldIndex).getType();
 
             if (sqlFunctionProperties.isLegacyRowFieldOrdinalAccessEnabled() && rowFieldType == null) {
                 OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, rowType.getFields());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -574,7 +574,7 @@ public class ExpressionAnalyzer
 
             int rowFieldIndex;
             try {
-                rowFieldIndex = RowFieldNameResolver.resolveFieldIndex(rowType, fieldName);
+                rowFieldIndex = RowFieldNameResolver.resolveFieldIndex(rowType, fieldName, node.getField().isDelimited());
             }
             catch (IllegalArgumentException e) {
                 throw new SemanticException(AMBIGUOUS_ATTRIBUTE, node, "%s", e.getMessage());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
@@ -41,41 +41,35 @@ public final class RowFieldNameResolver
         requireNonNull(rowType, "rowType is null");
         requireNonNull(fieldName, "fieldName is null");
 
-        int exactMatch = -1;
-        boolean exactMatchIsAmbiguous = false;
-        int caseInsensitiveMatch = -1;
-        boolean caseInsensitiveMatchIsAmbiguous = false;
-
         List<RowType.Field> fields = rowType.getFields();
+
+        int exactMatch = -1;
         for (int index = 0; index < fields.size(); index++) {
-            String candidateName = fields.get(index).getName().orElse(null);
-            if (candidateName == null || !fieldName.equalsIgnoreCase(candidateName)) {
-                continue;
-            }
-
-            if (caseInsensitiveMatch >= 0) {
-                caseInsensitiveMatchIsAmbiguous = true;
-            }
-            else {
-                caseInsensitiveMatch = index;
-            }
-
-            if (fieldName.equals(candidateName)) {
+            if (fieldName.equals(fields.get(index).getName().orElse(null))) {
                 if (exactMatch >= 0) {
-                    exactMatchIsAmbiguous = true;
+                    throw ambiguousField(fieldName, rowType);
                 }
-                else {
-                    exactMatch = index;
-                }
+                exactMatch = index;
             }
-        }
-
-        if (exactMatchIsAmbiguous || (exactMatch < 0 && caseInsensitiveMatchIsAmbiguous)) {
-            throw new IllegalArgumentException(format("Ambiguous field '%s' in type %s", fieldName, rowType.getDisplayName()));
         }
         if (exactMatch >= 0) {
             return exactMatch;
         }
+
+        int caseInsensitiveMatch = -1;
+        for (int index = 0; index < fields.size(); index++) {
+            if (fieldName.equalsIgnoreCase(fields.get(index).getName().orElse(null))) {
+                if (caseInsensitiveMatch >= 0) {
+                    throw ambiguousField(fieldName, rowType);
+                }
+                caseInsensitiveMatch = index;
+            }
+        }
         return caseInsensitiveMatch;
+    }
+
+    private static IllegalArgumentException ambiguousField(String fieldName, RowType rowType)
+    {
+        return new IllegalArgumentException(format("Ambiguous field '%s' in type %s", fieldName, rowType.getDisplayName()));
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
@@ -22,6 +22,11 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Keeps row-field resolution consistent across analysis, interpretation, and row-expression translation.
+ *
+ * <p>The "prefer the exact-case field, fall back to a unique case-insensitive match, otherwise ambiguous" policy
+ * used here is mirrored for physical Parquet paths by {@code ParquetTypeUtils.lookupDescriptor}. The two cannot
+ * share code because {@code presto-main-base} and {@code presto-parquet} must not depend on each other, so keep
+ * the two implementations in sync when the policy changes.
  */
 public final class RowFieldNameResolver
 {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.common.type.RowType;
+
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Keeps row-field resolution consistent across analysis, interpretation, and row-expression translation.
+ */
+public final class RowFieldNameResolver
+{
+    private RowFieldNameResolver() {}
+
+    /**
+     * Resolves a row field by preferring its original spelling while retaining the existing
+     * case-insensitive behavior when there is a single compatible field.
+     */
+    public static int resolveFieldIndex(RowType rowType, String fieldName)
+    {
+        requireNonNull(rowType, "rowType is null");
+        requireNonNull(fieldName, "fieldName is null");
+
+        int exactMatch = -1;
+        boolean exactMatchIsAmbiguous = false;
+        int caseInsensitiveMatch = -1;
+        boolean caseInsensitiveMatchIsAmbiguous = false;
+
+        List<RowType.Field> fields = rowType.getFields();
+        for (int index = 0; index < fields.size(); index++) {
+            String candidateName = fields.get(index).getName().orElse(null);
+            if (candidateName == null || !fieldName.equalsIgnoreCase(candidateName)) {
+                continue;
+            }
+
+            if (caseInsensitiveMatch >= 0) {
+                caseInsensitiveMatchIsAmbiguous = true;
+            }
+            else {
+                caseInsensitiveMatch = index;
+            }
+
+            if (fieldName.equals(candidateName)) {
+                if (exactMatch >= 0) {
+                    exactMatchIsAmbiguous = true;
+                }
+                else {
+                    exactMatch = index;
+                }
+            }
+        }
+
+        if (exactMatchIsAmbiguous || (exactMatch < 0 && caseInsensitiveMatchIsAmbiguous)) {
+            throw new IllegalArgumentException(format("Ambiguous field '%s' in type %s", fieldName, rowType.getDisplayName()));
+        }
+        if (exactMatch >= 0) {
+            return exactMatch;
+        }
+        return caseInsensitiveMatch;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RowFieldNameResolver.java
@@ -23,37 +23,39 @@ import static java.util.Objects.requireNonNull;
 /**
  * Keeps row-field resolution consistent across analysis, interpretation, and row-expression translation.
  *
- * <p>The "prefer the exact-case field, fall back to a unique case-insensitive match, otherwise ambiguous" policy
- * used here is mirrored for physical Parquet paths by {@code ParquetTypeUtils.lookupDescriptor}. The two cannot
- * share code because {@code presto-main-base} and {@code presto-parquet} must not depend on each other, so keep
- * the two implementations in sync when the policy changes.
+ * <p>Delimited identifiers prefer an exact-case field before falling back to a unique case-insensitive match.
+ * Unquoted identifiers use only case-insensitive matching. The delimited-identifier policy is mirrored for
+ * physical Parquet paths by {@code ParquetTypeUtils.lookupDescriptor}. The two cannot share code because
+ * {@code presto-main-base} and {@code presto-parquet} must not depend on each other.
  */
 public final class RowFieldNameResolver
 {
     private RowFieldNameResolver() {}
 
     /**
-     * Resolves a row field by preferring its original spelling while retaining the existing
+     * Resolves a row field, optionally preferring its original spelling, while retaining
      * case-insensitive behavior when there is a single compatible field.
      */
-    public static int resolveFieldIndex(RowType rowType, String fieldName)
+    public static int resolveFieldIndex(RowType rowType, String fieldName, boolean preferExactMatch)
     {
         requireNonNull(rowType, "rowType is null");
         requireNonNull(fieldName, "fieldName is null");
 
         List<RowType.Field> fields = rowType.getFields();
 
-        int exactMatch = -1;
-        for (int index = 0; index < fields.size(); index++) {
-            if (fieldName.equals(fields.get(index).getName().orElse(null))) {
-                if (exactMatch >= 0) {
-                    throw ambiguousField(fieldName, rowType);
+        if (preferExactMatch) {
+            int exactMatch = -1;
+            for (int index = 0; index < fields.size(); index++) {
+                if (fieldName.equals(fields.get(index).getName().orElse(null))) {
+                    if (exactMatch >= 0) {
+                        throw ambiguousField(fieldName, rowType);
+                    }
+                    exactMatch = index;
                 }
-                exactMatch = index;
             }
-        }
-        if (exactMatch >= 0) {
-            return exactMatch;
+            if (exactMatch >= 0) {
+                return exactMatch;
+            }
         }
 
         int caseInsensitiveMatch = -1;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -326,7 +326,7 @@ public class ExpressionInterpreter
 
             RowType rowType = (RowType) type;
             String fieldName = node.getField().getValue();
-            int index = resolveFieldIndex(rowType, fieldName);
+            int index = resolveFieldIndex(rowType, fieldName, node.getField().isDelimited());
 
             if (legacyRowFieldOrdinalAccess && index < 0) {
                 OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, rowType.getFields());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -24,7 +24,6 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.common.type.RowType;
-import com.facebook.presto.common.type.RowType.Field;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeUtils;
@@ -132,6 +131,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.createConstant
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.getSourceLocation;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.resolveEnumLiteral;
+import static com.facebook.presto.sql.analyzer.RowFieldNameResolver.resolveFieldIndex;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
 import static com.facebook.presto.sql.planner.ExpressionDeterminismEvaluator.isDeterministic;
@@ -326,18 +326,10 @@ public class ExpressionInterpreter
 
             RowType rowType = (RowType) type;
             String fieldName = node.getField().getValue();
-            List<Field> fields = rowType.getFields();
-            int index = -1;
-            for (int i = 0; i < fields.size(); i++) {
-                Field field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
-                    checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
-                    index = i;
-                }
-            }
+            int index = resolveFieldIndex(rowType, fieldName);
 
             if (legacyRowFieldOrdinalAccess && index < 0) {
-                OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, fields);
+                OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, rowType.getFields());
                 if (rowIndex.isPresent()) {
                     index = rowIndex.getAsInt();
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -22,7 +22,6 @@ import com.facebook.presto.common.type.DecimalParseResult;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.RowType;
-import com.facebook.presto.common.type.RowType.Field;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.UnknownType;
@@ -146,6 +145,7 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.getSourceLocation;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.resolveEnumLiteral;
+import static com.facebook.presto.sql.analyzer.RowFieldNameResolver.resolveFieldIndex;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -737,18 +737,10 @@ public final class SqlToRowExpressionTranslator
             }
             RowType rowType = (RowType) baseType;
             String fieldName = node.getField().getValue();
-            List<Field> fields = rowType.getFields();
-            int index = -1;
-            for (int i = 0; i < fields.size(); i++) {
-                Field field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
-                    checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
-                    index = i;
-                }
-            }
+            int index = resolveFieldIndex(rowType, fieldName);
 
             if (sqlFunctionProperties.isLegacyRowFieldOrdinalAccessEnabled() && index < 0) {
-                OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, fields);
+                OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, rowType.getFields());
                 if (rowIndex.isPresent()) {
                     index = rowIndex.getAsInt();
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -737,7 +737,7 @@ public final class SqlToRowExpressionTranslator
             }
             RowType rowType = (RowType) baseType;
             String fieldName = node.getField().getValue();
-            int index = resolveFieldIndex(rowType, fieldName);
+            int index = resolveFieldIndex(rowType, fieldName, node.getField().isDelimited());
 
             if (sqlFunctionProperties.isLegacyRowFieldOrdinalAccessEnabled() && index < 0) {
                 OptionalInt rowIndex = parseAnonymousRowFieldOrdinalAccess(fieldName, rowType.getFields());

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.sql;
 
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -26,13 +29,38 @@ import java.math.BigDecimal;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
 
 public class TestSqlToRowExpressionTranslator
 {
     private final TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator();
+
+    @Test
+    public void testExactCaseRowFieldDereference()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("currencyCode", VARCHAR),
+                RowType.field("currencycode", BIGINT)));
+        ImmutableMap<String, Type> types = ImmutableMap.of("x", rowType);
+
+        assertEquals(translator.translate("x.\"currencyCode\"", types).getType(), VARCHAR);
+        assertEquals(translator.translate("x.\"currencycode\"", types).getType(), BIGINT);
+        SemanticException ambiguousFallback = expectThrows(SemanticException.class, () -> translator.translate("x.\"CURRENCYCODE\"", types));
+        assertEquals(ambiguousFallback.getCode(), AMBIGUOUS_ATTRIBUTE);
+
+        RowType duplicateExactNames = RowType.from(ImmutableList.of(
+                RowType.field("currencyCode", VARCHAR),
+                RowType.field("currencyCode", BIGINT)));
+        SemanticException ambiguousExactMatch = expectThrows(SemanticException.class, () -> translator.translate(
+                "x.\"currencyCode\"",
+                ImmutableMap.of("x", duplicateExactNames)));
+        assertEquals(ambiguousExactMatch.getCode(), AMBIGUOUS_ATTRIBUTE);
+    }
 
     @Test(timeOut = 10_000)
     public void testPossibleExponentialOptimizationTime()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -53,6 +53,11 @@ public class TestSqlToRowExpressionTranslator
         SemanticException ambiguousFallback = expectThrows(SemanticException.class, () -> translator.translate("x.\"CURRENCYCODE\"", types));
         assertEquals(ambiguousFallback.getCode(), AMBIGUOUS_ATTRIBUTE);
 
+        for (String fieldName : ImmutableList.of("currencyCode", "currencycode", "CURRENCYCODE")) {
+            SemanticException ambiguousUnquoted = expectThrows(SemanticException.class, () -> translator.translate("x." + fieldName, types));
+            assertEquals(ambiguousUnquoted.getCode(), AMBIGUOUS_ATTRIBUTE);
+        }
+
         RowType duplicateExactNames = RowType.from(ImmutableList.of(
                 RowType.field("currencyCode", VARCHAR),
                 RowType.field("currencyCode", BIGINT)));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestRowFieldNameResolver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestRowFieldNameResolver.java
@@ -32,8 +32,8 @@ public class TestRowFieldNameResolver
                 RowType.field("currencyCode", VARCHAR),
                 RowType.field("currencycode", BIGINT)));
 
-        assertEquals(resolveFieldIndex(rowType, "currencyCode"), 0);
-        assertEquals(resolveFieldIndex(rowType, "currencycode"), 1);
+        assertEquals(resolveFieldIndex(rowType, "currencyCode", true), 0);
+        assertEquals(resolveFieldIndex(rowType, "currencycode", true), 1);
     }
 
     @Test
@@ -41,7 +41,8 @@ public class TestRowFieldNameResolver
     {
         RowType rowType = RowType.from(ImmutableList.of(RowType.field("currencyCode", VARCHAR)));
 
-        assertEquals(resolveFieldIndex(rowType, "CURRENCYCODE"), 0);
+        assertEquals(resolveFieldIndex(rowType, "CURRENCYCODE", true), 0);
+        assertEquals(resolveFieldIndex(rowType, "CURRENCYCODE", false), 0);
     }
 
     @Test
@@ -51,7 +52,9 @@ public class TestRowFieldNameResolver
                 RowType.field("currencyCode", VARCHAR),
                 RowType.field("currencycode", BIGINT)));
 
-        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "CURRENCYCODE"));
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "CURRENCYCODE", true));
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "currencyCode", false));
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "currencycode", false));
     }
 
     @Test
@@ -61,7 +64,7 @@ public class TestRowFieldNameResolver
                 RowType.field("currencyCode", VARCHAR),
                 RowType.field("currencyCode", BIGINT)));
 
-        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "currencyCode"));
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "currencyCode", true));
     }
 
     @Test
@@ -69,6 +72,7 @@ public class TestRowFieldNameResolver
     {
         RowType rowType = RowType.from(ImmutableList.of(RowType.field("currencyCode", VARCHAR)));
 
-        assertEquals(resolveFieldIndex(rowType, "missing"), -1);
+        assertEquals(resolveFieldIndex(rowType, "missing", true), -1);
+        assertEquals(resolveFieldIndex(rowType, "missing", false), -1);
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestRowFieldNameResolver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestRowFieldNameResolver.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.common.type.RowType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.RowFieldNameResolver.resolveFieldIndex;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestRowFieldNameResolver
+{
+    @Test
+    public void testExactMatchDisambiguatesCaseVariants()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("currencyCode", VARCHAR),
+                RowType.field("currencycode", BIGINT)));
+
+        assertEquals(resolveFieldIndex(rowType, "currencyCode"), 0);
+        assertEquals(resolveFieldIndex(rowType, "currencycode"), 1);
+    }
+
+    @Test
+    public void testUniqueCaseInsensitiveFallback()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(RowType.field("currencyCode", VARCHAR)));
+
+        assertEquals(resolveFieldIndex(rowType, "CURRENCYCODE"), 0);
+    }
+
+    @Test
+    public void testAmbiguousCaseInsensitiveFallback()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("currencyCode", VARCHAR),
+                RowType.field("currencycode", BIGINT)));
+
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "CURRENCYCODE"));
+    }
+
+    @Test
+    public void testAmbiguousDuplicateExactMatch()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("currencyCode", VARCHAR),
+                RowType.field("currencyCode", BIGINT)));
+
+        assertThrows(IllegalArgumentException.class, () -> resolveFieldIndex(rowType, "currencyCode"));
+    }
+
+    @Test
+    public void testMissingField()
+    {
+        RowType rowType = RowType.from(ImmutableList.of(RowType.field("currencyCode", VARCHAR)));
+
+        assertEquals(resolveFieldIndex(rowType, "missing"), -1);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 
+import java.util.Collection;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.lang.Math.max;
@@ -43,6 +45,37 @@ final class ReaderUtils
     public static int minNonNullValueSize(int nonNullCount)
     {
         return max(nonNullCount + 1, 1025);
+    }
+
+    /**
+     * Resolves a field without discarding its spelling. A case-insensitive fallback is safe only when unique.
+     */
+    public static <T> T resolveField(Collection<T> candidates, Function<T, String> nameGetter, String requestedName)
+    {
+        T exactMatch = null;
+        for (T candidate : candidates) {
+            String candidateName = nameGetter.apply(candidate);
+            if (requestedName.equals(candidateName)) {
+                if (exactMatch != null) {
+                    return null;
+                }
+                exactMatch = candidate;
+            }
+        }
+        if (exactMatch != null) {
+            return exactMatch;
+        }
+
+        T caseInsensitiveMatch = null;
+        for (T candidate : candidates) {
+            if (requestedName.equalsIgnoreCase(nameGetter.apply(candidate))) {
+                if (caseInsensitiveMatch != null) {
+                    return null;
+                }
+                caseInsensitiveMatch = candidate;
+            }
+        }
+        return caseInsensitiveMatch;
     }
 
     public static byte[] unpackByteNulls(byte[] values, boolean[] isNull)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
@@ -29,7 +29,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import jakarta.annotation.Nullable;
 import org.joda.time.DateTimeZone;
@@ -39,12 +38,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.BatchStreamReaders.createStreamReader;
+import static com.facebook.presto.orc.reader.ReaderUtils.resolveField;
 import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.getBooleanMissingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -79,17 +78,14 @@ public class StructBatchStreamReader
         this.type = (RowType) type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
 
-        Map<String, StreamDescriptor> nestedStreams = Maps.uniqueIndex(
-                streamDescriptor.getNestedStreams(), stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH));
         ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
         ImmutableMap.Builder<String, BatchStreamReader> structFields = ImmutableMap.builder();
         for (Field field : this.type.getFields()) {
             String fieldName = field.getName()
-                    .orElseThrow(() -> new IllegalArgumentException("ROW type does not have field names declared: " + type))
-                    .toLowerCase(Locale.ENGLISH);
+                    .orElseThrow(() -> new IllegalArgumentException("ROW type does not have field names declared: " + type));
             fieldNames.add(fieldName);
 
-            StreamDescriptor fieldStream = nestedStreams.get(fieldName);
+            StreamDescriptor fieldStream = resolveField(streamDescriptor.getNestedStreams(), StreamDescriptor::getFieldName, fieldName);
             if (fieldStream != null) {
                 structFields.put(fieldName, createStreamReader(field.getType(), fieldStream, hiveStorageTimeZone, options, systemMemoryContext));
             }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -157,6 +157,35 @@ public class TestStructBatchStreamReader
         assertEquals(actual.get(2), "fieldCValue");
     }
 
+    @Test
+    public void testCaseSensitiveFieldNamesAreResolvedExactly()
+            throws IOException
+    {
+        Type readerType = getType(ImmutableList.of("currencyCode", "currencycode"));
+        Type writerType = getType(ImmutableList.of("currencyCode", "currencycode"));
+
+        write(tempFile, writerType, ImmutableList.of("mixedCaseValue", "lowerCaseValue"));
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION.getSqlFunctionProperties(), readBlock, 0);
+
+        assertEquals(actual, ImmutableList.of("mixedCaseValue", "lowerCaseValue"));
+    }
+
+    @Test
+    public void testAmbiguousCaseInsensitiveFieldIsMissing()
+            throws IOException
+    {
+        Type readerType = getType(ImmutableList.of("CURRENCYCODE"));
+        Type writerType = getType(ImmutableList.of("currencyCode", "currencycode"));
+
+        write(tempFile, writerType, ImmutableList.of("mixedCaseValue", "lowerCaseValue"));
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION.getSqlFunctionProperties(), readBlock, 0);
+
+        assertEquals(actual.size(), 1);
+        assertNull(actual.get(0));
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
             "ROW type does not have field names declared: row\\(varchar,varchar,varchar\\)")
     public void testThrowsExceptionWhenFieldNameMissing()

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -20,7 +20,6 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.GroupColumnIO;
-import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.PrimitiveColumnIO;
@@ -32,9 +31,9 @@ import org.apache.parquet.schema.MessageType;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.facebook.presto.common.type.Decimals.MAX_SHORT_PRECISION;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -119,6 +118,10 @@ public final class ParquetTypeUtils
     /**
      * Looks up a physical Parquet column path without discarding its case.
      * An ambiguous case-insensitive match is not safe for predicate pushdown, so it is treated as absent.
+     *
+     * <p>This mirrors the "exact case, then unique case-insensitive, otherwise ambiguous" policy that
+     * {@code RowFieldNameResolver.resolveFieldIndex} applies to logical row fields. The two live in different
+     * modules that cannot depend on each other, so keep the implementations in sync when the policy changes.
      */
     public static RichColumnDescriptor lookupDescriptor(Map<List<String>, RichColumnDescriptor> descriptorsByPath, List<String> path)
     {
@@ -152,21 +155,6 @@ public final class ParquetTypeUtils
         return true;
     }
 
-    public static int getFieldIndex(MessageType fileSchema, String name)
-    {
-        try {
-            return fileSchema.getFieldIndex(name.toLowerCase(Locale.ENGLISH));
-        }
-        catch (InvalidRecordException e) {
-            for (org.apache.parquet.schema.Type type : fileSchema.getFields()) {
-                if (type.getName().equalsIgnoreCase(name)) {
-                    return fileSchema.getFieldIndex(type.getName());
-                }
-            }
-            return -1;
-        }
-    }
-
     @SuppressWarnings("deprecation")
     public static ParquetEncoding getParquetEncoding(Encoding encoding)
     {
@@ -194,18 +182,7 @@ public final class ParquetTypeUtils
 
     public static org.apache.parquet.schema.Type getParquetTypeByName(String columnName, GroupType messageType)
     {
-        if (messageType.containsField(columnName)) {
-            return messageType.getType(columnName);
-        }
-        // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
-        // check for direct match above but if no match found, try case-insensitive match
-        for (org.apache.parquet.schema.Type type : messageType.getFields()) {
-            if (type.getName().equalsIgnoreCase(columnName)) {
-                return type;
-            }
-        }
-
-        return null;
+        return lookupByName(messageType.getFields(), org.apache.parquet.schema.Type::getName, columnName);
     }
 
     /**
@@ -214,19 +191,42 @@ public final class ParquetTypeUtils
      */
     public static ColumnIO lookupColumnByName(GroupColumnIO groupColumnIO, String columnName)
     {
-        ColumnIO columnIO = groupColumnIO.getChild(columnName);
-
-        if (columnIO != null) {
-            return columnIO;
-        }
-
+        ImmutableList.Builder<ColumnIO> children = ImmutableList.builder();
         for (int i = 0; i < groupColumnIO.getChildrenCount(); i++) {
-            if (groupColumnIO.getChild(i).getName().equalsIgnoreCase(columnName)) {
-                return groupColumnIO.getChild(i);
+            children.add(groupColumnIO.getChild(i));
+        }
+        return lookupByName(children.build(), ColumnIO::getName, columnName);
+    }
+
+    /**
+     * Resolves a field without discarding its spelling. A case-insensitive fallback is safe only when unique.
+     */
+    private static <T> T lookupByName(List<T> candidates, Function<T, String> nameGetter, String requestedName)
+    {
+        T exactMatch = null;
+        for (T candidate : candidates) {
+            String candidateName = nameGetter.apply(candidate);
+            if (requestedName.equals(candidateName)) {
+                if (exactMatch != null) {
+                    return null;
+                }
+                exactMatch = candidate;
             }
         }
+        if (exactMatch != null) {
+            return exactMatch;
+        }
 
-        return null;
+        T caseInsensitiveMatch = null;
+        for (T candidate : candidates) {
+            if (requestedName.equalsIgnoreCase(nameGetter.apply(candidate))) {
+                if (caseInsensitiveMatch != null) {
+                    return null;
+                }
+                caseInsensitiveMatch = candidate;
+            }
+        }
+        return caseInsensitiveMatch;
     }
 
     /**

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -109,11 +109,9 @@ public final class ParquetTypeUtils
     public static Map<List<String>, RichColumnDescriptor> getDescriptors(MessageType fileSchema, MessageType requestedSchema)
     {
         Map<List<String>, RichColumnDescriptor> descriptorsByPath = new HashMap<>();
-        List<PrimitiveColumnIO> columns = getColumns(fileSchema, requestedSchema);
-        for (String[] paths : fileSchema.getPaths()) {
-            List<String> columnPath = Arrays.asList(paths);
-            getDescriptor(columns, columnPath)
-                    .ifPresent(richColumnDescriptor -> descriptorsByPath.put(columnPath, richColumnDescriptor));
+        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
+            RichColumnDescriptor descriptor = new RichColumnDescriptor(columnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+            descriptorsByPath.put(Arrays.asList(descriptor.getPath()), descriptor);
         }
         return descriptorsByPath;
     }
@@ -152,6 +150,42 @@ public final class ParquetTypeUtils
             }
         }
         return index;
+    }
+
+    /**
+     * Looks up a physical Parquet column path without discarding its case.
+     * An ambiguous case-insensitive match is not safe for predicate pushdown, so it is treated as absent.
+     */
+    public static RichColumnDescriptor lookupDescriptor(Map<List<String>, RichColumnDescriptor> descriptorsByPath, List<String> path)
+    {
+        RichColumnDescriptor descriptor = descriptorsByPath.get(path);
+        if (descriptor != null) {
+            return descriptor;
+        }
+
+        RichColumnDescriptor caseInsensitiveMatch = null;
+        for (Map.Entry<List<String>, RichColumnDescriptor> entry : descriptorsByPath.entrySet()) {
+            if (pathsMatch(entry.getKey(), path)) {
+                if (caseInsensitiveMatch != null) {
+                    return null;
+                }
+                caseInsensitiveMatch = entry.getValue();
+            }
+        }
+        return caseInsensitiveMatch;
+    }
+
+    private static boolean pathsMatch(List<String> left, List<String> right)
+    {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (int index = 0; index < left.size(); index++) {
+            if (!left.get(index).equalsIgnoreCase(right.get(index))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static int getFieldIndex(MessageType fileSchema, String name)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -116,42 +116,6 @@ public final class ParquetTypeUtils
         return descriptorsByPath;
     }
 
-    public static Optional<RichColumnDescriptor> getDescriptor(List<PrimitiveColumnIO> columns, List<String> path)
-    {
-        checkArgument(path.size() >= 1, "Parquet nested path should have at least one component");
-        int index = getPathIndex(columns, path);
-        if (index == -1) {
-            return Optional.empty();
-        }
-        PrimitiveColumnIO columnIO = columns.get(index);
-        return Optional.of(new RichColumnDescriptor(columnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType()));
-    }
-
-    private static int getPathIndex(List<PrimitiveColumnIO> columns, List<String> path)
-    {
-        int maxLevel = path.size();
-        int index = -1;
-        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
-            ColumnIO[] fields = columns.get(columnIndex).getPath();
-            if (fields.length <= maxLevel) {
-                continue;
-            }
-            if (fields[maxLevel].getName().equalsIgnoreCase(path.get(maxLevel - 1))) {
-                boolean match = true;
-                for (int level = 0; level < maxLevel - 1; level++) {
-                    if (!fields[level + 1].getName().equalsIgnoreCase(path.get(level))) {
-                        match = false;
-                    }
-                }
-
-                if (match) {
-                    index = columnIndex;
-                }
-            }
-        }
-        return index;
-    }
-
     /**
      * Looks up a physical Parquet column path without discarding its case.
      * An ambiguous case-insensitive match is not safe for predicate pushdown, so it is treated as absent.

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -72,7 +72,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -314,10 +313,7 @@ public final class MetadataReader
 
     private static ColumnPath getPath(ColumnMetaData metaData)
     {
-        String[] path = metaData.path_in_schema.stream()
-                .map(value -> value.toLowerCase(Locale.ENGLISH))
-                .toArray(String[]::new);
-        return ColumnPath.get(path);
+        return ColumnPath.get(metaData.path_in_schema.toArray(new String[0]));
     }
 
     private static void verifyFooterIntegrity(BasicSliceInput from, InternalFileDecryptor fileDecryptor, int combinedFooterLength)
@@ -385,7 +381,7 @@ public final class MetadataReader
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }
-            typeBuilder.named(element.name.toLowerCase(Locale.ENGLISH));
+            typeBuilder.named(element.name);
         }
     }
 

--- a/presto-parquet/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
@@ -25,7 +25,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
@@ -63,7 +62,7 @@ public class ColumnIOConverter
             boolean structHasParameters = false;
             for (int i = 0; i < fields.size(); i++) {
                 NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
-                String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
+                String name = namedTypeSignature.getName().get();
                 Optional<Field> field = constructField(parameters.get(i), lookupColumnByName(groupColumnIO, name));
                 structHasParameters |= field.isPresent();
                 fieldsBuilder.add(field);

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
@@ -15,7 +15,9 @@ package com.facebook.presto.parquet;
 
 import com.facebook.presto.common.type.RowType;
 import com.google.common.collect.ImmutableList;
+import org.apache.parquet.io.GroupColumnIO;
 import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
 import org.testng.annotations.Test;
@@ -27,6 +29,8 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
 import static org.apache.parquet.io.ColumnIOConverter.constructField;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
@@ -103,5 +107,20 @@ public class TestParquetTypeUtils
         PrimitiveField lowerCaseField = (PrimitiveField) field.getChildren().get(1).get();
         assertEquals(upperCaseField.getDescriptor().getPrimitiveType().getPrimitiveTypeName(), BINARY);
         assertEquals(lowerCaseField.getDescriptor().getPrimitiveType().getPrimitiveTypeName(), INT64);
+    }
+
+    @Test
+    public void testPhysicalFieldLookupRejectsAmbiguousCaseInsensitiveMatch()
+    {
+        GroupType responseBody = CASE_SENSITIVE_SCHEMA.getType("response_body").asGroupType();
+        GroupColumnIO responseBodyColumnIO = (GroupColumnIO) getColumnIO(CASE_SENSITIVE_SCHEMA, CASE_SENSITIVE_SCHEMA).getChild("response_body");
+
+        assertEquals(getParquetTypeByName("Status", responseBody).getName(), "Status");
+        assertEquals(lookupColumnByName(responseBodyColumnIO, "status").getName(), "status");
+        assertNull(getParquetTypeByName("STATUS", responseBody));
+        assertNull(lookupColumnByName(responseBodyColumnIO, "STATUS"));
+
+        RowType ambiguousFallbackRowType = RowType.from(ImmutableList.of(RowType.field("STATUS", VARCHAR)));
+        assertFalse(constructField(ambiguousFallbackRowType, responseBodyColumnIO).isPresent());
     }
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet;
+
+import com.facebook.presto.common.type.RowType;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupDescriptor;
+import static org.apache.parquet.io.ColumnIOConverter.constructField;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+
+public class TestParquetTypeUtils
+{
+    private static final RowType CASE_SENSITIVE_ROW_TYPE = RowType.from(ImmutableList.of(
+            RowType.field("Status", VARCHAR),
+            RowType.field("status", BIGINT)));
+
+    private static final MessageType CASE_SENSITIVE_SCHEMA = Types.buildMessage()
+            .optionalGroup()
+                .optional(BINARY).as(stringType()).id(115).named("Status")
+                .optional(INT64).id(122).named("status")
+                .named("response_body")
+            .named("schema");
+
+    @Test
+    public void testDescriptorsPreferExactCase()
+    {
+        Map<List<String>, RichColumnDescriptor> descriptors = getDescriptors(CASE_SENSITIVE_SCHEMA, CASE_SENSITIVE_SCHEMA);
+
+        assertEquals(descriptors.get(ImmutableList.of("response_body", "Status")).getPrimitiveType().getPrimitiveTypeName(), BINARY);
+        assertEquals(descriptors.get(ImmutableList.of("response_body", "status")).getPrimitiveType().getPrimitiveTypeName(), INT64);
+    }
+
+    @Test
+    public void testDescriptorsExcludeUnrequestedCaseVariant()
+    {
+        MessageType requestedSchema = Types.buildMessage()
+                .optionalGroup()
+                    .optional(BINARY).as(stringType()).id(115).named("Status")
+                    .named("response_body")
+                .named("schema");
+
+        Map<List<String>, RichColumnDescriptor> descriptors = getDescriptors(CASE_SENSITIVE_SCHEMA, requestedSchema);
+
+        assertEquals(descriptors.size(), 1);
+        assertEquals(descriptors.get(ImmutableList.of("response_body", "Status")).getPrimitiveType().getPrimitiveTypeName(), BINARY);
+        assertFalse(descriptors.containsKey(ImmutableList.of("response_body", "status")));
+    }
+
+    @Test
+    public void testDescriptorLookupFallsBackToCaseInsensitiveMatch()
+    {
+        MessageType mixedCaseSchema = Types.buildMessage()
+                .optional(INT64).named("MixedCase")
+                .named("schema");
+        Map<List<String>, RichColumnDescriptor> descriptors = getDescriptors(mixedCaseSchema, mixedCaseSchema);
+
+        assertEquals(lookupDescriptor(descriptors, ImmutableList.of("mixedcase")).getPrimitiveType().getPrimitiveTypeName(), INT64);
+    }
+
+    @Test
+    public void testDescriptorLookupRejectsAmbiguousCaseInsensitiveMatch()
+    {
+        Map<List<String>, RichColumnDescriptor> descriptors = getDescriptors(CASE_SENSITIVE_SCHEMA, CASE_SENSITIVE_SCHEMA);
+
+        assertNull(lookupDescriptor(descriptors, ImmutableList.of("RESPONSE_BODY", "STATUS")));
+    }
+
+    @Test
+    public void testConstructFieldPreservesCase()
+    {
+        MessageColumnIO columnIO = getColumnIO(CASE_SENSITIVE_SCHEMA, CASE_SENSITIVE_SCHEMA);
+        GroupField field = (GroupField) constructField(CASE_SENSITIVE_ROW_TYPE, columnIO.getChild("response_body")).get();
+
+        PrimitiveField upperCaseField = (PrimitiveField) field.getChildren().get(0).get();
+        PrimitiveField lowerCaseField = (PrimitiveField) field.getChildren().get(1).get();
+        assertEquals(upperCaseField.getDescriptor().getPrimitiveType().getPrimitiveTypeName(), BINARY);
+        assertEquals(lowerCaseField.getDescriptor().getPrimitiveType().getPrimitiveTypeName(), INT64);
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
@@ -16,6 +16,7 @@ package com.facebook.presto.parquet.writer;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
@@ -30,6 +31,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ColumnIOConverter;
 import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -63,6 +65,7 @@ import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -85,6 +88,50 @@ public class TestParquetWriter
             nativeValueGetter(VARCHAR),
             nativeValueGetter(VARCHAR));
     private static final Type ROW = RowType.from(ImmutableList.of(RowType.field("varchar", VARCHAR)));
+    private static final Type CASE_SENSITIVE_ROW = RowType.from(ImmutableList.of(
+            RowType.field("Status", VARCHAR),
+            RowType.field("status", BIGINT)));
+
+    @Test
+    public void testCaseSensitiveFieldNamesInMetadata()
+            throws Exception
+    {
+        temporaryDirectory = createTempDir();
+        parquetFile = new File(temporaryDirectory, randomUUID() + ".parquet");
+        List<Type> types = ImmutableList.of(CASE_SENSITIVE_ROW);
+
+        try (ParquetWriter parquetWriter = createParquetWriter(
+                parquetFile,
+                types,
+                ImmutableList.of("response_body"),
+                ParquetWriterOptions.builder().build(),
+                CompressionCodecName.UNCOMPRESSED)) {
+            PageBuilder pageBuilder = new PageBuilder(1, types);
+            BlockBuilder rowBuilder = pageBuilder.getBlockBuilder(0).beginBlockEntry();
+            VARCHAR.writeString(rowBuilder, "ok");
+            BIGINT.writeLong(rowBuilder, 200);
+            pageBuilder.getBlockBuilder(0).closeEntry();
+            pageBuilder.declarePosition();
+            parquetWriter.write(pageBuilder.build());
+        }
+
+        FileParquetDataSource dataSource = new FileParquetDataSource(parquetFile);
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(
+                dataSource,
+                parquetFile.length(),
+                Optional.empty(),
+                false).getParquetMetadata();
+
+        GroupType responseBody = parquetMetadata.getFileMetaData().getSchema().getType("response_body").asGroupType();
+        assertEquals(responseBody.getFields().stream().map(org.apache.parquet.schema.Type::getName).collect(toList()), ImmutableList.of("Status", "status"));
+        assertEquals(
+                parquetMetadata.getBlocks().get(0).getColumns().stream()
+                        .map(column -> ImmutableList.copyOf(column.getPath().toArray()))
+                        .collect(toList()),
+                ImmutableList.of(
+                        ImmutableList.of("response_body", "Status"),
+                        ImmutableList.of("response_body", "status")));
+    }
 
     @Test
     public void testWriteAllNullDataPageAfterRowGroupFlush()


### PR DESCRIPTION
## Summary

- preserve field-name case in Parquet file schemas and column paths read from footer metadata
- preserve mixed-case Iceberg row field names as delimited when converting external schemas
- build descriptor maps from requested physical columns so unrequested case-only siblings cannot alias selected fields
- consistently prefer exact-case physical field matches, then use a unique case-insensitive compatibility fallback
- avoid predicate pushdown or physical field selection when a case-insensitive match is ambiguous
- preserve nested ORC field spelling in the Java batch reader
- resolve quoted row dereferences by exact case while retaining case-insensitive semantics for unquoted identifiers
- remove the unused `ParquetTypeUtils.getFieldIndex` helper

## Root cause

The custom Parquet metadata reader lowercased schema names and column paths. `ColumnIOConverter` also lowercased row field names before resolution. A valid Parquet struct containing fields such as `Status` and `status` therefore collapsed onto one logical path, which could select the wrong physical type and decode column statistics with the wrong reader.

Descriptor construction also iterated every file path. When only one case-only sibling was projected, the unrequested path could fall back case-insensitively to the requested descriptor. Descriptor maps now contain only the requested physical leaves.

Iceberg type conversion treated uppercase letters as safe in unquoted row field names. A later insert-planning round trip normalized those identifiers to lowercase, so case-only siblings collided with `Duplicate field`. Mixed-case external names are now marked delimited before type serialization.

Row dereference resolution previously treated quoted and unquoted identifiers identically. Quoted identifiers now prefer a unique exact-case match before using the compatibility fallback. Unquoted identifiers remain case-insensitive and reject case-only siblings as ambiguous.

The Java ORC batch reader similarly lowercased nested field names into a unique map. Case-only siblings therefore collided before the file could be read. It now preserves field spelling and applies the same exact-then-unique-case-insensitive policy.

## Impact

The Java Parquet reader and Iceberg ORC batch-reader path can resolve nested fields that differ only by case. Existing case-insensitive Hive-style physical resolution is retained when there is a single unambiguous match. If only an ambiguous case-insensitive physical match exists, the field is treated as absent and predicate pushdown is skipped instead of targeting an arbitrary column.

Iceberg tables with case-only nested row fields can now use separate `CREATE TABLE` and `INSERT` statements in both Parquet and ORC. Quoted exact-case dereferences remain distinct; unquoted dereferences remain case-insensitive and are ambiguous when case-only siblings exist.

The selective ORC reader and Hive/Delta Parquet row schema validation are not changed by this PR and are tracked in #28171.

## Validation

- `./mvnw -o -pl presto-parquet -Dtest=TestParquetTypeUtils test` — 6 tests passed
- `./mvnw -o -pl presto-orc -Dtest=TestStructBatchStreamReader test` — 8 tests passed
- `./mvnw -o -pl presto-iceberg -Dtest=TestIcebergTypes#testStructWithMixedCaseFieldNames test` — passed against tables written as Parquet and ORC
- `./mvnw -o -pl presto-parquet test` — 156 tests passed
- `./mvnw -o -pl presto-hive -Dtest=TestParquetPredicateUtils test` — 6 tests passed
- native `IcebergExternalWorkerQueryRunner` — separate `CREATE TABLE` and `INSERT` finished on 2 nodes with 2 completed splits
- GitHub CI test suites completed without failures

## Follow-up

- fix the Velox native Parquet reader and synthesized-subfield mapping for fields that differ only by case; coordinator-side insert now succeeds, while native reads still lowercase case-only siblings
- fix selective ORC reads and Hive/Delta Parquet row schema validation in #28171

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix Java Parquet and Iceberg ORC batch reads of nested fields whose names differ only by case, preserve mixed-case Iceberg ROW field names when writing, resolve quoted row dereferences by exact case, and avoid incorrect predicate pushdown for ambiguous case-insensitive physical matches.
```

Fixes #27602
