### PR TITLE
fix: Duplicate key error when multiple dynamic filters target one probe variable

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
@@ -22,13 +22,13 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,16 +90,20 @@ public class LocalDynamicFilter
         }
         // Convert the predicate to use probe variables (instead dynamic filter IDs).
         // Note that in case of a probe-side union, a single dynamic filter may match multiple probe variables.
-        ImmutableMap.Builder<VariableReferenceExpression, Domain> builder = ImmutableMap.builder();
+        // Conversely, multiple dynamic filters may target the same probe variable (e.g. a two-sided range
+        // predicate "a >= x AND a < y", or BETWEEN, produces two comparison dynamic filters on the same
+        // variable "a"). In that case the resulting domains must be intersected instead of overwriting each
+        // other, otherwise building an ImmutableMap would fail with "Multiple entries with same key".
+        Map<VariableReferenceExpression, Domain> domains = new HashMap<>();
         for (Map.Entry<String, Domain> entry : result.getDomains().get().entrySet()) {
             Domain domain = entry.getValue();
             // Store all matching variables for each build channel index.
             for (DynamicFilterPlaceholder placeholder : probeVariables.get(entry.getKey())) {
                 Domain updatedDomain = placeholder.applyComparison(domain);
-                builder.put((VariableReferenceExpression) placeholder.getInput(), updatedDomain);
+                domains.merge((VariableReferenceExpression) placeholder.getInput(), updatedDomain, Domain::intersect);
             }
         }
-        return TupleDomain.withColumnDomains(builder.build());
+        return TupleDomain.withColumnDomains(domains);
     }
 
     public static Optional<LocalDynamicFilter> create(AbstractJoinNode planNode, int partitionCount)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
@@ -94,6 +94,10 @@ public class LocalDynamicFilter
         // predicate "a >= x AND a < y", or BETWEEN, produces two comparison dynamic filters on the same
         // variable "a"). In that case the resulting domains must be intersected instead of overwriting each
         // other, otherwise building an ImmutableMap would fail with "Multiple entries with same key".
+        // Intersection is correct because such filters are always conjunctive: they are collected via
+        // extractDynamicFilters/extractConjuncts, which only splits along top-level AND, so any placeholders
+        // that share a probe variable are AND-combined by construction (an OR subtree is kept opaque and is
+        // never decomposed into dynamic filters).
         Map<VariableReferenceExpression, Domain> domains = new HashMap<>();
         for (Map.Entry<String, Domain> entry : result.getDomains().get().entrySet()) {
             Domain domain = entry.getValue();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLocalDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLocalDynamicFilter.java
@@ -16,7 +16,9 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.expressions.DynamicFilters.DynamicFilterPlaceholder;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -40,6 +42,8 @@ import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERI
 import static com.facebook.presto.SystemSessionProperties.FORCE_SINGLE_NODE_OUTPUT;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -97,6 +101,35 @@ public class TestLocalDynamicFilter
         assertEquals(result.get(), TupleDomain.withColumnDomains(ImmutableMap.of(
                 new VariableReferenceExpression(Optional.empty(), "a1", INTEGER), Domain.singleValue(INTEGER, 7L),
                 new VariableReferenceExpression(Optional.empty(), "a2", INTEGER), Domain.singleValue(INTEGER, 7L))));
+    }
+
+    @Test
+    public void testMultipleDynamicFiltersOnSameProbeVariable()
+            throws ExecutionException, InterruptedException
+    {
+        // A two-sided range predicate "a >= x AND a < y" (or BETWEEN) produces two comparison dynamic
+        // filters (lower and upper bound) that both target the same probe variable "a". The resulting
+        // domains must be intersected rather than overwriting each other, otherwise building the result
+        // used to fail with "Multiple entries with same key: a=Domain@... and a=Domain@...".
+        LocalDynamicFilter filter = new LocalDynamicFilter(
+                ImmutableMultimap.of(
+                        "123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression(Optional.empty(), "a", INTEGER), GREATER_THAN_OR_EQUAL),
+                        "456", new DynamicFilterPlaceholder("456", new VariableReferenceExpression(Optional.empty(), "a", INTEGER), LESS_THAN)),
+                ImmutableMap.of("123", 0, "456", 1),
+                1);
+        assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0, "456", 1));
+        Consumer<TupleDomain<String>> consumer = filter.getTupleDomainConsumer();
+        ListenableFuture<TupleDomain<VariableReferenceExpression>> result = filter.getResultFuture();
+        assertFalse(result.isDone());
+
+        consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
+                "123", Domain.singleValue(INTEGER, 10L),
+                "456", Domain.singleValue(INTEGER, 20L))));
+
+        // "123" (>= 10) -> [10, +inf), "456" (< 20) -> (-inf, 20); intersected -> [10, 20)
+        Domain expectedDomain = Domain.create(ValueSet.ofRanges(Range.range(INTEGER, 10L, true, 20L, false)), false);
+        assertEquals(result.get(), TupleDomain.withColumnDomains(ImmutableMap.of(
+                new VariableReferenceExpression(Optional.empty(), "a", INTEGER), expectedDomain)));
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
A two-sided range predicate such as "a >= x AND a < y" (or BETWEEN) produces two comparison dynamic filters that both target the same probe variable "a". LocalDynamicFilter.convertTupleDomain built the probe-side TupleDomain with an ImmutableMap.Builder, which rejects duplicate keys, so such queries failed with "Multiple entries with same key: a=Domain@... and a=Domain@...".

Intersect the domains for the same probe variable instead of overwriting, which matches the semantics of combining a lower and an upper bound on one column.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

When dynamic filtering is enabled, a two-sided range predicate on a probe-side join key — most commonly a BETWEEN ... AND ... predicate, which is desugared into col >= lower AND col <= upper — produces two comparison dynamic filters (a lower bound and an upper bound) that both target the same probe variable.

LocalDynamicFilter.convertTupleDomain() built the probe-side TupleDomain with an ImmutableMap.Builder, which rejects duplicate keys. As soon as both bounds resolve to the same probe column, building the map throws:
```
java.lang.IllegalArgumentException: Multiple entries with same key:
  a=Domain@... and a=Domain@...
```
so the whole query fails. This is especially visible in cross-source / cross-connector joins, where such range dynamic filters are pushed down to the probe side.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Add a unit test covering two dynamic filters on the same probe variable.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).


## Summary by Sourcery

Tests:
- Add a unit test verifying that two dynamic filters on the same probe variable produce an intersected range domain rather than causing a duplicate key failure.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== RELEASE NOTES ==

General Changes
* Fix query failure with a ``Multiple entries with same key`` error when dynamic filtering is enabled and a probe-side join key has a two-sided range predicate (for example ``BETWEEN ... AND ...``, or ``a >= x AND a < y``).

```