### PR TITLE
test: Add Iceberg test coverage for expire snapshots in Nessie catalog

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2782,6 +2782,12 @@ public abstract class IcebergDistributedTestBase
 
             assertQuery("select snapshot_id from \"test_expire_snapshot_with_deleted_entry$snapshots\"", "values " + snapshotId1 + ", " + snapshotId2 + ", " + snapshotId3);
 
+            // Explicitly set `gc.enabled = true` to guarantee snapshot expiration works across all catalogs.
+            // Some catalogs (like Nessie) default to `false`, which would break snapshot expiration functionality.
+            table.updateProperties()
+                    .set("gc.enabled", "true")
+                    .commit();
+
             // Expire `snapshotId2` which contains a DELETED entry to delete a data file which is still referenced by `snapshotId1`
             assertUpdate(format("call iceberg.system.expire_snapshots(schema => '%s', table_name => '%s', snapshot_ids => ARRAY[%d])", "tpch", "test_expire_snapshot_with_deleted_entry", snapshotId2));
             assertQuery("select snapshot_id from \"test_expire_snapshot_with_deleted_entry$snapshots\"", "values " + snapshotId1 + ", " + snapshotId3);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static java.lang.String.format;
 
 @Test
 public class TestIcebergDistributedNessie
@@ -75,13 +75,14 @@ public class TestIcebergDistributedNessie
                 .build().getQueryRunner();
     }
 
-    @Override
-    public void testExpireSnapshotWithDeletedEntries()
+    @Test
+    public void testExpireSnapshotNotSupportedInNessieByDefault()
     {
+        String schema = getSession().getSchema().get();
+        String tableName = "lineitem";
         // Nessie do not support expire snapshots as it set table property `gc.enabled` to `false` by default
-        assertThatThrownBy(() -> super.testExpireSnapshotWithDeletedEntries())
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageMatching("Cannot expire snapshots: GC is disabled .*");
+        assertQueryFails(format("call iceberg.system.expire_snapshots('%s', '%s')", schema, tableName),
+                "Cannot expire snapshots: GC is disabled .*");
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR adds test coverage for the `expire_snapshots` functionality in Iceberg connector with Nessie catalog.

## Motivation and Context

Follow-up from https://github.com/prestodb/presto/pull/28083#discussion_r3568889762

## Impact

N/A

## Test Plan

Added test cases for expire snapshots in Iceberg with Nessie catalog.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add Nessie-specific coverage and make generic Iceberg snapshot expiration tests work across catalogs with differing GC settings.

Tests:
- Add a Nessie catalog test verifying expire_snapshots fails by default when GC is disabled.
- Ensure the generic expire snapshot test explicitly enables gc.enabled so it behaves consistently across all catalogs.

## Summary by Sourcery

Add targeted test coverage for Iceberg expire_snapshots behavior in Nessie and ensure generic snapshot expiration tests work consistently across catalogs.

Tests:
- Add a Nessie catalog test verifying expire_snapshots fails by default when GC is disabled.
- Update the generic expire snapshot with deleted entries test to explicitly enable gc.enabled so it behaves consistently across different catalogs.