### PR TITLE
build: Do not exclude mysql driver in native-plugin presto packaging

### DIFF
--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -392,7 +392,6 @@
     <artifactSet to="native-plugin/mysql">
         <artifact id="${project.groupId}:presto-mysql:zip:${project.version}">
             <unpack />
-            <exclude dir="mysql-connector-j-9.2.0.jar" />
         </artifact>
     </artifactSet>
 


### PR DESCRIPTION
## Description
The mysql driver was accidentally excluded from in previous commit from #26404, this allows it to be included in the presto packaging. 

## Motivation and Context
For OSS work, the mysql driver is needed.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Restore the MySQL driver to native-plugin Presto packages for OSS use.

Bug Fixes:
- Include the MySQL JDBC driver in native-plugin Presto packaging.

Build:
- Update native-plugin packaging configuration to stop excluding the MySQL connector.