### PR TITLE
fix: Remove redundant direct parquet deps causing shade conflict

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -73,36 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-column</artifactId>
-            <version>${dep.parquet.version}</version>
-            <exclusions>
-                <!-- excluding dependency due to vulnerability -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-common</artifactId>
-            <version>${dep.parquet.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-format-structures</artifactId>
-            <version>${dep.parquet.version}</version>
-            <exclusions>
-                <!-- excluding dependency due to vulnerability -->
-                <exclusion>
-                    <groupId>org.apache.thrift</groupId>
-                    <artifactId>libthrift</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-expressions</artifactId>
         </dependency>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -104,23 +104,6 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parquet</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-column</artifactId>
-            <version>${dep.parquet.version}</version>
-            <exclusions>
-                <!-- excluding dependency due to vulnerability -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-common</artifactId>
-            <version>${dep.parquet.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Remove three redundant direct parquet dependencies from `presto-hive/pom.xml` (`parquet-column`, `parquet-common`, `parquet-format-structures`) and two from `presto-hudi/pom.xml` (`parquet-column`, `parquet-common`), all added in
  #27552.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #28210

After #27552 (Delta variant support), every `presto-hive` / `presto-parquet` CI test that writes a parquet file fails with:

  ```
java.lang.NoSuchMethodError: 'com.facebook.presto.hive.$internal.parquet.org.apache.thrift.TFieldIdEnum org.apache.parquet.format.LogicalType.getSetField()'
      at org.apache.parquet.format.converter.ParquetMetadataConverter.getLogicalTypeAnnotation(ParquetMetadataConverter.java:1291)
  ```

  **Root cause.** `hive-apache-4.0.1-1` is a shaded fat jar that bundles `parquet-format-structures` 1.16.0 with the relocation `shaded.parquet` → `com.facebook.presto.hive.$internal.parquet` (see
  [prestodb/presto-hive-apache#65](https://github.com/prestodb/presto-hive-apache/pull/65)). Its `LogicalType.getSetField()` returns `com.facebook.presto.hive.$internal.parquet.org.apache.thrift.TFieldIdEnum`, and the bundled
  `ParquetMetadataConverter` is compiled against that shaded type.

  #27552 then declared `parquet-column`, `parquet-common`, and `parquet-format-structures` directly in `presto-hive/pom.xml` at `${dep.parquet.version}` = 1.16.0. The vanilla `parquet-format-structures` jar has `LogicalType.getSetField()`
  returning the unshaded `shaded.parquet.org.apache.thrift.TFieldIdEnum`. Because that dep is declared before `hive-apache`, its `LogicalType` wins on the classpath, but `ParquetMetadataConverter` still comes from `hive-apache`, so the
  runtime lookup fails with the `NoSuchMethodError` above. Every insert-into-parquet path hits it via `ParquetRecordWriterWrapper.close` → `ParquetFileReader.readFooter` → `getLogicalTypeAnnotation`.

`hive-apache-4.0.1-1` already bundles all the parquet artifacts at 1.16.0. `presto-hive` and `presto-hudi` only reference symbols that are present in it, so the direct declarations are redundant. Removing them restores a single, self-consistent set of parquet classes on the classpath.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Build/dependency graph only. Parquet writes work again on master.

## Test Plan
<!---Please fill in how you tested your change-->
  - `./mvnw -DskipTests -pl presto-hive,presto-hudi -am install` clean compile.
  - `./mvnw test -pl presto-hive -Dtest='TestParquetReader'`: 91 tests pass, including the three called out in #28210.
  - Full CI via this PR.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

