### PR TITLE
[Presto] Add MaterializedOutput large-row stats (#28160)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/operators/MaterializedOutput.h"
 
+#include <algorithm>
 #include <cstring>
 
 #include <folly/io/IOBuf.h>
@@ -187,6 +188,7 @@ void MaterializedOutput::serializeFixedWidthRows(
 
   rowSizes_.resize(startRow + numRows);
   std::fill(rowSizes_.begin() + startRow, rowSizes_.end(), fixedSize);
+  updateRowSizeStats(fixedSize, numRows);
 
   ensureFlatBufferCapacity(batchBytes);
 
@@ -219,6 +221,7 @@ void MaterializedOutput::serializeVariableWidthRows(
   for (vector_size_t i = 0; i < numRows; ++i) {
     const auto size = compactRow.rowSize(i);
     rowSizes_[startRow + i] = size;
+    updateRowSizeStats(size, 1);
     batchBytes += size;
   }
 
@@ -269,6 +272,15 @@ void MaterializedOutput::serializeRows(
     serializeFixedWidthRows(compactRow, numRows);
   } else {
     serializeVariableWidthRows(compactRow, numRows);
+  }
+}
+
+void MaterializedOutput::updateRowSizeStats(int32_t rowSize, int64_t numRows) {
+  maxSerializedRowBytes_ = std::max<int64_t>(maxSerializedRowBytes_, rowSize);
+  const auto rowGroupBytes = serializer::detail::RowGroupHeader::size() +
+      static_cast<int64_t>(sizeof(serializer::TRowSize)) + rowSize;
+  if (rowGroupBytes > rowGroupMaxBytes_) {
+    numRowsOverRowGroupMaxBytes_ += numRows;
   }
 }
 
@@ -408,6 +420,7 @@ void MaterializedOutput::flushRowGroup(
     rowDataBytes += sizeof(TRowSize) + rowSizes_[idx];
   }
   const int64_t totalBytes = kHeaderSize + rowDataBytes;
+  maxRowGroupBytes_ = std::max(maxRowGroupBytes_, totalBytes);
 
   auto iobuf = buffer_->allocateTrackedIOBuf(totalBytes);
   auto* dest = iobuf->writableData();
@@ -504,6 +517,17 @@ bool MaterializedOutput::isFinished() {
 }
 
 void MaterializedOutput::recordBufferStats() {
+  addRuntimeStat(
+      kMaxSerializedRowBytes,
+      velox::RuntimeCounter(
+          maxSerializedRowBytes_, velox::RuntimeCounter::Unit::kBytes));
+  addRuntimeStat(
+      kNumRowsOverRowGroupMaxBytes,
+      velox::RuntimeCounter(numRowsOverRowGroupMaxBytes_));
+  addRuntimeStat(
+      kMaxRowGroupBytes,
+      velox::RuntimeCounter(
+          maxRowGroupBytes_, velox::RuntimeCounter::Unit::kBytes));
   for (const auto& [key, metric] : buffer_->stats()) {
     addRuntimeStat(key, velox::RuntimeCounter(metric.sum, metric.unit));
   }

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -106,6 +106,16 @@ class MaterializedOutputNode : public velox::core::PlanNode {
 
 class MaterializedOutput : public velox::exec::Operator {
  public:
+  /// Reports the largest CompactRow payload serialized by this operator.
+  static constexpr std::string_view kMaxSerializedRowBytes =
+      "materializedOutput.maxSerializedRowBytes";
+  /// Counts rows whose one-row RowGroup would exceed the RowGroup target.
+  static constexpr std::string_view kNumRowsOverRowGroupMaxBytes =
+      "materializedOutput.numRowsOverRowGroupMaxBytes";
+  /// Reports the largest RowGroup emitted to MaterializedOutputBuffer.
+  static constexpr std::string_view kMaxRowGroupBytes =
+      "materializedOutput.maxRowGroupBytes";
+
   MaterializedOutput(
       int32_t operatorId,
       velox::exec::DriverCtx* ctx,
@@ -137,6 +147,9 @@ class MaterializedOutput : public velox::exec::Operator {
 
   // Publish buffer stats as operator runtime stats.
   void recordBufferStats();
+
+  // Track diagnostics for identifying true large-row RowGroups.
+  void updateRowSizeStats(int32_t rowSize, int64_t numRows);
 
   // Partition input, serialize into flat buffer, and flush if threshold
   // reached.
@@ -236,6 +249,12 @@ class MaterializedOutput : public velox::exec::Operator {
   // per-partition pages.
   int32_t rowCount_{0};
   int64_t flatBufferSize_{0};
+  // Largest serialized CompactRow payload seen by this operator.
+  int64_t maxSerializedRowBytes_{0};
+  // Number of input rows that cannot fit under the RowGroup byte target.
+  int64_t numRowsOverRowGroupMaxBytes_{0};
+  // Largest RowGroup emitted to the shared MaterializedOutputBuffer.
+  int64_t maxRowGroupBytes_{0};
   velox::BufferPtr flatBuffer_;
   std::vector<int64_t> rowOffsets_;
   std::vector<int32_t> rowSizes_;

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -486,6 +486,32 @@ TEST_F(MaterializedExchangeTest, boundsCollectSizeForLargeInputBatch) {
     EXPECT_LE(collectSize, collectSizeLimit);
   }
 
+  const auto taskStats = task->taskStats();
+  const exec::OperatorStats* materializedOutputStats{nullptr};
+  for (const auto& pipelineStats : taskStats.pipelineStats) {
+    for (const auto& operatorStats : pipelineStats.operatorStats) {
+      if (operatorStats.operatorType == "MaterializedOutput") {
+        materializedOutputStats = &operatorStats;
+        break;
+      }
+    }
+  }
+  ASSERT_NE(materializedOutputStats, nullptr);
+  const auto& runtimeStats = materializedOutputStats->runtimeStats;
+  const auto maxSerializedRowBytes =
+      runtimeStats.at(std::string(MaterializedOutput::kMaxSerializedRowBytes))
+          .sum;
+  EXPECT_GT(maxSerializedRowBytes, valueBytes);
+  EXPECT_LT(maxSerializedRowBytes, collectSizeLimit);
+  EXPECT_EQ(
+      runtimeStats
+          .at(std::string(MaterializedOutput::kNumRowsOverRowGroupMaxBytes))
+          .sum,
+      0);
+  EXPECT_LE(
+      runtimeStats.at(std::string(MaterializedOutput::kMaxRowGroupBytes)).sum,
+      collectSizeLimit);
+
   auto actual = runExchangeRead(numPartitions, dataType);
   exec::test::assertEqualResults({data}, actual);
   cleanupDirectory(tempDir_->getPath());


### PR DESCRIPTION
Summary:

Add MaterializedOutput runtime stats to diagnose true large-row RowGroups after row-group chunking: max serialized CompactRow payload, count of rows that exceed the RowGroup target by themselves, and max emitted RowGroup bytes. Extend the large-input MaterializedExchange regression test to assert the new stats for bounded multi-row batches.

Differential Revision: D112160006


