### PR TITLE
feat(parser): Add support for ANSI SQL syntax in trim function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -256,6 +256,16 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
         SELECT trim('test', 't'); -- es
         SELECT trim('.t.e.s.t.', '.t'); -- e.s
 
+.. function:: trim( [ [ specification ] [ string ] FROM ] source ) -> varchar
+
+     Removes any leading and/or trailing characters as specified up to and
+     including ``string`` from ``source``::
+
+         SELECT trim('!' FROM '!foo!'); -- 'foo'
+         SELECT trim(LEADING FROM '  abcd');  -- 'abcd'
+         SELECT trim(BOTH '$' FROM '$var$'); -- 'var'
+         SELECT trim(TRAILING 'ER' FROM upper('worker')); -- 'WORK'
+
 .. function:: upper(string) -> varchar
 
     Converts ``string`` to uppercase.

--- a/presto-docs/src/main/sphinx/language/reserved.rst
+++ b/presto-docs/src/main/sphinx/language/reserved.rst
@@ -70,6 +70,7 @@ Keyword                        SQL:2016      SQL-92
 ``SELECT``                     reserved      reserved
 ``TABLE``                      reserved      reserved
 ``THEN``                       reserved      reserved
+``TRIM``                       reserved      reserved
 ``TRUE``                       reserved      reserved
 ``UESCAPE``                    reserved
 ``UNION``                      reserved      reserved

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -62,6 +62,7 @@ import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
@@ -278,6 +279,13 @@ class AggregationAnalyzer
         protected Boolean visitNullIfExpression(NullIfExpression node, Void context)
         {
             return process(node.getFirst(), context) && process(node.getSecond(), context);
+        }
+
+        @Override
+        protected Boolean visitTrim(Trim node, Void context)
+        {
+            return process(node.getTrimSource(), context)
+                    && (!node.getTrimCharacter().isPresent() || process(node.getTrimCharacter().get(), context));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -109,6 +109,7 @@ import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
@@ -1400,6 +1401,18 @@ public class ExpressionAnalyzer
 
             Type resultType = process(parameters.get(NodeRef.of(node)), context);
             return setExpressionType(node, resultType);
+        }
+
+        @Override
+        protected Type visitTrim(Trim node, StackableAstVisitorContext<Context> context)
+        {
+            ImmutableList.Builder<Expression> arguments = ImmutableList.builder();
+            arguments.add(node.getTrimSource());
+            node.getTrimCharacter().ifPresent(arguments::add);
+
+            FunctionCall functionCall = new FunctionCall(QualifiedName.of(node.getSpecification().getFunctionName()), arguments.build());
+            Type type = process(functionCall, context);
+            return setExpressionType(node, type);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -90,6 +90,7 @@ import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.type.LikeFunctions;
 import com.facebook.presto.util.Failures;
@@ -1256,6 +1257,18 @@ public class ExpressionInterpreter
 
             // Subscript on Array or Map is interpreted using operator.
             return invokeOperator(OperatorType.SUBSCRIPT, types(node.getBase(), node.getIndex()), ImmutableList.of(base, index));
+        }
+
+        @Override
+        protected Object visitTrim(Trim node, Object context)
+        {
+            ImmutableList.Builder<Expression> arguments = ImmutableList.builder();
+            arguments.add(node.getTrimSource());
+            node.getTrimCharacter().ifPresent(arguments::add);
+
+            FunctionCall functionCall = new FunctionCall(QualifiedName.of(node.getSpecification().getFunctionName()), arguments.build());
+            addGeneratedExpressionType(functionCall, type(node));
+            return visitFunctionCall(functionCall, context);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -94,6 +94,7 @@ import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.google.common.collect.ImmutableList;
@@ -1173,6 +1174,18 @@ public final class SqlToRowExpressionTranslator
             }
 
             throw new UnsupportedOperationException("not yet implemented: " + node.getField());
+        }
+
+        @Override
+        protected RowExpression visitTrim(Trim node, Context context)
+        {
+            String functionName = node.getSpecification().getFunctionName();
+            RowExpression trimSource = process(node.getTrimSource(), context);
+            if (node.getTrimCharacter().isPresent()) {
+                RowExpression trimChar = process(node.getTrimCharacter().get(), context);
+                return call(functionAndTypeResolver, functionName, getType(node), trimSource, trimChar);
+            }
+            return call(functionAndTypeResolver, functionName, getType(node), trimSource);
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -920,6 +920,62 @@ public class TestStringFunctions
     }
 
     @Test
+    public void testAnsiTrimSyntax()
+    {
+        // TRIM(BOTH FROM ...) is equivalent to TRIM(...)
+        assertFunction("TRIM(BOTH FROM '')", createVarcharType(0), "");
+        assertFunction("TRIM(BOTH FROM '   ')", createVarcharType(3), "");
+        assertFunction("TRIM(BOTH FROM '  hello  ')", createVarcharType(9), "hello");
+        assertFunction("TRIM(BOTH FROM '  hello')", createVarcharType(7), "hello");
+        assertFunction("TRIM(BOTH FROM 'hello  ')", createVarcharType(7), "hello");
+        assertFunction("TRIM(BOTH FROM ' hello world ')", createVarcharType(13), "hello world");
+
+        // TRIM(LEADING FROM ...) is equivalent to LTRIM(...)
+        assertFunction("TRIM(LEADING FROM '')", createVarcharType(0), "");
+        assertFunction("TRIM(LEADING FROM '   ')", createVarcharType(3), "");
+        assertFunction("TRIM(LEADING FROM '  hello  ')", createVarcharType(9), "hello  ");
+        assertFunction("TRIM(LEADING FROM '  hello')", createVarcharType(7), "hello");
+        assertFunction("TRIM(LEADING FROM 'hello  ')", createVarcharType(7), "hello  ");
+        assertFunction("TRIM(LEADING FROM ' hello world ')", createVarcharType(13), "hello world ");
+
+        // TRIM(TRAILING FROM ...) is equivalent to RTRIM(...)
+        assertFunction("TRIM(TRAILING FROM '')", createVarcharType(0), "");
+        assertFunction("TRIM(TRAILING FROM '   ')", createVarcharType(3), "");
+        assertFunction("TRIM(TRAILING FROM '  hello  ')", createVarcharType(9), "  hello");
+        assertFunction("TRIM(TRAILING FROM '  hello')", createVarcharType(7), "  hello");
+        assertFunction("TRIM(TRAILING FROM 'hello  ')", createVarcharType(7), "hello");
+        assertFunction("TRIM(TRAILING FROM ' hello world ')", createVarcharType(13), " hello world");
+
+        // TRIM(BOTH char FROM ...) is equivalent to TRIM(str, char)
+        assertFunction("TRIM(BOTH ' ' FROM '  hello  ')", createVarcharType(9), "hello");
+        assertFunction("TRIM(BOTH 'he ' FROM '  hello  ')", createVarcharType(9), "llo");
+        assertFunction("TRIM(BOTH ' ' FROM ' hello world ')", createVarcharType(13), "hello world");
+
+        // TRIM(LEADING char FROM ...) is equivalent to LTRIM(str, char)
+        assertFunction("TRIM(LEADING ' ' FROM '  hello  ')", createVarcharType(9), "hello  ");
+        assertFunction("TRIM(LEADING 'he ' FROM '  hello  ')", createVarcharType(9), "llo  ");
+        assertFunction("TRIM(LEADING ' ' FROM ' hello world ')", createVarcharType(13), "hello world ");
+
+        // TRIM(TRAILING char FROM ...) is equivalent to RTRIM(str, char)
+        assertFunction("TRIM(TRAILING ' ' FROM '  hello  ')", createVarcharType(9), "  hello");
+        assertFunction("TRIM(TRAILING 'lo ' FROM '  hello  ')", createVarcharType(9), "  he");
+        assertFunction("TRIM(TRAILING ' ' FROM ' hello world ')", createVarcharType(13), " hello world");
+
+        // non latin characters
+        assertFunction("TRIM(BOTH '\u0107\u017a' FROM '\u017a\u00f3\u0142\u0107')", createVarcharType(4), "\u00f3\u0142");
+        assertFunction("TRIM(LEADING '\u00f3\u017a' FROM '\u017a\u00f3\u0142\u0107')", createVarcharType(4), "\u0142\u0107");
+        assertFunction("TRIM(TRAILING '\u0107\u0142' FROM '\u017a\u00f3\u0142\u0107')", createVarcharType(4), "\u017a\u00f3");
+
+        // TRIM(char FROM ...) is equivalent to TRIM(str, char)
+        assertFunction("TRIM(' ' FROM '  hello  ')", createVarcharType(9), "hello");
+        assertFunction("TRIM('he ' FROM '  hello  ')", createVarcharType(9), "llo");
+        assertFunction("TRIM(' ' FROM ' hello world ')", createVarcharType(13), "hello world");
+
+        assertFunction("TRIM('!' FROM '!foo!')", createVarcharType(5), "foo");
+        assertFunction("TRIM(' ' FROM '  hello  ')", createVarcharType(9), "hello");
+    }
+
+    @Test
     public void testVarcharToVarcharX()
     {
         assertFunction("LOWER(CAST('HELLO' AS VARCHAR))", createUnboundedVarcharType(), "hello");

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -447,6 +447,9 @@ primaryExpression
     | name=LOCALTIME ('(' precision=INTEGER_VALUE ')')?                                   #specialDateTimeFunction
     | name=LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?                              #specialDateTimeFunction
     | name=CURRENT_USER                                                                   #currentUser
+    | TRIM '(' (trimsSpecification? trimChar=valueExpression? FROM)?
+        trimSource=valueExpression ')'                                                    #trim
+    | TRIM '(' trimSource=valueExpression ',' trimChar=valueExpression ')'                #trim
     | SUBSTRING '(' valueExpression FROM valueExpression (FOR valueExpression)? ')'       #substring
     | NORMALIZE '(' valueExpression (',' normalForm)? ')'                                 #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                     #extract
@@ -705,10 +708,16 @@ constraintEnforced
     : ENFORCED | NOT ENFORCED
     ;
 
+trimsSpecification
+    : LEADING
+    | TRAILING
+    | BOTH
+    ;
+
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | ALL | ANALYZE | ANY | ARRAY | ASC | AT
-    | BEFORE | BERNOULLI | BRANCH
+    | BEFORE | BERNOULLI | BOTH | BRANCH
     | CALL | CALLED | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | COPARTITION | CURRENT | CURRENT_ROLE
     | DATA | DATE | DAY | DEFAULT | DEFINER | DESC | DESCRIPTOR | DETERMINISTIC | DISABLED | DISTRIBUTED | DAYS
     | EMPTY | ENABLED | ENFORCED | EXCLUDING | EXECUTE | EXPLAIN | EXTERNAL
@@ -718,7 +727,7 @@ nonReserved
     | IF | IGNORE | INCLUDING | INDEX | INPUT | INTERVAL | INVOKER | IO | ISOLATION
     | JSON
     | KEEP | KEY
-    | LANGUAGE | LAST | LATERAL | LEVEL | LIMIT | LOGICAL
+    | LANGUAGE | LAST | LATERAL | LEADING | LEVEL | LIMIT | LOGICAL
     | MAP | MATCHED | MATERIALIZED | MERGE | MINUTE | MONTH
     | NAME | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | OF | OFFSET | ONLY | OPTION | ORDINALITY | OUTPUT | OVER
@@ -726,7 +735,7 @@ nonReserved
     | RANGE | READ | REFRESH | RELY | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | RETAIN | RETENTION | RETURN | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SERIALIZABLE | SESSION | SET | SETS | SNAPSHOT | SNAPSHOTS | SQL
     | SHOW | SOME | START | STATS | SUBSTRING | SYSTEM | SYSTEM_TIME | SYSTEM_VERSION
-    | TABLES | TABLESAMPLE | TAG | TEMPORARY | TEXT | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
+    | TABLES | TABLESAMPLE | TAG | TEMPORARY | TEXT | TIME | TIMESTAMP | TO | TRAILING | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | UNIQUE | UPDATE | UPDATING | USE | USER
     | VALIDATE | VECTOR | VERBOSE | VERSION | VIEW
     | WORK | WRITE
@@ -748,6 +757,7 @@ AT: 'AT';
 BEFORE: 'BEFORE';
 BERNOULLI: 'BERNOULLI';
 BETWEEN: 'BETWEEN';
+BOTH: 'BOTH';
 BRANCH: 'BRANCH';
 BY: 'BY';
 CALL: 'CALL';
@@ -843,6 +853,7 @@ KEY: 'KEY';
 LANGUAGE: 'LANGUAGE';
 LAST: 'LAST';
 LATERAL: 'LATERAL';
+LEADING: 'LEADING';
 LEFT: 'LEFT';
 LEVEL: 'LEVEL';
 LIKE: 'LIKE';
@@ -942,7 +953,9 @@ THEN: 'THEN';
 TIME: 'TIME';
 TIMESTAMP: 'TIMESTAMP';
 TO: 'TO';
+TRAILING: 'TRAILING';
 TRANSACTION: 'TRANSACTION';
+TRIM: 'TRIM';
 TRUE: 'TRUE';
 TRUNCATE: 'TRUNCATE';
 TRY_CAST: 'TRY_CAST';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TableVersionExpression;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
@@ -185,6 +186,16 @@ public final class ExpressionFormatter
             }
 
             return builder.toString();
+        }
+
+        @Override
+        protected String visitTrim(Trim node, Void context)
+        {
+            if (!node.getTrimCharacter().isPresent()) {
+                return format("trim(%s FROM %s)", node.getSpecification(), process(node.getTrimSource(), context));
+            }
+
+            return format("trim(%s %s FROM %s)", node.getSpecification(), process(node.getTrimCharacter().get(), context), process(node.getTrimSource(), context));
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -195,6 +195,7 @@ import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
 import com.facebook.presto.sql.tree.TransactionMode;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TruncateTable;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.Union;
@@ -2134,6 +2135,36 @@ class AstBuilder
             throw parseError("Invalid EXTRACT field: " + fieldString, context);
         }
         return new Extract(getLocation(context), (Expression) visit(context.valueExpression()), field);
+    }
+
+    @Override
+    public Node visitTrim(SqlBaseParser.TrimContext context)
+    {
+        if (context.FROM() != null && context.trimsSpecification() == null && context.trimChar == null) {
+            throw parseError("The 'trim' function must have specification, char or both arguments when it takes FROM", context);
+        }
+
+        Trim.Specification specification = context.trimsSpecification() == null
+                ? Trim.Specification.BOTH
+                : toTrimSpecification((Token) context.trimsSpecification().getChild(0).getPayload());
+        return new Trim(
+                getLocation(context),
+                specification,
+                (Expression) visit(context.trimSource),
+                visitIfPresent(context.trimChar, Expression.class));
+    }
+
+    private static Trim.Specification toTrimSpecification(Token token)
+    {
+        switch (token.getType()) {
+            case SqlBaseLexer.BOTH:
+                return Trim.Specification.BOTH;
+            case SqlBaseLexer.LEADING:
+                return Trim.Specification.LEADING;
+            case SqlBaseLexer.TRAILING:
+                return Trim.Specification.TRAILING;
+        }
+        throw new IllegalArgumentException("Unsupported trim specification: " + token.getText());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -347,6 +347,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitTrim(Trim node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitNullIfExpression(NullIfExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -17,6 +17,15 @@ public abstract class DefaultTraversalVisitor<R, C>
         extends AstVisitor<R, C>
 {
     @Override
+    protected R visitTrim(Trim node, C context)
+    {
+        process(node.getTrimSource(), context);
+        node.getTrimCharacter().ifPresent(trimChar -> process(trimChar, context));
+
+        return null;
+    }
+
+    @Override
     protected R visitExtract(Extract node, C context)
     {
         return process(node.getExpression(), context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
@@ -214,4 +214,9 @@ public class ExpressionRewriter<C>
     {
         return rewriteExpression(node, context, treeRewriter);
     }
+
+    public Expression rewriteTrim(Trim node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -812,6 +812,27 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
+        protected Expression visitTrim(Trim node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteTrim(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            Expression trimSource = rewrite(node.getTrimSource(), context.get());
+            Optional<Expression> trimChar = node.getTrimCharacter()
+                    .map(trimCharacter -> rewrite(trimCharacter, context.get()));
+
+            if (trimSource != node.getTrimSource() || !sameElements(trimChar, node.getTrimCharacter())) {
+                return new Trim(node.getSpecification(), trimSource, trimChar);
+            }
+
+            return node;
+        }
+
+        @Override
         protected Expression visitExtract(Extract node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Trim.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Trim.java
@@ -1,0 +1,121 @@
+
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class Trim
+        extends Expression
+{
+    private final Specification specification;
+    private final Expression trimSource;
+    private final Optional<Expression> trimCharacter;
+
+    public Trim(Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.empty(), specification, trimSource, trimCharacter);
+    }
+
+    public Trim(NodeLocation location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        this(Optional.of(location), specification, trimSource, trimCharacter);
+    }
+
+    private Trim(Optional<NodeLocation> location, Specification specification, Expression trimSource, Optional<Expression> trimCharacter)
+    {
+        super(location);
+        this.specification = requireNonNull(specification, "specification is null");
+        this.trimSource = requireNonNull(trimSource, "trimSource is null");
+        this.trimCharacter = requireNonNull(trimCharacter, "trimCharacter is null");
+    }
+
+    public Specification getSpecification()
+    {
+        return specification;
+    }
+
+    public Expression getTrimSource()
+    {
+        return trimSource;
+    }
+
+    public Optional<Expression> getTrimCharacter()
+    {
+        return trimCharacter;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTrim(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.add(trimSource);
+        trimCharacter.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Trim that = (Trim) o;
+        return specification == that.specification &&
+                Objects.equals(trimSource, that.trimSource) &&
+                Objects.equals(trimCharacter, that.trimCharacter);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(specification, trimSource, trimCharacter);
+    }
+
+    public enum Specification
+    {
+        BOTH("trim"),
+        LEADING("ltrim"),
+        TRAILING("rtrim");
+
+        private final String functionName;
+
+        Specification(String functionName)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+        }
+
+        public String getFunctionName()
+        {
+            return functionName;
+        }
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -169,6 +169,7 @@ import com.facebook.presto.sql.tree.TableVersionExpression;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
+import com.facebook.presto.sql.tree.Trim;
 import com.facebook.presto.sql.tree.TruncateTable;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
@@ -881,6 +882,32 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));
+    }
+
+    @Test
+    public void testTrim()
+    {
+        assertExpression("trim(BOTH FROM ' abc ')",
+                new Trim(Trim.Specification.BOTH, new StringLiteral(" abc "), Optional.empty()));
+        assertExpression("trim(LEADING FROM ' abc ')",
+                new Trim(Trim.Specification.LEADING, new StringLiteral(" abc "), Optional.empty()));
+        assertExpression("trim(TRAILING FROM ' abc ')",
+                new Trim(Trim.Specification.TRAILING, new StringLiteral(" abc "), Optional.empty()));
+
+        assertExpression("trim(BOTH ' ' FROM ' abc ')",
+                new Trim(Trim.Specification.BOTH, new StringLiteral(" abc "), Optional.of(new StringLiteral(" "))));
+        assertExpression("trim(LEADING ' ' FROM ' abc ')",
+                new Trim(Trim.Specification.LEADING, new StringLiteral(" abc "), Optional.of(new StringLiteral(" "))));
+        assertExpression("trim(TRAILING ' ' FROM ' abc ')",
+                new Trim(Trim.Specification.TRAILING, new StringLiteral(" abc "), Optional.of(new StringLiteral(" "))));
+
+        assertExpression("trim(' abc ')",
+                new Trim(Trim.Specification.BOTH, new StringLiteral(" abc "), Optional.empty()));
+        assertExpression("trim(' ' FROM ' abc ')",
+                new Trim(Trim.Specification.BOTH, new StringLiteral(" abc "), Optional.of(new StringLiteral(" "))));
+        assertExpression("trim(' abc ', ' ')",
+                new Trim(Trim.Specification.BOTH, new StringLiteral(" abc "), Optional.of(new StringLiteral(" "))));
+        assertInvalidExpression("trim(FROM ' abc ')", "The 'trim' function must have specification, char or both arguments when it takes FROM");
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
ANSI SQL TRIM Syntax – Port from Trino to Presto

Trino Commit https://github.com/trinodb/trino/commit/a319b0b6edd9a0d5295af29b29d00aa9d88850e0

Co-Authored By: Yuya Ebihara [ebyhry@gmail.com](mailto:ebyhry@gmail.com) 

## Motivation and Context

Bring Presto's SQL surface in line with the ANSI SQL standard and with Trino, which already supports this syntax.

This PR adds support for ANSI SQL TRIM syntax to Presto while preserving compatibility with the existing function-call syntax.

Adds support for the ANSI SQL TRIM syntax in addition to the existing function-call syntax, ported from Trino commit a319b0b6edd9a0d5295af29b29d00aa9d88850e0 (Yuya Ebihara, 2022-02-28).

Three forms are now supported:

```
TRIM(BOTH | LEADING | TRAILING FROM <source>)
TRIM(BOTH | LEADING | TRAILING <char> FROM <source>)
TRIM(<source>, <char>)   -- existing comma form, unchanged

```
Each specification maps to an existing built-in scalar: `BOTH → trim`, `LEADING → ltrim`, `TRAILING → rtrim`. A new Trim AST node is introduced as the canonical representation, with a new trimsSpecification grammar rule to parse the keyword form.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

**Before**
```
presto> SELECT trim('!' FROM '!foo!');

Query 20260720_141658_00002_5b9ir, FAILED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 14ms, server-side: 0ms] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260720_141658_00002_5b9ir failed: line 1:17: mismatched input 'FROM'. Expecting: ',', <expression>
SELECT trim('!' FROM '!foo!')

```
**After**
```
presto> SELECT trim('!' FROM '!foo!');
 _col0
-------
 foo
(1 row)

Query 20260720_135852_00000_jyf5x, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:02] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT trim(LEADING FROM '  abcd');
 _col0
-------
 abcd
(1 row)

Query 20260720_135908_00001_jyf5x, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 323ms, server-side: 231ms] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT trim(BOTH '$' FROM '$var$');
 _col0
-------
 var
(1 row)

Query 20260720_135917_00002_jyf5x, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 236ms, server-side: 177ms] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT trim(TRAILING 'ER' FROM upper('worker'));
 _col0
-------
 WORK
(1 row)

Query 20260720_135926_00003_jyf5x, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:01, server-side: 451ms] [0 rows, 0B] [0 rows/s, 0B/s]
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for ANSI SQL syntax in trim function

```

## Summary by Sourcery

Add support for ANSI SQL TRIM syntax with BOTH/LEADING/TRAILING forms while preserving existing function-call behavior.

New Features:
- Support ANSI SQL TRIM syntaxes including `TRIM([BOTH|LEADING|TRAILING] FROM source)` and `TRIM([BOTH|LEADING|TRAILING] char FROM source)`, mapped to existing trim functions via a new Trim AST node.

Enhancements:
- Extend SQL grammar, analysis, planning, and formatting pipelines to understand and rewrite the new Trim AST node into existing trim/ltrim/rtrim scalar functions.

Documentation:
- Update SQL language and string function documentation to describe the new TRIM syntax and reserved keywords.

Tests:
- Add parser and scalar function tests covering the new TRIM syntaxes, including behavior with custom trim characters and non-Latin characters.