### PR TITLE
test(native): Add E2E tests for geometry_union_agg and convex_hull_agg

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/GeoSpatialTestUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/GeoSpatialTestUtils.java
@@ -65,7 +65,12 @@ public class GeoSpatialTestUtils
                 "(8, 'POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))'), " +
                 // Multipoints on the line y = 2x.
                 "(9, 'MULTIPOINT ((1 2), (2 4), (3 6))'), " +
-                "(9, 'MULTIPOINT ((4 8), (5 10))')");
+                "(9, 'MULTIPOINT ((4 8), (5 10))'), " +
+                // Empty geometry absorbed by a non-empty one: result is the non-empty geometry.
+                "(10, 'LINESTRING EMPTY'), " +
+                "(10, 'LINESTRING (1 1, 3 3)'), " +
+                // Only-empty geometry: result is empty, so ST_Area is 0 and the envelope is null.
+                "(11, 'POLYGON EMPTY')");
     }
 
     public static void createCoordinates(QueryRunner queryRunner)

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/GeoSpatialTestUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/GeoSpatialTestUtils.java
@@ -31,6 +31,43 @@ public class GeoSpatialTestUtils
         return tableName;
     }
 
+    public static void createGeometries(QueryRunner queryRunner)
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS geometries");
+        queryRunner.execute("CREATE TABLE geometries (gid integer, wkt varchar)");
+        queryRunner.execute("INSERT INTO geometries VALUES " +
+                // Three overlapping triangles: union and convex hull are single polygons.
+                "(1, 'POLYGON ((2 2, 3 1, 1 1, 2 2))'), " +
+                "(1, 'POLYGON ((3 2, 4 1, 2 1, 3 2))'), " +
+                "(1, 'POLYGON ((4 2, 5 1, 3 1, 4 2))'), " +
+                // Two disjoint triangles: union is a multipolygon, convex hull is a polygon.
+                "(2, 'POLYGON ((1 1, 3 1, 2 2, 1 1))'), " +
+                "(2, 'POLYGON ((4 1, 6 1, 5 2, 4 1))'), " +
+                // Points at the corners of a unit square: union is a multipoint, convex hull is a polygon.
+                "(3, 'POINT (0 0)'), " +
+                "(3, 'POINT (1 0)'), " +
+                "(3, 'POINT (1 1)'), " +
+                "(3, 'POINT (0 1)'), " +
+                // Collinear points: union is a multipoint, convex hull collapses to a linestring.
+                "(4, 'POINT (1 1)'), " +
+                "(4, 'POINT (2 2)'), " +
+                "(4, 'POINT (3 3)'), " +
+                // Two overlapping rectangles forming a cross.
+                "(5, 'POLYGON ((1 3, 1 4, 6 4, 6 3, 1 3))'), " +
+                "(5, 'POLYGON ((3 1, 4 1, 4 6, 3 6, 3 1))'), " +
+                // Linestrings: union is a multilinestring, convex hull is a polygon.
+                "(6, 'LINESTRING (0 0, 1 1)'), " +
+                "(6, 'LINESTRING (1 0, 2 1)'), " +
+                // Null mixed with a value: nulls are skipped by the aggregate.
+                "(7, NULL), " +
+                "(7, 'POINT (5 5)'), " +
+                // Single geometry: union and convex hull return the input unchanged.
+                "(8, 'POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))'), " +
+                // Multipoints on the line y = 2x.
+                "(9, 'MULTIPOINT ((1 2), (2 4), (3 6))'), " +
+                "(9, 'MULTIPOINT ((4 8), (5 10))')");
+    }
+
     public static void createCoordinates(QueryRunner queryRunner)
     {
         queryRunner.execute("DROP TABLE IF EXISTS coordinates");

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeGeospatial.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeGeospatial.java
@@ -24,6 +24,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.nativetests.GeoSpatialTestUtils.createCoordinates;
+import static com.facebook.presto.nativetests.GeoSpatialTestUtils.createGeometries;
 import static com.facebook.presto.nativetests.GeoSpatialTestUtils.generateRandomTableName;
 import static com.facebook.presto.sidecar.TestNativeSidecarPlugin.setupNativeSidecarPlugin;
 import static java.lang.Boolean.parseBoolean;
@@ -49,6 +50,7 @@ public class TestPrestoNativeGeospatial
     {
         QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
         createCoordinates(queryRunner);
+        createGeometries(queryRunner);
     }
 
     @AfterClass(alwaysRun = true)
@@ -56,6 +58,7 @@ public class TestPrestoNativeGeospatial
     {
         QueryRunner expectedQueryRunner = (QueryRunner) getExpectedQueryRunner();
         expectedQueryRunner.execute("DROP TABLE IF EXISTS coordinates");
+        expectedQueryRunner.execute("DROP TABLE IF EXISTS geometries");
     }
 
     @Override
@@ -166,5 +169,27 @@ public class TestPrestoNativeGeospatial
                 "(?s)(?i).*Latitude.*range.*-90.*90.*");
         assertQueryFails("SELECT great_circle_distance(lat1, lon1, lat2, lon2) FROM coordinates WHERE lon1 = 200.0",
                 "(?s)(?i).*Longitude.*range.*-180.*180.*");
+    }
+
+    @Test
+    public void testGeometryUnionAgg()
+    {
+        // Compare geometry-invariant properties (area and envelope) instead of the serialized
+        // geometry, since native and Java may order vertices differently for equal geometries.
+        assertQuery("SELECT gid, ST_Area(g), ST_XMin(g), ST_XMax(g), ST_YMin(g), ST_YMax(g) FROM " +
+                "(SELECT gid, geometry_union_agg(ST_GeometryFromText(wkt)) AS g FROM geometries GROUP BY gid) " +
+                "ORDER BY gid");
+        assertQuery("SELECT ST_Area(g), ST_XMin(g), ST_XMax(g), ST_YMin(g), ST_YMax(g) FROM " +
+                "(SELECT geometry_union_agg(ST_GeometryFromText(wkt)) AS g FROM geometries)");
+    }
+
+    @Test
+    public void testConvexHullAgg()
+    {
+        assertQuery("SELECT gid, ST_Area(g), ST_XMin(g), ST_XMax(g), ST_YMin(g), ST_YMax(g) FROM " +
+                "(SELECT gid, convex_hull_agg(ST_GeometryFromText(wkt)) AS g FROM geometries GROUP BY gid) " +
+                "ORDER BY gid");
+        assertQuery("SELECT ST_Area(g), ST_XMin(g), ST_XMax(g), ST_YMin(g), ST_YMax(g) FROM " +
+                "(SELECT convex_hull_agg(ST_GeometryFromText(wkt)) AS g FROM geometries)");
     }
 }


### PR DESCRIPTION
Add native (Prestissimo vs Java) end-to-end coverage for the geometry_union_agg and convex_hull_agg aggregation functions in TestPrestoNativeGeospatial, backed by a new geometries test table in GeoSpatialTestUtils.


## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add native geospatial E2E coverage for geometry_union_agg and convex_hull_agg using a shared geometries test table.

Tests:
- Introduce a geometries test table with diverse geospatial cases to validate aggregation behavior across geometry types and nulls.
- Add end-to-end native vs Java tests for geometry_union_agg and convex_hull_agg based on geometry-invariant properties rather than serialized output.