### PR TITLE
fix(security): Upgrade async-http-client to 3.0.11 to address CVE-2026-55688

### DIFF
--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>3.0.10</version>
+                <version>3.0.11</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Upgrade async-http-client to 3.0.11 to address CVE-2026-55688

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

<img width="856" height="980" alt="image" src="https://github.com/user-attachments/assets/534d63b6-479f-4570-b411-81ca77ba60a8" />


<img width="1728" height="1117" alt="Screenshot 2026-07-16 at 4 57 33 PM" src="https://github.com/user-attachments/assets/07176a49-8a37-4224-a97f-542542e76191" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade async-http-client to 3.0.11 in response to `CVE-2026-55688  <https://nvd.nist.gov/vuln/detail/CVE-2026-55688>`_.

```

