### PR TITLE
fix(plugin-iceberg): Add TIMESTAMP_MICROSECONDS support in Iceberg partition transforms

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.common.type.Decimals.readBigDecimal;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -91,6 +92,12 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP, block, transformYear),
                             ValueTransform.from(TIMESTAMP, transformYear));
                 }
+                if (type.equals(TIMESTAMP_MICROSECONDS)) {
+                    LongUnaryOperator transformYear = value -> epochYear(value / 1000);
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformYear),
+                            ValueTransform.from(TIMESTAMP_MICROSECONDS, transformYear));
+                }
                 if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     LongUnaryOperator transformYear = value -> epochYear(unpackMillisUtc(value));
                     return new ColumnTransform(transform, INTEGER,
@@ -110,6 +117,12 @@ public final class PartitionTransforms
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP, block, transformMonth),
                             ValueTransform.from(TIMESTAMP, transformMonth));
+                }
+                if (type.equals(TIMESTAMP_MICROSECONDS)) {
+                    LongUnaryOperator transformMonth = value -> epochMonth(value / 1000);
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformMonth),
+                            ValueTransform.from(TIMESTAMP_MICROSECONDS, transformMonth));
                 }
                 if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     LongUnaryOperator transformMonth = value -> epochMonth(unpackMillisUtc(value));
@@ -131,6 +144,12 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP, block, transformDay),
                             ValueTransform.from(TIMESTAMP, transformDay));
                 }
+                if (type.equals(TIMESTAMP_MICROSECONDS)) {
+                    LongUnaryOperator transformDay = value -> epochDay(value / 1000);
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformDay),
+                            ValueTransform.from(TIMESTAMP_MICROSECONDS, transformDay));
+                }
                 if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     LongUnaryOperator transformDay = value -> epochDay(unpackMillisUtc(value));
                     return new ColumnTransform(transform, INTEGER,
@@ -144,6 +163,12 @@ public final class PartitionTransforms
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP, block, transformHour),
                             ValueTransform.from(TIMESTAMP, transformHour));
+                }
+                if (type.equals(TIMESTAMP_MICROSECONDS)) {
+                    LongUnaryOperator transformHour = value -> epochHour(value / 1000);
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformHour),
+                            ValueTransform.from(TIMESTAMP_MICROSECONDS, transformHour));
                 }
                 if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     LongUnaryOperator transformHour = value -> epochHour(unpackMillisUtc(value));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -93,7 +93,7 @@ public final class PartitionTransforms
                             ValueTransform.from(TIMESTAMP, transformYear));
                 }
                 if (type.equals(TIMESTAMP_MICROSECONDS)) {
-                    LongUnaryOperator transformYear = value -> epochYear(value / 1000);
+                    LongUnaryOperator transformYear = value -> epochYear(Math.floorDiv(value, 1000));
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformYear),
                             ValueTransform.from(TIMESTAMP_MICROSECONDS, transformYear));
@@ -119,7 +119,7 @@ public final class PartitionTransforms
                             ValueTransform.from(TIMESTAMP, transformMonth));
                 }
                 if (type.equals(TIMESTAMP_MICROSECONDS)) {
-                    LongUnaryOperator transformMonth = value -> epochMonth(value / 1000);
+                    LongUnaryOperator transformMonth = value -> epochMonth(Math.floorDiv(value, 1000));
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformMonth),
                             ValueTransform.from(TIMESTAMP_MICROSECONDS, transformMonth));
@@ -145,7 +145,7 @@ public final class PartitionTransforms
                             ValueTransform.from(TIMESTAMP, transformDay));
                 }
                 if (type.equals(TIMESTAMP_MICROSECONDS)) {
-                    LongUnaryOperator transformDay = value -> epochDay(value / 1000);
+                    LongUnaryOperator transformDay = value -> epochDay(Math.floorDiv(value, 1000));
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformDay),
                             ValueTransform.from(TIMESTAMP_MICROSECONDS, transformDay));
@@ -165,7 +165,7 @@ public final class PartitionTransforms
                             ValueTransform.from(TIMESTAMP, transformHour));
                 }
                 if (type.equals(TIMESTAMP_MICROSECONDS)) {
-                    LongUnaryOperator transformHour = value -> epochHour(value / 1000);
+                    LongUnaryOperator transformHour = value -> epochHour(Math.floorDiv(value, 1000));
                     return new ColumnTransform(transform, INTEGER,
                             block -> transformBlock(TIMESTAMP_MICROSECONDS, block, transformHour),
                             ValueTransform.from(TIMESTAMP_MICROSECONDS, transformHour));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
@@ -20,6 +20,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.Instant;
@@ -79,152 +80,45 @@ public class TestPartitionTransforms
         return ChronoUnit.MICROS.between(Instant.EPOCH, dt.toInstant());
     }
 
-    @Test
-    public void testDayTransformOnTimestampMicroseconds()
-    {
-        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
-        long micros = toMicros(dt);
-        long expectedDay = ChronoUnit.DAYS.between(Instant.EPOCH, dt.toInstant());
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(dayField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        assertEquals(result.getInt(0), (int) expectedDay);
-    }
-
-    @Test
-    public void testMonthTransformOnTimestampMicroseconds()
-    {
-        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
-        long micros = toMicros(dt);
-        // Iceberg month transform: months since 1970-01-01 = (year-1970)*12 + (month-1)
-        long expectedMonth = (long) (dt.getYear() - 1970) * 12 + (dt.getMonthValue() - 1);
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(monthField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        assertEquals(result.getInt(0), (int) expectedMonth);
-    }
-
-    @Test
-    public void testYearTransformOnTimestampMicroseconds()
-    {
-        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
-        long micros = toMicros(dt);
-        // Iceberg year transform: years since 1970
-        long expectedYear = dt.getYear() - 1970;
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(yearField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        assertEquals(result.getInt(0), (int) expectedYear);
-    }
-
-    @Test
-    public void testHourTransformOnTimestampMicroseconds()
-    {
-        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 3, 0, 0, 0, ZoneOffset.UTC);
-        long micros = toMicros(dt);
-        long expectedHour = ChronoUnit.HOURS.between(Instant.EPOCH, dt.toInstant());
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(hourField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        assertEquals(result.getInt(0), (int) expectedHour);
-    }
-
-    // Negative-timestamp tests — catch the truncation-toward-zero bug where
-    // `value / 1000` gives the wrong millisecond bucket for negative µs values.
-    //
-    // Chosen timestamp: 1969-12-31T23:59:59.999_001Z = −999 µs since epoch.
-    // This is sub-millisecond before the epoch, so the two divisions diverge:
-    //
-    //   −999 / 1000               =  0  ms  (Java truncates toward zero)
-    //   Math.floorDiv(−999, 1000) = −1  ms  (correct: floor toward −∞)
-
-    /*
+    /**
      * −999 µs since epoch = 1969-12-31T23:59:59.999_001Z.
-     * Java: −999 / 1000 = 0 (truncates toward zero); Math.floorDiv(−999, 1000) = −1 (correct).
+     * Chosen because it is sub-millisecond before the epoch, making the two
+     * divisions diverge: −999 / 1000 = 0 (Java truncates toward zero, wrong)
+     * vs Math.floorDiv(−999, 1000) = −1 (correct floor toward −∞).
+     * This directly catches the truncation-toward-zero bug in the µs→ms conversion.
      */
     private static final long MICROS_JUST_BEFORE_EPOCH = -999L;
 
-    @Test
-    public void testDayTransformOnTimestampMicrosecondsNegative()
+    @DataProvider(name = "timestampMicrosecondsTransforms")
+    public Object[][] timestampMicrosecondsTransforms()
     {
-        // −999 µs is 999 µs before epoch: in Dec 31 1969 (day −1), but only 0.999 ms before
-        // midnight, so value/1000 = 0 (wrong) while floorDiv = −1 (correct).
-        long micros = MICROS_JUST_BEFORE_EPOCH;
+        ZonedDateTime positiveDt = ZonedDateTime.of(2026, 1, 18, 3, 0, 0, 0, ZoneOffset.UTC);
+        long positiveMicros = toMicros(positiveDt);
 
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(dayField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        // Dec 31 1969 = epoch day −1
-        assertEquals(result.getInt(0), -1);
+        return new Object[][] {
+                // positive timestamps (post-epoch)
+                {dayField(), positiveMicros, (int) ChronoUnit.DAYS.between(Instant.EPOCH, positiveDt.toInstant()), "day/positive"},
+                {monthField(), positiveMicros, (int) ((long) (positiveDt.getYear() - 1970) * 12 + (positiveDt.getMonthValue() - 1)), "month/positive"},
+                {yearField(), positiveMicros, positiveDt.getYear() - 1970, "year/positive"},
+                {hourField(), positiveMicros, (int) ChronoUnit.HOURS.between(Instant.EPOCH, positiveDt.toInstant()), "hour/positive"},
+                // negative timestamps (pre-epoch): -999 / 1000 = 0 (wrong); Math.floorDiv(-999, 1000) = -1 (correct)
+                {dayField(), MICROS_JUST_BEFORE_EPOCH, -1, "day/negative"},
+                {monthField(), MICROS_JUST_BEFORE_EPOCH, -1, "month/negative"},
+                {yearField(), MICROS_JUST_BEFORE_EPOCH, -1, "year/negative"},
+                {hourField(), MICROS_JUST_BEFORE_EPOCH, -1, "hour/negative"},
+        };
     }
 
-    @Test
-    public void testHourTransformOnTimestampMicrosecondsNegative()
+    @Test(dataProvider = "timestampMicrosecondsTransforms")
+    public void testTimestampMicrosecondsTransform(PartitionField field, long inputMicros, int expectedValue, String description)
     {
-        // Same timestamp: −999 µs is within the hour ending at epoch (hour −1 = 23:00–24:00 on Dec 31 1969).
-        // value/1000 = 0 → epochHour = 0 (wrong); floorDiv = −1 → epochHour = −1 (correct).
-        long micros = MICROS_JUST_BEFORE_EPOCH;
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(field, TIMESTAMP_MICROSECONDS);
 
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(hourField(), TIMESTAMP_MICROSECONDS);
         BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, inputMicros);
         Block result = transform.getTransform().apply(builder.build());
 
-        assertFalse(result.isNull(0));
-        // The hour spanning 1969-12-31T23:xx is epoch hour −1
-        assertEquals(result.getInt(0), -1);
-    }
-
-    @Test
-    public void testMonthTransformOnTimestampMicrosecondsNegative()
-    {
-        // 1969-12-31T23:59:59.999_001Z is in December 1969 = month −1.
-        // epochMonth delegates to epochYear/MONTH_OF_YEAR_UTC on the millisecond value,
-        // and −999 µs → floorDiv → −1 ms is still Dec 1969, so the month result is −1.
-        long micros = MICROS_JUST_BEFORE_EPOCH;
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(monthField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        // Dec 1969 = months since epoch: (1969 − 1970) * 12 + (12 − 1) = −12 + 11 = −1
-        assertEquals(result.getInt(0), -1);
-    }
-
-    @Test
-    public void testYearTransformOnTimestampMicrosecondsNegative()
-    {
-        // 1969-12-31T23:59:59.999_001Z is in 1969 = year −1 (years since 1970).
-        long micros = MICROS_JUST_BEFORE_EPOCH;
-
-        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(yearField(), TIMESTAMP_MICROSECONDS);
-        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
-        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
-        Block result = transform.getTransform().apply(builder.build());
-
-        assertFalse(result.isNull(0));
-        // 1969 = −1 years since 1970
-        assertEquals(result.getInt(0), -1);
+        assertFalse(result.isNull(0), description + ": result should not be null");
+        assertEquals(result.getInt(0), expectedValue, description);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
@@ -13,10 +13,23 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 public class TestPartitionTransforms
 {
@@ -30,5 +43,105 @@ public class TestPartitionTransforms
         assertEquals(Transforms.month().toString(), "month");
         assertEquals(Transforms.day().toString(), "day");
         assertEquals(Transforms.hour().toString(), "hour");
+    }
+
+    // Schema with a single timestamp_ntz column (Iceberg TimestampType.withoutZone),
+    // matching what Spark writes for timestamp_ntz / TIMESTAMP_MICROSECONDS columns.
+    private static final Schema TIMESTAMP_NTZ_SCHEMA = new Schema(
+            Types.NestedField.required(1, "ts", Types.TimestampType.withoutZone()));
+
+    private static PartitionField dayField()
+    {
+        return PartitionSpec.builderFor(TIMESTAMP_NTZ_SCHEMA).day("ts").build().fields().get(0);
+    }
+
+    private static PartitionField monthField()
+    {
+        return PartitionSpec.builderFor(TIMESTAMP_NTZ_SCHEMA).month("ts").build().fields().get(0);
+    }
+
+    private static PartitionField yearField()
+    {
+        return PartitionSpec.builderFor(TIMESTAMP_NTZ_SCHEMA).year("ts").build().fields().get(0);
+    }
+
+    private static PartitionField hourField()
+    {
+        return PartitionSpec.builderFor(TIMESTAMP_NTZ_SCHEMA).hour("ts").build().fields().get(0);
+    }
+
+    /**
+     * Converts a ZonedDateTime to microseconds since the Unix epoch, which is how
+     * TIMESTAMP_MICROSECONDS (Spark timestamp_ntz) stores its values.
+     */
+    private static long toMicros(ZonedDateTime dt)
+    {
+        return ChronoUnit.MICROS.between(Instant.EPOCH, dt.toInstant());
+    }
+
+    @Test
+    public void testDayTransformOnTimestampMicroseconds()
+    {
+        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
+        long micros = toMicros(dt);
+        long expectedDay = ChronoUnit.DAYS.between(Instant.EPOCH, dt.toInstant());
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(dayField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        assertEquals(result.getInt(0), (int) expectedDay);
+    }
+
+    @Test
+    public void testMonthTransformOnTimestampMicroseconds()
+    {
+        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
+        long micros = toMicros(dt);
+        // Iceberg month transform: months since 1970-01-01 = (year-1970)*12 + (month-1)
+        long expectedMonth = (long) (dt.getYear() - 1970) * 12 + (dt.getMonthValue() - 1);
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(monthField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        assertEquals(result.getInt(0), (int) expectedMonth);
+    }
+
+    @Test
+    public void testYearTransformOnTimestampMicroseconds()
+    {
+        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 0, 0, 0, 0, ZoneOffset.UTC);
+        long micros = toMicros(dt);
+        // Iceberg year transform: years since 1970
+        long expectedYear = dt.getYear() - 1970;
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(yearField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        assertEquals(result.getInt(0), (int) expectedYear);
+    }
+
+    @Test
+    public void testHourTransformOnTimestampMicroseconds()
+    {
+        ZonedDateTime dt = ZonedDateTime.of(2026, 1, 18, 3, 0, 0, 0, ZoneOffset.UTC);
+        long micros = toMicros(dt);
+        long expectedHour = ChronoUnit.HOURS.between(Instant.EPOCH, dt.toInstant());
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(hourField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        assertEquals(result.getInt(0), (int) expectedHour);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionTransforms.java
@@ -144,4 +144,87 @@ public class TestPartitionTransforms
         assertFalse(result.isNull(0));
         assertEquals(result.getInt(0), (int) expectedHour);
     }
+
+    // Negative-timestamp tests — catch the truncation-toward-zero bug where
+    // `value / 1000` gives the wrong millisecond bucket for negative µs values.
+    //
+    // Chosen timestamp: 1969-12-31T23:59:59.999_001Z = −999 µs since epoch.
+    // This is sub-millisecond before the epoch, so the two divisions diverge:
+    //
+    //   −999 / 1000               =  0  ms  (Java truncates toward zero)
+    //   Math.floorDiv(−999, 1000) = −1  ms  (correct: floor toward −∞)
+
+    /*
+     * −999 µs since epoch = 1969-12-31T23:59:59.999_001Z.
+     * Java: −999 / 1000 = 0 (truncates toward zero); Math.floorDiv(−999, 1000) = −1 (correct).
+     */
+    private static final long MICROS_JUST_BEFORE_EPOCH = -999L;
+
+    @Test
+    public void testDayTransformOnTimestampMicrosecondsNegative()
+    {
+        // −999 µs is 999 µs before epoch: in Dec 31 1969 (day −1), but only 0.999 ms before
+        // midnight, so value/1000 = 0 (wrong) while floorDiv = −1 (correct).
+        long micros = MICROS_JUST_BEFORE_EPOCH;
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(dayField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        // Dec 31 1969 = epoch day −1
+        assertEquals(result.getInt(0), -1);
+    }
+
+    @Test
+    public void testHourTransformOnTimestampMicrosecondsNegative()
+    {
+        // Same timestamp: −999 µs is within the hour ending at epoch (hour −1 = 23:00–24:00 on Dec 31 1969).
+        // value/1000 = 0 → epochHour = 0 (wrong); floorDiv = −1 → epochHour = −1 (correct).
+        long micros = MICROS_JUST_BEFORE_EPOCH;
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(hourField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        // The hour spanning 1969-12-31T23:xx is epoch hour −1
+        assertEquals(result.getInt(0), -1);
+    }
+
+    @Test
+    public void testMonthTransformOnTimestampMicrosecondsNegative()
+    {
+        // 1969-12-31T23:59:59.999_001Z is in December 1969 = month −1.
+        // epochMonth delegates to epochYear/MONTH_OF_YEAR_UTC on the millisecond value,
+        // and −999 µs → floorDiv → −1 ms is still Dec 1969, so the month result is −1.
+        long micros = MICROS_JUST_BEFORE_EPOCH;
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(monthField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        // Dec 1969 = months since epoch: (1969 − 1970) * 12 + (12 − 1) = −12 + 11 = −1
+        assertEquals(result.getInt(0), -1);
+    }
+
+    @Test
+    public void testYearTransformOnTimestampMicrosecondsNegative()
+    {
+        // 1969-12-31T23:59:59.999_001Z is in 1969 = year −1 (years since 1970).
+        long micros = MICROS_JUST_BEFORE_EPOCH;
+
+        PartitionTransforms.ColumnTransform transform = PartitionTransforms.getColumnTransform(yearField(), TIMESTAMP_MICROSECONDS);
+        BlockBuilder builder = TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(1);
+        TIMESTAMP_MICROSECONDS.writeLong(builder, micros);
+        Block result = transform.getTransform().apply(builder.build());
+
+        assertFalse(result.isNull(0));
+        // 1969 = −1 years since 1970
+        assertEquals(result.getInt(0), -1);
+    }
 }


### PR DESCRIPTION
## Description

PartitionTransforms.getColumnTransform() handles time-based partition transforms (year, month, day, hour) for DATE and TIMESTAMP (milliseconds) types, but throws UnsupportedOperationException for any other type:

Unsupported type for 'day': int_load_ts_day: day(3)

This PR adds TIMESTAMP_MICROSECONDS (precision=6, microseconds since epoch) support for all four transforms by dividing by 1000 before delegating to the existing epochYear / epochMonth / epochDay / epochHour helpers, which all operate in milliseconds.

## Motivation and Context

Spark writes timestamp_ntz columns as TIMESTAMP_MICROSECONDS (microseconds since epoch, no timezone). When an Iceberg table created by Spark has a timestamp_ntz column used in a time-based partition transform (e.g. day(int_load_ts)), calling rewrite_data_files in Presto fails immediately with:

Unsupported type for 'day': int_load_ts_day: day(3)

This is the blocking error : the rewrite cannot proceed at all. The fix is consistent with how TIMESTAMP_WITH_TIME_ZONE is already handled: extract milliseconds first (unpackMillisUtc() for tz, ÷ 1000 for microseconds), then pass to the same epoch helpers.

Companion PR (partition evolution NULL reads + snapshot resolution): https://github.com/prestodb/presto/pull/28147

## Impact

- No public API changes.
- No user-facing behavior change for existing tables.
- Unblocks rewrite_data_files on Iceberg tables created by Spark with timestamp_ntz partition columns. Previously these would always throw; after this fix they work correctly.


## Test Plan

Added TestPartitionTransforms unit tests covering all four transforms (day, month, year, hour) against a TIMESTAMP_MICROSECONDS value

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```