### PR TITLE
[DNR] - fix(plugin-iceberg): When ROW sub-field name is a valid identifier written with double-quotes

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
@@ -382,4 +382,22 @@ public class TestIcebergTypes
             assertUpdate("DROP TABLE IF EXISTS " + tableName);
         }
     }
+
+    @Test
+    public void testInsertIntoRowWithQuotedButValidIdentifierSubFieldName()
+    {
+        String tableName = "test_quoted_valid_subfield";
+        try {
+            // "myfield" and "amount" are valid unquoted identifiers, but the user quoted them.
+            // needsDelimiting("myfield") == false  → delimited=false  (from toPrestoType / read-back)
+            // parseTypeSignature("myfield")        → delimited=true   (from DDL parser, because quoted)
+            // RowFieldName.equals: false != true   → TypeValidator throws on INSERT
+            assertUpdate("CREATE TABLE " + tableName + " (id INT, info ROW(\"myfield\" VARCHAR, \"amount\" INT))");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW('hello', 42))", 1);
+            assertQuery("SELECT info.\"myfield\", info.\"amount\" FROM " + tableName, "VALUES ('hello', 42)");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
 }


### PR DESCRIPTION
…e-quotes

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add coverage for handling quoted but otherwise valid ROW sub-field identifiers in the Iceberg connector.

Bug Fixes:
- Ensure INSERT and SELECT work correctly when ROW sub-field names are valid identifiers but specified with double quotes in table definitions.

Tests:
- Add an integration test verifying creating, inserting into, and querying a ROW column with quoted valid sub-field names in Iceberg tables.