### PR TITLE
fix(native-pos): Classify native worker deaths by exit signal (#28192)

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
@@ -42,6 +42,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -87,6 +88,15 @@ public abstract class AbstractNativeProcess
     private static final String WORKER_NODE_CONFIG_FILE = "node.properties";
     private static final String WORKER_CONNECTOR_CONFIG_DIR = "catalog";
     private static final int SIGSYS = 31;
+    // The forked worker's stderr is teed to the JVM's own stderr, FileDescriptor.err (OS file descriptor 2),
+    // which is shared process-wide (System.err and every worker's pipe write to it). This stream MUST NOT be
+    // closed: closing it closes that shared descriptor for the whole executor JVM, so every subsequently
+    // launched worker's pipe then dies on its first write and never captures the "*** Aborted" banner. Pre-fix,
+    // a fresh FileOutputStream(FileDescriptor.err) was opened per worker and closed on worker death, so only the
+    // FIRST crash per executor was ever captured. Shared + never closed. It is a PrintStream (not a raw
+    // FileOutputStream) so writes are synchronized/atomic across the concurrent worker pipes (a dying worker's
+    // pipe can still be draining while the relaunched worker's pipe starts writing), preventing interleaved lines.
+    private static final PrintStream EXECUTOR_STDERR = new PrintStream(new FileOutputStream(FileDescriptor.err), false, UTF_8);
 
     private final String executablePath;
     private final String programArguments;
@@ -148,7 +158,7 @@ public abstract class AbstractNativeProcess
             processOutputPipe = new ProcessOutputPipe(
                     getPid(process),
                     process.getErrorStream(),
-                    new FileOutputStream(FileDescriptor.err));
+                    EXECUTOR_STDERR);
             processOutputPipe.start();
         }
         catch (IOException e) {
@@ -337,6 +347,8 @@ public abstract class AbstractNativeProcess
         if (pipe == null) {
             return "";
         }
+        // Called from processFailure() only after the process is dead, by which point the stderr pipe has
+        // read the crash banner into abortMessage.
         return pipe.getAbortMessage();
     }
 
@@ -455,7 +467,8 @@ public abstract class AbstractNativeProcess
         return configBasePath.resolve(WORKER_CONNECTOR_CONFIG_DIR);
     }
 
-    private static class ProcessOutputPipe
+    @VisibleForTesting
+    static class ProcessOutputPipe
             implements Runnable
     {
         private final long pid;
@@ -484,8 +497,12 @@ public abstract class AbstractNativeProcess
         @Override
         public void run()
         {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
-                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
+            // Only the per-worker reader (the forked process's stderr) is auto-closed. The writer wraps the
+            // shared executor stderr (EXECUTOR_STDERR / FileDescriptor.err) and is deliberately NOT closed —
+            // closing it would close the JVM's shared stderr descriptor. Every line is flushed, so nothing is
+            // buffered/lost by not closing it.
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8));
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
                 String line;
                 boolean aborted = false;
                 while ((line = reader.readLine()) != null) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/AbstractNativeProcess.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -350,6 +351,20 @@ public abstract class AbstractNativeProcess
         // Called from processFailure() only after the process is dead, by which point the stderr pipe has
         // read the crash banner into abortMessage.
         return pipe.getAbortMessage();
+    }
+
+    /**
+     * Returns the native process exit code if the process has terminated, otherwise empty. Useful for
+     * classifying deaths that leave no crash banner (e.g. 137 = SIGKILL/OOM-kill, 139 = SIGSEGV,
+     * 134 = SIGABRT).
+     */
+    public OptionalInt getExitCode()
+    {
+        Process running = process;
+        if (running == null || running.isAlive()) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(running.exitValue());
     }
 
     public int getPort()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -91,6 +91,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -700,6 +701,15 @@ public class PrestoSparkNativeTaskExecutorFactory
             }
             else {
                 message = "Native execution process is dead";
+                // Record the exit code so a death with no crash banner (e.g. an OOM-kill) is still classifiable.
+                OptionalInt exitCode = process.getExitCode();
+                if (exitCode.isPresent()) {
+                    int code = exitCode.getAsInt();
+                    String signal = describeExitCode(code);
+                    message += signal.isEmpty()
+                            ? format(" (exit code %s)", code)
+                            : format(" (exit code %s %s)", code, signal);
+                }
                 String crashReport = process.getCrashReport();
                 if (!crashReport.isEmpty()) {
                     message += ":\n" + crashReport;
@@ -722,5 +732,21 @@ public class PrestoSparkNativeTaskExecutorFactory
         }
         PrestoTransportException transportException = (PrestoTransportException) failure;
         return TOO_MANY_REQUESTS_FAILED.toErrorCode().equals(transportException.getErrorCode());
+    }
+
+    // A process terminated by signal N exits with code 128 + N. Annotating the common native crash
+    // signals keeps a death with no crash banner (e.g. an OOM-kill) classifiable from the exit code alone.
+    private static String describeExitCode(int exitCode)
+    {
+        switch (exitCode) {
+            case 137:
+                return "SIGKILL - likely OOM-killed by the container";
+            case 139:
+                return "SIGSEGV";
+            case 134:
+                return "SIGABRT";
+            default:
+                return "";
+        }
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestAbstractNativeProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestAbstractNativeProcess.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.nativeprocess;
+
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestAbstractNativeProcess
+{
+    /**
+     * The crash report contains the full folly/velox crash banner captured from the "*** Aborted" line
+     * onward; earlier ordinary log lines are teed to the executor stderr but excluded from the report.
+     */
+    @Test
+    public void testCrashBannerCaptured()
+    {
+        String stderr = "I0715 12:00:00 native log line 1\n" +
+                "I0715 12:00:01 native log line 2\n" +
+                "*** Aborted at 1784160518 (Unix time, try 'date -d @1784160518') ***\n" +
+                "*** Signal 11 (SIGSEGV) (0x110) received by PID 123 (code: address not mapped to object) ***\n" +
+                "    @ facebook::velox::exec::TopNRowNumber::reclaim\n" +
+                "Fatal signal handler. Query Id= 20260716_000432_00000_34rky Task Id= 20260716_000432_00000_34rky.9.0.98.0\n";
+        ByteArrayInputStream in = new ByteArrayInputStream(stderr.getBytes(UTF_8));
+        ByteArrayOutputStream tee = new ByteArrayOutputStream();
+
+        AbstractNativeProcess.ProcessOutputPipe pipe = new AbstractNativeProcess.ProcessOutputPipe(123, in, tee);
+        // Run synchronously: the reader loop fills abortMessage and returns at stderr EOF.
+        pipe.run();
+
+        String crashReport = pipe.getAbortMessage();
+        assertTrue(crashReport.contains("*** Aborted at 1784160518"), "missing abort banner: " + crashReport);
+        assertTrue(crashReport.contains("*** Signal 11 (SIGSEGV)"), "missing signal line: " + crashReport);
+        assertTrue(crashReport.contains("TopNRowNumber::reclaim"), "missing native frame: " + crashReport);
+        assertTrue(crashReport.contains("Query Id= 20260716_000432_00000_34rky"), "missing query id: " + crashReport);
+        // Capture starts at the banner: earlier ordinary log lines are not part of the crash report.
+        assertFalse(crashReport.contains("native log line 1"), "should not capture pre-abort lines: " + crashReport);
+
+        // Every line (including pre-crash logs) is still teed to the executor's stderr.
+        String teed = new String(tee.toByteArray(), UTF_8);
+        assertTrue(teed.contains("native log line 1"), "tee is missing a normal log line");
+        assertTrue(teed.contains("*** Aborted at 1784160518"), "tee is missing the crash banner");
+    }
+
+    /**
+     * A death with no crash banner (e.g. SIGKILL / OOM-kill, which prints nothing) drains cleanly and
+     * yields an empty crash report — the case where the exit code fallback is the only diagnostic.
+     */
+    @Test
+    public void testNoBannerYieldsEmptyCrashReport()
+    {
+        String stderr = "I0715 12:00:00 line a\nI0715 12:00:01 line b\n";
+        ByteArrayInputStream in = new ByteArrayInputStream(stderr.getBytes(UTF_8));
+        ByteArrayOutputStream tee = new ByteArrayOutputStream();
+
+        AbstractNativeProcess.ProcessOutputPipe pipe = new AbstractNativeProcess.ProcessOutputPipe(1, in, tee);
+        pipe.run();
+
+        assertTrue(pipe.getAbortMessage().isEmpty(), "expected empty crash report when no banner is present");
+        assertTrue(new String(tee.toByteArray(), UTF_8).contains("line a"), "tee is missing a normal log line");
+    }
+
+    /**
+     * A pipe must NOT close its (shared) executor-stderr stream. FileDescriptor.err (OS fd 2) is shared by every
+     * worker's pipe on the executor, so closing it after the first worker dies breaks the next relaunched
+     * worker's pipe — its reader throws on the first write and never reaches the "*** Aborted" banner. Regression
+     * for the bug where only the first native crash per executor attached a banner.
+     */
+    @Test
+    public void testPipeDoesNotCloseSharedStderr()
+    {
+        // Models the shared stderr descriptor: once closed, further writes throw — like closing FileOutputStream(FileDescriptor.err).
+        class SharedStderr
+                extends OutputStream
+        {
+            private final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+            private volatile boolean closed;
+
+            @Override
+            public void write(int b)
+                    throws IOException
+            {
+                if (closed) {
+                    throw new IOException("Stream Closed");
+                }
+                sink.write(b);
+            }
+
+            @Override
+            public void close()
+            {
+                closed = true;
+            }
+        }
+        SharedStderr stderr = new SharedStderr();
+
+        // First worker crash: banner is captured AND the shared stderr must stay open.
+        String crash1 = "I0715 12:00:00 starting\n*** Aborted at 1 ***\n*** Signal 11 (SIGSEGV) ***\n";
+        AbstractNativeProcess.ProcessOutputPipe pipe1 = new AbstractNativeProcess.ProcessOutputPipe(
+                1, new ByteArrayInputStream(crash1.getBytes(UTF_8)), stderr);
+        pipe1.run();
+        assertTrue(pipe1.getAbortMessage().contains("*** Aborted at 1"), "pipe1 missed its banner");
+        assertFalse(stderr.closed, "pipe must not close the shared executor stderr (FileDescriptor.err)");
+
+        // Relaunched worker on the SAME executor: its banner must still be captured. Pre-fix, pipe1 closed the
+        // shared stderr, so pipe2's reader threw on the first (pre-banner) line and never reached the banner.
+        String crash2 = "I0715 12:02:00 starting\n*** Aborted at 2 ***\n*** Signal 11 (SIGSEGV) ***\n";
+        AbstractNativeProcess.ProcessOutputPipe pipe2 = new AbstractNativeProcess.ProcessOutputPipe(
+                2, new ByteArrayInputStream(crash2.getBytes(UTF_8)), stderr);
+        pipe2.run();
+        assertTrue(pipe2.getAbortMessage().contains("*** Aborted at 2"), "pipe2 missed its banner (shared stderr was closed)");
+
+        // The shared stderr stayed writable across both crashes: both workers' output was teed to it.
+        String teed = new String(stderr.sink.toByteArray(), UTF_8);
+        assertTrue(teed.contains("*** Aborted at 1"), "shared stderr missing first worker's output: " + teed);
+        assertTrue(teed.contains("*** Aborted at 2"), "shared stderr missing second worker's output: " + teed);
+    }
+}


### PR DESCRIPTION
Summary:

Stacked on D112364867 (which restores reliable capture of the native `*** Aborted` crash banner).
This diff adds a fallback for native worker deaths that produce NO banner at all: OOM-kills
(SIGKILL) print nothing, and even many SIGSEGV crashes are torn down before folly flushes a banner.
Even with D112364867, only crashes that emit a banner are self-describing; a bannerless death is
still an opaque "Native execution process is dead".

`AbstractNativeProcess.getExitCode()` returns the terminated process's exit code, and
`PrestoSparkNativeTaskExecutorFactory.processFailure()` appends it to the failure message,
annotating the common crash signals via `describeExitCode()` — `137` (SIGKILL, typically OOM-killed
by the container), `139` (SIGSEGV), `134` (SIGABRT). A process terminated by signal N exits with
code 128 + N.

Driver-visible task failure reason becomes e.g.:
  before: Native execution process is dead
  after:  Native execution process is dead (exit code 139 SIGSEGV)

So every native death is now self-classifying by signal, including the ones that leave no banner
for D112364867 to capture. Validated E2E: the exit code is recorded on 100% of crash tasklets (up
from 0%) — see Test Plan.

## Release Note

```== NO RELEASE NOTE ==```

Reviewed By: shrinidhijoshi

Differential Revision: D112555454
