### PR TITLE
fix(optimizer): Handle CAST wrapping an RPC function call (#28179)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -685,7 +685,7 @@ public class PlanOptimizers
 
         builder.add(new IterativeOptimizer(metadata, ruleStats, statsCalculator, estimatedExchangesCostCalculator,
                 new RewriteRowExpressions(expressionOptimizerManager).rules()));
-        builder.add(new RpcFunctionOptimizer(rpcFunctionNames, statsCalculator, rpcExecutionPolicy));
+        builder.add(new RpcFunctionOptimizer(rpcFunctionNames, metadata.getFunctionAndTypeManager(), statsCalculator, rpcExecutionPolicy));
 
         builder.add(new IterativeOptimizer(
                 metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -20,6 +20,7 @@ import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.Assignments;
@@ -41,7 +42,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;
@@ -64,28 +64,20 @@ public class RpcFunctionOptimizer
 {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final Supplier<Set<String>> rpcFunctionNamesSupplier;
+    private final FunctionAndTypeManager functionAndTypeManager;
     // Nullable: when absent, the execution policy receives a NaN row estimate.
     private final StatsCalculator statsCalculator;
     private final RpcExecutionPolicy executionPolicy;
 
-    public RpcFunctionOptimizer()
+    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, FunctionAndTypeManager functionAndTypeManager)
     {
-        this(ImmutableSet::of, null, new DefaultRpcExecutionPolicy());
+        this(rpcFunctionNamesSupplier, functionAndTypeManager, null, new DefaultRpcExecutionPolicy());
     }
 
-    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier)
-    {
-        this(rpcFunctionNamesSupplier, null, new DefaultRpcExecutionPolicy());
-    }
-
-    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, StatsCalculator statsCalculator)
-    {
-        this(rpcFunctionNamesSupplier, statsCalculator, new DefaultRpcExecutionPolicy());
-    }
-
-    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, StatsCalculator statsCalculator, RpcExecutionPolicy executionPolicy)
+    public RpcFunctionOptimizer(Supplier<Set<String>> rpcFunctionNamesSupplier, FunctionAndTypeManager functionAndTypeManager, StatsCalculator statsCalculator, RpcExecutionPolicy executionPolicy)
     {
         this.rpcFunctionNamesSupplier = requireNonNull(rpcFunctionNamesSupplier, "rpcFunctionNamesSupplier is null");
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
         this.statsCalculator = statsCalculator;
         this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
     }
@@ -118,7 +110,7 @@ public class RpcFunctionOptimizer
         StatsProvider statsProvider = statsCalculator != null
                 ? new CachingStatsProvider(statsCalculator, session, types)
                 : null;
-        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get(), statsProvider, executionPolicy);
+        Rewriter rewriter = new Rewriter(session, idAllocator, variableAllocator, rpcFunctionNamesSupplier.get(), functionAndTypeManager, statsProvider, executionPolicy);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -130,17 +122,19 @@ public class RpcFunctionOptimizer
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final Set<String> rpcFunctionNames;
+        private final FunctionAndTypeManager functionAndTypeManager;
         // Nullable: when null, the execution policy receives a NaN row estimate.
         private final StatsProvider statsProvider;
         private final RpcExecutionPolicy executionPolicy;
         private boolean planChanged;
 
-        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames, StatsProvider statsProvider, RpcExecutionPolicy executionPolicy)
+        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<String> rpcFunctionNames, FunctionAndTypeManager functionAndTypeManager, StatsProvider statsProvider, RpcExecutionPolicy executionPolicy)
         {
             this.session = requireNonNull(session, "session is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
             this.rpcFunctionNames = requireNonNull(rpcFunctionNames, "rpcFunctionNames is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
             this.statsProvider = statsProvider;
             this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
         }
@@ -252,12 +246,106 @@ public class RpcFunctionOptimizer
                 currentSource = rpcNode;
             }
 
-            return new ProjectNode(
+            Assignments assignments = newAssignments.build();
+
+            // Once the RPC calls are extracted into the RPCNode(s) above, an assignment that was
+            // only valid in a REMOTE projection because it wrapped an external RPC function may no
+            // longer be: AIFunctionRewriteOptimizer emits CAST(fb_text_embedding(...) AS
+            // ARRAY<DOUBLE>), and after fb_text_embedding becomes an RPC result variable the
+            // surviving CAST(__rpc_result__) is a plain, non-external call. VerifyProjectionLocality
+            // forbids such a call in a REMOTE projection. The RPCNode keeps its true output type
+            // (e.g. ARRAY<REAL>) and the CAST that converts it must run locally, so partition the
+            // assignments and, when both remote and local expressions are present, stack a LOCAL
+            // projection over the REMOTE one (the shape PlanRemoteProjections produces).
+            if (node.getLocality() != ProjectNode.Locality.REMOTE) {
+                return new ProjectNode(
+                        node.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        currentSource,
+                        assignments,
+                        node.getLocality());
+            }
+
+            // Partition the REMOTE projection's assignments into three outcomes:
+            //   (1) all remote-safe  -> keep a single REMOTE projection (shape unchanged);
+            //   (2) all local        -> a single LOCAL projection (the common meta.ai.embedding
+            //                           case, where the only assignment is CAST(__rpc_result__));
+            //   (3) mixed            -> a LOCAL projection stacked over a REMOTE one, with each
+            //                           layer forwarding the other layer's variables so downstream
+            //                           column references still resolve.
+            // An assignment must move to LOCAL iff it is neither a variable reference nor an
+            // external function call (e.g. the CAST of an RPC result), because
+            // VerifyProjectionLocality forbids a plain non-external call in a REMOTE projection.
+            //
+            // Precondition (PlanRemoteProjections has already run): each REMOTE assignment value is a
+            // variable reference or a top-level CallExpression, so partitioning by whether it is/contains
+            // an external function is sufficient here (we don't need to decompose SpecialForms).
+            ExternalCallExpressionChecker externalChecker = new ExternalCallExpressionChecker(functionAndTypeManager);
+            Assignments.Builder remoteBuilder = Assignments.builder();
+            Assignments.Builder localBuilder = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> assignment : assignments.getMap().entrySet()) {
+                RowExpression value = assignment.getValue();
+                if (value instanceof VariableReferenceExpression || value.accept(externalChecker, null)) {
+                    remoteBuilder.put(assignment.getKey(), value);
+                }
+                else {
+                    localBuilder.put(assignment.getKey(), value);
+                }
+            }
+            Assignments remoteOnly = remoteBuilder.build();
+            Assignments localOnly = localBuilder.build();
+
+            if (localOnly.getMap().isEmpty()) {
+                // Every assignment is REMOTE-safe (variable reference or external function).
+                return new ProjectNode(
+                        node.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        currentSource,
+                        assignments,
+                        ProjectNode.Locality.REMOTE);
+            }
+            if (remoteOnly.getMap().isEmpty()) {
+                // Nothing must stay remote (the common meta.ai.embedding case: the only assignment is
+                // the CAST of the RPC result). The whole projection can run locally.
+                return new ProjectNode(
+                        node.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        currentSource,
+                        assignments,
+                        ProjectNode.Locality.LOCAL);
+            }
+
+            // Mixed: keep the external functions in a REMOTE projection and evaluate the local
+            // expressions in a LOCAL projection stacked on top of it.
+            Assignments.Builder remoteLayer = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> remoteAssignment : remoteOnly.getMap().entrySet()) {
+                remoteLayer.put(remoteAssignment.getKey(), remoteAssignment.getValue());
+            }
+            for (VariableReferenceExpression sourceVariable : currentSource.getOutputVariables()) {
+                if (!remoteOnly.getMap().containsKey(sourceVariable)) {
+                    remoteLayer.put(sourceVariable, sourceVariable);
+                }
+            }
+            ProjectNode remoteProject = new ProjectNode(
                     node.getSourceLocation(),
                     idAllocator.getNextId(),
                     currentSource,
-                    newAssignments.build(),
-                    node.getLocality());
+                    remoteLayer.build(),
+                    ProjectNode.Locality.REMOTE);
+
+            Assignments.Builder localLayer = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> localAssignment : localOnly.getMap().entrySet()) {
+                localLayer.put(localAssignment.getKey(), localAssignment.getValue());
+            }
+            for (VariableReferenceExpression remoteVariable : remoteOnly.getMap().keySet()) {
+                localLayer.put(remoteVariable, remoteVariable);
+            }
+            return new ProjectNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    remoteProject,
+                    localLayer.build(),
+                    ProjectNode.Locality.LOCAL);
         }
 
         private RowExpressionRewriter<RpcExtractionContext> createRpcRewriter()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
@@ -35,6 +37,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.RPCNode;
+import com.facebook.presto.sql.planner.sanity.VerifyProjectionLocality;
 import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -46,8 +49,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -56,6 +63,9 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestRpcFunctionOptimizer
 {
+    private static final MetadataManager METADATA = createTestMetadataManager();
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = METADATA.getFunctionAndTypeManager();
+
     private static CallExpression createRpcCall(RowExpression optionsArg)
     {
         FunctionHandle handle = createFunctionHandle("test_rpc_function");
@@ -143,13 +153,14 @@ public class TestRpcFunctionOptimizer
         for (Class<?> inner : innerClasses) {
             if (inner.getSimpleName().equals("Rewriter")) {
                 for (java.lang.reflect.Constructor<?> ctor : inner.getDeclaredConstructors()) {
-                    if (ctor.getParameterCount() == 6) {
+                    if (ctor.getParameterCount() == 7) {
                         ctor.setAccessible(true);
                         return ctor.newInstance(
                                 session,
                                 new com.facebook.presto.spi.plan.PlanNodeIdAllocator(),
                                 new com.facebook.presto.spi.VariableAllocator(),
                                 com.google.common.collect.ImmutableSet.of(),
+                                FUNCTION_AND_TYPE_MANAGER,
                                 null,
                                 new DefaultRpcExecutionPolicy());
                     }
@@ -337,7 +348,7 @@ public class TestRpcFunctionOptimizer
                         .build());
 
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
-                () -> ImmutableSet.of("test_rpc_function"));
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
@@ -399,7 +410,7 @@ public class TestRpcFunctionOptimizer
                         .build());
 
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
-                () -> ImmutableSet.of("test_rpc_function"));
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
@@ -446,7 +457,7 @@ public class TestRpcFunctionOptimizer
                         .build());
 
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
-                () -> ImmutableSet.of("test_rpc_function"));
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
@@ -460,6 +471,150 @@ public class TestRpcFunctionOptimizer
         assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for direct RPC function calls");
         assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
                 "Optimized plan should contain an RPCNode");
+    }
+
+    @Test
+    public void testCastOfRpcFunctionInRemoteProjectionRelocatesToLocal()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", BIGINT);
+
+        // A REMOTE projection holding CAST(test_rpc_function(...) AS BIGINT) — the meta.ai.embedding shape
+        // (AIFunctionRewriteOptimizer wraps the RPC function in a CAST). A REAL resolved CAST handle is used
+        // so ExternalCallExpressionChecker resolves it; the RPC call itself becomes a variable reference before
+        // the checker sees it. Before the fix, VerifyProjectionLocality rejected this CAST in a REMOTE projection
+        // ("Expect expression CAST(...) to be an external function").
+        CallExpression rpcCall = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(inputVar, varchar("model"), varchar("system"), varchar("{}")));
+        CallExpression castCall = call(
+                "CAST",
+                FUNCTION_AND_TYPE_MANAGER.lookupCast(CAST, VARCHAR, BIGINT),
+                BIGINT,
+                rpcCall);
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder().put(outputVar, castCall).build(),
+                ProjectNode.Locality.REMOTE);
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode,
+                session,
+                TypeProvider.empty(),
+                variableAllocator,
+                idAllocator,
+                WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized");
+
+        // RPCNode keeps the RPC function's real type (VARCHAR), not the CAST target (BIGINT).
+        RPCNode rpcNode = (RPCNode) findPlanNode(result.getPlanNode(), RPCNode.class);
+        assertTrue(rpcNode != null, "Optimized plan should contain an RPCNode");
+        assertEquals(rpcNode.getOutputVariable().getType(), VARCHAR,
+                "RPCNode output must keep the RPC function's real type, not the CAST target type");
+
+        // The CAST-of-RPC assignment must have moved out of the REMOTE projection into a LOCAL one.
+        ProjectNode topProject = (ProjectNode) findPlanNode(result.getPlanNode(), ProjectNode.class);
+        assertEquals(topProject.getLocality(), ProjectNode.Locality.LOCAL,
+                "CAST of an RPC result must run in a LOCAL projection, not REMOTE");
+        RowExpression outputExpression = topProject.getAssignments().getMap().get(outputVar);
+        assertTrue(outputExpression instanceof CallExpression, "Output should still be the CAST call");
+        CallExpression outputCall = (CallExpression) outputExpression;
+        assertEquals(outputCall.getType(), BIGINT);
+        assertTrue(outputCall.getArguments().get(0) instanceof VariableReferenceExpression,
+                "CAST should apply to the RPC result variable");
+        assertEquals(((VariableReferenceExpression) outputCall.getArguments().get(0)).getType(), VARCHAR);
+
+        // The optimized plan must now pass the sanity check that originally rejected the CAST-in-REMOTE.
+        new VerifyProjectionLocality().validate(result.getPlanNode(), session, METADATA, WarningCollector.NOOP);
+    }
+
+    @Test
+    public void testCastOfRpcFunctionKeepsRpcResultType()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", BIGINT);
+
+        // Build: CAST(test_rpc_function(input_col, "model", "system", "{}") AS BIGINT)
+        // Mirrors AIFunctionRewriteOptimizer wrapping an RPC function in a CAST to a wider declared
+        // return type (fb_text_embedding ARRAY<REAL> -> meta.ai.embedding ARRAY<DOUBLE>). The
+        // optimizer must NOT relabel the RPC result to the CAST target type: it must keep the RPC
+        // function's real type and let the surviving CAST perform the conversion.
+        CallExpression rpcCall = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(inputVar, varchar("model"), varchar("system"), varchar("{}")));
+        CallExpression castCall = new CallExpression(
+                "CAST",
+                createFunctionHandle("CAST"),
+                BIGINT,
+                ImmutableList.of(rpcCall));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(outputVar, castCall)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode,
+                session,
+                TypeProvider.empty(),
+                variableAllocator,
+                idAllocator,
+                WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered(), "Plan should be optimized when a CAST wraps an RPC function");
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class), "Optimized plan should contain an RPCNode");
+
+        // The CAST must be preserved (not dropped) and applied to the RPC result variable, and that
+        // variable must keep the RPC function's real type (VARCHAR), not be relabeled to the CAST
+        // target type (BIGINT).
+        ProjectNode topProject = (ProjectNode) findPlanNode(result.getPlanNode(), ProjectNode.class);
+        RowExpression outputExpression = topProject.getAssignments().getMap().get(outputVar);
+        assertTrue(outputExpression instanceof CallExpression, "Output assignment should still be a CAST call");
+        CallExpression outputCall = (CallExpression) outputExpression;
+        assertEquals(outputCall.getDisplayName(), "CAST");
+        assertEquals(outputCall.getType(), BIGINT);
+        RowExpression castArgument = outputCall.getArguments().get(0);
+        assertTrue(castArgument instanceof VariableReferenceExpression, "CAST should apply to the RPC result variable");
+        assertEquals(((VariableReferenceExpression) castArgument).getType(), VARCHAR,
+                "RPC result variable must keep the RPC function's real type, not the CAST target type");
     }
 
     @Test
@@ -551,7 +706,7 @@ public class TestRpcFunctionOptimizer
                         .build());
 
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
-                () -> ImmutableSet.of("test_rpc_function"));
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
@@ -584,7 +739,7 @@ public class TestRpcFunctionOptimizer
                         .build());
 
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
-                () -> ImmutableSet.of("test_rpc_function"));
+                () -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER);
         Session session = TestingSession.testSessionBuilder().build();
 
         return optimizer.optimize(
@@ -635,7 +790,7 @@ public class TestRpcFunctionOptimizer
                         .put(outputVar, rpcCall)
                         .build());
 
-        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(() -> ImmutableSet.of("test_rpc_function"), null, policy);
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(() -> ImmutableSet.of("test_rpc_function"), FUNCTION_AND_TYPE_MANAGER, null, policy);
 
         PlanOptimizerResult result = optimizer.optimize(
                 projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);


### PR DESCRIPTION
Summary:

The AIFunctionRewriteOptimizer rewrites meta.ai.embedding to CAST(fb_text_embedding(...) AS ARRAY<DOUBLE>) because fb_text_embedding returns ARRAY<REAL> but meta.ai.embedding is defined to return ARRAY<DOUBLE>.

When RpcFunctionOptimizer extracts fb_text_embedding into an RPCNode, the surviving CAST(__rpc_result) stays in the Project node. If that projection is REMOTE, VerifyProjectionLocality fails because a REMOTE projection may only contain variable references or external functions (Python UDFs) — a plain CAST is neither:
  Expect expression CAST(__rpc_result) to be an external function

Fix: In RpcFunctionOptimizer.visitProject(), keep the RPCNode's output at the RPC function's real type (ARRAY<REAL>) and relocate the CAST to a LOCAL projection. After extracting the RPC calls, partition the projection's assignments using ExternalCallExpressionChecker: variable references and genuine external functions stay in the REMOTE projection; local expressions such as the CAST move to a LOCAL projection. When only local expressions remain (the meta.ai.embedding case) the whole projection becomes LOCAL; when both are present, a LOCAL projection is stacked over the REMOTE one — the same shape PlanRemoteProjections produces.

This keeps the CAST so it performs a real ARRAY<REAL> -> ARRAY<DOUBLE> conversion at runtime (the native fb_text_embedding hardcodes ARRAY<REAL> output and does not coerce to a declared type, so relabeling the RPC output type would produce incorrect values), and it satisfies VerifyProjectionLocality because the CAST now runs in a LOCAL projection.

== RELEASE NOTES ==

General Changes
* Fix a query failure that occurred when the result of a remote function (RPC) call was wrapped in a ``CAST`` expression. :pr:`28179`

Reviewed By: sebastianopeluso

Differential Revision: D112621072


