### PR TITLE
feat(native-pos): Make MaterializedOutputBuffer lock-free with backpressure (#28172)

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -243,6 +243,10 @@ SystemConfig::SystemConfig() {
           NUM_PROP(
               kExchangeMaterializationOutputBufferPerPartitionMaxBytes,
               130L * 1024),
+          NUM_PROP(kExchangeMaterializationOutputBufferHighWatermarkRatio, 0.9),
+          NUM_PROP(kExchangeMaterializationOutputBufferLowWatermarkRatio, 0.7),
+          NUM_PROP(
+              kExchangeMaterializationOutputBufferDrainChunkMultiplier, 2.0),
           NUM_PROP(kExchangeMaterializationReclaimDrainThresholdRatio, 0.67),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
@@ -801,6 +805,27 @@ int64_t SystemConfig::exchangeMaterializationOutputBufferPerPartitionMaxBytes()
   return optionalProperty<int64_t>(
              kExchangeMaterializationOutputBufferPerPartitionMaxBytes)
       .value_or(130L * 1024);
+}
+
+double SystemConfig::exchangeMaterializationOutputBufferHighWatermarkRatio()
+    const {
+  return optionalProperty<double>(
+             kExchangeMaterializationOutputBufferHighWatermarkRatio)
+      .value_or(0.9);
+}
+
+double SystemConfig::exchangeMaterializationOutputBufferLowWatermarkRatio()
+    const {
+  return optionalProperty<double>(
+             kExchangeMaterializationOutputBufferLowWatermarkRatio)
+      .value_or(0.7);
+}
+
+double SystemConfig::exchangeMaterializationOutputBufferDrainChunkMultiplier()
+    const {
+  return optionalProperty<double>(
+             kExchangeMaterializationOutputBufferDrainChunkMultiplier)
+      .value_or(2.0);
 }
 
 double SystemConfig::exchangeMaterializationReclaimDrainThresholdRatio() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -693,6 +693,22 @@ class SystemConfig : public ConfigBase {
       kExchangeMaterializationOutputBufferPerPartitionMaxBytes{
           "exchange.materialization.output-buffer.per-partition-max-bytes"};
 
+  /// Producer-blocking watermark. Must exceed the low ratio. Default: 0.9.
+  static constexpr std::string_view
+      kExchangeMaterializationOutputBufferHighWatermarkRatio{
+          "exchange.materialization.output-buffer.high-watermark-ratio"};
+
+  /// Producer-wake watermark. Must be below the high ratio. Default: 0.7.
+  static constexpr std::string_view
+      kExchangeMaterializationOutputBufferLowWatermarkRatio{
+          "exchange.materialization.output-buffer.low-watermark-ratio"};
+
+  /// Maximum collect() size as a multiple of the partition drain threshold.
+  /// Default: 2.0.
+  static constexpr std::string_view
+      kExchangeMaterializationOutputBufferDrainChunkMultiplier{
+          "exchange.materialization.output-buffer.drain-chunk-multiplier"};
+
   /// Fraction of the per-partition drain threshold used during memory reclaim.
   /// The reclaim drain threshold is generally lower than the regular drain
   /// threshold, but high enough that draining actually reduces memory. Without
@@ -1181,6 +1197,12 @@ class SystemConfig : public ConfigBase {
   int64_t exchangeMaterializationOutputBufferMaxBytes() const;
 
   int64_t exchangeMaterializationOutputBufferPerPartitionMaxBytes() const;
+
+  double exchangeMaterializationOutputBufferHighWatermarkRatio() const;
+
+  double exchangeMaterializationOutputBufferLowWatermarkRatio() const;
+
+  double exchangeMaterializationOutputBufferDrainChunkMultiplier() const;
 
   double exchangeMaterializationReclaimDrainThresholdRatio() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -392,6 +392,12 @@ void MaterializedOutput::addInput(RowVectorPtr input) {
 
   output_.reset();
 
+  // Reserve drain headroom while this operator is reclaimable.
+  {
+    velox::exec::Operator::ReclaimableSectionGuard guard(this);
+    buffer_->ensureDrainMemoryHeadroom();
+  }
+
   if (flatBufferSize_ >= targetSizeInBytes_) {
     flushBatch();
   }
@@ -490,13 +496,8 @@ void MaterializedOutput::noMoreInput() {
 }
 
 BlockingReason MaterializedOutput::isBlocked(ContinueFuture* future) {
-  if (blockingReason_ != BlockingReason::kNotBlocked) {
-    *future = std::move(future_);
-    auto reason = blockingReason_;
-    blockingReason_ = BlockingReason::kNotBlocked;
-    return reason;
-  }
-  return BlockingReason::kNotBlocked;
+  // Drain at the high watermark or park until below the low watermark.
+  return buffer_->backpressure(future);
 }
 
 bool MaterializedOutput::isFinished() {

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.h
@@ -116,8 +116,7 @@ class MaterializedOutput : public velox::exec::Operator {
   velox::RowVectorPtr getOutput() override;
 
   bool needsInput() const override {
-    return !finished_ &&
-        blockingReason_ == velox::exec::BlockingReason::kNotBlocked;
+    return !finished_;
   }
 
   void noMoreInput() override;
@@ -212,9 +211,6 @@ class MaterializedOutput : public velox::exec::Operator {
   std::optional<int32_t> fixedRowSize_;
 
   // Operator state.
-  velox::exec::BlockingReason blockingReason_{
-      velox::exec::BlockingReason::kNotBlocked};
-  velox::ContinueFuture future_;
   bool finished_{false};
 
   // Reusable per-batch buffers.

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 #include <folly/ExceptionString.h>
+#include <folly/ScopeGuard.h>
 #include <glog/logging.h>
 #include <algorithm>
 #include <chrono>
@@ -82,56 +83,137 @@ struct TrackedBufInfo {
   size_t size;
 };
 
+int64_t MaterializedOutputBuffer::PartitionBuffer::drainAvailable(
+    std::deque<std::unique_ptr<folly::IOBuf>>& out) {
+  int64_t drainedBytes = 0;
+  std::unique_ptr<folly::IOBuf> item;
+  while (rowGroupsQueue_.try_dequeue(item)) {
+    drainedBytes += static_cast<int64_t>(item->computeChainDataLength());
+    out.push_back(std::move(item));
+  }
+  return drainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::drainAndFlush() {
+  // Drain all available RowGroups in bounded chunks to the writer.
+  int64_t totalDrainedBytes = 0;
+  std::deque<std::unique_ptr<folly::IOBuf>> chunk;
+  int64_t chunkBytes = 0;
+  const int64_t chunkThresholdBytes = buffer_->drainChunkThresholdBytes_;
+
+  // Flush the current chunk and update its buffered-byte accounting.
+  auto flushChunk = [&]() {
+    buffer_->flushToWriter(partition_, buffer_->coalesceRowGroups(chunk));
+    bufferedBytes_ -= chunkBytes;
+    totalDrainedBytes += chunkBytes;
+    chunk.clear();
+    chunkBytes = 0;
+  };
+
+  std::unique_ptr<folly::IOBuf> item;
+  // Consume the queue without exceeding the per-collect size target.
+  while (rowGroupsQueue_.try_dequeue(item)) {
+    const int64_t itemBytes =
+        static_cast<int64_t>(item->computeChainDataLength());
+    // Roll over before exceeding the cap; send an oversized RowGroup alone.
+    if (chunkBytes > 0 && chunkBytes + itemBytes > chunkThresholdBytes) {
+      flushChunk();
+    }
+    chunk.push_back(std::move(item));
+    chunkBytes += itemBytes;
+  }
+  if (!chunk.empty()) {
+    flushChunk();
+  }
+  return totalDrainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::tryDrainPartition(
+    int64_t targetBytes) {
+  if (!tryAcquireFlushing()) {
+    // Another driver is already draining and it will pick up our data.
+    return 0;
+  }
+
+  int64_t totalDrainedBytes = 0;
+  do {
+    {
+      // Never leave the partition wedged if flushing throws.
+      SCOPE_EXIT {
+        releaseFlushing();
+      };
+      totalDrainedBytes += drainAndFlush();
+    }
+    // Release before rechecking so a racing appender can become the flusher.
+  } while (bufferedBytes_ >= targetBytes && tryAcquireFlushing());
+  return totalDrainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::noMoreData() {
+  // Teardown is quiescent, so this acquire must be uncontended.
+  VELOX_CHECK(tryAcquireFlushing(), "unexpected concurrent flush at teardown");
+  SCOPE_EXIT {
+    releaseFlushing();
+  };
+  if (closed_.exchange(true)) {
+    return 0;
+  }
+  return drainAndFlush();
+}
+
 int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
     int32_t partition,
     std::unique_ptr<folly::IOBuf> rowGroup) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  VELOX_DCHECK_EQ(partition, partition_);
   VELOX_CHECK(!closed_, "enqueue called on closed partition");
-  auto dataSize = static_cast<int64_t>(rowGroup->computeChainDataLength());
-  auto drain = [&]() {
-    std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
-    toDrain.swap(rowGroups_);
-    auto drainedBytes = bufferedBytes_.load();
-    bufferedBytes_ = 0;
-
-    auto coalesced = buffer_->coalesceRowGroups(toDrain);
-    buffer_->flushToWriter(partition, std::move(coalesced));
-    return drainedBytes;
-  };
-
-  int64_t drainedBytes = 0;
-  if (!rowGroups_.empty() && bufferedBytes_ + dataSize > drainThreshold_) {
-    drainedBytes += drain();
+  const int64_t rowGroupBytes =
+      static_cast<int64_t>(rowGroup->computeChainDataLength());
+  rowGroupsQueue_.enqueue(std::move(rowGroup));
+  const int64_t newBytes = (bufferedBytes_ += rowGroupBytes);
+  if (newBytes >= drainThreshold_) {
+    return tryDrainPartition(drainThreshold_);
   }
-
-  rowGroups_.push_back(std::move(rowGroup));
-  bufferedBytes_ += dataSize;
-
-  if (bufferedBytes_ < drainThreshold_) {
-    return drainedBytes;
-  }
-
-  drainedBytes += drain();
-  return drainedBytes;
+  return 0;
 }
 
 void MaterializedOutputBuffer::initPartitionBuffers(int32_t numPartitions) {
   VELOX_CHECK_NOT_NULL(pool_, "MemoryPool must be non-null");
   VELOX_CHECK_NOT_NULL(writer_, "ShuffleWriter must be non-null");
   VELOX_CHECK_GT(numPartitions, 0, "Must have at least one partition");
+  // Watermark ordering (guards against a bad ratio config):
+  // 0 < low < high <= maxBufferedBytes.
+  VELOX_CHECK_GT(
+      lowWatermarkBytes_, 0, "backpressure low watermark must be positive");
+  VELOX_CHECK_LT(
+      lowWatermarkBytes_,
+      highWatermarkBytes_,
+      "backpressure low watermark must be below the high watermark");
+  VELOX_CHECK_LE(
+      highWatermarkBytes_,
+      maxBufferedBytes_,
+      "backpressure high watermark must not exceed the max buffer size");
+  // One producer must be able to drain below the wake watermark; otherwise all
+  // producers could park with no remaining waker.
+  VELOX_CHECK_LT(
+      numPartitions_ * reclaimDrainThresholdBytes_,
+      lowWatermarkBytes_,
+      "reclaim drain threshold too high vs the backpressure low watermark");
   partitionBuffers_.reserve(numPartitions);
   for (int32_t i = 0; i < numPartitions; ++i) {
     partitionBuffers_.push_back(
         std::make_unique<PartitionBuffer>(
-            partitionDrainThreshold_, writer_.get(), this));
+            i, partitionDrainThreshold_, writer_.get(), this));
   }
   LOG(INFO) << fmt::format(
       "MaterializedOutputBuffer: partitions={}, maxBufferedBytes={}, "
-      "drainThreshold={}, reclaimDrainThreshold={}, pool={}",
+      "drainThreshold={}, reclaimDrainThreshold={}, blockThreshold={}, "
+      "unblockThreshold={}, pool={}",
       numPartitions_,
       velox::succinctBytes(maxBufferedBytes_),
       velox::succinctBytes(partitionDrainThreshold_),
       velox::succinctBytes(reclaimDrainThresholdBytes_),
+      velox::succinctBytes(highWatermarkBytes_),
+      velox::succinctBytes(lowWatermarkBytes_),
       pool_->name());
 }
 
@@ -156,6 +238,21 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
               partitionDrainThreshold_ *
               SystemConfig::instance()
                   ->exchangeMaterializationReclaimDrainThresholdRatio())),
+      drainChunkThresholdBytes_(
+          static_cast<int64_t>(
+              partitionDrainThreshold_ *
+              SystemConfig::instance()
+                  ->exchangeMaterializationOutputBufferDrainChunkMultiplier())),
+      highWatermarkBytes_(
+          static_cast<int64_t>(
+              maxBufferedBytes_ *
+              SystemConfig::instance()
+                  ->exchangeMaterializationOutputBufferHighWatermarkRatio())),
+      lowWatermarkBytes_(
+          static_cast<int64_t>(
+              maxBufferedBytes_ *
+              SystemConfig::instance()
+                  ->exchangeMaterializationOutputBufferLowWatermarkRatio())),
       pool_(pool->addLeafChild(
           fmt::format("materialized_output_buffer.{}", taskId),
           true,
@@ -177,6 +274,8 @@ MaterializedOutputBuffer::~MaterializedOutputBuffer() {
       LOG(ERROR) << "MaterializedOutputBuffer abort failed in destructor";
     }
   }
+  // MemoryPool teardown requires the drain-headroom reservation to be released.
+  pool_->release();
 }
 
 std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::allocateTrackedIOBuf(
@@ -230,6 +329,74 @@ void MaterializedOutputBuffer::enqueue(
           static_cast<int64_t>(drainCount_),
           velox::succinctBytes(bufferedBytes_));
     }
+    maybeWakeBlockedDrivers();
+  }
+}
+
+void MaterializedOutputBuffer::addBlockedPromise(
+    velox::ContinueFuture* future) {
+  velox::ContinuePromise promise{"MaterializedOutputBuffer::addBlockedPromise"};
+  *future = promise.getSemiFuture();
+  blockedPromises_.withWLock(
+      [&](auto& promises) { promises.push_back(std::move(promise)); });
+  // Avoid missing a concurrent low-watermark crossing during registration.
+  maybeWakeBlockedDrivers();
+}
+
+void MaterializedOutputBuffer::tryDrainPartitions() {
+  while (bufferedBytes_ >= lowWatermarkBytes_) {
+    // Flush the fullest partitions this thread can acquire.
+    const uint64_t drainedBytes = tryDrainPartitionsInternal();
+    if (drainedBytes == 0) {
+      // Nothing left this thread can drain (others are flushing the rest).
+      break;
+    }
+  }
+}
+
+velox::exec::BlockingReason MaterializedOutputBuffer::backpressure(
+    velox::ContinueFuture* future) {
+  if (!isBufferFull()) {
+    return velox::exec::BlockingReason::kNotBlocked;
+  }
+
+  // Drain on the producer before parking.
+  tryDrainPartitions();
+
+  // Park until a drain crosses the low watermark.
+  if (isBufferFull() && reclaimableBufferedBytes() > 0) {
+    addBlockedPromise(future);
+    return velox::exec::BlockingReason::kWaitForConsumer;
+  }
+
+  // With nothing reclaimable, parking would have no waker.
+  if (isBufferFull()) {
+    LOG_EVERY_N(WARNING, 256)
+        << "MaterializedOutputBuffer: buffer full but nothing reclaimable; not "
+           "parking (bufferedBytes="
+        << bufferedBytes() << ")";
+  }
+  return velox::exec::BlockingReason::kNotBlocked;
+}
+
+void MaterializedOutputBuffer::ensureDrainMemoryHeadroom() {
+  // Reserve one drain's coalesce and compression allocations before entering
+  // the non-reclaimable flush window. Failure falls back to on-demand growth.
+  const int64_t headroom = 2 * partitionDrainThreshold_;
+  if (pool_->availableReservation() >= headroom) {
+    return;
+  }
+  pool_->maybeReserve(headroom);
+}
+
+void MaterializedOutputBuffer::maybeWakeBlockedDrivers() {
+  if (bufferedBytes_ >= lowWatermarkBytes_) {
+    return;
+  }
+  std::vector<velox::ContinuePromise> toFulfill;
+  blockedPromises_.withWLock([&](auto& promises) { toFulfill.swap(promises); });
+  for (auto& promise : toFulfill) {
+    promise.setValue();
   }
 }
 
@@ -273,27 +440,18 @@ int64_t MaterializedOutputBuffer::drainPartition(
   VELOX_CHECK_GE(partition, 0);
   VELOX_CHECK_LT(partition, numPartitions_);
 
-  std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
-  int64_t drainedBytes = 0;
-  {
-    std::unique_lock<std::mutex> lock(
-        partitionBuffers_[partition]->mutex_, std::defer_lock);
-    if (force) {
-      lock.lock();
-      partitionBuffers_[partition]->closed_ = true;
-    } else {
-      if (!lock.try_lock()) {
-        return 0;
-      }
-    }
-    toDrain.swap(partitionBuffers_[partition]->rowGroups_);
-    drainedBytes = partitionBuffers_[partition]->bufferedBytes_.exchange(0);
+  auto& partitionBuffer = *partitionBuffers_[partition];
+  int64_t drainedBytes;
+  if (force) {
+    drainedBytes = partitionBuffer.noMoreData();
+  } else {
+    drainedBytes =
+        partitionBuffer.tryDrainPartition(reclaimDrainThresholdBytes_);
   }
 
-  if (!toDrain.empty()) {
-    auto coalesced = coalesceRowGroups(toDrain);
-    flushToWriter(partition, std::move(coalesced));
+  if (drainedBytes > 0) {
     updateDrainStats(drainedBytes);
+    maybeWakeBlockedDrivers();
   }
 
   return drainedBytes;
@@ -310,7 +468,7 @@ uint64_t MaterializedOutputBuffer::reclaimableBufferedBytes() const {
   return reclaimableBytes;
 }
 
-uint64_t MaterializedOutputBuffer::tryDrainPartitions() {
+uint64_t MaterializedOutputBuffer::tryDrainPartitionsInternal() {
   std::vector<int32_t> orderedPartitions(numPartitions_);
   std::iota(orderedPartitions.begin(), orderedPartitions.end(), 0);
 
@@ -383,13 +541,8 @@ void MaterializedOutputBuffer::abort() {
     return;
   }
 
-  // Free partition buffers.
-  for (int32_t i = 0; i < numPartitions_; ++i) {
-    std::lock_guard<std::mutex> lock(partitionBuffers_[i]->mutex_);
-    partitionBuffers_[i]->rowGroups_.clear();
-    bufferedBytes_ -= partitionBuffers_[i]->bufferedBytes_;
-    partitionBuffers_[i]->bufferedBytes_ = 0;
-  }
+  // Unpark any producers blocked on backpressure so they observe kAborted.
+  maybeWakeBlockedDrivers();
 
   LOG(INFO)
       << "MaterializedOutputBuffer: calling writer noMoreData(false) [abort]";
@@ -448,7 +601,7 @@ bool MaterializedOutputBuffer::Reclaimer::reclaimableBytes(
 
 void MaterializedOutputBuffer::Reclaimer::tryReclaimPartitionBuffers(
     velox::memory::MemoryPool* pool) {
-  auto flushedBytes = partitionBuffer_->tryDrainPartitions();
+  auto flushedBytes = partitionBuffer_->tryDrainPartitionsInternal();
   MATERIALIZED_BUFFER_LOG(
       "FLUSH", pool, "flushedBytes={}", velox::succinctBytes(flushedBytes));
 }

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -21,28 +21,29 @@
 
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <folly/concurrency/UnboundedQueue.h>
 #include <folly/container/F14Map.h>
 #include <folly/io/IOBuf.h>
 #include "presto_cpp/main/operators/ShuffleInterface.h"
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/exec/Driver.h"
 #include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::presto::operators {
 
-/// Thread-safe shared buffer between MaterializedOutput operators and a
-/// ShuffleWriter. Multiple MaterializedOutput drivers enqueue concurrently;
-/// the buffer drains to the writer when per-partition thresholds are hit.
-///
-/// Memory pressure is handled by the Velox memory arbitrator via the
-/// nested Reclaimer class, not cooperative backpressure.
+/// Shared MaterializedOutput buffer with lock-free per-partition appends.
+/// One CAS-elected flusher preserves writer order per partition. Producers
+/// park near 90% capacity and wake below 70%; arbitration is the backstop.
+/// Concurrent appends may interleave, so this supports non-sort shuffle only.
 ///
 /// Lifecycle state machine:
 ///   kActive -> kDraining -> kClosed  (noMoreData: success)
 ///   kActive -> kDraining -> kAborted (noMoreData: writer failure)
 ///   kActive -> kAborted              (abort: error teardown)
-/// Reclaim Phase 1 (flush partitions) runs only in kActive. Phase 2
-/// (wait for writer network drain) also runs in kClosed.
+/// Partition reclaim runs only in kActive. Writer-drain waiting runs in
+/// kActive or kDraining; kClosed and kAborted are not reclaimable.
 class MaterializedOutputBuffer {
  public:
   enum class State : uint8_t {
@@ -79,16 +80,9 @@ class MaterializedOutputBuffer {
   static constexpr std::string_view kReclaimedBytes =
       "materializedOutputBuffer.reclaimedBytes";
 
-  /// Memory reclaimer for the exchange writer pool. Nested inside
-  /// MaterializedOutputBuffer so the raw back-pointer is always valid — the
-  /// pool owns the reclaimer, and MaterializedOutputBuffer owns the pool.
-  ///
-  /// Two-phase reclaim:
-  /// (1) flush MaterializedOutputBuffer partition buffers to the writer;
-  /// (2) wait for writer background threads to drain packages to network.
-  ///
-  /// Priority kHighReclaimPriority ensures this pool is reclaimed before
-  /// operator pools (priority 0+).
+  /// Reclaims partition buffers, then waits for writer network drain. The
+  /// nested lifetime keeps the raw back-pointer valid. Priority -1 runs before
+  /// ordinary operator reclaimers.
   class Reclaimer : public velox::exec::MemoryReclaimer {
    public:
     static constexpr int32_t kHighReclaimPriority = -1;
@@ -111,14 +105,10 @@ class MaterializedOutputBuffer {
     bool canReclaim(const velox::memory::MemoryPool& pool, uint64_t targetBytes)
         const;
 
-    /// Returns true if partition flush should run: kActive state and
-    /// bufferedBytes > 0. During kDraining, noMoreData() is already
-    /// draining partitions so we skip to waiting for writer drain.
+    /// Partition flush runs only while active with buffered data.
     bool canReclaimFromPartitionBuffers() const;
 
-    /// Flush partition buffers to the writer. Calls tryDrainPartitions()
-    /// which sorts partitions largest-first and flushes each above
-    /// reclaimDrainThresholdBytes via try_lock.
+    /// Flushes eligible partitions largest-first via the CAS flusher gate.
     void tryReclaimPartitionBuffers(velox::memory::MemoryPool* pool);
 
     /// Wait for writer background threads to drain packages to network.
@@ -163,19 +153,6 @@ class MaterializedOutputBuffer {
   /// Enqueue a serialized RowGroup for a partition.
   void enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
 
-  /// Best-effort drain for reclaim. Uses try_lock — skips contested
-  /// partitions to avoid deadlock with enqueue() -> collect() ->
-  /// arbitration. Partitions below reclaimDrainThresholdBytes() are skipped.
-  uint64_t tryDrainPartitions();
-
-  /// Minimum partition bytes worth flushing during reclaim.
-  int64_t reclaimDrainThresholdBytes() const {
-    return reclaimDrainThresholdBytes_;
-  }
-
-  /// Returns the bytes that tryDrainPartitions() will actually flush.
-  uint64_t reclaimableBufferedBytes() const;
-
   /// Signal that no more data will be enqueued. Drains remaining data
   /// and calls writer->noMoreData(true).
   void noMoreData();
@@ -205,6 +182,12 @@ class MaterializedOutputBuffer {
   /// (kBytes, kNone). Only meaningful after close.
   folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const;
 
+  /// Drains at the high watermark, then parks until below the low watermark.
+  velox::exec::BlockingReason backpressure(velox::ContinueFuture* future);
+
+  /// Best-effort reservation for coalesce and compression during one drain.
+  void ensureDrainMemoryHeadroom();
+
   /// Allocate an IOBuf tracked through pool_. Used by MaterializedOutput
   /// to create RowGroup IOBufs that are visible for memory accounting.
   std::unique_ptr<folly::IOBuf> allocateTrackedIOBuf(size_t size);
@@ -218,36 +201,68 @@ class MaterializedOutputBuffer {
   }
 
  private:
-  // Per-partition buffer. Single mutex serializes enqueue and drain.
-  // When buffered bytes exceed the drain threshold, enqueue coalesces
-  // and flushes to the writer under the same lock — prevents concurrent
-  // collect() calls on the same partition.
+  // Appenders enqueue without locking. One appender, reclaimer, or closer
+  // CAS-acquires 'flushing_' and calls collect(); losers keep appending. This
+  // single-flusher gate preserves per-partition writer order and checksums.
   class PartitionBuffer {
    public:
     PartitionBuffer() = default;
 
     PartitionBuffer(
+        int32_t partition,
         int64_t drainThreshold,
         ShuffleWriter* writer,
         MaterializedOutputBuffer* buffer)
-        : drainThreshold_(drainThreshold), writer_(writer), buffer_(buffer) {}
+        : partition_(partition),
+          drainThreshold_(drainThreshold),
+          writer_(writer),
+          buffer_(buffer) {}
 
-    // Append a RowGroup under the partition lock. If threshold is reached,
-    // drains under the same lock — coalesces + calls writer->collect().
-    // Returns bytes drained (0 if no drain occurred).
+    // Lock-free append; if over 'drainThreshold_', tries to become flusher and
+    // drain. Returns bytes drained (0 if not the flusher).
     int64_t enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
 
    private:
     friend class MaterializedOutputBuffer;
 
-    mutable std::mutex mutex_;
-    std::deque<std::unique_ptr<folly::IOBuf>> rowGroups_;
+    // A successful sole-flusher CAS must be paired with releaseFlushing().
+    bool tryAcquireFlushing() {
+      bool expected = false;
+      return flushing_.compare_exchange_strong(expected, true);
+    }
+
+    // Release the flusher flag (seq_cst store). Only the current flusher calls
+    // this.
+    void releaseFlushing() {
+      flushing_ = false;
+    }
+
+    // Pop all currently-available RowGroups into 'out' (caller must hold
+    // 'flushing_'). Returns total bytes popped.
+    int64_t drainAvailable(std::deque<std::unique_ptr<folly::IOBuf>>& out);
+
+    // Flushes bounded chunks; an oversized RowGroup is sent alone. Caller
+    // holds 'flushing_'. Returns total bytes flushed.
+    int64_t drainAndFlush();
+
+    // Release, recheck, and reacquire until below target so a concurrent append
+    // cannot leave an over-threshold partition without a flusher.
+    int64_t tryDrainPartition(int64_t targetBytes);
+
+    // Closes once and flushes all remaining data. Teardown is quiescent, but
+    // still uses the flusher gate to preserve writer ordering.
+    int64_t noMoreData();
+
+    folly::UMPMCQueue<std::unique_ptr<folly::IOBuf>, /*MayBlock=*/false>
+        rowGroupsQueue_;
     std::atomic_int64_t bufferedBytes_{0};
+    std::atomic<bool> flushing_{false};
+    // Set true by close()/abort(); rejects further appends.
+    std::atomic<bool> closed_{false};
+    // This partition's index in the parent's partitionBuffers_; passed to the
+    // writer on flush.
+    const int32_t partition_{-1};
     int64_t drainThreshold_{0};
-    // Per-partition safety net: set under the partition lock by
-    // drainPartition(close=true). Guards against data loss if enqueue
-    // races past the global state_ check.
-    bool closed_{false};
     ShuffleWriter* writer_{nullptr};
     MaterializedOutputBuffer* buffer_{nullptr};
   };
@@ -255,10 +270,30 @@ class MaterializedOutputBuffer {
   /// Initialize partition buffers and validate invariants.
   void initPartitionBuffers(int32_t numPartitions);
 
-  /// Drain buffered data for a single partition. When force=false (default),
-  /// uses try_lock and returns 0 if the partition mutex is contested. When
-  /// force=true, uses blocking lock and marks the partition closed.
+  /// Drains buffered data for one partition. When force is false, tries the
+  /// single-flusher CAS gate and returns 0 if another flusher owns it. When
+  /// force is true, closes the partition and fully drains it; teardown must be
+  /// quiescent, so the gate is expected to be uncontended.
   int64_t drainPartition(int32_t partition, bool force = false);
+
+  /// Best-effort largest-first pass over reclaimable, uncontended partitions.
+  uint64_t tryDrainPartitionsInternal();
+
+  /// True when total buffered bytes are at/above the configured high watermark.
+  bool isBufferFull() const {
+    return bufferedBytes_ >= highWatermarkBytes_;
+  }
+
+  /// Loop tryDrainPartitionsInternal() until buffered drops below the low
+  /// watermark (or this thread can drain no more).
+  void tryDrainPartitions();
+
+  /// Bytes above the per-partition reclaim thresholds — what a drain can free.
+  uint64_t reclaimableBufferedBytes() const;
+
+  /// Register a producer's ContinueFuture, woken once buffered falls below the
+  /// low watermark. Moves a fresh future into '*future'.
+  void addBlockedPromise(velox::ContinueFuture* future);
 
   /// Drains all partitions and marks them closed.
   uint64_t close();
@@ -268,6 +303,9 @@ class MaterializedOutputBuffer {
 
   // Coalesce data into a contiguous buffer and send to the ShuffleWriter.
   void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
+
+  // Wake parked producers after crossing the low watermark.
+  void maybeWakeBlockedDrivers();
 
   // Merge a deque of RowGroup IOBufs into a single contiguous IOBuf.
   std::unique_ptr<folly::IOBuf> coalesceRowGroups(
@@ -282,6 +320,12 @@ class MaterializedOutputBuffer {
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
   const int64_t reclaimDrainThresholdBytes_;
+  // Per-collect cap for lock-free drain overshoot.
+  const int64_t drainChunkThresholdBytes_;
+  // Global backpressure high/low watermarks: block producers at ~90% of the
+  // cap, wake them once total buffered drops below ~70% (hysteresis).
+  const int64_t highWatermarkBytes_;
+  const int64_t lowWatermarkBytes_;
 
   // Pool created first so the writer can allocate from it.
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -289,9 +333,10 @@ class MaterializedOutputBuffer {
 
   std::atomic<State> state_{State::kActive};
 
-  // Per-partition buffers. Each PartitionBuffer has its own mutex that
-  // serializes enqueue + drain for that partition.
+  // Buffer-wide total across partitions; drives the backpressure watermarks.
   std::atomic_int64_t bufferedBytes_{0};
+  // Per-partition buffers. Each PartitionBuffer has a lock-free queue and a
+  // single-flusher CAS gate that serializes drains for that partition.
   std::vector<std::unique_ptr<PartitionBuffer>> partitionBuffers_;
 
   // Stats counters.
@@ -300,8 +345,13 @@ class MaterializedOutputBuffer {
   std::atomic_int64_t peakBufferedBytes_{0};
   std::atomic_int64_t reclaimCount_{0};
   std::atomic_int64_t reclaimedBytes_{0};
+
   std::atomic_int64_t lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;
+
+  // Producer promises parked by backpressure, fulfilled by
+  // maybeWakeBlockedDrivers() once buffered drops below the low watermark.
+  folly::Synchronized<std::vector<velox::ContinuePromise>> blockedPromises_;
 
   // Process-wide registry of buffers keyed by taskId, following the same
   // pattern as Velox OutputBufferManager. Buffer creation is done under

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -11,10 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/ScopeGuard.h>
 #include <folly/Uri.h>
 #include <folly/init/Init.h>
+#include <folly/synchronization/Baton.h>
 
 #include <boost/range/algorithm/find_if.hpp>
+
+#include <cstring>
+#include <thread>
 
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/tests/MutableConfigs.h"
@@ -212,6 +217,101 @@ class RecordingShuffleFactory : public ShuffleInterfaceFactory {
  private:
   ShuffleInterfaceFactory* delegate_;
   std::shared_ptr<std::vector<size_t>> collectSizes_;
+};
+
+// Holds the first collect() while the test exercises flush serialization and
+// backpressure.
+class BlockingCollectShuffleWriter : public ShuffleWriter {
+ public:
+  BlockingCollectShuffleWriter(
+      std::shared_ptr<ShuffleWriter> delegate,
+      folly::Baton<>* collectReached,
+      folly::Baton<>* releaseCollect)
+      : delegate_(std::move(delegate)),
+        collectReached_(collectReached),
+        releaseCollect_(releaseCollect) {}
+
+  void collect(int32_t partition, std::string_view key, std::string_view data)
+      override {
+    const auto active = activeCollects_.fetch_add(1) + 1;
+    auto maxActive = maxActiveCollects_.load();
+    while (active > maxActive &&
+           !maxActiveCollects_.compare_exchange_weak(maxActive, active)) {
+    }
+    SCOPE_EXIT {
+      --activeCollects_;
+    };
+    collectSizes_.withWLock([&](auto& sizes) { sizes.push_back(data.size()); });
+    if (!blockedOnce_.exchange(true)) {
+      collectReached_->post();
+      releaseCollect_->wait();
+    }
+    delegate_->collect(partition, key, data);
+  }
+
+  void noMoreData(bool success) override {
+    delegate_->noMoreData(success);
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return delegate_->stats();
+  }
+
+  int maxActiveCollects() const {
+    return maxActiveCollects_;
+  }
+
+  std::vector<size_t> collectSizes() const {
+    return collectSizes_.copy();
+  }
+
+ private:
+  std::shared_ptr<ShuffleWriter> delegate_;
+  folly::Baton<>* const collectReached_;
+  folly::Baton<>* const releaseCollect_;
+  std::atomic<bool> blockedOnce_{false};
+  std::atomic<int> activeCollects_{0};
+  std::atomic<int> maxActiveCollects_{0};
+  folly::Synchronized<std::vector<size_t>> collectSizes_;
+};
+
+class BlockingCollectShuffleFactory : public ShuffleInterfaceFactory {
+ public:
+  BlockingCollectShuffleFactory(
+      ShuffleInterfaceFactory* delegate,
+      folly::Baton<>* collectReached,
+      folly::Baton<>* releaseCollect)
+      : delegate_(delegate),
+        collectReached_(collectReached),
+        releaseCollect_(releaseCollect) {}
+
+  std::shared_ptr<ShuffleReader> createReader(
+      const std::string& serializedShuffleInfo,
+      int32_t partition,
+      velox::memory::MemoryPool* pool) override {
+    return delegate_->createReader(serializedShuffleInfo, partition, pool);
+  }
+
+  std::shared_ptr<ShuffleWriter> createWriter(
+      const std::string& serializedShuffleInfo,
+      velox::memory::MemoryPool* pool) override {
+    auto writer = std::make_shared<BlockingCollectShuffleWriter>(
+        delegate_->createWriter(serializedShuffleInfo, pool),
+        collectReached_,
+        releaseCollect_);
+    writer_ = writer;
+    return writer;
+  }
+
+  std::shared_ptr<BlockingCollectShuffleWriter> writer() const {
+    return writer_.lock();
+  }
+
+ private:
+  ShuffleInterfaceFactory* delegate_;
+  folly::Baton<>* const collectReached_;
+  folly::Baton<>* const releaseCollect_;
+  std::weak_ptr<BlockingCollectShuffleWriter> writer_;
 };
 
 } // namespace
@@ -422,6 +522,33 @@ TEST_F(MaterializedExchangeTest, largeDataEndToEnd) {
   cleanupDirectory(tempDir_->getPath());
 }
 
+TEST_F(MaterializedExchangeTest, concurrentSamePartitionPreservesData) {
+  constexpr int numRows = 2'000;
+  constexpr int numDrivers = 8;
+  facebook::presto::test::setupMutableSystemConfig();
+  // Keep 2x chunks below LocalShuffleWriter's 64KiB test-only partition cap.
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      std::to_string(16L * 1024));
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+      makeFlatVector<std::string>(
+          numRows,
+          [](auto row) {
+            return fmt::format("driver-concurrent-row-{}", row);
+          }),
+  });
+
+  auto expected = runExchangeWrite({data}, /*numPartitions=*/1, numDrivers);
+  auto actual = runExchangeRead(/*numPartitions=*/1, asRowType(data->type()));
+
+  // The real shuffle round trip checks concurrent appends and writer checksum.
+  exec::test::assertEqualResults(expected, actual);
+  cleanupDirectory(tempDir_->getPath());
+}
+
 TEST_F(MaterializedExchangeTest, boundsCollectSizeForLargeInputBatch) {
   constexpr int numRows = 128;
   constexpr int valueBytes = 8 * 1024;
@@ -477,9 +604,12 @@ TEST_F(MaterializedExchangeTest, boundsCollectSizeForLargeInputBatch) {
   auto stats = buffer->stats();
   const auto collectCount =
       stats.at(std::string(MaterializedOutputBuffer::kTotalCollectCalls)).sum;
-  const auto collectSizeLimit =
+  const auto collectSizeLimit = static_cast<int64_t>(
+      SystemConfig::instance()
+          ->exchangeMaterializationOutputBufferDrainChunkMultiplier() *
       stats.at(std::string(MaterializedOutputBuffer::kCurrentDrainThreshold))
-          .sum;
+          .sum);
+  // A large drain must split into bounded collect() calls.
   EXPECT_GT(collectCount, 1);
   ASSERT_EQ(recordingFactory.collectSizes().size(), collectCount);
   for (auto collectSize : recordingFactory.collectSizes()) {
@@ -864,7 +994,7 @@ TEST_F(MaterializedExchangeTest, abortFromActiveState) {
 
   buffer->abort();
   EXPECT_EQ(buffer->state(), MaterializedOutputBuffer::State::kAborted);
-  EXPECT_EQ(buffer->bufferedBytes(), 0);
+  EXPECT_EQ(buffer->bufferedBytes(), 1024);
 
   // Second abort is a no-op (CAS fails, already kAborted).
   buffer->abort();
@@ -875,6 +1005,258 @@ TEST_F(MaterializedExchangeTest, abortFromActiveState) {
   std::memset(iobuf2->writableData(), 'y', 64);
   iobuf2->append(64);
   buffer->enqueue(0, std::move(iobuf2));
+
+  buffer.reset();
+  EXPECT_EQ(rootPool->usedBytes(), 0);
+
+  cleanupDirectory(shuffleDir->getPath());
+}
+
+// A producer parks at the high watermark and wakes below the low watermark.
+TEST_F(MaterializedExchangeTest, backpressureParksAndWakesProducer) {
+  constexpr int32_t numPartitions = 1;
+  constexpr int64_t kMaxBytes = 1L << 20; // 1MB backpressure cap.
+  constexpr int64_t kPerPartitionMax = 100L * 1024; // 100KB drain threshold.
+  // One RowGroup crosses both the drain and high watermarks.
+  constexpr int64_t kRowGroupBytes = kMaxBytes;
+
+  facebook::presto::test::setupMutableSystemConfig();
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kExchangeMaterializationOutputBufferMaxBytes),
+      std::to_string(kMaxBytes));
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      std::to_string(kPerPartitionMax));
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "backpressureParkTest", 64L << 20, memory::MemoryReclaimer::create());
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+
+  folly::Baton<> collectReached;
+  folly::Baton<> releaseCollect;
+  BlockingCollectShuffleFactory blockingFactory(
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      &collectReached,
+      &releaseCollect);
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions, writeInfo, &blockingFactory, "bp.0.0.0.0", rootPool.get());
+
+  std::thread producer([&]() {
+    auto iobuf = buffer->allocateTrackedIOBuf(kRowGroupBytes);
+    std::memset(iobuf->writableData(), 'x', kRowGroupBytes);
+    iobuf->append(kRowGroupBytes);
+    buffer->enqueue(0, std::move(iobuf));
+  });
+
+  // The blocked collect keeps bytes above the high watermark.
+  collectReached.wait();
+  ASSERT_GE(buffer->bufferedBytes(), kMaxBytes * 9 / 10);
+
+  // The flusher gate prevents this producer from draining, so it parks.
+  velox::ContinueFuture future = velox::ContinueFuture::makeEmpty();
+  auto reason = buffer->backpressure(&future);
+  EXPECT_EQ(reason, velox::exec::BlockingReason::kWaitForConsumer);
+  ASSERT_TRUE(future.valid());
+  EXPECT_FALSE(future.isReady());
+
+  // Completing the drain crosses the low watermark and wakes the producer.
+  releaseCollect.post();
+  producer.join();
+  EXPECT_TRUE(future.isReady());
+  EXPECT_EQ(buffer->bufferedBytes(), 0);
+
+  buffer->noMoreData();
+  cleanupDirectory(shuffleDir->getPath());
+}
+
+TEST_F(MaterializedExchangeTest, singleFlusherAndBoundedRollover) {
+  constexpr int32_t numPartitions = 1;
+  constexpr int64_t kDrainThreshold = 16L * 1024;
+  constexpr int64_t kRowGroupBytes = 8L * 1024;
+  constexpr int kQueuedWhileFlushing = 9;
+
+  facebook::presto::test::setupMutableSystemConfig();
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      std::to_string(kDrainThreshold));
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kExchangeMaterializationOutputBufferMaxBytes),
+      std::to_string(64L << 20));
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "singleFlusherTest", 64L << 20, memory::MemoryReclaimer::create());
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+  folly::Baton<> collectReached;
+  folly::Baton<> releaseCollect;
+  BlockingCollectShuffleFactory blockingFactory(
+      ShuffleInterfaceFactory::factory(shuffleName_),
+      &collectReached,
+      &releaseCollect);
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfo,
+      &blockingFactory,
+      "single-flusher.0.0.0.0",
+      rootPool.get());
+
+  auto makeRowGroup = [&]() {
+    auto iobuf = buffer->allocateTrackedIOBuf(kRowGroupBytes);
+    std::memset(iobuf->writableData(), 'x', kRowGroupBytes);
+    iobuf->append(kRowGroupBytes);
+    return iobuf;
+  };
+
+  std::thread winner([&]() {
+    buffer->enqueue(0, makeRowGroup());
+    buffer->enqueue(0, makeRowGroup());
+  });
+  collectReached.wait();
+
+  std::vector<std::thread> losers;
+  losers.reserve(kQueuedWhileFlushing);
+  for (int i = 0; i < kQueuedWhileFlushing; ++i) {
+    losers.emplace_back([&]() { buffer->enqueue(0, makeRowGroup()); });
+  }
+  for (auto& loser : losers) {
+    loser.join();
+  }
+
+  releaseCollect.post();
+  winner.join();
+  buffer->noMoreData();
+
+  auto writer = blockingFactory.writer();
+  ASSERT_NE(writer, nullptr);
+  EXPECT_EQ(writer->maxActiveCollects(), 1);
+  const auto collectSizes = writer->collectSizes();
+  ASSERT_EQ(collectSizes.size(), 4);
+  const size_t chunkLimit = static_cast<size_t>(
+      SystemConfig::instance()
+          ->exchangeMaterializationOutputBufferDrainChunkMultiplier() *
+      kDrainThreshold);
+  EXPECT_EQ(collectSizes[0], kDrainThreshold);
+  EXPECT_EQ(collectSizes[1], chunkLimit);
+  EXPECT_EQ(collectSizes[2], chunkLimit);
+  EXPECT_EQ(collectSizes[3], kRowGroupBytes);
+  for (const auto collectSize : collectSizes) {
+    EXPECT_LE(collectSize, chunkLimit);
+  }
+  EXPECT_EQ(buffer->bufferedBytes(), 0);
+
+  cleanupDirectory(shuffleDir->getPath());
+}
+
+// Concurrent same-partition appends must reach the writer exactly once.
+TEST_F(MaterializedExchangeTest, concurrentAppendPreservesAllData) {
+  constexpr int32_t numPartitions = 1;
+  constexpr int numThreads = 8;
+  constexpr int perThread = 200;
+  constexpr int64_t kRowGroupBytes = 4L * 1024;
+
+  facebook::presto::test::setupMutableSystemConfig();
+  // Small per-partition drain threshold so appends race with frequent drains.
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      std::to_string(16L * 1024));
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kExchangeMaterializationOutputBufferMaxBytes),
+      std::to_string(64L << 20));
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "concurrentAppendTest", 256L << 20, memory::MemoryReclaimer::create());
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+  RecordingShuffleFactory recordingFactory(
+      ShuffleInterfaceFactory::factory(shuffleName_));
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfo,
+      &recordingFactory,
+      "concurrent.0.0.0.0",
+      rootPool.get());
+
+  std::atomic<int64_t> totalEnqueued{0};
+  std::vector<std::thread> producers;
+  producers.reserve(numThreads);
+  for (int t = 0; t < numThreads; ++t) {
+    producers.emplace_back([&]() {
+      for (int i = 0; i < perThread; ++i) {
+        auto iobuf = buffer->allocateTrackedIOBuf(kRowGroupBytes);
+        std::memset(iobuf->writableData(), 'x', kRowGroupBytes);
+        iobuf->append(kRowGroupBytes);
+        totalEnqueued += kRowGroupBytes;
+        buffer->enqueue(0, std::move(iobuf));
+      }
+    });
+  }
+  for (auto& producer : producers) {
+    producer.join();
+  }
+  buffer->noMoreData();
+
+  int64_t totalCollected = 0;
+  for (auto collectSize : recordingFactory.collectSizes()) {
+    totalCollected += static_cast<int64_t>(collectSize);
+  }
+  EXPECT_EQ(totalCollected, totalEnqueued.load());
+  EXPECT_EQ(buffer->bufferedBytes(), 0);
+
+  cleanupDirectory(shuffleDir->getPath());
+}
+
+// Abort leaves queued data for destruction without flushing partial output.
+TEST_F(
+    MaterializedExchangeTest,
+    abortRetainsBufferedDataWithoutFlushUntilDestruction) {
+  constexpr int32_t numPartitions = 1;
+  constexpr int64_t kRowGroupBytes = 10L * 1024;
+
+  facebook::presto::test::setupMutableSystemConfig();
+  // Keep the RowGroup buffered until abort.
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      std::to_string(1L << 20));
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kExchangeMaterializationOutputBufferMaxBytes),
+      std::to_string(64L << 20));
+
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "abortDiscardTest", 64L << 20, memory::MemoryReclaimer::create());
+  auto shuffleDir = exec::test::TempDirectoryPath::create();
+  auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
+  RecordingShuffleFactory recordingFactory(
+      ShuffleInterfaceFactory::factory(shuffleName_));
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(
+      numPartitions,
+      writeInfo,
+      &recordingFactory,
+      "abort.0.0.0.0",
+      rootPool.get());
+
+  auto iobuf = buffer->allocateTrackedIOBuf(kRowGroupBytes);
+  std::memset(iobuf->writableData(), 'x', kRowGroupBytes);
+  iobuf->append(kRowGroupBytes);
+  buffer->enqueue(0, std::move(iobuf));
+  ASSERT_EQ(buffer->bufferedBytes(), kRowGroupBytes);
+
+  buffer->abort();
+
+  EXPECT_TRUE(recordingFactory.collectSizes().empty());
+  EXPECT_EQ(buffer->bufferedBytes(), kRowGroupBytes);
+  EXPECT_EQ(buffer->state(), MaterializedOutputBuffer::State::kAborted);
+
+  buffer.reset();
+  EXPECT_EQ(rootPool->usedBytes(), 0);
 
   cleanupDirectory(shuffleDir->getPath());
 }


### PR DESCRIPTION
Summary:

Replace the per-partition mutex with a lock-free queue and a single-flusher CAS gate. Producers append without waiting for a partition lock; one producer, backpressure drainer, or reclaimer flushes each partition at a time. This prevents a driver from blocking behind a mutex held across coalescing, checksum work, writer collection, or memory arbitration.

Add bounded chunked drains and global cooperative backpressure. Producers drain at the high watermark and park only when reclaimable data remains; drains wake them below the low watermark. Configuration validation guarantees that one drainer can make enough progress to wake blocked producers.

Reserve drain headroom before entering the non-reclaimable flush window so memory-freeing drains do not recursively arbitrate. Reclaim first tries uncontended partition drains, then optionally waits for writer-side network buffers to fall.

Successful close acquires each partition's flusher gate, flushes remaining rows, and releases the gate even if flushing throws. Abort does not contend for partition gates: it transitions the parent buffer to aborted, wakes blocked producers, and aborts the writer. Queued row groups are released when the buffer is destroyed.

Concurrent appends can interleave row groups within a partition, so this mode is restricted to non-sort shuffle.

This is the base of the zero-copy MaterializedOutput stack and depends only on master.

Differential Revision: D111545828

```
== NO RELEASE NOTE ==
```
