### PR TITLE
refactor: Remove unused code

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
@@ -131,37 +131,6 @@ public class Field
         return !prefix.isPresent() || relationAlias.isPresent() && relationAlias.get().hasSuffix(prefix.get());
     }
 
-    /*
-      Namespaces can have names such as "x", "x.y" or "" if there's no name
-      Name to resolve can have names like "a", "x.a", "x.y.a"
-
-      namespace  name     possible match
-       ""         "a"           y
-       "x"        "a"           y
-       "x.y"      "a"           y
-
-       ""         "x.a"         n
-       "x"        "x.a"         y
-       "x.y"      "x.a"         n
-
-       ""         "x.y.a"       n
-       "x"        "x.y.a"       n
-       "x.y"      "x.y.a"       n
-
-       ""         "y.a"         n
-       "x"        "y.a"         n
-       "x.y"      "y.a"         y
-     */
-    public boolean canResolve(QualifiedName name)
-    {
-        if (!this.name.isPresent()) {
-            return false;
-        }
-
-        // TODO: need to know whether the qualified name and the name of this field were quoted
-        return matchesPrefix(name.getPrefix()) && this.name.get().equalsIgnoreCase(name.getSuffix());
-    }
-
     @Override
     public String toString()
     {

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -38,7 +38,6 @@ import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InetAddresses;
 import io.airlift.slice.Slice;
@@ -58,7 +57,6 @@ import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.net.InetAddresses.toAddrString;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -617,40 +615,6 @@ public enum CassandraType
             case MAP:
             default:
                 return false;
-        }
-    }
-
-    public Object validateClusteringKey(Object value)
-    {
-        switch (this) {
-            case ASCII:
-            case TEXT:
-            case VARCHAR:
-            case BIGINT:
-            case BOOLEAN:
-            case DOUBLE:
-            case INET:
-            case INT:
-            case SMALLINT:
-            case TINYINT:
-            case FLOAT:
-            case DECIMAL:
-            case TIMESTAMP:
-            case TIMESTAMP_WITH_TIMEZONE:
-            case DATE:
-            case UUID:
-            case TIMEUUID:
-                return value;
-            case COUNTER:
-            case BLOB:
-            case CUSTOM:
-            case VARINT:
-            case SET:
-            case LIST:
-            case MAP:
-            default:
-                // todo should we just skip partition pruning instead of throwing an exception?
-                throw new PrestoException(NOT_SUPPORTED, "Unsupported clustering key type: " + this);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.expressions.CanonicalRowExpressionRewriter.canonicalizeRowExpression;
-import static com.facebook.presto.hive.HiveColumnHandle.isRowIdColumnHandle;
 import static com.facebook.presto.hive.MetadataUtils.createPredicate;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -61,7 +60,6 @@ public class HiveTableLayoutHandle
     private final Optional<Set<HiveColumnHandle>> requestedColumns;
     private final boolean partialAggregationsPushedDown;
     private final boolean appendRowNumberEnabled;
-    private final boolean appendRowId;
     private final boolean footerStatsUnreliable;
 
     // coordinator-only properties
@@ -154,15 +152,6 @@ public class HiveTableLayoutHandle
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.partialAggregationsPushedDown = partialAggregationsPushedDown;
-        if (requestedColumns.isPresent() && requestedColumns.get().stream().anyMatch(column -> isRowIdColumnHandle(column))) {
-            this.appendRowId = true;
-        }
-        else if (predicateColumns.values().stream().anyMatch(column -> isRowIdColumnHandle(column))) {
-            this.appendRowId = true;
-        }
-        else {
-            this.appendRowId = false;
-        }
         this.appendRowNumberEnabled = appendRowNumberEnabled;
         this.footerStatsUnreliable = footerStatsUnreliable;
         this.hiveTableHandle = requireNonNull(hiveTableHandle, "hiveTableHandle is null");
@@ -365,12 +354,6 @@ public class HiveTableLayoutHandle
                 .setFooterStatsUnreliable(isFooterStatsUnreliable())
                 .setHiveTableHandle(getHiveTableHandle());
     }
-
-    boolean isAppendRowId()
-    {
-        return this.appendRowId;
-    }
-
     public static class Builder
     {
         private SchemaTableName schemaTableName;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -116,7 +116,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -124,7 +123,6 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.Chars.isCharType;
 import static com.facebook.presto.common.type.Chars.trimTrailingSpaces;
 import static com.facebook.presto.common.type.DateType.DATE;
-import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.Decimals.isLongDecimal;
 import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -535,11 +533,6 @@ public final class HiveUtil
         }
     }
 
-    public static boolean isDeserializerClass(Properties schema, Class<?> deserializerClass)
-    {
-        return getDeserializerClassName(schema).equals(deserializerClass.getName());
-    }
-
     public static String getDeserializerClassName(Properties schema)
     {
         String name = schema.getProperty(SERIALIZATION_LIB);
@@ -810,24 +803,6 @@ public final class HiveUtil
         data = data.substring(prefix.length());
         data = data.substring(0, data.length() - suffix.length());
         return new String(Base64.getDecoder().decode(data), UTF_8);
-    }
-
-    public static Optional<DecimalType> getDecimalType(HiveType hiveType)
-    {
-        return getDecimalType(hiveType.getHiveTypeName().toString());
-    }
-
-    public static Optional<DecimalType> getDecimalType(String hiveTypeName)
-    {
-        Matcher matcher = SUPPORTED_DECIMAL_TYPE.matcher(hiveTypeName);
-        if (matcher.matches()) {
-            int precision = parseInt(matcher.group(DECIMAL_PRECISION_GROUP));
-            int scale = parseInt(matcher.group(DECIMAL_SCALE_GROUP));
-            return Optional.of(createDecimalType(precision, scale));
-        }
-        else {
-            return Optional.empty();
-        }
     }
 
     public static boolean isStructuralType(Type type)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
@@ -35,7 +35,6 @@ public class HiveWriter
     private final String targetPath;
     private final Consumer<HiveWriter> onCommit;
     private final HiveWriterStats hiveWriterStats;
-    private final boolean writeTempData;
 
     private long rowCount;
     private long inputSizeInBytes;
@@ -49,8 +48,7 @@ public class HiveWriter
             String writePath,
             String targetPath,
             Consumer<HiveWriter> onCommit,
-            HiveWriterStats hiveWriterStats,
-            boolean writeTempData)
+            HiveWriterStats hiveWriterStats)
     {
         this.fileWriter = requireNonNull(fileWriter, "fileWriter is null");
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
@@ -60,7 +58,6 @@ public class HiveWriter
         this.targetPath = requireNonNull(targetPath, "targetPath is null");
         this.onCommit = requireNonNull(onCommit, "onCommit is null");
         this.hiveWriterStats = requireNonNull(hiveWriterStats, "hiveWriterStats is null");
-        this.writeTempData = writeTempData;
     }
 
     public long getWrittenBytes()
@@ -81,11 +78,6 @@ public class HiveWriter
     public Optional<String> getPartitionName()
     {
         return partitionName;
-    }
-
-    public boolean isWriteTempData()
-    {
-        return writeTempData;
     }
 
     public void append(Page dataPage)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -74,7 +74,6 @@ import static com.facebook.presto.hive.HiveSessionProperties.isFileRenamingEnabl
 import static com.facebook.presto.hive.HiveSessionProperties.isSortedWriteToTempPathEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static com.facebook.presto.hive.HiveWriteUtils.checkPartitionIsWritable;
-import static com.facebook.presto.hive.LocationHandle.TableType.TEMPORARY;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
 import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.createPartitionValues;
@@ -404,9 +403,6 @@ public class HiveWriterFactory
                     bucketNumber.orElseGet(() -> abs(path.hashCode() % 1024)),
                     writerParameters.getWriteInfo().getTempPath());
         }
-
-        boolean writeTempData = locationHandle.getTableType() == TEMPORARY || locationHandle.getTempPath().isPresent() || writeToTempFile;
-
         return new HiveWriter(
                 hiveFileWriter,
                 partitionName,
@@ -415,8 +411,7 @@ public class HiveWriterFactory
                 writerParameters.getWriteInfo().getWritePath().toString(),
                 writerParameters.getWriteInfo().getTargetPath().toString(),
                 createCommitEventListener(path, partitionName, hiveFileWriter, writerParameters),
-                hiveWriterStats,
-                writeTempData);
+                hiveWriterStats);
     }
 
     private WriterParameters getWriterParameters(Optional<String> partitionName, OptionalInt bucketNumber)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionLoader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPartitionLoader.java
@@ -148,7 +148,7 @@ public class IcebergPartitionLoader
                         partitionStringValue = value.toString();
                     }
 
-                    NullableValue partitionValue = parsePartitionValue(fileFormat, partitionStringValue, toPrestoType(type, typeManager), partition.toString());
+                    NullableValue partitionValue = parsePartitionValue(partitionStringValue, toPrestoType(type, typeManager), partition.toString());
                     Optional<IcebergColumnHandle> column = partitionColumns.stream()
                             .filter(icebergColumnHandle -> Objects.equals(icebergColumnHandle.getId(), field.sourceId()))
                             .findAny();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -747,7 +747,6 @@ public final class IcebergUtil
     }
 
     protected static NullableValue parsePartitionValue(
-            FileFormat fileFormat,
             String partitionStringValue,
             Type prestoType,
             String partitionName)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -73,7 +73,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -235,13 +234,6 @@ public class IcebergEqualityDeleteAsJoin
             for (Map.Entry<Set<Integer>, DeleteSetInfo> entry : deleteSchemas.entrySet()) {
                 DeleteSetInfo deleteGroupInfo = entry.getValue();
 
-                List<Types.NestedField> deleteFields = deleteGroupInfo
-                        .equalityFieldIds
-                        .stream()
-                        .map(fieldId -> icebergTable.schema().findField(fieldId))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-
                 VariableReferenceExpression joinSequenceNumber = toVariableReference(DATA_SEQUENCE_NUMBER_COLUMN_HANDLE);
                 deleteVersionColumns.add(joinSequenceNumber);
                 ImmutableMap<VariableReferenceExpression, ColumnHandle> deleteColumnAssignments = ImmutableMap.<VariableReferenceExpression, ColumnHandle>builder()
@@ -271,7 +263,6 @@ public class IcebergEqualityDeleteAsJoin
                 TableScanNode deleteTableScan = createDeletesTableScan(deleteColumnAssignments,
                         icebergTableHandle,
                         tableName,
-                        deleteFields,
                         table,
                         deleteGroupInfo);
 
@@ -349,7 +340,6 @@ public class IcebergEqualityDeleteAsJoin
         private TableScanNode createDeletesTableScan(ImmutableMap<VariableReferenceExpression, ColumnHandle> deleteColumnAssignments,
                 IcebergTableHandle icebergTableHandle,
                 IcebergTableName tableName,
-                List<Types.NestedField> deleteFields,
                 TableHandle table,
                 DeleteSetInfo deleteInfo)
         {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
@@ -35,11 +35,6 @@ public class IcebergRewriteDataFilesProcedureContext
     final IcebergAbstractMetadata metadata;
     final Map<String, String> options;
 
-    public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata)
-    {
-        this(table, metadata, ImmutableMap.of());
-    }
-
     public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata, Map<String, String> options)
     {
         this.table = requireNonNull(table, "table is null");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -109,7 +109,6 @@ public final class IcebergQueryRunner
         private Builder() {}
 
         private CatalogType catalogType = HIVE;
-        private Map<String, Map<String, String>> icebergCatalogs = new HashMap<>();
         private Map<String, String> extraProperties = new HashMap<>();
         private Map<String, String> extraConnectorProperties = new HashMap<>();
         private Map<String, String> tpcdsProperties = new HashMap<>();

--- a/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
+++ b/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
@@ -149,7 +149,7 @@ public class IcebergRestCatalogServlet
                             request,
                             context.route().responseClass(),
                             handleResponseError(response),
-                            handleResponseHeader(response));
+                            handleResponseHeader());
 
             if (responseBody != null) {
                 RESTObjectMapper.mapper().writeValue(response.getWriter(), responseBody);
@@ -164,7 +164,7 @@ public class IcebergRestCatalogServlet
         }
     }
 
-    private Consumer<Map<String, String>> handleResponseHeader(HttpServletResponse response)
+    private Consumer<Map<String, String>> handleResponseHeader()
     {
         return (responseHeaders) -> {
             throw new RuntimeException("Unexpected response header: " + responseHeaders);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -34,10 +34,8 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -114,8 +112,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
     private final long[] maxBytesPerCell;
     private long maxCombinedBytesPerRow;
 
-    private final Map<String, Slice> userMetadata;
-
     private final Optional<OrcWriteValidation> writeValidation;
     private final Optional<OrcWriteValidation.WriteChecksumBuilder> writeChecksumBuilder;
     private final Optional<OrcWriteValidation.StatisticsValidation> rowGroupStatisticsValidation;
@@ -149,7 +145,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             DataSize maxMergeDistance,
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,
-            Map<String, Slice> userMetadata,
             OrcAggregatedMemoryContext systemMemoryUsage,
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
@@ -170,7 +165,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         requireNonNull(dwrfEncryptionGroupMap, "dwrfEncryptionGroupMap is null");
         requireNonNull(columnToIntermediateKeyMap, "columnToIntermediateKeyMap is null");
         requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        requireNonNull(userMetadata, "userMetadata is null");
         requireNonNull(systemMemoryUsage, "systemMemoryUsage is null");
 
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
@@ -239,8 +233,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
                 .map(StripeInfo::getStripe)
                 .mapToLong(StripeInformation::getNumberOfRows)
                 .sum();
-
-        this.userMetadata = ImmutableMap.copyOf(Maps.transformValues(userMetadata, Slices::copyOf));
 
         this.currentStripeSystemMemoryContext = this.systemMemoryUsage.newOrcAggregatedMemoryContext();
 
@@ -534,11 +526,6 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
     public boolean isColumnPresent(int hiveColumnIndex)
     {
         return presentColumns.contains(hiveColumnIndex);
-    }
-
-    public Map<String, Slice> getUserMetadata()
-    {
-        return ImmutableMap.copyOf(Maps.transformValues(userMetadata, Slices::copyOf));
     }
 
     private boolean advanceToNextRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -101,7 +101,6 @@ public class OrcBatchRecordReader
                 options.getMaxMergeDistance(),
                 options.getTinyStripeThreshold(),
                 options.getMaxBlockSize(),
-                userMetadata,
                 systemMemoryUsage,
                 writeValidation,
                 initialBatchSize,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -223,7 +223,6 @@ public class OrcSelectiveRecordReader
                 options.getMaxMergeDistance(),
                 options.getTinyStripeThreshold(),
                 options.getMaxBlockSize(),
-                userMetadata,
                 systemMemoryUsage,
                 writeValidation,
                 initialBatchSize,

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -20,7 +20,6 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.GroupColumnIO;
-import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.PrimitiveColumnIO;
@@ -32,7 +31,6 @@ import org.apache.parquet.schema.MessageType;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -152,21 +150,6 @@ public final class ParquetTypeUtils
             }
         }
         return index;
-    }
-
-    public static int getFieldIndex(MessageType fileSchema, String name)
-    {
-        try {
-            return fileSchema.getFieldIndex(name.toLowerCase(Locale.ENGLISH));
-        }
-        catch (InvalidRecordException e) {
-            for (org.apache.parquet.schema.Type type : fileSchema.getFields()) {
-                if (type.getName().equalsIgnoreCase(name)) {
-                    return fileSchema.getFieldIndex(type.getName());
-                }
-            }
-            return -1;
-        }
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
## Description
While working on some of the connectors, found some unused code.
Remove unused code

## Motivation and Context
Remove unused code

## Impact
Maintainance

## Test Plan
None

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Remove unused field resolution, Parquet field index helper, and ORC user metadata accessors to simplify the codebase.

Enhancements:
- Clean up analyzer Field API by removing an unused name resolution method.
- Remove unused ParquetTypeUtils helper and related imports to reduce dead code.
- Drop unused ORC record reader user metadata accessor to streamline the reader interface.