### PR TITLE
feat(function): Support any-typed variadic tail in JSON-file function definitions

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -61,6 +61,11 @@ public final class StandardTypes
     public static final String DISTINCT_TYPE = "DistinctType";
     public static final String UUID = "uuid";
     public static final String UNKNOWN = "unknown";
+    // Internal sentinel usable ONLY as the tail type of a variable-arity function signature. It means
+    // "each trailing argument may be any type, bound independently" (no unification across the tail,
+    // unlike a shared type variable). It is not a registered Type and never reaches execution -- the
+    // dispatcher folds the tail into a single JSON argument. The __NAME__ form marks it as internal.
+    public static final String ANY = "__ANY__";
 
     private StandardTypes() {}
 

--- a/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
+++ b/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
@@ -87,6 +87,32 @@ public class JsonBasedUdfFunctionMetadata
      * Set by the sidecar based on AsyncRPCFunctionRegistry.
      */
     private final boolean isRpcFunction;
+    /**
+     * Optional function body. For SQL-language functions this is the routine body that is inlined and
+     * executed locally; empty for remote/CPP functions whose implementation lives elsewhere.
+     */
+    private final Optional<String> body;
+
+    // Backwards-compatible constructor (no body) used by non-JSON construction sites.
+    public JsonBasedUdfFunctionMetadata(
+            String docString,
+            FunctionKind functionKind,
+            TypeSignature outputType,
+            List<TypeSignature> paramTypes,
+            String schema,
+            boolean variableArity,
+            RoutineCharacteristics routineCharacteristics,
+            Optional<AggregationFunctionMetadata> aggregateMetadata,
+            Optional<SqlFunctionId> functionId,
+            Optional<String> version,
+            Optional<List<TypeVariableConstraint>> typeVariableConstraints,
+            Optional<List<LongVariableConstraint>> longVariableConstraints,
+            Optional<URI> executionEndpoint,
+            boolean isRpcFunction)
+    {
+        this(docString, functionKind, outputType, paramTypes, schema, variableArity, routineCharacteristics, aggregateMetadata, functionId, version,
+                typeVariableConstraints, longVariableConstraints, executionEndpoint, isRpcFunction, Optional.empty());
+    }
 
     @JsonCreator
     public JsonBasedUdfFunctionMetadata(
@@ -103,7 +129,8 @@ public class JsonBasedUdfFunctionMetadata
             @JsonProperty("typeVariableConstraints") Optional<List<TypeVariableConstraint>> typeVariableConstraints,
             @JsonProperty("longVariableConstraints") Optional<List<LongVariableConstraint>> longVariableConstraints,
             @JsonProperty("executionEndpoint") Optional<URI> executionEndpoint,
-            @JsonProperty("isRpcFunction") boolean isRpcFunction)
+            @JsonProperty("isRpcFunction") boolean isRpcFunction,
+            @JsonProperty("body") Optional<String> body)
     {
         this.docString = requireNonNull(docString, "docString is null");
         this.functionKind = requireNonNull(functionKind, "functionKind is null");
@@ -128,6 +155,7 @@ public class JsonBasedUdfFunctionMetadata
             }
         });
         this.isRpcFunction = isRpcFunction;
+        this.body = requireNonNull(body, "body is null");
     }
 
     @JsonProperty
@@ -218,5 +246,11 @@ public class JsonBasedUdfFunctionMetadata
     public boolean getIsRpcFunction()
     {
         return isRpcFunction;
+    }
+
+    @JsonProperty
+    public Optional<String> getBody()
+    {
+        return body;
     }
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.functionNamespace.json;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.UserDefinedType;
@@ -30,11 +31,15 @@ import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.TypeVariableConstraint;
 import com.google.common.collect.ImmutableList;
 import jakarta.inject.Inject;
 
@@ -42,6 +47,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
@@ -107,10 +113,13 @@ public class JsonFileBasedFunctionNamespaceManager
         return new SqlInvokedFunction(
                 function.getSignature().getName(),
                 function.getParameters(),
+                function.getSignature().getTypeVariableConstraints(),
+                function.getSignature().getLongVariableConstraints(),
                 function.getSignature().getReturnType(),
                 function.getDescription(),
                 function.getRoutineCharacteristics(),
                 function.getBody(),
+                function.getVariableArity(),
                 function.getVersion(),
                 function.getSignature().getKind(),
                 function.getAggregationMetadata());
@@ -140,21 +149,46 @@ public class JsonFileBasedFunctionNamespaceManager
         List<String> parameterNameList = jsonBasedUdfFunctionMetaData.getParamNames();
         List<TypeSignature> parameterTypeList = jsonBasedUdfFunctionMetaData.getParamTypes();
 
+        boolean variableArity = jsonBasedUdfFunctionMetaData.getVariableArity();
+        validateAnyType(qualifiedFunctionName, parameterTypeList, variableArity);
+
         ImmutableList.Builder<Parameter> parameterBuilder = ImmutableList.builder();
         for (int i = 0; i < parameterNameList.size(); i++) {
             parameterBuilder.add(new Parameter(parameterNameList.get(i), parameterTypeList.get(i)));
         }
 
+        List<TypeVariableConstraint> typeVariableConstraints = jsonBasedUdfFunctionMetaData.getTypeVariableConstraints().orElse(ImmutableList.of());
+        List<LongVariableConstraint> longVariableConstraints = jsonBasedUdfFunctionMetaData.getLongVariableConstraints().orElse(ImmutableList.of());
+
         return new SqlInvokedFunction(
                 qualifiedFunctionName,
                 parameterBuilder.build(),
+                typeVariableConstraints,
+                longVariableConstraints,
                 jsonBasedUdfFunctionMetaData.getOutputType(),
                 jsonBasedUdfFunctionMetaData.getDocString(),
                 jsonBasedUdfFunctionMetaData.getRoutineCharacteristics(),
-                "",
+                jsonBasedUdfFunctionMetaData.getBody().orElse(""),
+                variableArity,
                 notVersioned(),
                 jsonBasedUdfFunctionMetaData.getFunctionKind(),
                 jsonBasedUdfFunctionMetaData.getAggregateMetadata());
+    }
+
+    // The "any" sentinel type is only meaningful as the tail of a variable-arity signature (each
+    // trailing argument may then be of any type). Reject any other usage so it cannot leak into a
+    // non-variadic or non-tail position, where it would fail to bind in a confusing way.
+    private static void validateAnyType(QualifiedObjectName functionName, List<TypeSignature> parameterTypes, boolean variableArity)
+    {
+        for (int i = 0; i < parameterTypes.size(); i++) {
+            if (StandardTypes.ANY.equals(parameterTypes.get(i).getBase())) {
+                if (!variableArity || i != parameterTypes.size() - 1) {
+                    throw new PrestoException(
+                            GENERIC_USER_ERROR,
+                            format("Function '%s' uses type '%s', which is only allowed as the last argument of a variable-arity function", functionName, StandardTypes.ANY));
+                }
+            }
+        }
     }
 
     @Override
@@ -169,9 +203,17 @@ public class JsonFileBasedFunctionNamespaceManager
     @Override
     protected FunctionMetadata sqlInvokedFunctionToMetadata(SqlInvokedFunction function)
     {
+        return toMetadata(function, function.getSignature().getArgumentTypes());
+    }
+
+    // Builds metadata using the supplied argument types rather than the declared ones. For a
+    // variable-arity call the supplied types are the call-arity (expanded) types, so the analyzer's
+    // per-argument checks line up with the actual call site.
+    private FunctionMetadata toMetadata(SqlInvokedFunction function, List<TypeSignature> argumentTypes)
+    {
         return new FunctionMetadata(
                 function.getSignature().getName(),
-                function.getSignature().getArgumentTypes(),
+                argumentTypes,
                 function.getParameters().stream()
                         .map(Parameter::getName)
                         .collect(toImmutableList()),
@@ -182,7 +224,22 @@ public class JsonFileBasedFunctionNamespaceManager
                 function.isDeterministic(),
                 function.isCalledOnNullInput(),
                 function.getVersion(),
-                function.getDescription());
+                function.getDescription(),
+                anyVariadicTailPosition(function));
+    }
+
+    // For a variable-arity function whose declared tail is the internal __ANY__ sentinel, returns the
+    // index where the trailing (any-typed) arguments begin. The RowExpression translator uses this to
+    // fold the tail into a single JSON argument. Empty for all other functions.
+    private static OptionalInt anyVariadicTailPosition(SqlInvokedFunction function)
+    {
+        List<TypeSignature> declaredArgumentTypes = function.getSignature().getArgumentTypes();
+        if (function.getVariableArity()
+                && !declaredArgumentTypes.isEmpty()
+                && StandardTypes.ANY.equals(declaredArgumentTypes.get(declaredArgumentTypes.size() - 1).getBase())) {
+            return OptionalInt.of(declaredArgumentTypes.size() - 1);
+        }
+        return OptionalInt.empty();
     }
 
     @Override
@@ -194,19 +251,78 @@ public class JsonFileBasedFunctionNamespaceManager
     @Override
     protected FunctionMetadata fetchFunctionMetadataDirect(SqlFunctionHandle functionHandle)
     {
-        return fetchFunctionsDirect(functionHandle.getFunctionId().getFunctionName()).stream()
+        return toMetadata(resolveFunctionForHandle(functionHandle), functionHandle.getFunctionId().getArgumentTypes());
+    }
+
+    // A variable-arity call's argument types are expanded during binding, so its handle does not
+    // match any declared function by exact handle equality. Fall back to the declared variable-arity
+    // function whose signature accepts the (call-arity) argument types carried by the handle.
+    private SqlInvokedFunction resolveFunctionForHandle(SqlFunctionHandle functionHandle)
+    {
+        Collection<SqlInvokedFunction> candidates = fetchFunctionsDirect(functionHandle.getFunctionId().getFunctionName());
+        List<TypeSignature> argumentTypes = functionHandle.getFunctionId().getArgumentTypes();
+        return candidates.stream()
                 .filter(function -> function.getRequiredFunctionHandle().equals(functionHandle))
-                .map(this::sqlInvokedFunctionToMetadata)
-                .collect(onlyElement());
+                .findFirst()
+                .orElseGet(() -> candidates.stream()
+                        .filter(SqlInvokedFunction::getVariableArity)
+                        .filter(function -> variableArityAccepts(function.getSignature().getArgumentTypes(), argumentTypes))
+                        .collect(onlyElement()));
+    }
+
+    @Override
+    public FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature)
+    {
+        SqlFunctionId functionId = new SqlFunctionId(signature.getName(), signature.getArgumentTypes());
+        if (!latestFunctions.containsKey(functionId)) {
+            // Variable-arity call: bind to the declared variable-arity function and carry the
+            // call-arity argument types in the handle (mirrors the native function namespace manager).
+            SqlInvokedFunction variableArityFunction = findVariableArityFunction(signature);
+            if (variableArityFunction != null) {
+                return new SqlFunctionHandle(functionId, variableArityFunction.getRequiredVersion());
+            }
+        }
+        return super.getFunctionHandle(transactionHandle, signature);
+    }
+
+    private SqlInvokedFunction findVariableArityFunction(Signature signature)
+    {
+        return latestFunctions.values().stream()
+                .filter(function -> function.getSignature().getName().equals(signature.getName()))
+                .filter(SqlInvokedFunction::getVariableArity)
+                .filter(function -> variableArityAccepts(function.getSignature().getArgumentTypes(), signature.getArgumentTypes()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // Whether a declared variable-arity signature (fixed head + repeated/any tail) accepts the given
+    // (already-bound) call-arity argument types.
+    private static boolean variableArityAccepts(List<TypeSignature> declared, List<TypeSignature> actual)
+    {
+        if (declared.isEmpty() || actual.size() < declared.size() - 1) {
+            return false;
+        }
+        for (int i = 0; i < declared.size() - 1; i++) {
+            if (!declared.get(i).equals(actual.get(i))) {
+                return false;
+            }
+        }
+        TypeSignature tail = declared.get(declared.size() - 1);
+        if (StandardTypes.ANY.equals(tail.getBase())) {
+            return true;
+        }
+        for (int i = declared.size() - 1; i < actual.size(); i++) {
+            if (!tail.equals(actual.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     protected ScalarFunctionImplementation fetchFunctionImplementationDirect(SqlFunctionHandle functionHandle)
     {
-        return fetchFunctionsDirect(functionHandle.getFunctionId().getFunctionName()).stream()
-                .filter(function -> function.getRequiredFunctionHandle().equals(functionHandle))
-                .map(this::sqlInvokedFunctionToImplementation)
-                .collect(onlyElement());
+        return sqlInvokedFunctionToImplementation(resolveFunctionForHandle(functionHandle));
     }
 
     @Override

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestJsonFileBasedFunctionNamespaceManager.java
@@ -14,20 +14,33 @@
 package com.facebook.presto.functionNamespace;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutorsModule;
 import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManager;
 import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerModule;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.inject.Injector;
 import org.testng.annotations.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.TEST_CATALOG;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TestJsonFileBasedFunctionNamespaceManager
 {
@@ -49,6 +62,53 @@ public class TestJsonFileBasedFunctionNamespaceManager
         jsonFileBasedFunctionNameSpaceManager = createFunctionNamespaceManager(jsonDirName);
         functionList = jsonFileBasedFunctionNameSpaceManager.listFunctions(Optional.empty(), Optional.empty());
         assertEquals(functionList.size(), dirFunctionCount);
+    }
+
+    @Test
+    public void testLoadVariableArityAnyFunction()
+    {
+        JsonFileBasedFunctionNamespaceManager manager = createFunctionNamespaceManager("json_udf_variable_arity.json");
+        SqlInvokedFunction function = manager.listFunctions(Optional.empty(), Optional.empty()).stream()
+                .filter(candidate -> candidate.getSignature().getName().getObjectName().equals("format_any"))
+                .collect(onlyElement());
+
+        assertTrue(function.getVariableArity());
+        assertEquals(function.getSignature().getArgumentTypes().get(function.getSignature().getArgumentTypes().size() - 1).getBase(), "__ANY__");
+    }
+
+    @Test
+    public void testAnyTypeRejectedOutsideVariadicTail()
+    {
+        try {
+            createFunctionNamespaceManager("json_udf_invalid_any.json");
+            fail("expected loading a function that misuses the 'any' type to fail");
+        }
+        catch (RuntimeException e) {
+            String trace = getStackTraceAsString(e);
+            assertTrue(
+                    trace.contains("only allowed as the last argument of a variable-arity function"),
+                    "unexpected failure: " + trace);
+        }
+    }
+
+    @Test
+    public void testVariableArityAnyCallResolvesEndToEnd()
+    {
+        JsonFileBasedFunctionNamespaceManager manager = createFunctionNamespaceManager("json_udf_variable_arity.json");
+        QualifiedObjectName name = QualifiedObjectName.valueOf(TEST_CATALOG, "test_schema", "format_any");
+        List<TypeSignature> callArgumentTypes = ImmutableList.of(
+                parseTypeSignature("varchar"),
+                parseTypeSignature("double"),
+                parseTypeSignature("varchar"));
+        // The bound signature the analyzer produces for format_any(varchar, double, varchar).
+        Signature boundSignature = new Signature(name, SCALAR, parseTypeSignature("varchar"), callArgumentTypes);
+
+        FunctionHandle handle = manager.getFunctionHandle(Optional.empty(), boundSignature);
+        FunctionMetadata metadata = manager.getFunctionMetadata(handle);
+
+        assertEquals(metadata.getName(), name);
+        // Metadata carries the call-arity argument types, so per-argument analysis lines up with the call.
+        assertEquals(metadata.getArgumentTypes(), callArgumentTypes);
     }
 
     private JsonFileBasedFunctionNamespaceManager createFunctionNamespaceManager(String filePath)

--- a/presto-function-namespace-managers/src/test/resources/json_udf_invalid_any.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_invalid_any.json
@@ -1,0 +1,22 @@
+{
+  "udfSignatureMap": {
+    "bad_any": [
+      {
+        "docString": "invalid: 'any' is not the last argument of a variable-arity function",
+        "functionKind": "SCALAR",
+        "outputType": "varchar",
+        "paramTypes": [
+          "__ANY__",
+          "varchar"
+        ],
+        "schema": "test_schema",
+        "variableArity": true,
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}

--- a/presto-function-namespace-managers/src/test/resources/json_udf_variable_arity.json
+++ b/presto-function-namespace-managers/src/test/resources/json_udf_variable_arity.json
@@ -1,0 +1,22 @@
+{
+  "udfSignatureMap": {
+    "format_any": [
+      {
+        "docString": "formats a template with a variable number of arguments of any type",
+        "functionKind": "SCALAR",
+        "outputType": "varchar",
+        "paramTypes": [
+          "varchar",
+          "__ANY__"
+        ],
+        "schema": "test_schema",
+        "variableArity": true,
+        "routineCharacteristics": {
+          "language": "CPP",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        }
+      }
+    ]
+  }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.Signature;
@@ -58,8 +60,12 @@ public final class FunctionSignatureMatcher
 
     public Optional<Signature> match(Collection<? extends SqlFunction> candidates, List<TypeSignatureProvider> parameterTypes, boolean coercionAllowed)
     {
+        // An "any" variadic tail matches almost anything, so treat such functions as generic (not exact):
+        // this lets a same-named fixed-arity overload (e.g. the concrete (varchar, json) an "any" tail is
+        // folded into) win the exact match first, instead of colliding ambiguously with the variadic one.
         List<SqlFunction> exactCandidates = candidates.stream()
                 .filter(function -> function.getSignature().getTypeVariableConstraints().isEmpty())
+                .filter(function -> !isAnyVariadic(function))
                 .collect(Collectors.toList());
 
         Optional<Signature> match = matchFunctionExact(exactCandidates, parameterTypes);
@@ -68,7 +74,7 @@ public final class FunctionSignatureMatcher
         }
 
         List<SqlFunction> genericCandidates = candidates.stream()
-                .filter(function -> !function.getSignature().getTypeVariableConstraints().isEmpty())
+                .filter(function -> !function.getSignature().getTypeVariableConstraints().isEmpty() || isAnyVariadic(function))
                 .collect(Collectors.toList());
 
         match = matchFunctionGeneric(genericCandidates, parameterTypes);
@@ -84,6 +90,17 @@ public final class FunctionSignatureMatcher
         }
 
         return Optional.empty();
+    }
+
+    // A variable-arity function whose tail is the internal "any" sentinel (StandardTypes.ANY). It binds
+    // almost any argument list, so it is matched as a generic candidate rather than an exact one.
+    private static boolean isAnyVariadic(SqlFunction function)
+    {
+        Signature signature = function.getSignature();
+        List<TypeSignature> argumentTypes = signature.getArgumentTypes();
+        return signature.isVariableArity()
+                && !argumentTypes.isEmpty()
+                && StandardTypes.ANY.equals(argumentTypes.get(argumentTypes.size() - 1).getBase());
     }
 
     private Optional<Signature> matchFunctionExact(List<SqlFunction> candidates, List<TypeSignatureProvider> actualParameters)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -75,6 +75,12 @@ public class SignatureBinder
     // 4 is chosen arbitrarily here. This limit is set to avoid having infinite loops in iterative solving.
     private static final int SOLVE_ITERATION_LIMIT = 4;
 
+    // Prefix for the synthetic, per-position type variables that an "any" variadic tail
+    // (StandardTypes.ANY as the last formal of a variable-arity signature) expands into. Each
+    // trailing argument binds an independent, unconstrained variable, so a mixed-type tail such
+    // as (varchar, double, varchar) binds without unifying to a common supertype.
+    private static final String ANY_VARARG_VARIABLE_PREFIX = "$any$";
+
     private final FunctionAndTypeManager functionAndTypeManager;
     private final Signature declaredSignature;
     private final boolean allowCoercion;
@@ -318,13 +324,19 @@ public class SignatureBinder
         }
 
         if (formalTypeSignature.getParameters().isEmpty()) {
-            TypeVariableConstraint typeVariableConstraint = typeVariableConstraints.get(formalTypeSignature.getBase());
+            String base = formalTypeSignature.getBase();
+            TypeVariableConstraint typeVariableConstraint = typeVariableConstraints.get(base);
+            if (typeVariableConstraint == null && isAnyVarargVariable(base)) {
+                // synthetic per-position variable produced by an "any" variadic tail: unconstrained,
+                // so it binds to whatever concrete type appears at this position.
+                typeVariableConstraint = new TypeVariableConstraint(base, false, false, null, false);
+            }
             if (typeVariableConstraint == null) {
                 return true;
             }
             Type actualType = functionAndTypeManager.getType(actualTypeSignatureProvider.getTypeSignature());
             resultBuilder.add(new TypeParameterSolver(
-                    formalTypeSignature.getBase(),
+                    base,
                     actualType,
                     typeVariableConstraint));
             return true;
@@ -365,9 +377,19 @@ public class SignatureBinder
         return typeBase.equals(StandardTypes.ARRAY) || typeBase.equals(StandardTypes.MAP);
     }
 
+    private static boolean isAnyVarargType(TypeSignature typeSignature)
+    {
+        return StandardTypes.ANY.equals(typeSignature.getBase()) && typeSignature.getParameters().isEmpty();
+    }
+
+    private static boolean isAnyVarargVariable(String base)
+    {
+        return base.startsWith(ANY_VARARG_VARIABLE_PREFIX);
+    }
+
     private Set<String> typeVariablesOf(TypeSignature typeSignature)
     {
-        if (typeVariableConstraints.containsKey(typeSignature.getBase())) {
+        if (typeVariableConstraints.containsKey(typeSignature.getBase()) || isAnyVarargVariable(typeSignature.getBase())) {
             return ImmutableSet.of(typeSignature.getBase());
         }
         Set<String> variables = new HashSet<>();
@@ -477,7 +499,15 @@ public class SignatureBinder
 
     private boolean allTypeVariablesBound(BoundVariables boundVariables)
     {
-        return boundVariables.getTypeVariables().keySet().equals(typeVariableConstraints.keySet());
+        Set<String> boundTypeVariables = boundVariables.getTypeVariables().keySet();
+        // Synthetic per-position variables from an "any" variadic tail are not part of the declared
+        // constraints; ignore them and require exactly the declared type variables to be bound.
+        for (String bound : boundTypeVariables) {
+            if (!isAnyVarargVariable(bound) && !typeVariableConstraints.containsKey(bound)) {
+                return false;
+            }
+        }
+        return boundTypeVariables.containsAll(typeVariableConstraints.keySet());
     }
 
     private static TypeSignatureParameter applyBoundVariables(TypeSignatureParameter parameter, BoundVariables boundVariables)
@@ -515,6 +545,16 @@ public class SignatureBinder
         int variableArityArgumentsCount = actualArity - formalTypeSignatures.size() + 1;
         if (variableArityArgumentsCount == 0) {
             return formalTypeSignatures.subList(0, formalTypeSignatures.size() - 1);
+        }
+        // An "any" variadic tail expands to a distinct fresh type variable per trailing position,
+        // so each argument binds its own concrete type (no unification across the tail).
+        if (isAnyVarargType(formalTypeSignatures.get(formalTypeSignatures.size() - 1))) {
+            ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
+            builder.addAll(formalTypeSignatures.subList(0, formalTypeSignatures.size() - 1));
+            for (int i = 0; i < variableArityArgumentsCount; i++) {
+                builder.add(new TypeSignature(ANY_VARARG_VARIABLE_PREFIX + i));
+            }
+            return builder.build();
         }
         if (variableArityArgumentsCount == 1) {
             return formalTypeSignatures;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -551,14 +551,51 @@ public final class SqlToRowExpressionTranslator
                     .map(TypeSignatureProvider::new)
                     .collect(toImmutableList());
 
-            return call(node.getName().toString(),
-                    functionAndTypeResolver.resolveFunction(
-                            Optional.of(sessionFunctions),
-                            transactionId,
-                            functionAndTypeResolver.qualifyObjectName(node.getName()),
-                            argumentTypes),
-                    getType(node),
-                    arguments);
+            FunctionHandle functionHandle = functionAndTypeResolver.resolveFunction(
+                    Optional.of(sessionFunctions),
+                    transactionId,
+                    functionAndTypeResolver.qualifyObjectName(node.getName()),
+                    argumentTypes);
+
+            OptionalInt varArgPosStart = functionAndTypeResolver.getFunctionMetadata(functionHandle).getVarArgPosStart();
+            if (varArgPosStart.isPresent()) {
+                return foldAnyVariadicTailToJson(node, arguments, varArgPosStart.getAsInt());
+            }
+
+            return call(node.getName().toString(), functionHandle, getType(node), arguments);
+        }
+
+        // A call to a variable-arity "__ANY__" function: pack the trailing (any-typed) arguments into a
+        // single JSON value -- CAST(ROW(tail...) AS JSON) -- and dispatch to the concrete (head..., json)
+        // overload, so the RowExpression layer only ever sees a fixed-arity, executable call.
+        private RowExpression foldAnyVariadicTailToJson(FunctionCall node, List<RowExpression> arguments, int varArgPosStart)
+        {
+            List<RowExpression> tail = arguments.subList(varArgPosStart, arguments.size());
+            RowExpression tailRow = specialForm(
+                    ROW_CONSTRUCTOR,
+                    RowType.anonymous(tail.stream().map(RowExpression::getType).collect(toImmutableList())),
+                    tail);
+            RowExpression tailJson = call(
+                    CAST.name(),
+                    functionAndTypeResolver.lookupCast("CAST", tailRow.getType(), JSON),
+                    JSON,
+                    tailRow);
+
+            List<RowExpression> foldedArguments = ImmutableList.<RowExpression>builder()
+                    .addAll(arguments.subList(0, varArgPosStart))
+                    .add(tailJson)
+                    .build();
+            List<TypeSignatureProvider> foldedArgumentTypes = foldedArguments.stream()
+                    .map(RowExpression::getType)
+                    .map(Type::getTypeSignature)
+                    .map(TypeSignatureProvider::new)
+                    .collect(toImmutableList());
+            FunctionHandle concreteFunctionHandle = functionAndTypeResolver.resolveFunction(
+                    Optional.of(sessionFunctions),
+                    transactionId,
+                    functionAndTypeResolver.qualifyObjectName(node.getName()),
+                    foldedArgumentTypes);
+            return call(node.getName().toString(), concreteFunctionHandle, getType(node), foldedArguments);
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
@@ -1100,6 +1100,63 @@ public class TestSignatureBinder
                 expectedTypeSignature);
     }
 
+    @Test
+    public void testBindAnyVariadic()
+    {
+        Signature function = functionSignature()
+                .returnType(parseTypeSignature(StandardTypes.VARCHAR))
+                .argumentTypes(parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.ANY))
+                .setVariableArity(true)
+                .build();
+
+        // zero trailing args (just the fixed head)
+        assertThat(function).boundTo("varchar").succeeds();
+        // a single trailing arg
+        assertThat(function).boundTo("varchar", "bigint").succeeds();
+        // mixed-type trailing args bind even though they share no common supertype -- the point of "any"
+        assertThat(function).boundTo("varchar", "double", "varchar", "boolean").succeeds();
+        // fewer arguments than the fixed head -> no match
+        assertThat(function).boundTo().fails();
+
+        // the bound signature carries the concrete per-position types, not "any"
+        assertEquals(
+                bindConcreteArguments(function, "varchar", "double", "varchar"),
+                ImmutableList.of(
+                        parseTypeSignature(StandardTypes.VARCHAR),
+                        parseTypeSignature(StandardTypes.DOUBLE),
+                        parseTypeSignature(StandardTypes.VARCHAR)));
+    }
+
+    @Test
+    public void testAnyVariadicBindsEachPositionIndependently()
+    {
+        // A shared type-variable tail unifies every trailing position to one common supertype,
+        // so a mixed tail with no common supertype fails to bind...
+        Signature withTypeVariable = functionSignature()
+                .returnType(parseTypeSignature(StandardTypes.VARCHAR))
+                .typeVariableConstraints(ImmutableList.of(typeVariable("T")))
+                .argumentTypes(parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature("T"))
+                .setVariableArity(true)
+                .build();
+        assertThat(withTypeVariable).boundTo("varchar", "double", "varchar").withCoercion().fails();
+
+        // ...whereas an "any" tail binds each position to its own concrete type.
+        Signature withAny = functionSignature()
+                .returnType(parseTypeSignature(StandardTypes.VARCHAR))
+                .argumentTypes(parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.ANY))
+                .setVariableArity(true)
+                .build();
+        assertThat(withAny).boundTo("varchar", "double", "varchar").succeeds();
+    }
+
+    private List<TypeSignature> bindConcreteArguments(Signature function, String... arguments)
+    {
+        Optional<Signature> bound = new SignatureBinder(functionAndTypeManager, function, false)
+                .bind(fromTypes(types(arguments)));
+        assertTrue(bound.isPresent());
+        return bound.get().getArgumentTypes();
+    }
+
     private static SignatureBuilder functionSignature()
     {
         return new SignatureBuilder()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestAnyVariadicFunctionFold.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestAnyVariadicFunctionFold.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.functionNamespace.FunctionNamespaceManagerPlugin;
+import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerFactory;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.SystemSessionProperties.FIELD_NAMES_IN_JSON_CAST_ENABLED;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * End-to-end coverage for the internal {@code __ANY__} variable-arity tail: a call to a facing
+ * {@code f(varchar, __ANY__)} function binds (ANY gate), the RowExpression translator folds the
+ * trailing mixed-type arguments into a single {@code CAST(ROW(...) AS JSON)} and dispatches to the
+ * concrete {@code f(varchar, json)} overload, whose SQL body inlines and executes.
+ */
+public class TestAnyVariadicFunctionFold
+{
+    @Test
+    public void testAnyVariadicFoldsToJsonAndExecutes()
+    {
+        // Emit the folded ROW as a positional JSON array (not a field-named object) so the backend sees
+        // the trailing arguments as [1, "b", true].
+        Session session = Session.builder(TEST_SESSION)
+                .setSystemProperty(FIELD_NAMES_IN_JSON_CAST_ENABLED, "false")
+                .build();
+        try (LocalQueryRunner queryRunner = new LocalQueryRunner(session)) {
+            queryRunner.installPlugin(new FunctionNamespaceManagerPlugin());
+            queryRunner.loadFunctionNamespaceManager(
+                    JsonFileBasedFunctionNamespaceManagerFactory.NAME,
+                    "json",
+                    ImmutableMap.of(
+                            "supported-function-languages", "SQL",
+                            "function-implementation-type", "SQL",
+                            "json-based-function-manager.path-to-function-definition",
+                            Resources.getResource("json_udf_any_variadic_executable.json").getFile()));
+
+            // Three trailing mixed-type args (bigint, varchar, boolean) fold into a JSON array of length 3.
+            MaterializedResult result = queryRunner.execute("SELECT json.test_schema.count_any('fmt', 1, 'b', true)");
+            assertEquals(result.getOnlyValue(), 3L);
+        }
+    }
+}

--- a/presto-main-base/src/test/resources/json_udf_any_variadic_executable.json
+++ b/presto-main-base/src/test/resources/json_udf_any_variadic_executable.json
@@ -1,0 +1,39 @@
+{
+  "udfSignatureMap": {
+    "count_any": [
+      {
+        "docString": "facing variable-arity any function; the RowExpression translator folds its tail into a single JSON argument and dispatches to the concrete (varchar, json) overload",
+        "functionKind": "SCALAR",
+        "outputType": "bigint",
+        "paramTypes": [
+          "varchar",
+          "__ANY__"
+        ],
+        "schema": "test_schema",
+        "variableArity": true,
+        "routineCharacteristics": {
+          "language": "SQL",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        },
+        "body": "RETURN 0"
+      },
+      {
+        "docString": "concrete backend over (varchar, json): counts the folded trailing arguments",
+        "functionKind": "SCALAR",
+        "outputType": "bigint",
+        "paramTypes": [
+          "varchar",
+          "json"
+        ],
+        "schema": "test_schema",
+        "routineCharacteristics": {
+          "language": "SQL",
+          "determinism": "DETERMINISTIC",
+          "nullCallClause": "CALLED_ON_NULL_INPUT"
+        },
+        "body": "RETURN JSON_ARRAY_LENGTH(input1)"
+      }
+    ]
+  }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.spi.function.ComplexTypeFunctionDescriptor.defaultFunctionDescriptor;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
@@ -43,6 +44,10 @@ public class FunctionMetadata
     private final FunctionVersion version;
     private final ComplexTypeFunctionDescriptor descriptor;
     private final Optional<String> description;
+    // For a variable-arity function whose tail is the internal StandardTypes.ANY sentinel, the
+    // (zero-based) index of the first trailing argument. Empty for all other functions. Used by the
+    // RowExpression translator to fold the trailing arguments into a single JSON argument.
+    private final OptionalInt varArgPosStart;
 
     public FunctionMetadata(
             QualifiedObjectName name,
@@ -79,7 +84,8 @@ public class FunctionMetadata
                 calledOnNullInput,
                 notVersioned(),
                 functionDescriptor,
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.empty());
     }
 
     public FunctionMetadata(
@@ -111,7 +117,25 @@ public class FunctionMetadata
             String description)
     {
         this(name, Optional.empty(), argumentTypes, Optional.of(argumentNames), returnType, functionKind, Optional.of(language), implementationType, deterministic, calledOnNullInput, version,
-                defaultFunctionDescriptor(), Optional.ofNullable(description));
+                defaultFunctionDescriptor(), Optional.ofNullable(description), OptionalInt.empty());
+    }
+
+    public FunctionMetadata(
+            QualifiedObjectName name,
+            List<TypeSignature> argumentTypes,
+            List<String> argumentNames,
+            TypeSignature returnType,
+            FunctionKind functionKind,
+            Language language,
+            FunctionImplementationType implementationType,
+            boolean deterministic,
+            boolean calledOnNullInput,
+            FunctionVersion version,
+            String description,
+            OptionalInt varArgPosStart)
+    {
+        this(name, Optional.empty(), argumentTypes, Optional.of(argumentNames), returnType, functionKind, Optional.of(language), implementationType, deterministic, calledOnNullInput, version,
+                defaultFunctionDescriptor(), Optional.ofNullable(description), varArgPosStart);
     }
 
     public FunctionMetadata(
@@ -128,7 +152,7 @@ public class FunctionMetadata
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
         this(name, Optional.empty(), argumentTypes, Optional.of(argumentNames), returnType, functionKind, Optional.of(language), implementationType, deterministic,
-                calledOnNullInput, version, functionDescriptor, Optional.empty());
+                calledOnNullInput, version, functionDescriptor, Optional.empty(), OptionalInt.empty());
     }
 
     public FunctionMetadata(
@@ -153,7 +177,7 @@ public class FunctionMetadata
             boolean calledOnNullInput,
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
-        this(operatorType.getFunctionName(), Optional.of(operatorType), argumentTypes, Optional.empty(), returnType, functionKind, Optional.empty(), implementationType, deterministic, calledOnNullInput, notVersioned(), functionDescriptor, Optional.empty());
+        this(operatorType.getFunctionName(), Optional.of(operatorType), argumentTypes, Optional.empty(), returnType, functionKind, Optional.empty(), implementationType, deterministic, calledOnNullInput, notVersioned(), functionDescriptor, Optional.empty(), OptionalInt.empty());
     }
 
     private FunctionMetadata(
@@ -182,7 +206,8 @@ public class FunctionMetadata
                 calledOnNullInput,
                 version,
                 defaultFunctionDescriptor(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.empty());
     }
 
     private FunctionMetadata(
@@ -198,7 +223,8 @@ public class FunctionMetadata
             boolean calledOnNullInput,
             FunctionVersion version,
             ComplexTypeFunctionDescriptor functionDescriptor,
-            Optional<String> description)
+            Optional<String> description,
+            OptionalInt varArgPosStart)
     {
         this.name = requireNonNull(name, "name is null");
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
@@ -220,6 +246,7 @@ public class FunctionMetadata
                 argumentTypes,
                 functionDescriptor.getPushdownSubfieldArgIndex());
         this.description = requireNonNull(description, "additionalInformation is null");
+        this.varArgPosStart = requireNonNull(varArgPosStart, "varArgPosStart is null");
     }
 
     public FunctionKind getFunctionKind()
@@ -287,6 +314,11 @@ public class FunctionMetadata
         return description;
     }
 
+    public OptionalInt getVarArgPosStart()
+    {
+        return varArgPosStart;
+    }
+
     @Override
     public boolean equals(Object obj)
     {
@@ -309,12 +341,13 @@ public class FunctionMetadata
                 Objects.equals(this.calledOnNullInput, other.calledOnNullInput) &&
                 Objects.equals(this.version, other.version) &&
                 Objects.equals(this.descriptor, other.descriptor) &&
-                Objects.equals(this.description, other.description);
+                Objects.equals(this.description, other.description) &&
+                Objects.equals(this.varArgPosStart, other.varArgPosStart);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, operatorType, argumentTypes, argumentNames, returnType, functionKind, language, implementationType, deterministic, calledOnNullInput, version, descriptor, description);
+        return Objects.hash(name, operatorType, argumentTypes, argumentNames, returnType, functionKind, language, implementationType, deterministic, calledOnNullInput, version, descriptor, description, varArgPosStart);
     }
 }


### PR DESCRIPTION
## Summary

Adds support for an internal `__ANY__` sentinel type usable **only** as the tail of a variable-arity function signature in JSON-file-based function definitions. A function declared as `f(head..., __ANY__)` (with `variableArity`) accepts zero-or-more trailing arguments of any, possibly-mixed types with **no explicit `CAST`** at the call site. The mixed-typed tail is folded into a single JSON argument during RowExpression translation and dispatched to a concrete `f(head..., json)` overload.

## Changes

- `SignatureBinder`: an `__ANY__` tail expands to distinct fresh per-position type variables, so a mixed-type tail (e.g. `(varchar, double, varchar)`) binds without unifying to a common supertype.
- `JsonFileBasedFunctionNamespaceManager`: thread `variableArity` + type/long constraints through (previously dropped); resolve variable-arity handles (mirroring the native namespace manager); reject `__ANY__` outside a variadic tail; support an optional SQL `body`.
- `SqlToRowExpressionTranslator`: fold an `__ANY__` tail into `CAST(ROW(...) AS JSON)` and dispatch to the concrete `(head..., json)` overload (via `varArgPosStart` on `FunctionMetadata`).
- `FunctionSignatureMatcher`: treat an `__ANY__` variadic as a generic candidate so a same-name fixed-arity overload wins exact matching.

## Test Plan

- `TestSignatureBinder`, `TestJsonFileBasedFunctionNamespaceManager`, `TestFunctionAndTypeManager`, `TestPolymorphicScalarFunction`, and an end-to-end `TestAnyVariadicFunctionFold` that folds an any-typed variadic call and executes it.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add support for an any-typed variadic tail in JSON-file-based function definitions.
```

## Summary by Sourcery

Add support for an internal __ANY__ variadic tail type in JSON-defined scalar functions and wire it through binding, resolution, and execution so mixed-type trailing arguments can be folded into a single JSON parameter.

New Features:
- Introduce the internal StandardTypes.ANY sentinel type for use as the variadic tail in function signatures.
- Allow JSON-file-based SQL functions to declare variable-arity signatures and optional SQL bodies that accept an any-typed tail folded into JSON.
- Expose vararg tail position metadata so the RowExpression translator can fold trailing arguments into a JSON value and dispatch to a concrete overload.

Enhancements:
- Extend SignatureBinder, FunctionSignatureMatcher, and function handle resolution to support any-typed variadic tails without disrupting existing overload selection.
- Propagate type and long variable constraints, variable-arity flags, and bodies through JsonFileBasedFunctionNamespaceManager and related metadata.
- Ensure variable-arity JSON UDF calls carry call-arity argument types in their handles and metadata for accurate per-argument analysis.

Tests:
- Add unit tests for SignatureBinder behavior with an __ANY__ variadic tail and its interaction with type-variable tails.
- Add tests for JsonFileBasedFunctionNamespaceManager to cover loading variable-arity any functions, rejecting invalid ANY usage, and resolving mixed-type calls end-to-end.
- Add an end-to-end SqlToRowExpressionTranslator test that verifies folding of any-typed variadic calls into JSON and successful execution of the concrete overload.