### PR TITLE
fix: Relax Jackson name-length and nesting-depth limits for Presto on Spark plan serialization

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -180,6 +180,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -22,6 +22,8 @@ import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionModule;
 import com.facebook.presto.spark.execution.property.NativeExecutionConfigModule;
 import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
@@ -42,6 +44,7 @@ public class PrestoSparkServiceFactory
     @Override
     public IPrestoSparkService createService(SparkProcessType sparkProcessType, PrestoSparkConfiguration configuration, PrestoSparkBootstrapTimer bootstrapTimer)
     {
+        overrideJacksonStreamConstraints();
         bootstrapTimer.beginPrestoSparkServiceCreation();
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(configuration.getConfigProperties());
@@ -64,6 +67,17 @@ public class PrestoSparkServiceFactory
         bootstrapTimer.endPrestoSparkServiceCreation();
         log.info("Initialized");
         return prestoSparkService;
+    }
+
+    // Presto on Spark bootstraps here instead of PrestoServer.run(); relax Jackson's default read
+    // name-length and write nesting-depth limits so large plan fragments (de)serialize. Mutates
+    // JVM-global Jackson defaults, so it must run before any JsonFactory is constructed.
+    static void overrideJacksonStreamConstraints()
+    {
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(
+                StreamReadConstraints.builder().maxNameLength(Integer.MAX_VALUE).build());
+        StreamWriteConstraints.overrideDefaultStreamWriteConstraints(
+                StreamWriteConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build());
     }
 
     protected List<Module> getAdditionalModules(PrestoSparkConfiguration configuration)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkServiceFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestPrestoSparkServiceFactory
+{
+    private static final int LONG_NAME_LENGTH = 60_000;
+    private static final int NESTING_DEPTH = 1_500;
+
+    private StreamReadConstraints originalReadConstraints;
+    private StreamWriteConstraints originalWriteConstraints;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        // Capture the JVM-global Jackson defaults, then start each test from the stock limits.
+        originalReadConstraints = StreamReadConstraints.defaults();
+        originalWriteConstraints = StreamWriteConstraints.defaults();
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(StreamReadConstraints.builder().build());
+        StreamWriteConstraints.overrideDefaultStreamWriteConstraints(StreamWriteConstraints.builder().build());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(originalReadConstraints);
+        StreamWriteConstraints.overrideDefaultStreamWriteConstraints(originalWriteConstraints);
+    }
+
+    @Test
+    public void testOverrideRelaxesJsonPropertyNameLimit()
+    {
+        Map<String, String> value = ImmutableMap.of(Strings.repeat("a", LONG_NAME_LENGTH), "v");
+        PrestoSparkServiceFactory.overrideJacksonStreamConstraints();
+
+        JsonCodec<Map<String, String>> codec = new JsonCodecFactory().mapJsonCodec(String.class, String.class);
+        assertEquals(codec.fromJson(codec.toJsonBytes(value)), value);
+    }
+
+    @Test
+    public void testOverrideRelaxesJsonNestingDepthLimit()
+    {
+        Object nested = "v";
+        for (int i = 0; i < NESTING_DEPTH; i++) {
+            nested = Collections.singletonList(nested);
+        }
+        PrestoSparkServiceFactory.overrideJacksonStreamConstraints();
+
+        JsonCodec<Object> codec = new JsonCodecFactory().jsonCodec(Object.class);
+        assertTrue(codec.toJsonBytes(nested).length > 0);
+    }
+}


### PR DESCRIPTION
Summary:
## Description

Presto on Spark bootstraps through `PrestoSparkServiceFactory.createService()` rather than `PrestoServer.run()`, so it never applied the Jackson `StreamReadConstraints` / `StreamWriteConstraints` overrides the Presto server uses after the Jackson 2.18 upgrade (#28084). As a result, Presto on Spark tasks failed on large plan fragments:

- Read: `StreamConstraintsException` when a JSON property name (an `Assignments` map key / `VariableReferenceExpression` name) exceeds the default 50,000-char `maxNameLength`, during plan deserialization on executors.
- Write: `StreamConstraintsException` when the plan JSON nests deeper than the default 1,000-level `maxNestingDepth` (for example long left-deep `add(add(A, B), C), ...` chains), during serialization on the driver.

Both overrides are centralized in `PrestoSparkServiceFactory.overrideJacksonStreamConstraints()`, invoked at the start of `createService()` -- the single service-creation entry point for the driver service and every executor -- before any `JsonFactory` is constructed.

Two regression tests in `presto-spark-base` guard each side: they reset the Jackson defaults, invoke `overrideJacksonStreamConstraints()`, round-trip an oversized payload through an airlift `JsonCodec`, and restore the global constraints afterwards. They fail without the override and pass with it.

## Motivation and Context

Jackson 2.18 (#28084) enforces default limits on JSON property-name length (read) and nesting depth (write). `PrestoServer.run()` raises the read limit and `PrestoObjectMapperProvider` raises the write limit for the Presto server; #28200 added the read override for Presto on Spark. This change completes Presto on Spark coverage by also relaxing the write nesting-depth limit and adds regression tests for both sides, so a future Jackson upgrade or refactor cannot silently reintroduce the failures.

## Impact

Fixes Presto on Spark query failures on large plan fragments. No public API change.

## Contributor checklist

- [x] Please make sure your submission complies with our development and contributing guidelines
- [x] PR description addresses the issue accurately and concisely.
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D113116291
