### PR TITLE
fix(native): Carry the internal JWT on worker announcements and heartbeats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -31,6 +31,7 @@ PeriodicServiceInventoryManager::PeriodicServiceInventoryManager(
       id_(std::move(id)),
       frequencyMs_(frequencyMs),
       pool_(velox::memory::deprecatedAddDefaultLeafMemoryPool(id_)),
+      jwtOptions_(SystemConfig::instance()->jwtOptions()),
       eventBaseThread_(false /*autostart*/) {}
 
 void PeriodicServiceInventoryManager::start() {
@@ -111,6 +112,16 @@ void PeriodicServiceInventoryManager::sendRequest() {
   }
 
   auto [request, body] = httpRequest();
+
+  // Subclasses hand-build their request instead of going through
+  // RequestBuilder::send(), so this is the one place the cluster-internal JWT
+  // gets attached to them. Without it a coordinator that authenticates the
+  // announcement and heartbeat endpoints rejects both with 401 and the node
+  // never registers. httpRequest() returns the subclass's message by value, so
+  // the stored request is left untouched.
+  if (auto token = http::makeInternalJwt(jwtOptions_)) {
+    request.getHeaders().set(http::kPrestoInternalBearer, *token);
+  }
 
   client_->sendRequest(request, body)
       .via(eventBaseThread_.getEventBase())

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -70,6 +70,11 @@ class PeriodicServiceInventoryManager {
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
   /// jitter value for backoff delay time in case of failure
   const double backOffjitterParam_{0.1};
+  /// Snapshot of the internal-JWT settings, cached the same way
+  /// PrestoExchangeSource caches them: no shipped path mutates the shared
+  /// secret at runtime. The token itself is still minted per request, because
+  /// it carries an expiry.
+  const http::JwtOptions jwtOptions_;
 
   folly::EventBaseThread eventBaseThread_;
   folly::SocketAddress serviceAddress_;

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -606,29 +606,30 @@ folly::SemiFuture<std::unique_ptr<HttpResponse>> HttpClient::sendRequest(
   return future;
 }
 
-void RequestBuilder::addJwtIfConfigured() {
+// 'options' is unused when the binary is built without PRESTO_ENABLE_JWT.
+std::optional<std::string> makeInternalJwt(
+    [[maybe_unused]] const JwtOptions& options) {
 #ifdef PRESTO_ENABLE_JWT
-  if (jwtOptions_.jwtEnabled) {
+  if (options.jwtEnabled) {
     // If JWT was enabled the secret cannot be empty.
     auto secretHash = std::vector<uint8_t>(SHA256_DIGEST_LENGTH);
     folly::ssl::OpenSSLHash::sha256(
         folly::range(secretHash),
-        folly::ByteRange(folly::StringPiece(jwtOptions_.sharedSecret)));
+        folly::ByteRange(folly::StringPiece(options.sharedSecret)));
 
     const auto time = std::chrono::system_clock::now();
-    const auto token =
-        jwt::create<jwt::traits::nlohmann_json>()
-            .set_subject(jwtOptions_.nodeId)
-            .set_issued_at(time)
-            .set_expires_at(
-                time + std::chrono::seconds{jwtOptions_.jwtExpirationSeconds})
-            .sign(
-                jwt::algorithm::hs256{std::string(
-                    reinterpret_cast<char*>(secretHash.data()),
-                    secretHash.size())});
-    header(kPrestoInternalBearer, token);
+    return jwt::create<jwt::traits::nlohmann_json>()
+        .set_subject(options.nodeId)
+        .set_issued_at(time)
+        .set_expires_at(
+            time + std::chrono::seconds{options.jwtExpirationSeconds})
+        .sign(
+            jwt::algorithm::hs256{std::string(
+                reinterpret_cast<char*>(secretHash.data()),
+                secretHash.size())});
   }
 #endif // PRESTO_ENABLE_JWT
+  return std::nullopt;
 }
 
 } // namespace facebook::presto::http

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 #pragma once
+#include <optional>
+
 #include <folly/futures/Future.h>
 #include <proxygen/lib/http/HTTPConnector.h>
 #include <proxygen/lib/http/connpool/ServerIdleSessionController.h>
@@ -24,6 +26,15 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto::http {
+
+/// Mints a cluster-internal JWT from the shared secret, or returns nullopt when
+/// internal JWT is disabled or this binary was built without PRESTO_ENABLE_JWT.
+/// Callers attach the result as the kPrestoInternalBearer header.
+///
+/// Call this per request rather than caching the token: it carries an expiry
+/// (internal-communication.jwt.expiration-seconds), so a value minted once and
+/// reused is eventually rejected by the peer.
+std::optional<std::string> makeInternalJwt(const JwtOptions& options);
 
 /// NOTE: this class is not thread safe.
 class HttpResponse {
@@ -254,7 +265,11 @@ class RequestBuilder {
   }
 
  private:
-  void addJwtIfConfigured();
+  void addJwtIfConfigured() {
+    if (auto token = makeInternalJwt(jwtOptions_)) {
+      header(kPrestoInternalBearer, *token);
+    }
+  }
 
   JwtOptions jwtOptions_;
   proxygen::HTTPMessage headers_;

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -16,6 +16,8 @@
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/http/HttpConstants.h"
@@ -229,8 +231,14 @@ class BearerCapturingDiscoverer : public CoordinatorDiscoverer {
       folly::Promise<std::string> bearerPromise) {
     auto onAnnouncement =
         [promiseHolder = std::make_shared<PromiseHolder<std::string>>(
-             std::move(bearerPromise))](const std::string& bearer) mutable {
-          if (!promiseHolder->get().isFulfilled()) {
+             std::move(bearerPromise)),
+         captured = std::make_shared<std::atomic<bool>>(false)](
+            const std::string& bearer) {
+          // The discovery server runs on an 8-thread IO pool, so announcements
+          // can land concurrently; claim the one-shot promise with an atomic
+          // exchange rather than a non-atomic isFulfilled() check, since a
+          // second setValue() on a folly::Promise throws PromiseAlreadySatisfied.
+          if (!captured->exchange(true)) {
             promiseHolder->get().setValue(bearer);
           }
         };
@@ -290,7 +298,18 @@ std::string announceAndCaptureBearer(bool jwtEnabled) {
       /*sslContext=*/nullptr);
 
   announcer.start();
-  auto bearer = std::move(future).get();
+  // Bound the wait so a wiring regression fails the test instead of hanging the
+  // whole presto_server_test process; the announcer fires every 50ms, so 30s is
+  // an ample ceiling. stop() still runs on the timeout path because the base
+  // destructor does not.
+  auto semiFuture = std::move(future);
+  if (!semiFuture.wait(std::chrono::seconds(30)).isReady()) {
+    announcer.stop();
+    ADD_FAILURE() << "announcement never arrived; no "
+                  << http::kPrestoInternalBearer << " captured";
+    return {};
+  }
+  auto bearer = std::move(semiFuture).get();
   announcer.stop();
   return bearer;
 }

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -237,7 +237,8 @@ class BearerCapturingDiscoverer : public CoordinatorDiscoverer {
           // The discovery server runs on an 8-thread IO pool, so announcements
           // can land concurrently; claim the one-shot promise with an atomic
           // exchange rather than a non-atomic isFulfilled() check, since a
-          // second setValue() on a folly::Promise throws PromiseAlreadySatisfied.
+          // second setValue() on a folly::Promise throws
+          // PromiseAlreadySatisfied.
           if (!captured->exchange(true)) {
             promiseHolder->get().setValue(bearer);
           }
@@ -303,13 +304,21 @@ std::string announceAndCaptureBearer(bool jwtEnabled) {
   // an ample ceiling. stop() still runs on the timeout path because the base
   // destructor does not.
   auto semiFuture = std::move(future);
-  if (!semiFuture.wait(std::chrono::seconds(30)).isReady()) {
+  folly::Try<std::string> result;
+  try {
+    result = std::move(semiFuture).getTry(std::chrono::seconds(30));
+  } catch (const folly::FutureTimeout&) {
     announcer.stop();
     ADD_FAILURE() << "announcement never arrived; no "
                   << http::kPrestoInternalBearer << " captured";
     return {};
   }
-  auto bearer = std::move(semiFuture).get();
+  if (!result.hasValue()) {
+    announcer.stop();
+    ADD_FAILURE() << "announcement failed: " << result.exception().what();
+    return {};
+  }
+  auto bearer = std::move(result.value());
   announcer.stop();
   return bearer;
 }

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -15,7 +15,10 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
+#include "presto_cpp/main/http/HttpConstants.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
@@ -189,3 +192,139 @@ INSTANTIATE_TEST_CASE_P(
     AnnouncerTest,
     AnnouncerTestSuite,
     ::testing::Values(true, false));
+
+#ifdef PRESTO_ENABLE_JWT
+namespace {
+
+// Discovery server that reports the cluster-internal bearer of every
+// announcement it receives, empty when the header is absent.
+// makeDiscoveryServer above ignores the request entirely, which is why an
+// announcement missing the header went unnoticed.
+std::unique_ptr<facebook::presto::test::HttpServerWrapper>
+makeBearerCapturingDiscoveryServer(
+    std::function<void(const std::string&)> onAnnouncement) {
+  auto httpServer = createHttpServer(/*useHttps=*/false);
+
+  httpServer->registerPut(
+      R"(/v1/announcement/(.+))",
+      [onAnnouncement = std::move(onAnnouncement)](
+          proxygen::HTTPMessage* message,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
+          proxygen::ResponseHandler* downstream) mutable {
+        onAnnouncement(message->getHeaders().getSingleOrEmpty(
+            http::kPrestoInternalBearer));
+        proxygen::ResponseBuilder(downstream)
+            .status(http::kHttpAccepted, "Accepted")
+            .sendWithEOM();
+      });
+  return std::make_unique<facebook::presto::test::HttpServerWrapper>(
+      std::move(httpServer));
+}
+
+// Fires its promise with the bearer of the first announcement, so the test does
+// not have to wait for the announcer's steady state.
+class BearerCapturingDiscoverer : public CoordinatorDiscoverer {
+ public:
+  explicit BearerCapturingDiscoverer(
+      folly::Promise<std::string> bearerPromise) {
+    auto onAnnouncement =
+        [promiseHolder = std::make_shared<PromiseHolder<std::string>>(
+             std::move(bearerPromise))](const std::string& bearer) mutable {
+          if (!promiseHolder->get().isFulfilled()) {
+            promiseHolder->get().setValue(bearer);
+          }
+        };
+    discoveryServer_ =
+        makeBearerCapturingDiscoveryServer(std::move(onAnnouncement));
+    serverAddress_ = discoveryServer_->start().get();
+  }
+
+  folly::SocketAddress updateAddress() override {
+    return serverAddress_;
+  }
+
+ private:
+  std::unique_ptr<test::HttpServerWrapper> discoveryServer_;
+  folly::SocketAddress serverAddress_;
+};
+
+std::unique_ptr<facebook::velox::config::ConfigBase> makeConfig(
+    std::unordered_map<std::string, std::string> values) {
+  return std::make_unique<facebook::velox::config::ConfigBase>(
+      std::move(values), /*_mutable=*/true);
+}
+
+// Announces once and returns whatever arrived in X-Presto-Internal-Bearer.
+// The options are snapshotted in PeriodicServiceInventoryManager's constructor,
+// so the config has to be installed before the Announcer is constructed, not
+// merely before start().
+std::string announceAndCaptureBearer(bool jwtEnabled) {
+  SystemConfig::instance()->initialize(makeConfig(
+      {{std::string(SystemConfig::kMutableConfig), "true"},
+       {std::string(SystemConfig::kInternalCommunicationJwtEnabled),
+        jwtEnabled ? "true" : "false"},
+       {std::string(SystemConfig::kInternalCommunicationSharedSecret),
+        "announcer-test-secret"}}));
+
+  NodeConfig::instance()->initialize(makeConfig(
+      {{std::string(NodeConfig::kMutableConfig), "true"},
+       {std::string(NodeConfig::kNodeId), "announcer-test-node"}}));
+
+  auto [promise, future] = folly::makePromiseContract<std::string>();
+  auto discoverer =
+      std::make_shared<BearerCapturingDiscoverer>(std::move(promise));
+
+  Announcer announcer(
+      "127.0.0.1",
+      /*useHttps=*/false,
+      1234,
+      discoverer,
+      "testversion",
+      "testing",
+      "announcer-test-node",
+      "test-node-location",
+      "DEFAULT",
+      true,
+      {"hive"},
+      50 /*milliseconds*/,
+      /*sslContext=*/nullptr);
+
+  announcer.start();
+  auto bearer = std::move(future).get();
+  announcer.stop();
+  return bearer;
+}
+
+} // namespace
+
+// SystemConfig and NodeConfig are process-global and presto_server_test runs
+// many suites in one process, so restore both to a default-valued config after
+// each case rather than leaving this test's JWT settings installed.
+class AnnouncerJwtTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    FLAGS_velox_memory_leak_check_enabled = true;
+  }
+
+  void TearDown() override {
+    SystemConfig::instance()->initialize(makeConfig({}));
+    NodeConfig::instance()->initialize(makeConfig({}));
+  }
+};
+
+// The announcement is built by hand in Announcer rather than through
+// RequestBuilder, so nothing else guards that it carries the internal JWT: a
+// coordinator that authenticates the announcement endpoint 401s an unsigned
+// announcement and the node never registers.
+TEST_F(AnnouncerJwtTest, carriesInternalJwtWhenEnabled) {
+  const auto bearer = announceAndCaptureBearer(/*jwtEnabled=*/true);
+  ASSERT_FALSE(bearer.empty())
+      << "announcement carried no " << http::kPrestoInternalBearer;
+  // A signed JWS is three dot-separated segments.
+  EXPECT_EQ(std::count(bearer.begin(), bearer.end(), '.'), 2);
+}
+
+TEST_F(AnnouncerJwtTest, omitsInternalJwtWhenDisabled) {
+  EXPECT_TRUE(announceAndCaptureBearer(/*jwtEnabled=*/false).empty());
+}
+#endif // PRESTO_ENABLE_JWT


### PR DESCRIPTION
## Description

`PeriodicServiceInventoryManager::sendRequest()` sends the message its subclass
hands back from `httpRequest()` straight through `HttpClient::sendRequest`. That
path never goes through `RequestBuilder::send()`, which is the only place that
attaches the cluster-internal JWT, so the two requests it drives —
`Announcer`'s `PUT /v1/announcement/{nodeId}` and `PeriodicHeartbeatManager`'s
`PATCH /v1/resource-manager/node/{nodeId}` — are the only requests a native
worker sends to the coordinator without `X-Presto-Internal-Bearer`, even when
`internal-communication.jwt.enabled=true`.

This change:

* extracts the token minting from `RequestBuilder`'s private
  `addJwtIfConfigured()` into a free function `http::makeInternalJwt()`, which
  returns the token or `std::nullopt`;
* attaches the header in `PeriodicServiceInventoryManager::sendRequest()`, so a
  single change covers both subclasses;
* snapshots the JWT options in the constructor — the same caching
  `PrestoExchangeSource` already does — while minting the token per request,
  because it carries an expiry.

The header is attached in `PeriodicServiceInventoryManager` rather than in
`HttpClient::sendRequest` on purpose. `RestRemoteClient` is the other caller of
`HttpClient::sendRequest`, and it talks to an external remote function server
that must not receive cluster-internal credentials.

## Motivation and Context

A Java worker does not have this problem: `InternalAuthenticationManager` is
bound as a global HTTP client filter in `CommonInternalCommunicationModule`, so
it signs every internal request the worker makes, including its announcement.
The native worker only signs the requests that go through `RequestBuilder`,
which is what this change corrects. Enabling
`internal-communication.jwt.enabled` should mean "every request this node makes
to the cluster is signed", and today it does not for native workers.

A coordinator that authenticates these endpoints by the internal bearer has no
credential it can accept on an unsigned announcement, so it rejects it. Because
the announcement is what establishes cluster membership, the worker simply never
registers: the coordinator reports no active workers and queries fail in
scheduling with `NO_NODES_AVAILABLE` (for example `sortedCandidates is null or
empty for ModularHashingNodeProvider`), rather than surfacing an authentication
error.

This completes the internal-JWT support tracked in #19861 for the two request
paths that are not built through `RequestBuilder`.

### Not addressed here

`AuthenticationFilter.doesRequestSupportAuthentication()` runs the configured
*client* authenticators (`http-server.authentication.type`) over every path,
including `/v1/announcement`, and does not treat `X-Presto-Internal-Bearer` as
an internal credential. So on a coordinator with client authentication and HTTPS
enabled, worker announcements are rejected whether or not they are signed — this
affects Java workers equally and is a separate gap from the one fixed here. This
PR makes the native worker consistent with the Java worker and with its own
configuration; it does not change how the coordinator decides which filter
applies.

## Impact

Affects native workers configured with `internal-communication.jwt.enabled=true`
in a binary built with `PRESTO_ENABLE_JWT`. The announcement and heartbeat now
carry `X-Presto-Internal-Bearer`, matching every other request the worker sends
and matching the Java worker.

No behavior change otherwise: with internal JWT disabled, or in a binary built
without `PRESTO_ENABLE_JWT` (the default), `makeInternalJwt()` returns
`std::nullopt` and no header is set. No new configuration property.

## Test Plan

* `AnnouncerTest` gained two cases behind `#ifdef PRESTO_ENABLE_JWT`. Nothing
  previously inspected the announcement's headers, which is why this went
  unnoticed:
  * `AnnouncerJwtTest.carriesInternalJwtWhenEnabled` — announces against a
    discovery server that captures request headers, and asserts a
    three-segment JWS arrives in `X-Presto-Internal-Bearer`.
  * `AnnouncerJwtTest.omitsInternalJwtWhenDisabled` — asserts the header is
    absent when `internal-communication.jwt.enabled=false`.
* Locally the change compiles clean under `-DPRESTO_ENABLE_JWT` both ON and OFF (`-Wall -Wextra -Werror`) and passes `clang-format`. The two gtest cases were not run on the dev machine (an unrelated Homebrew/Arrow toolchain issue there); they are exercised by CI, as noted below.
* These cases run in CI as-is: `prestocpp-linux-build-and-unit-test` builds with
  `PRESTO_OPTIONAL_FEATURES="remote-functions,jwt"` (which the Makefile maps to
  `-DPRESTO_ENABLE_JWT=ON`) and its unit-test step runs `ctest`, which includes
  `presto_server_test`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix native worker announcements and heartbeats to carry the cluster-internal
  JWT when ``internal-communication.jwt.enabled`` is true. Previously these were
  the only requests a worker sent without ``X-Presto-Internal-Bearer``, so a
  coordinator that authenticates them by the internal bearer rejected the
  announcement and the worker never joined the cluster. :pr:`XXXXX`
```

## Summary by Sourcery

Ensure native worker announcements and heartbeats carry the cluster-internal JWT when internal communication JWT is enabled, aligning them with other signed internal requests.

Bug Fixes:
- Fix native worker announcements and heartbeats being sent without the X-Presto-Internal-Bearer header when internal-communication.jwt.enabled is true, which prevented workers from registering with JWT-authenticated coordinators.

Enhancements:
- Extract internal JWT minting into a reusable helper so non-RequestBuilder HTTP call sites can attach the cluster-internal bearer token.

Tests:
- Add announcer JWT tests that verify X-Presto-Internal-Bearer is present when internal JWT is enabled and absent when it is disabled.