### PR TITLE
feat(server): Report node as INACTIVE until server startup completes (#28193)

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -228,6 +228,21 @@ at the server level. Error codes are matched by their name (such as ``GENERIC_IN
 
 The corresponding session property is :ref:`admin/properties-session:\`\`try_function_catchable_errors\`\``.
 
+``server.startup-complete-required-for-active``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+When enabled, the coordinator reports itself as not ready until the server has fully
+completed startup: ``/v1/info/state`` returns ``INACTIVE`` and ``/v1/info`` reports
+``"starting": true`` until the server reaches the ``SERVER STARTED`` point. By default,
+a coordinator can report ``ACTIVE`` as soon as its catalogs and resource group
+configuration manager are loaded, which happens before the remaining startup steps
+complete. Enabling this property defers the ``ACTIVE`` state until startup has fully
+finished, so that external components such as load balancers, routers, and health
+checks do not route queries to a coordinator that is still initializing.
+
 Memory Management Properties
 ----------------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -44,6 +44,7 @@ public class ServerConfig
     private Duration clusterResourceGroupStateInfoExpirationDuration = new Duration(0, MILLISECONDS);
     private String clusterTag;
     private boolean webUIEnabled = true;
+    private boolean startupCompleteRequiredForActive;
 
     public boolean isResourceManager()
     {
@@ -264,6 +265,18 @@ public class ServerConfig
     public ServerConfig setClusterTag(String clusterTag)
     {
         this.clusterTag = clusterTag;
+        return this;
+    }
+
+    public boolean isStartupCompleteRequiredForActive()
+    {
+        return startupCompleteRequiredForActive;
+    }
+
+    @Config("server.startup-complete-required-for-active")
+    public ServerConfig setStartupCompleteRequiredForActive(boolean startupCompleteRequiredForActive)
+    {
+        this.startupCompleteRequiredForActive = startupCompleteRequiredForActive;
         return this;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerStartupState.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerStartupState.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ServerStartupState
+{
+    private final AtomicBoolean startupComplete = new AtomicBoolean(false);
+
+    public void setStartupComplete()
+    {
+        startupComplete.set(true);
+    }
+
+    public boolean isStartupComplete()
+    {
+        return startupComplete.get();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -51,7 +51,8 @@ public class TestServerConfig
                 .setClusterStatsExpirationDuration(new Duration(0, MILLISECONDS))
                 .setNestedDataSerializationEnabled(true)
                 .setClusterResourceGroupStateInfoExpirationDuration(new Duration(0, MILLISECONDS))
-                .setClusterTag(null));
+                .setClusterTag(null)
+                .setStartupCompleteRequiredForActive(false));
     }
 
     @Test
@@ -76,6 +77,7 @@ public class TestServerConfig
                 .put("nested-data-serialization-enabled", "false")
                 .put("cluster-resource-group-state-info-expiration-duration", "10s")
                 .put("cluster-tag", "test-cluster")
+                .put("server.startup-complete-required-for-active", "true")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -96,7 +98,8 @@ public class TestServerConfig
                 .setClusterStatsExpirationDuration(new Duration(10, SECONDS))
                 .setNestedDataSerializationEnabled(false)
                 .setClusterResourceGroupStateInfoExpirationDuration(new Duration(10, SECONDS))
-                .setClusterTag("test-cluster");
+                .setClusterTag("test-cluster")
+                .setStartupCompleteRequiredForActive(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -263,6 +263,8 @@ public class PrestoServer
 
             injector.getInstance(Announcer.class).start();
 
+            injector.getInstance(ServerStartupState.class).setStartupComplete();
+
             log.info("======== SERVER STARTED ========");
         }
         catch (Throwable e) {

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
@@ -58,10 +58,12 @@ public class ServerInfoResource
     private final long startTime = System.nanoTime();
     private final NodeResourceStatusProvider nodeResourceStatusProvider;
     private final ResourceGroupManager resourceGroupManager;
+    private final boolean startupCompleteRequiredForActive;
+    private final ServerStartupState serverStartupState;
     private NodeState nodeState = ACTIVE;
 
     @Inject
-    public ServerInfoResource(NodeVersion nodeVersion, NodeInfo nodeInfo, ServerConfig serverConfig, StaticCatalogStore catalogStore, GracefulShutdownHandler shutdownHandler, NodeResourceStatusProvider nodeResourceStatusProvider, ResourceGroupManager resourceGroupManager)
+    public ServerInfoResource(NodeVersion nodeVersion, NodeInfo nodeInfo, ServerConfig serverConfig, StaticCatalogStore catalogStore, GracefulShutdownHandler shutdownHandler, NodeResourceStatusProvider nodeResourceStatusProvider, ResourceGroupManager resourceGroupManager, ServerStartupState serverStartupState)
     {
         this.version = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = requireNonNull(nodeInfo, "nodeInfo is null").getEnvironment();
@@ -71,13 +73,15 @@ public class ServerInfoResource
         this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
         this.nodeResourceStatusProvider = requireNonNull(nodeResourceStatusProvider, "nodeResourceStatusProvider is null");
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+        this.startupCompleteRequiredForActive = serverConfig.isStartupCompleteRequiredForActive();
+        this.serverStartupState = requireNonNull(serverStartupState, "serverStartupState is null");
     }
 
     @GET
     @Produces({APPLICATION_JSON, APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
     public ServerInfo getInfo()
     {
-        boolean starting = resourceManager ? true : !catalogStore.areCatalogsLoaded();
+        boolean starting = resourceManager ? true : (startupCompleteRequiredForActive ? !serverStartupState.isStartupComplete() : !catalogStore.areCatalogsLoaded());
         return new ServerInfo(version, environment, coordinator, starting, Optional.of(nanosSince(startTime)));
     }
 
@@ -121,7 +125,9 @@ public class ServerInfoResource
         if (shutdownHandler.isShutdownRequested()) {
             return SHUTTING_DOWN;
         }
-        else if (!nodeResourceStatusProvider.hasResources() || !resourceGroupManager.isConfigurationManagerLoaded()) {
+        else if (!nodeResourceStatusProvider.hasResources()
+                || !resourceGroupManager.isConfigurationManagerLoaded()
+                || (startupCompleteRequiredForActive && !serverStartupState.isStartupComplete())) {
             return INACTIVE;
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -799,6 +799,7 @@ public class ServerMainModule
         }
 
         // server info resource
+        binder.bind(ServerStartupState.class).in(Scopes.SINGLETON);
         jaxrsBinder(binder).bind(ServerInfoResource.class);
         jsonCodecBinder(binder).bindJsonCodec(ServerInfo.class);
 


### PR DESCRIPTION
Summary:

## Description
Adds a new server configuration property `server.startup-complete-required-for-active`
(default `false`). When enabled, the coordinator reports `"starting": true` on
`GET /v1/info` and `INACTIVE` on `GET /v1/info/state` until the server has fully
completed startup — i.e. until the `======== SERVER STARTED ========` point in
`PrestoServer` — instead of as soon as catalogs and the resource group configuration
manager are loaded.

A `ServerInfoResource.startupComplete()` latch is set as the last step of
`PrestoServer` startup, after every startup step (plugins, catalogs, function
namespace managers, resource groups, and built-in worker function registration) has
succeeded. `getInfo()` and `getServerState()` consult this latch only when the new
property is enabled, so the default behavior is unchanged.

## Motivation and Context
`GET /v1/info` derives `starting` from whether catalogs are loaded, and
`GET /v1/info/state` reports `ACTIVE` once the resource group configuration manager is
loaded. Both happen partway through `PrestoServer` startup, before later steps such as
built-in worker function registration complete. External components that use these
endpoints as a readiness signal (load balancers, routers, health checks, deployment
automation) can therefore treat the coordinator as ready and route queries to it while
it is still initializing, causing those queries to fail. This change lets operators
opt into a stricter readiness signal that only reports ready once startup has fully
completed.

## Impact
New optional config property `server.startup-complete-required-for-active`
(default `false`). With the default, behavior is unchanged. When `true`,
`GET /v1/info` and `GET /v1/info/state` report not-ready until the server finishes
startup.

## Contributor checklist

- [ ] Please make sure your submission complies with our development, coding, and formatting guidelines.
- [ ] PR description addresses the issue accurately and concisely.
- [ ] Documented the new configuration property and its default value.
- [ ] Release notes entry is included and follows the release notes guidelines.
- [ ] Adequate tests were added (unit test coverage for the new property).
- [ ] CI passes.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Add configuration property ``server.startup-complete-required-for-active`` to report a node as not ready (``/v1/info`` ``starting`` and ``/v1/info/state``) until server startup has fully completed. Defaults to ``false``.
```

Differential Revision: D112758657
