### PR TITLE
refactor(native): DO NOT REVIEW Use velox IcebergTableHandle in protocol

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -24,6 +24,7 @@
 #include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::presto {
@@ -176,14 +177,24 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
     finalDataColumns = ROW(std::move(names), std::move(types));
   }
 
-  return std::make_unique<velox::connector::hive::HiveTableHandle>(
+  std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
+      icebergColumnHandles;
+  icebergColumnHandles.reserve(columnHandles.size());
+  for (const auto& h : columnHandles) {
+    icebergColumnHandles.emplace_back(
+        std::dynamic_pointer_cast<
+            const velox::connector::hive::iceberg::IcebergColumnHandle>(h));
+  }
+
+  return std::make_unique<velox::connector::hive::iceberg::IcebergTableHandle>(
       tableHandle.connectorId,
       tableName,
       std::move(subfieldFilters),
       remainingFilter,
       finalDataColumns,
-      std::unordered_map<std::string, std::string>{},
-      columnHandles);
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      std::move(icebergColumnHandles));
 }
 
 velox::connector::hive::iceberg::IcebergPartitionSpec::Field


### PR DESCRIPTION
## Description
Advance velox to use IcebergTableHandle that is added to Velox replacing the HiveTableHandle

## Motivation and Context
Supporting Iceberg specific features requires separate IcebergTableHandle.

## Impact
No impact

## Test Plan
Existing E2E tests will cover this change.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Adapt IcebergPrestoToVeloxConnector to construct and pass Iceberg-specific column and table handles to Velox.