### PR TITLE
fix(native): Fix lint warnings in GFlags config support

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -12,8 +12,7 @@
  * limitations under the License.
  */
 #include <folly/init/Init.h>
-#include <gflags/gflags.h>
-#include <gflags/gflags_declare.h>
+#include <folly/portability/GFlags.h>
 #include <glog/logging.h>
 #include "presto_cpp/main/PrestoServer.h"
 #include "presto_cpp/main/common/ConfigReader.h"

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -13,8 +13,8 @@
  */
 
 #include "presto_cpp/main/common/Configs.h"
+#include <folly/portability/GFlags.h>
 #include <folly/system/HardwareConcurrency.h>
-#include <gflags/gflags.h>
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/core/QueryConfig.h"
@@ -1291,20 +1291,21 @@ std::string NodeConfig::nodeInternalAddress(
   }
 }
 
-void applyGFlags(const std::unordered_map<std::string, std::string>& configs) {
+void applyGFlags(
+    const std::unordered_map<std::string, std::string>& configs) noexcept {
   static constexpr std::string_view kGflagPrefix{"gflag."};
   static constexpr size_t kPrefixLen = kGflagPrefix.size();
   for (const auto& [key, value] : configs) {
-    if (key.rfind(kGflagPrefix, 0) != 0) {
+    if (!key.starts_with(kGflagPrefix)) {
       continue;
     }
     // Strip "gflag." prefix and convert hyphens to underscores to get the
     // flag name. e.g., "gflag.velox-memory-num-shared-leaf-pools" becomes
     // "velox_memory_num_shared_leaf_pools".
-    auto flagName = key.substr(kPrefixLen);
-    std::replace(flagName.begin(), flagName.end(), '-', '_');
+    std::string flagName = key.substr(kPrefixLen);
+    std::ranges::replace(flagName, '-', '_');
 
-    auto result = gflags::SetCommandLineOptionWithMode(
+    const std::string result = gflags::SetCommandLineOptionWithMode(
         flagName.c_str(), value.c_str(), gflags::SET_FLAG_IF_DEFAULT);
     if (result.empty()) {
       PRESTO_STARTUP_LOG(WARNING) << "Failed to set gflag '" << flagName

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1398,6 +1398,7 @@ class NodeConfig : public ConfigBase {
 /// Strips the "gflag." prefix and converts hyphens to underscores to derive
 /// the flag name. Uses SET_FLAG_IF_DEFAULT so command-line flags take
 /// precedence.
-void applyGFlags(const std::unordered_map<std::string, std::string>& configs);
+void applyGFlags(
+    const std::unordered_map<std::string, std::string>& configs) noexcept;
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -15,9 +15,14 @@
 #include <filesystem>
 #include <unordered_set>
 
+#include <folly/portability/GFlags.h>
 #include <folly/system/HardwareConcurrency.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
@@ -426,6 +431,8 @@ DECLARE_bool(avx2);
 
 namespace facebook::presto::test {
 
+// Saves and restores the gflags touched by applyGFlags() so tests do not leak
+// flag state to one another.
 class GFlagConfigTest : public ConfigTest {
  protected:
   void SetUp() override {
@@ -444,10 +451,11 @@ class GFlagConfigTest : public ConfigTest {
   }
 
  private:
-  void saveFlagState(const char* name) {
+  void saveFlagState(std::string_view name) {
     gflags::CommandLineFlagInfo info;
-    if (gflags::GetCommandLineFlagInfo(name, &info)) {
-      savedFlags_.emplace_back(name, info.current_value);
+    const std::string nameStr{name};
+    if (gflags::GetCommandLineFlagInfo(nameStr.c_str(), &info)) {
+      savedFlags_.emplace_back(nameStr, info.current_value);
     }
   }
 
@@ -466,7 +474,7 @@ TEST_F(GFlagConfigTest, applyGFlags) {
 }
 
 TEST_F(GFlagConfigTest, applyGFlagsIgnoresNonGflagKeys) {
-  auto origPools = FLAGS_velox_memory_num_shared_leaf_pools;
+  const int32_t origPools = FLAGS_velox_memory_num_shared_leaf_pools;
 
   applyGFlags({{"velox-memory-num-shared-leaf-pools", "99"}});
 


### PR DESCRIPTION
Summary:
Resolves the clang-tidy warnings raised by Meta internal code linting on the code that adds `applyGFlags` to apply `gflag.*` config properties to Velox gflags. This is a follow-up on top of that change and only touches the lines it flagged.

Fixes applied:
- Include `<folly/portability/GFlags.h>` instead of `<gflags/gflags.h>` directly in `PrestoMain.cpp`, `Configs.cpp`, and `ConfigTest.cpp`. Folly supports being built without gflags, so the portability header is required.
- Mark `applyGFlags` `noexcept` in `Configs.h` and `Configs.cpp`.
- Use `std::string::starts_with` instead of `rfind(..., 0)`, and `std::ranges::replace` instead of the iterator-pair `std::replace`.
- Use explicit types (`std::string`, `int32_t`) instead of `auto`.
- Take `std::string_view` instead of `const char*` in `saveFlagState`.
- Add the missing `<cstdint>` and `<utility>` includes (for `int32_t` and `std::pair`) and document the `GFlagConfigTest` fixture.

Differential Revision: D112196317


