### PR TITLE
feat: Add scanRawInputDataSizeInBytes to TaskStats (Java + native) (#28213)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -464,6 +464,7 @@ public class TaskContext
         long totalAllocation = 0;
 
         long rawInputDataSize = 0;
+        long scanRawInputDataSize = 0;
         long rawInputPositions = 0;
 
         long processedInputDataSize = 0;
@@ -520,7 +521,15 @@ public class TaskContext
             }
 
             physicalWrittenDataSize += pipeline.getPhysicalWrittenDataSizeInBytes();
-            pipeline.getOperatorSummaries().stream().forEach(stats -> mergedRuntimeStats.mergeWith(stats.getRuntimeStats()));
+            for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
+                mergedRuntimeStats.mergeWith(operatorStats.getRuntimeStats());
+                // Scan-only raw input: leaf table scans exclude exchange/shuffle bytes,
+                // matching the operator-filtered rawInputDataSize in QueryStats.create().
+                String operatorType = operatorStats.getOperatorType();
+                if (operatorType.equals(TableScanOperator.class.getSimpleName()) || operatorType.equals(ScanFilterAndProjectOperator.class.getSimpleName())) {
+                    scanRawInputDataSize += operatorStats.getRawInputDataSizeInBytes();
+                }
+            }
         }
 
         long startNanos = this.startNanos.get();
@@ -613,6 +622,7 @@ public class TaskContext
                 blockedReasons.build(),
                 totalAllocation,
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
                 processedInputDataSize,
                 processedInputPositions,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -81,6 +81,7 @@ public class TaskStats
     private final long totalAllocationInBytes;
 
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
 
     private final long processedInputDataSizeInBytes;
@@ -140,6 +141,7 @@ public class TaskStats
                 ImmutableSet.of(),
                 0L,
                 0L,
+                0L,
                 0,
                 0L,
                 0,
@@ -191,6 +193,7 @@ public class TaskStats
                 0L,
                 false,
                 ImmutableSet.of(),
+                0L,
                 0L,
                 0L,
                 0,
@@ -255,6 +258,7 @@ public class TaskStats
             @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
             @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("scanRawInputDataSizeInBytes") long scanRawInputDataSizeInBytes,
             @JsonProperty("rawInputPositions") long rawInputPositions,
 
             @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
@@ -346,6 +350,7 @@ public class TaskStats
         this.totalAllocationInBytes = totalAllocationInBytes;
 
         this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.scanRawInputDataSizeInBytes = scanRawInputDataSizeInBytes;
         this.rawInputPositions = (rawInputPositions >= 0) ? rawInputPositions : Long.MAX_VALUE;
 
         this.processedInputDataSizeInBytes = processedInputDataSizeInBytes;
@@ -732,6 +737,16 @@ public class TaskStats
         return completedNewDrivers;
     }
 
+    /**
+     * Sum of leaf table-scan (TableScan/ScanFilterAndProject) raw input bytes; excludes exchange/shuffle. Populated by workers.
+     */
+    @JsonProperty
+    @ThriftField(50)
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -774,6 +789,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,
@@ -828,6 +844,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -70,6 +70,7 @@ public class TestTaskStats
             123,
 
             19,
+            17,
             20,
 
             21,
@@ -130,6 +131,7 @@ public class TestTaskStats
         assertEquals(actual.getTotalAllocationInBytes(), 123);
 
         assertEquals(actual.getRawInputDataSizeInBytes(), 19);
+        assertEquals(actual.getScanRawInputDataSizeInBytes(), 17);
         assertEquals(actual.getRawInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSizeInBytes(), 21);

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -859,6 +859,7 @@ void PrestoTask::updateExecutionInfoLocked(
 
   prestoTaskStats.rawInputPositions = 0;
   prestoTaskStats.rawInputDataSizeInBytes = 0;
+  prestoTaskStats.scanRawInputDataSizeInBytes = 0;
   prestoTaskStats.processedInputPositions = 0;
   prestoTaskStats.processedInputDataSizeInBytes = 0;
   prestoTaskStats.outputPositions = 0;
@@ -909,6 +910,14 @@ void PrestoTask::updateExecutionInfoLocked(
             firstVeloxOpStats.rawInputPositions;
         prestoTaskStats.rawInputDataSizeInBytes +=
             firstVeloxOpStats.rawInputBytes;
+        // Scan-only raw input: count only leaf TableScan sources, excluding the
+        // Exchange/Merge shuffle inputs that inflate rawInputDataSizeInBytes.
+        // The task-level source is operatorStats[0] (the scan itself), never
+        // the FilterProject copy made at the per-operator level below.
+        if (firstVeloxOpStats.operatorType == "TableScan") {
+          prestoTaskStats.scanRawInputDataSizeInBytes +=
+              firstVeloxOpStats.rawInputBytes;
+        }
         prestoTaskStats.processedInputPositions +=
             firstVeloxOpStats.inputPositions;
         prestoTaskStats.processedInputDataSizeInBytes +=

--- a/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
+++ b/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
@@ -101,6 +101,7 @@
         ],
         "totalAllocationInBytes": 123,
         "rawInputDataSizeInBytes": 456,
+        "scanRawInputDataSizeInBytes": 123,
         "rawInputPositions": 789,
         "processedInputDataSizeInBytes": 123,
         "processedInputPositions": 456,

--- a/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
@@ -1204,6 +1204,9 @@ void toThrift(
   toThrift(proto.queuedNewDrivers, *thrift.queuedNewDrivers_ref());
   toThrift(proto.runningNewDrivers, *thrift.runningNewDrivers_ref());
   toThrift(proto.completedNewDrivers, *thrift.completedNewDrivers_ref());
+  toThrift(
+      proto.scanRawInputDataSizeInBytes,
+      *thrift.scanRawInputDataSizeInBytes_ref());
 }
 void fromThrift(
     const TaskStats& thrift,
@@ -1282,6 +1285,9 @@ void fromThrift(
   fromThrift(*thrift.queuedNewDrivers_ref(), proto.queuedNewDrivers);
   fromThrift(*thrift.runningNewDrivers_ref(), proto.runningNewDrivers);
   fromThrift(*thrift.completedNewDrivers_ref(), proto.completedNewDrivers);
+  fromThrift(
+      *thrift.scanRawInputDataSizeInBytes_ref(),
+      proto.scanRawInputDataSizeInBytes);
 }
 
 void toThrift(

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -451,6 +451,7 @@ struct TaskStats {
   47: i32 queuedNewDrivers;
   48: i32 runningNewDrivers;
   49: i32 completedNewDrivers;
+  50: i64 scanRawInputDataSizeInBytes;
 }
 struct PipelineStats {
   1: i32 pipelineId;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -12035,6 +12035,13 @@ void to_json(json& j, const TaskStats& p) {
       "rawInputDataSizeInBytes");
   to_json_key(
       j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
+  to_json_key(
+      j,
       "rawInputPositions",
       p.rawInputPositions,
       "TaskStats",
@@ -12344,6 +12351,13 @@ void from_json(const json& j, TaskStats& p) {
       "TaskStats",
       "int64_t",
       "rawInputDataSizeInBytes");
+  from_json_key(
+      j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
   from_json_key(
       j,
       "rawInputPositions",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2674,6 +2674,7 @@ struct TaskStats {
   List<BlockedReason> blockedReasons = {};
   int64_t totalAllocationInBytes = {};
   int64_t rawInputDataSizeInBytes = {};
+  int64_t scanRawInputDataSizeInBytes = {};
   int64_t rawInputPositions = {};
   int64_t processedInputDataSizeInBytes = {};
   int64_t processedInputPositions = {};


### PR DESCRIPTION
Summary:

Add a new `scanRawInputDataSizeInBytes` statistic to `TaskStats` and populate it
on both the Java and native workers. It reports the raw input data size read by
source (leaf table scan) operators only, distinct from the existing
`rawInputDataSizeInBytes`, which on the running/aggregated stats path can also
include input received by exchange (shuffle) operators.

- `TaskStats` (Java): new field, constructor parameter, getter
  (`ThriftField` / `JsonProperty`), and pass-through in `summarize()` and
  `summarizeFinal()`.
- Native `presto_protocol` `TaskStats` struct: matching field, regenerated via
  `make presto_protocol`.
- `TaskContext` (Java worker): sums `rawInputDataSizeInBytes` across operator
  summaries whose type is a leaf scan (`TableScanOperator` /
  `ScanFilterAndProjectOperator`), mirroring the operator-type filter that
  `QueryStats.create()` applies for completed queries.
- `PrestoTask` (native worker): sums `rawInputBytes` only from input pipelines
  whose source operator is a Velox `TableScan`, excluding `Exchange` / `Merge`
  shuffle sources. A leaf scan is always the first operator of its pipeline, so
  this captures exactly the source bytes and avoids the `FilterProject`
  double-count (the task-level source read is the scan itself, not the
  per-operator copy).

The field is additive and defaults to `0`, so it is forward/backward compatible
across mixed coordinator/worker (Java and native) deployments: a missing value
deserializes to `0` and an unknown property is ignored.

== Motivation and Context ==

`rawInputDataSizeInBytes` is a per-task aggregate that, on the live path, sums
input across all input pipelines, including exchange sources. Consumers that
need the bytes physically read from source connectors (excluding shuffle) cannot
currently obtain that value from `TaskStats`. A dedicated scan-only statistic
provides that signal without altering the semantics of the existing field.

== Impact ==

Additive, backward-compatible field defaulting to `0`. No behavior change to
existing statistics.

== RELEASE NOTES ==

General Changes
* Add ``scanRawInputDataSizeInBytes`` to task statistics, reporting the raw input data size read by table scan operators.

Differential Revision: D113454040


