### PR TITLE
chore(ci): Advance velox

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -225,7 +225,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -11,7 +11,7 @@ jobs:
   prestocpp-linux-adapters-build:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-adapters-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-build-test-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -128,7 +128,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -253,7 +253,7 @@ jobs:
         storage-format: [PARQUET, DWRF]
         enable-sidecar: [true, false]
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -382,7 +382,7 @@ jobs:
       group: ${{ github.workflow }}-prestocpp-linux-presto-on-spark-e2e-tests-${{ matrix.storage-format }}-${{ matrix.enable-sidecar }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -495,7 +495,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -607,7 +607,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202606161331-03dfaf88
+      image: prestodb/presto-native-dependency:0.299-202607230500-3d95f459
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Update Velox submodule reference under presto-native-execution to track a newer upstream version.