### PR TITLE
fix(ci): Allow unsafe checkout in codenotify workflow to unblock pull_request_target

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -19,6 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           show-progress: false
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: sourcegraph/codenotify@54e4320f0d93f162a371d8d9dc1fb11018199746 # v0.6.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Since codenotify.yml only reads CODENOTIFY files and never executes the checked-out fork code, explicitly opting in with allow-unsafe-pr-checkout: true is safe and matches what actions/checkout@v6 now requires for pull_request_target workflows.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Recent changes introduced by GitHub: https://github.com/actions/checkout/pull/2454 and https://github.com/actions/checkout/pull/2500

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Enable unsafe PR checkout in the codenotify workflow so pull_request_target jobs can continue to run with actions/checkout@v6.