### PR TITLE
fix: StreamConstraintsException in Presto on Spark plan serialization

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -180,6 +180,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionModule;
 import com.facebook.presto.spark.execution.property.NativeExecutionConfigModule;
 import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
@@ -42,6 +43,17 @@ public class PrestoSparkServiceFactory
     @Override
     public IPrestoSparkService createService(SparkProcessType sparkProcessType, PrestoSparkConfiguration configuration, PrestoSparkBootstrapTimer bootstrapTimer)
     {
+        // Presto on Spark does not run PrestoServer.run(), so apply the same relaxation of
+        // Jackson 2.18's default 50,000-char maxNameLength here. createService() is the single
+        // chokepoint for both the driver service and every executor, and runs inside the Presto
+        // classloader where StreamReadConstraints is available. Without this, JsonCodec<PlanFragment>
+        // fails when Assignments map keys (VariableReferenceExpression names) exceed the limit.
+        // Must run before any JsonFactory is constructed (including the static one in JsonCodec).
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(
+                StreamReadConstraints.builder()
+                        .maxNameLength(Integer.MAX_VALUE)
+                        .build());
+
         bootstrapTimer.beginPrestoSparkServiceCreation();
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(configuration.getConfigProperties());


### PR DESCRIPTION
## Description
Jackson 2.18 (adopted in #28084) enforces a default maximum JSON property-name
length of 50,000 characters via `StreamReadConstraints`. `PrestoServer.run()`
already raises this limit so that `JsonCodec<PlanFragment>` can serialize plans
whose `Assignments` map keys (`VariableReferenceExpression` names) exceed it.

Presto on Spark does not run `PrestoServer.run()`: its driver service and every
executor are created in `PrestoSparkServiceFactory.createService()`, which never
applied the override. As a result, Presto on Spark tasks could fail with
`com.fasterxml.jackson.core.exc.StreamConstraintsException` when serializing plan
fragments that contain long JSON property names.

This applies the same `StreamReadConstraints.overrideDefaultStreamReadConstraints(...)`
call at the start of `PrestoSparkServiceFactory.createService()`, the single
service-creation entry point for both the driver service and the executors. It runs
inside the Presto classloader (where `StreamReadConstraints` is available) and before
any `JsonFactory` is constructed, including the static one inside `JsonCodec`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).


## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix query failures on Presto on Spark caused by Jackson's default maximum JSON property-name length by applying the same ``StreamReadConstraints`` override used by the Presto server.

```

Differential Revision: D113076907

## Summary by Sourcery

Bug Fixes:
- Prevent Presto on Spark tasks from failing with StreamConstraintsException when serializing plan fragments containing long JSON property names.