### PR TITLE
feat(plugin-iceberg): Add proxy support for Iceberg REST catalogs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -254,6 +254,20 @@ Property Name                                        Description
 ``iceberg.catalog.warehouse``                        A catalog warehouse root path for Iceberg tables (optional).
                                                      Example: ``s3://warehouse/``
 
+``iceberg.rest.proxy.hostname``                      IP address or hostname of the proxy server (required when access to
+                                                     the REST catalog is through a proxy).
+                                                     Example: ``proxy.example.com``
+
+``iceberg.rest.proxy.port``                          Port for the proxy server (required when access to the REST catalog
+                                                     is through a proxy).
+                                                     Example: ``8080``
+
+``iceberg.rest.proxy.username``                      Username for proxy Basic authentication (optional).
+                                                     Example: ``proxy_user``
+
+``iceberg.rest.proxy.password``                      Password for proxy Basic authentication (optional).
+                                                     Example: ``proxy_password``
+
 ``iceberg.rest.tls.enabled``                         Whether to enable TLS for REST catalog communication
                                                      (default: ``false``).
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -23,6 +23,7 @@ import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.jsonwebtoken.Jwts;
@@ -66,6 +67,17 @@ import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 public class IcebergRestCatalogFactory
         extends IcebergNativeCatalogFactory
 {
+    // These keys mirror org.apache.iceberg.rest.HTTPClient's package-private REST_PROXY_* constants,
+    // which HTTPClient.Builder.build() reads to configure the Apache HttpClient proxy.
+    @VisibleForTesting
+    static final String REST_PROXY_HOSTNAME = "rest.client.proxy.hostname";
+    @VisibleForTesting
+    static final String REST_PROXY_PORT = "rest.client.proxy.port";
+    @VisibleForTesting
+    static final String REST_PROXY_USERNAME = "rest.client.proxy.username";
+    @VisibleForTesting
+    static final String REST_PROXY_PASSWORD = "rest.client.proxy.password";
+
     private final IcebergRestConfig catalogConfig;
     private final NodeVersion nodeVersion;
     private final String catalogName;
@@ -158,6 +170,13 @@ public class IcebergRestCatalogFactory
                 properties.put(BASIC_PASSWORD, basicAuthPassword);
             }
         });
+
+        if (catalogConfig.isProxyEnabled()) {
+            properties.put(REST_PROXY_HOSTNAME, catalogConfig.getProxyHostname().get());
+            properties.put(REST_PROXY_PORT, String.valueOf(catalogConfig.getProxyPort().get()));
+            catalogConfig.getProxyUsername().ifPresent(username -> properties.put(REST_PROXY_USERNAME, username));
+            catalogConfig.getProxyPassword().ifPresent(password -> properties.put(REST_PROXY_PASSWORD, password));
+        }
 
         catalogConfig.getSessionType().filter(type -> type.equals(USER))
                 .ifPresent(type -> properties.put(CatalogProperties.USER, session.getUser()));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.rest;
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+import com.google.common.base.Strings;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
@@ -38,6 +39,10 @@ public class IcebergRestConfig
     private String keystorePassword;
     private String truststorePath;
     private String truststorePassword;
+    private String proxyHostname;
+    private Integer proxyPort;
+    private String proxyUsername;
+    private String proxyPassword;
 
     @NotNull
     public Optional<String> getServerUri()
@@ -257,5 +262,80 @@ public class IcebergRestConfig
     public boolean credentialOrTokenExists()
     {
         return credential != null || token != null;
+    }
+
+    public Optional<String> getProxyHostname()
+    {
+        return Optional.ofNullable(proxyHostname);
+    }
+
+    @Config("iceberg.rest.proxy.hostname")
+    @ConfigDescription("The IP address or hostname of the proxy that will access the REST catalog")
+    public IcebergRestConfig setProxyHostname(String proxyHostname)
+    {
+        this.proxyHostname = proxyHostname;
+        return this;
+    }
+
+    public Optional<Integer> getProxyPort()
+    {
+        return Optional.ofNullable(proxyPort);
+    }
+
+    @Config("iceberg.rest.proxy.port")
+    @ConfigDescription("The port of the proxy that will access the REST catalog")
+    public IcebergRestConfig setProxyPort(Integer proxyPort)
+    {
+        this.proxyPort = proxyPort;
+        return this;
+    }
+
+    public Optional<String> getProxyUsername()
+    {
+        return Optional.ofNullable(proxyUsername);
+    }
+
+    @Config("iceberg.rest.proxy.username")
+    @ConfigDescription("The user of the proxy that will access the REST catalog")
+    public IcebergRestConfig setProxyUsername(String proxyUsername)
+    {
+        this.proxyUsername = proxyUsername;
+        return this;
+    }
+
+    public Optional<String> getProxyPassword()
+    {
+        return Optional.ofNullable(proxyPassword);
+    }
+
+    @Config("iceberg.rest.proxy.password")
+    @ConfigDescription("The password of the proxy that will access the REST catalog")
+    @ConfigSecuritySensitive
+    public IcebergRestConfig setProxyPassword(String proxyPassword)
+    {
+        this.proxyPassword = proxyPassword;
+        return this;
+    }
+
+    public boolean isProxyEnabled()
+    {
+        return proxyHostname != null && proxyPort != null;
+    }
+
+    @AssertTrue(message = "iceberg.rest.proxy.hostname must be non-blank when set; " +
+            "iceberg.rest.proxy.port is required when hostname is set and must be in 1-65535; " +
+            "iceberg.rest.proxy.username and iceberg.rest.proxy.password must be set together")
+    public boolean isValidProxyConfig()
+    {
+        if (proxyHostname == null) {
+            return proxyPort == null && proxyUsername == null && proxyPassword == null;
+        }
+        if (proxyHostname.trim().isEmpty()) {
+            return false;
+        }
+        if (proxyPort == null || proxyPort < 1 || proxyPort > 65535) {
+            return false;
+        }
+        return (Strings.isNullOrEmpty(proxyUsername) == (Strings.isNullOrEmpty(proxyPassword)));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
@@ -46,7 +46,11 @@ public class TestIcebergRestConfig
                 .setKeystorePath(null)
                 .setKeystorePassword(null)
                 .setTruststorePath(null)
-                .setTruststorePassword(null));
+                .setTruststorePassword(null)
+                .setProxyHostname(null)
+                .setProxyPort(null)
+                .setProxyUsername(null)
+                .setProxyPassword(null));
     }
 
     @Test
@@ -68,6 +72,10 @@ public class TestIcebergRestConfig
                 .put("iceberg.rest.tls.keystore-password", "keystorePassword")
                 .put("iceberg.rest.tls.truststore-path", "/path/to/truststore")
                 .put("iceberg.rest.tls.truststore-password", "truststorePassword")
+                .put("iceberg.rest.proxy.hostname", "localhost")
+                .put("iceberg.rest.proxy.port", "8080")
+                .put("iceberg.rest.proxy.username", "admin")
+                .put("iceberg.rest.proxy.password", "admin")
                 .build();
 
         IcebergRestConfig expected = new IcebergRestConfig()
@@ -85,7 +93,11 @@ public class TestIcebergRestConfig
                 .setKeystorePath("/path/to/keystore")
                 .setKeystorePassword("keystorePassword")
                 .setTruststorePath("/path/to/truststore")
-                .setTruststorePassword("truststorePassword");
+                .setTruststorePassword("truststorePassword")
+                .setProxyHostname("localhost")
+                .setProxyPort(8080)
+                .setProxyUsername("admin")
+                .setProxyPassword("admin");
 
         assertFullMapping(properties, expected);
     }
@@ -168,5 +180,50 @@ public class TestIcebergRestConfig
         assertFalse(new IcebergRestConfig().setTlsEnabled(true)
                 .setTruststorePassword("secret")
                 .isValidTlsConfig());
+    }
+
+    @Test
+    public void testNoProxyIsValid()
+    {
+        assertTrue(new IcebergRestConfig().isValidProxyConfig());
+    }
+
+    @Test
+    public void testProxyHostAndPortIsValid()
+    {
+        assertTrue(new IcebergRestConfig()
+                .setProxyHostname("proxy.example.com")
+                .setProxyPort(8080)
+                .isValidProxyConfig());
+    }
+
+    @Test
+    public void testProxyWithCredentialsIsValid()
+    {
+        assertTrue(new IcebergRestConfig()
+                .setProxyHostname("proxy.example.com")
+                .setProxyPort(8080)
+                .setProxyUsername("user")
+                .setProxyPassword("secret")
+                .isValidProxyConfig());
+    }
+
+    @Test
+    public void testProxyHostnameWithoutPortIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig()
+                .setProxyHostname("proxy.example.com")
+                .isValidProxyConfig());
+    }
+
+    @Test
+    public void testProxyUsernameWithoutPasswordIsInvalid()
+    {
+        assertFalse(new IcebergRestConfig()
+                .setProxyHostname("proxy.example.com")
+                .setProxyPort(8080)
+                .setProxyUsername("user")
+                .setProxyPassword("")
+                .isValidProxyConfig());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -45,6 +45,10 @@ import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
+import static com.facebook.presto.iceberg.rest.IcebergRestCatalogFactory.REST_PROXY_HOSTNAME;
+import static com.facebook.presto.iceberg.rest.IcebergRestCatalogFactory.REST_PROXY_PASSWORD;
+import static com.facebook.presto.iceberg.rest.IcebergRestCatalogFactory.REST_PROXY_PORT;
+import static com.facebook.presto.iceberg.rest.IcebergRestCatalogFactory.REST_PROXY_USERNAME;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -184,5 +188,72 @@ public class TestIcebergSmokeRest
         assertNull(properties.get(AUTH_TYPE));
         assertNull(properties.get(BASIC_USERNAME));
         assertNull(properties.get(BASIC_PASSWORD));
+    }
+
+    @Test
+    public void testAllProxyProperties()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri)
+                .setProxyHostname("proxy.example.com")
+                .setProxyPort(8080)
+                .setProxyUsername("proxyUser")
+                .setProxyPassword("proxyPass");
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        Map<String, String> properties = catalogFactory.getCatalogProperties(getSession().toConnectorSession());
+
+        assertEquals(properties.get(REST_PROXY_HOSTNAME), "proxy.example.com");
+        assertEquals(properties.get(REST_PROXY_PORT), "8080");
+        assertEquals(properties.get(REST_PROXY_USERNAME), "proxyUser");
+        assertEquals(properties.get(REST_PROXY_PASSWORD), "proxyPass");
+    }
+
+    @Test
+    public void testProxyHostAndPortWithoutCredentials()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri)
+                .setProxyHostname("proxy.example.com")
+                .setProxyPort(8080);
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        Map<String, String> properties = catalogFactory.getCatalogProperties(getSession().toConnectorSession());
+
+        assertEquals(properties.get(REST_PROXY_HOSTNAME), "proxy.example.com");
+        assertEquals(properties.get(REST_PROXY_PORT), "8080");
+        assertNull(properties.get(REST_PROXY_USERNAME));
+        assertNull(properties.get(REST_PROXY_PASSWORD));
+    }
+
+    @Test
+    public void testProxyIgnoredWithoutPort()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri)
+                .setProxyHostname("proxy.example.com");
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        Map<String, String> properties = catalogFactory.getCatalogProperties(getSession().toConnectorSession());
+
+        assertNull(properties.get(REST_PROXY_HOSTNAME));
+        assertNull(properties.get(REST_PROXY_PORT));
+        assertNull(properties.get(REST_PROXY_USERNAME));
+        assertNull(properties.get(REST_PROXY_PASSWORD));
+    }
+
+    @Test
+    public void testNoProxy()
+    {
+        IcebergRestConfig restConfig = new IcebergRestConfig()
+                .setServerUri(serverUri);
+
+        IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
+        Map<String, String> properties = catalogFactory.getCatalogProperties(getSession().toConnectorSession());
+
+        assertNull(properties.get(REST_PROXY_HOSTNAME));
+        assertNull(properties.get(REST_PROXY_PORT));
+        assertNull(properties.get(REST_PROXY_USERNAME));
+        assertNull(properties.get(REST_PROXY_PASSWORD));
     }
 }


### PR DESCRIPTION
## Description
Add proxy support for Iceberg REST catalogs connections:

- `iceberg.rest.proxy.hostname`
- `iceberg.rest.proxy.port`
- `iceberg.rest.proxy.username`
- `iceberg.rest.proxy.password`

## Motivation and Context
The underlying` httpclient5` library used by Iceberg dependencies does not automatically respect the standard Java system proxy properties (`http.proxyHost`, `http.proxyPort`, `http.nonProxyHosts`, etc.) or environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, etc.).

## Impact
Enables Presto to connect to Iceberg REST catalogs when corporate proxies are mandatory.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add proxy support for Iceberg REST catalogs

```
## Summary by Sourcery

Add configurable proxy support for Iceberg REST catalogs and propagate proxy settings into REST client properties.

New Features:
- Introduce configuration properties to define proxy host, port, username, and password for Iceberg REST catalogs.
- Enable Iceberg REST catalog factory to pass proxy connection and optional authentication settings to the underlying REST client when proxy is configured.

Documentation:
- Document the new Iceberg REST proxy configuration properties in the Iceberg connector documentation.

Tests:
- Extend Iceberg REST config tests to cover proxy configuration mappings and defaults.
- Add catalog-level tests to verify proxy properties are populated only when both hostname and port are provided and remain absent otherwise.