### PR TITLE
fix(security): Upgrade fast-uri version  to 3.1.4

### DIFF
--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -81,6 +81,7 @@
     "test:ci": "jest --ci --coverage --maxWorkers=2"
   },
   "resolutions": {
-    "d3-color": "3.1.0"
+    "d3-color": "3.1.0",
+    "fast-uri": "3.1.4"
   }
 }

--- a/presto-ui/src/yarn.lock
+++ b/presto-ui/src/yarn.lock
@@ -4247,10 +4247,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ecz"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@3.1.4, fast-uri@^3.0.1:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
## Description
Upgrades `fast-uri` from 3.1.2 to 3.1.4 in the Presto UI to address a reported security vulnerability. The version is pinned via the `resolutions` field in `package.json` and the lockfile is updated accordingly.

<img width="1207" height="916" alt="image" src="https://github.com/user-attachments/assets/16f2ba97-c4c6-4477-a779-2c5c066cc3ce" />


## Motivation and Context
`fast-uri` 3.1.3 contains a security fix. This upgrade ensures the Presto UI does not ship a vulnerable version of the dependency.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade fast-uri version to 3.1.4 to address `CVE-2026-13676 <https://nvd.nist.gov/vuln/detail/CVE-2026-13676>`_.
```

## Summary by Sourcery

Build:
- Pin fast-uri to version 3.1.3 via the package.json resolutions field and update the lockfile accordingly.