### PR TITLE
perf(planner): Restrict CoalesceCascadingProjections to single-use and trivial expressions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CoalesceCascadingProjections.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CoalesceCascadingProjections.java
@@ -24,13 +24,13 @@ import com.facebook.presto.spi.plan.Assignments.Builder;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.ProjectNodeUtils;
-import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
@@ -50,19 +50,20 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * Coalesces a chain of {@code Project -> Project} into a single {@link ProjectNode} by fully
- * inlining the child projection's expressions into the parent.
+ * Coalesces a chain of {@code Project -> Project} into a single {@link ProjectNode} by inlining the
+ * child projection's expressions into the parent, then dropping the residual child projection when it
+ * collapses to a pure passthrough.
  *
- * <p>This is the opposite tradeoff from {@link InlineProjections}: where {@code InlineProjections}
- * conservatively only inlines constants or single-use expressions (to avoid duplicating
- * computation), this rule inlines <em>all</em> deterministic child expressions regardless of how
- * many times they are referenced. On the native (Velox) engine, common-subexpression elimination
- * runs <em>within</em> a single operator, so collapsing the chain into one project exposes the
- * shared subexpressions to CSE rather than hiding them across operators.
+ * <p>Like {@link InlineProjections}, this rule never duplicates real computation: a child output is
+ * inlined only when it is referenced exactly once by the parent, or when its defining expression is
+ * <em>trivial</em> to duplicate -- a constant (including a constant-folded {@code Block}) or a pure
+ * variable rename. A non-trivial expression referenced more than once is left in the child, so the
+ * chain is not collapsed at that output.
  *
- * <p>To preserve semantics this rule still skips: non-deterministic expressions that are referenced
- * more than once (which would duplicate side-effecting computation), inputs to {@code TRY(...)}
- * expressions, and identity assignments (which would otherwise make the rule fire forever).
+ * <p>To preserve semantics this rule also skips inputs to {@code TRY(...)} expressions (inlining into
+ * a TRY could change which errors are masked) and identity assignments (which would otherwise make
+ * the rule fire forever). A single-use child output is safe to inline even when non-deterministic,
+ * because a lone reference cannot duplicate the side-effecting computation.
  *
  * <p>This rule is gated behind {@code optimize_cascading_filters_and_projections} and is disabled by
  * default.
@@ -76,13 +77,11 @@ public class CoalesceCascadingProjections
             .with(source().matching(project().capturedAs(CHILD)));
 
     private final FunctionResolution functionResolution;
-    private final RowExpressionDeterminismEvaluator determinismEvaluator;
 
     public CoalesceCascadingProjections(FunctionAndTypeManager functionAndTypeManager)
     {
         requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
         this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
-        this.determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
     }
 
     @Override
@@ -190,12 +189,11 @@ public class CoalesceCascadingProjections
         // candidates for inlining are child outputs that are referenced by the parent and
         //   a. are not inputs to try() expressions (otherwise inlining might change semantics)
         //   b. are not identity projections (otherwise this rule would keep firing forever)
-        //   c. are either deterministic (any number of references) OR referenced exactly once
-        //      (a single reference never duplicates computation, even for non-deterministic
-        //      expressions)
-        // Unlike InlineProjections (which only inlines constants or single-use expressions), this
-        // rule deliberately inlines multiply-referenced deterministic expressions so the native
-        // engine's common-subexpression elimination can dedupe them within one operator.
+        //   c. are either referenced exactly once (a single reference never duplicates computation,
+        //      even for a non-deterministic expression) OR are trivial to duplicate -- a constant or
+        //      a pure variable rename (see isTrivial)
+        // Like InlineProjections, this rule never inlines a multiply-referenced non-trivial
+        // expression, so it does not duplicate real computation across the coalesced projection.
 
         Set<VariableReferenceExpression> childOutputSet = ImmutableSet.copyOf(child.getOutputVariables());
 
@@ -214,9 +212,19 @@ public class CoalesceCascadingProjections
         return dependencies.entrySet().stream()
                 .filter(entry -> !tryArguments.contains(entry.getKey()))
                 .filter(entry -> !isIdentity(child.getAssignments(), entry.getKey()))
-                .filter(entry -> entry.getValue() == 1 || determinismEvaluator.isDeterministic(child.getAssignments().get(entry.getKey())))
+                .filter(entry -> entry.getValue() == 1 || isTrivial(child.getAssignments().get(entry.getKey())))
                 .map(Map.Entry::getKey)
                 .collect(toSet());
+    }
+
+    /**
+     * A trivial expression is free to duplicate, so it may be inlined even when the child output is
+     * referenced more than once: a constant (including a constant-folded {@code Block}) or a pure
+     * variable rename. Inlining these never duplicates real computation.
+     */
+    private static boolean isTrivial(RowExpression expression)
+    {
+        return expression instanceof ConstantExpression || expression instanceof VariableReferenceExpression;
     }
 
     private Set<VariableReferenceExpression> extractTryArguments(RowExpression expression)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCoalesceCascadingProjections.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCoalesceCascadingProjections.java
@@ -31,10 +31,11 @@ public class TestCoalesceCascadingProjections
         extends BaseRuleTest
 {
     @Test
-    public void testFullyInlinesMultiplyReferencedDeterministicExpression()
+    public void testDoesNotInlineMultiplyReferencedNonTrivialExpression()
     {
-        // Unlike InlineProjections, a deterministic child expression referenced multiple times is
-        // still fully inlined so the native engine's CSE can dedupe it within one operator.
+        // A non-trivial deterministic child expression referenced more than once must not be inlined,
+        // otherwise the coalesced projection would duplicate its computation. With no other inlining
+        // target, the rule does not fire.
         tester().assertThat(new CoalesceCascadingProjections(getFunctionManager()))
                 .setSystemProperty(OPTIMIZE_CASCADING_FILTERS_AND_PROJECTIONS, "true")
                 .on(p -> {
@@ -51,13 +52,68 @@ public class TestCoalesceCascadingProjections
                                             .build(),
                                     p.values(p.variable("x"))));
                 })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testInlinesMultiplyReferencedConstant()
+    {
+        // A constant is trivial to duplicate, so it is inlined even when referenced more than once.
+        tester().assertThat(new CoalesceCascadingProjections(getFunctionManager()))
+                .setSystemProperty(OPTIMIZE_CASCADING_FILTERS_AND_PROJECTIONS, "true")
+                .on(p -> {
+                    p.variable("x");
+                    p.variable("c");
+                    return p.project(
+                            Assignments.builder()
+                                    .put(p.variable("out1"), p.rowExpression("c + 1"))
+                                    .put(p.variable("out2"), p.rowExpression("c + 2"))
+                                    .build(),
+                            p.project(
+                                    Assignments.builder()
+                                            .put(p.variable("c"), p.rowExpression("5"))
+                                            .build(),
+                                    p.values(p.variable("x"))));
+                })
                 .matches(
-                        // The residual child collapses to a pure passthrough and is dropped, so the
-                        // single coalesced project sits directly on the values node.
+                        // The inlined constant has no inputs, so the child collapses to a pure
+                        // passthrough and is dropped; the coalesced project sits directly on values.
                         project(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("out1", PlanMatchPattern.expression("x * 2 + 1"))
-                                        .put("out2", PlanMatchPattern.expression("x * 2 + 2"))
+                                        .put("out1", PlanMatchPattern.expression("5 + 1"))
+                                        .put("out2", PlanMatchPattern.expression("5 + 2"))
+                                        .build(),
+                                values(ImmutableMap.of("x", 0))));
+    }
+
+    @Test
+    public void testInlinesMultiplyReferencedVariableRename()
+    {
+        // A pure variable rename is trivial to duplicate, so it is inlined even when referenced more
+        // than once; each parent reference is simply repointed at the underlying variable.
+        tester().assertThat(new CoalesceCascadingProjections(getFunctionManager()))
+                .setSystemProperty(OPTIMIZE_CASCADING_FILTERS_AND_PROJECTIONS, "true")
+                .on(p -> {
+                    p.variable("x");
+                    p.variable("renamed");
+                    return p.project(
+                            Assignments.builder()
+                                    .put(p.variable("out1"), p.rowExpression("renamed + 1"))
+                                    .put(p.variable("out2"), p.rowExpression("renamed + 2"))
+                                    .build(),
+                            p.project(
+                                    Assignments.builder()
+                                            .put(p.variable("renamed"), p.rowExpression("x"))
+                                            .build(),
+                                    p.values(p.variable("x"))));
+                })
+                .matches(
+                        // After the rename is inlined the child collapses to an identity passthrough
+                        // of x and is dropped; the coalesced project sits directly on values.
+                        project(
+                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                        .put("out1", PlanMatchPattern.expression("x + 1"))
+                                        .put("out2", PlanMatchPattern.expression("x + 2"))
                                         .build(),
                                 values(ImmutableMap.of("x", 0))));
     }
@@ -118,30 +174,29 @@ public class TestCoalesceCascadingProjections
     }
 
     @Test
-    public void testRecursivelyCollapsesProjectionChain()
+    public void testRecursivelyCollapsesSingleUseProjectionChain()
     {
-        // A three-deep projection chain must collapse to a single project after the rule reaches
-        // fixpoint (driven here by an IterativeOptimizer), with every intermediate
-        // (multiply-referenced, deterministic) expression fully inlined and the residual passthrough
-        // projects dropped.
+        // A three-deep projection chain whose intermediate expressions are each referenced exactly
+        // once must collapse to a single project after the rule reaches fixpoint (driven here by an
+        // IterativeOptimizer), inlining every single-use expression and dropping the residual
+        // passthrough projects.
         //   values(x)
         //     -> doubled := x * 2
-        //       -> summed := doubled + doubled
-        //         -> out1 := summed + 1, out2 := summed + 2
+        //       -> shifted := doubled + 1
+        //         -> out1 := shifted * 3
         tester().assertThat(ImmutableSet.of(new CoalesceCascadingProjections(getFunctionManager())))
                 .setSystemProperty(OPTIMIZE_CASCADING_FILTERS_AND_PROJECTIONS, "true")
                 .on(p -> {
                     p.variable("x");
                     p.variable("doubled");
-                    p.variable("summed");
+                    p.variable("shifted");
                     return p.project(
                             Assignments.builder()
-                                    .put(p.variable("out1"), p.rowExpression("summed + 1"))
-                                    .put(p.variable("out2"), p.rowExpression("summed + 2"))
+                                    .put(p.variable("out1"), p.rowExpression("shifted * 3"))
                                     .build(),
                             p.project(
                                     Assignments.builder()
-                                            .put(p.variable("summed"), p.rowExpression("doubled + doubled"))
+                                            .put(p.variable("shifted"), p.rowExpression("doubled + 1"))
                                             .build(),
                                     p.project(
                                             Assignments.builder()
@@ -152,8 +207,7 @@ public class TestCoalesceCascadingProjections
                 .matches(
                         project(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("out1", PlanMatchPattern.expression("x * 2 + x * 2 + 1"))
-                                        .put("out2", PlanMatchPattern.expression("x * 2 + x * 2 + 2"))
+                                        .put("out1", PlanMatchPattern.expression("(x * 2 + 1) * 3"))
                                         .build(),
                                 values(ImmutableMap.of("x", 0))));
     }


### PR DESCRIPTION
## Summary

`CoalesceCascadingProjections` previously inlined every deterministic child
projection expression into the parent regardless of how many times the parent
referenced it. For a multiply-referenced non-trivial expression this duplicates
the computation across the coalesced projection.

This change restricts inlining so a child output is inlined only when it is:
- referenced exactly once by the parent (a single reference never duplicates
  computation, even for a non-deterministic expression), or
- trivial to duplicate — a constant (including a constant-folded `Block`) or a
  pure variable rename.

A non-trivial expression referenced more than once is left in the child and the
chain is not collapsed at that output, matching the conservative tradeoff used
by `InlineProjections`. The rule still skips inputs to `TRY(...)` (inlining into
a TRY can change which errors are masked) and identity assignments (which would
otherwise make the rule fire forever).

The rule remains gated behind the default-off
`optimize_cascading_filters_and_projections` session property.

## Motivation

Unconditionally inlining multiply-referenced non-trivial expressions can
recompute expensive subexpressions instead of evaluating them once. On a large
production-scale query, the restricted behavior measured roughly **40% lower
wall time** and **41% lower CPU** versus the previous unconditional inlining,
with the savings concentrated in the expression-heavy fragment.

## Test Plan

- Unit: `TestCoalesceCascadingProjections` — multiply-referenced non-trivial
  expression no longer fires; multiply-referenced constant and pure variable
  rename still inline; single-use (including non-deterministic) still inlines;
  a recursive single-use chain still collapses; TRY-arg, identity-only, and
  disabled negative cases. `mvn test -pl presto-main-base -Dtest=TestCoalesceCascadingProjections` -> 9/9.
- e2e: `AbstractTestQueries#testOptimizeCascadingFiltersAndProjections` compares
  results with the property enabled vs disabled over cascading and
  multiply-referenced projection shapes (results identical either way).
- `mvn validate -pl presto-main-base` (checkstyle) passes.

```
== RELEASE NOTES ==

General Changes
* Improve the ``optimize_cascading_filters_and_projections`` optimization to avoid duplicating multiply-referenced non-trivial expressions when coalescing cascading projections.
```

<!-- rerun release-notes check -->
