### PR TITLE
feat(native): Default presto_cpp.http_request_size_bytes to false

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/metrics.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/metrics.rst
@@ -83,7 +83,10 @@ These metrics track HTTP requests and responses in the Presto C++ worker.
 
 * **Type:** histogram
 * **Unit:** bytes
-* **Description:** Size distribution of HTTP request payloads.
+* **Description:** Size distribution of HTTP request payloads. Disabled by
+  default because its large number of buckets significantly slows down
+  Prometheus metrics scraping. Enable it by setting
+  ``http-server.enable-request-size-histogram=true``.
 
 HTTP Client Metrics
 ===================

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1646,7 +1646,8 @@ void PrestoServer::unregisterFileReadersAndWriters() {
 }
 
 void PrestoServer::registerStatsCounters() {
-  registerPrestoMetrics();
+  registerPrestoMetrics(
+      SystemConfig::instance()->enableHttpRequestSizeHistogram());
   velox::registerVeloxMetrics();
   velox::filesystems::registerS3Metrics();
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1685,7 +1685,8 @@ void PrestoServer::unregisterFileReadersAndWriters() {
 }
 
 void PrestoServer::registerStatsCounters() {
-  registerPrestoMetrics();
+  registerPrestoMetrics(
+      SystemConfig::instance()->enableHttpRequestSizeHistogram());
   velox::registerVeloxMetrics();
   velox::filesystems::registerS3Metrics();
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -249,6 +249,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kHttpEnableAccessLog, false),
           BOOL_PROP(kHttpEnableStatsFilter, false),
           BOOL_PROP(kHttpEnableEndpointLatencyFilter, false),
+          BOOL_PROP(kHttpEnableRequestSizeHistogram, false),
           NUM_PROP(kHttpMaxAllocateBytes, 65536),
           STR_PROP(kQueryMaxMemoryPerNode, "4GB"),
           BOOL_PROP(kEnableMemoryLeakCheck, true),
@@ -990,6 +991,10 @@ bool SystemConfig::enableHttpStatsFilter() const {
 
 bool SystemConfig::enableHttpEndpointLatencyFilter() const {
   return optionalProperty<bool>(kHttpEnableEndpointLatencyFilter).value();
+}
+
+bool SystemConfig::enableHttpRequestSizeHistogram() const {
+  return optionalProperty<bool>(kHttpEnableRequestSizeHistogram).value();
 }
 
 uint64_t SystemConfig::httpMaxAllocateBytes() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -255,6 +255,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kHttpEnableAccessLog, false),
           BOOL_PROP(kHttpEnableStatsFilter, false),
           BOOL_PROP(kHttpEnableEndpointLatencyFilter, false),
+          BOOL_PROP(kHttpEnableRequestSizeHistogram, false),
           NUM_PROP(kHttpMaxAllocateBytes, 65536),
           STR_PROP(kQueryMaxMemoryPerNode, "4GB"),
           BOOL_PROP(kEnableMemoryLeakCheck, true),
@@ -1026,6 +1027,10 @@ bool SystemConfig::enableHttpStatsFilter() const {
 
 bool SystemConfig::enableHttpEndpointLatencyFilter() const {
   return optionalProperty<bool>(kHttpEnableEndpointLatencyFilter).value();
+}
+
+bool SystemConfig::enableHttpRequestSizeHistogram() const {
+  return optionalProperty<bool>(kHttpEnableRequestSizeHistogram).value();
 }
 
 uint64_t SystemConfig::httpMaxAllocateBytes() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -749,6 +749,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpEnableEndpointLatencyFilter{
       "http-server.enable-endpoint-latency-filter"};
 
+  /// Enables the http request size histogram metric
+  /// (presto_cpp.http_request_size_bytes). This histogram has a large number of
+  /// buckets which can significantly slow down Prometheus metrics scraping, so
+  /// it is disabled by default.
+  static constexpr std::string_view kHttpEnableRequestSizeHistogram{
+      "http-server.enable-request-size-histogram"};
+
   /// The options to configure the max quantized memory allocation size to store
   /// the received http response data.
   static constexpr std::string_view kHttpMaxAllocateBytes{
@@ -1274,6 +1281,8 @@ class SystemConfig : public ConfigBase {
   bool enableHttpStatsFilter() const;
 
   bool enableHttpEndpointLatencyFilter() const;
+
+  bool enableHttpRequestSizeHistogram() const;
 
   bool registerTestFunctions() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -722,6 +722,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpEnableEndpointLatencyFilter{
       "http-server.enable-endpoint-latency-filter"};
 
+  /// Enables the http request size histogram metric
+  /// (presto_cpp.http_request_size_bytes). This histogram has a large number of
+  /// buckets which can significantly slow down Prometheus metrics scraping, so
+  /// it is disabled by default.
+  static constexpr std::string_view kHttpEnableRequestSizeHistogram{
+      "http-server.enable-request-size-histogram"};
+
   /// The options to configure the max quantized memory allocation size to store
   /// the received http response data.
   static constexpr std::string_view kHttpMaxAllocateBytes{
@@ -1237,6 +1244,8 @@ class SystemConfig : public ConfigBase {
   bool enableHttpStatsFilter() const;
 
   bool enableHttpEndpointLatencyFilter() const;
+
+  bool enableHttpRequestSizeHistogram() const;
 
   bool registerTestFunctions() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -17,7 +17,7 @@
 
 namespace facebook::presto {
 
-void registerPrestoMetrics() {
+void registerPrestoMetrics(bool enableHttpRequestSizeHistogram) {
   DEFINE_METRIC(
       kCounterDriverCPUExecutorQueueSize, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
@@ -30,15 +30,17 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumHTTPRequest, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterNumHTTPRequestError, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterHTTPRequestLatencyMs, facebook::velox::StatType::AVG);
-  DEFINE_HISTOGRAM_METRIC(
-      kCounterHTTPRequestSizeBytes,
-      1 * 1024, // 1KB bucket size
-      0,
-      5 * 1024 * 1024, // 5MB max
-      50,
-      90,
-      99,
-      100);
+  if (enableHttpRequestSizeHistogram) {
+    DEFINE_HISTOGRAM_METRIC(
+        kCounterHTTPRequestSizeBytes,
+        1 * 1024, // 1KB bucket size
+        0,
+        5 * 1024 * 1024, // 5MB max
+        50,
+        90,
+        99,
+        100);
+  }
   DEFINE_METRIC(
       kCounterHttpClientNumConnectionsCreated, facebook::velox::StatType::SUM);
   DEFINE_METRIC(

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -20,7 +20,10 @@ namespace facebook::presto {
 
 // Sets up all the counters in the presto cpp, but specifying their types.
 // See velox/common/base/StatsReporter.h for the interface.
-void registerPrestoMetrics();
+// The http request size histogram is only registered when
+// 'enableHttpRequestSizeHistogram' is true (see kHttpEnableRequestSizeHistogram
+// in Configs.h).
+void registerPrestoMetrics(bool enableHttpRequestSizeHistogram = false);
 
 constexpr std::string_view kCounterDriverCPUExecutorQueueSize{
     "presto_cpp.driver_cpu_executor_queue_size"};


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
closes #28140 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
```
curl -o /dev/null -s -w "Connect: %{time_connect}s\nTTFB: %{time_starttransfer}s\nTotal: %{time_total}s\n" http://localhost:7777/v1/info/metrics

Connect: 0.000664s
TTFB: 0.001522s
Total: 0.001533s
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Make the HTTP request size histogram metric in Presto C++ optional and disabled by default to avoid performance impact on metrics scraping.

New Features:
- Add a configuration option to enable the presto_cpp.http_request_size_bytes HTTP request size histogram metric on the native server.

Enhancements:
- Wire the new configuration into metric registration so the HTTP request size histogram is only registered when explicitly enabled.