### PR TITLE
feat(analyzer): Reject non-deterministic functions in materialized views

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
@@ -44,6 +44,12 @@ cause an error if used.
 The optional ``WITH`` clause specifies connector-specific properties. Connector properties vary by
 connector implementation. Consult connector documentation for supported properties.
 
+.. note::
+
+    The defining query cannot contain non-deterministic functions (such as ``random`` or ``uuid``)
+    or session-time functions (such as ``current_timestamp`` or ``now``). Their values cannot be
+    reproduced across refreshes, so the engine rejects such queries at creation time.
+
 Examples
 --------
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -3148,122 +3148,107 @@ public abstract class TestIcebergMaterializedViewsBase
     }
 
     /**
-     * Data provider for non-deterministic function tests.
-     * Returns: [function expression, description, needs base tables]
+     * Data provider of non-deterministic functions that are rejected in a materialized view definition.
+     * Returns: [function expression, description]
      */
     @DataProvider(name = "nonDeterministicFunctions")
     public Object[][] nonDeterministicFunctions()
     {
         return new Object[][] {
-                {"RAND()", "RAND() in SELECT", true},
-                {"NOW()", "NOW() in SELECT", true},
-                {"CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP in SELECT", true},
+                {"RAND()", "RAND()"},
+                {"RANDOM()", "RANDOM()"},
+        };
+    }
+
+    private static final String NON_DETERMINISTIC_MV_ERROR = ".*Non-deterministic function.*not allowed in a materialized view definition";
+
+    /**
+     * Non-deterministic functions in the SELECT list are rejected at CREATE time: their value
+     * cannot be reproduced across refreshes, so the materialized view would be inconsistent.
+     */
+    @Test(dataProvider = "nonDeterministicFunctions")
+    public void testNonDeterministicFunctionInSelectRejected(String functionExpr, String description)
+    {
+        assertUpdate("CREATE TABLE test_nondeterministic_base (id INTEGER, value INTEGER, dt DATE) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        try {
+            assertQueryFails("CREATE MATERIALIZED VIEW test_nondeterministic_mv AS " +
+                            "SELECT id, value, " + functionExpr + " as nondeterministic_value, dt FROM test_nondeterministic_base",
+                    NON_DETERMINISTIC_MV_ERROR);
+        }
+        finally {
+            assertUpdate("DROP TABLE test_nondeterministic_base");
+        }
+    }
+
+    /**
+     * Non-deterministic functions in the WHERE clause are rejected at CREATE time.
+     */
+    @Test(dataProvider = "nonDeterministicFunctions")
+    public void testNonDeterministicFunctionInWhereRejected(String functionExpr, String description)
+    {
+        assertUpdate("CREATE TABLE test_nondeterministic_where (id INTEGER, value INTEGER, dt DATE) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        try {
+            assertQueryFails("CREATE MATERIALIZED VIEW test_nondeterministic_where_mv AS " +
+                            "SELECT id, value, dt FROM test_nondeterministic_where WHERE " + functionExpr + " >= 0",
+                    NON_DETERMINISTIC_MV_ERROR);
+        }
+        finally {
+            assertUpdate("DROP TABLE test_nondeterministic_where");
+        }
+    }
+
+    /**
+     * Non-deterministic functions inside an aggregation are rejected at CREATE time.
+     */
+    @Test
+    public void testNonDeterministicFunctionInAggregationRejected()
+    {
+        assertUpdate("CREATE TABLE test_nondeterministic_agg (id INTEGER, category VARCHAR, value INTEGER, dt DATE) " +
+                "WITH (partitioning = ARRAY['dt'])");
+        try {
+            assertQueryFails("CREATE MATERIALIZED VIEW test_nondeterministic_agg_mv AS " +
+                            "SELECT category, SUM(value * (1 + RAND())) as total FROM test_nondeterministic_agg GROUP BY category",
+                    NON_DETERMINISTIC_MV_ERROR);
+        }
+        finally {
+            assertUpdate("DROP TABLE test_nondeterministic_agg");
+        }
+    }
+
+    /**
+     * Data provider of session-time functions rejected in a materialized view definition.
+     * Covers both the function-call form (NOW()) and the bare-keyword CurrentTime form.
+     */
+    @DataProvider(name = "sessionTimeFunctions")
+    public Object[][] sessionTimeFunctions()
+    {
+        return new Object[][] {
+                {"NOW()"},
+                {"CURRENT_TIMESTAMP"},
+                {"CURRENT_DATE"},
+                {"LOCALTIMESTAMP"},
         };
     }
 
     /**
-     * Test that non-deterministic functions in SELECT cause fallback to full recompute.
-     * Materialized views with non-deterministic functions should never use stitching because:
-     * - Fresh branch would compute RAND()/NOW()/UUID() at read time
-     * - Stale branch would compute different values
-     * - Results would be inconsistent
+     * Session-time functions are constant within a query but vary across refreshes, so they
+     * are rejected at CREATE time to keep the materialized data consistent with the query.
      */
-    @Test(dataProvider = "nonDeterministicFunctions")
-    public void testNonDeterministicFunctionInSelect(String functionExpr, String description, boolean needsBaseTables)
+    @Test(dataProvider = "sessionTimeFunctions")
+    public void testSessionTimeFunctionRejected(String functionExpr)
     {
-        // Create base table
-        assertUpdate("CREATE TABLE test_nondeterministic_base (id INTEGER, value INTEGER, dt DATE) " +
+        assertUpdate("CREATE TABLE test_time_fn_base (id INTEGER, value INTEGER, dt DATE) " +
                 "WITH (partitioning = ARRAY['dt'])");
-        assertUpdate("INSERT INTO test_nondeterministic_base VALUES (1, 100, DATE '2024-01-01'), (2, 200, DATE '2024-01-01')", 2);
-
-        // Create MV with non-deterministic function
-        assertUpdate("CREATE MATERIALIZED VIEW test_nondeterministic_mv AS " +
-                "SELECT id, value, " + functionExpr + " as nondeterministic_value, dt FROM test_nondeterministic_base");
-
-        // Initial refresh
-        assertRefreshAndFullyMaterialized("test_nondeterministic_mv", 2);
-
-        // Introduce staleness
-        assertUpdate("INSERT INTO test_nondeterministic_base VALUES (3, 300, DATE '2024-01-02')", 1);
-
-        // Query should fall back to full recompute (not use stitching)
-        // We verify this by checking that the query succeeds and returns correct row count
-        // The optimizer will automatically use full recompute instead of stitching
-        assertQuery("SELECT id, value FROM test_nondeterministic_mv ORDER BY id",
-                "VALUES (1, 100), (2, 200), (3, 300)");
-
-        assertUpdate("DROP MATERIALIZED VIEW test_nondeterministic_mv");
-        assertUpdate("DROP TABLE test_nondeterministic_base");
-    }
-
-    /**
-     * Test that non-deterministic functions in WHERE clause cause fallback to full recompute.
-     */
-    @Test(dataProvider = "nonDeterministicFunctions")
-    public void testNonDeterministicFunctionInWhere(String functionExpr, String description, boolean needsBaseTables)
-    {
-        // Skip functions that can't be used in WHERE clause (UUID returns VARCHAR, can't compare with numbers easily)
-        if (functionExpr.equals("UUID()")) {
-            return;
+        try {
+            assertQueryFails("CREATE MATERIALIZED VIEW test_time_fn_mv AS " +
+                            "SELECT id, value, " + functionExpr + " as created_at, dt FROM test_time_fn_base",
+                    NON_DETERMINISTIC_MV_ERROR);
         }
-
-        // Create base table
-        assertUpdate("CREATE TABLE test_nondeterministic_where (id INTEGER, value INTEGER, dt DATE) " +
-                "WITH (partitioning = ARRAY['dt'])");
-        assertUpdate("INSERT INTO test_nondeterministic_where VALUES (1, 100, DATE '2024-01-01'), (2, 200, DATE '2024-01-01')", 2);
-
-        // Create MV with non-deterministic function in WHERE clause
-        // Use a condition that's always true but contains the non-deterministic function
-        String whereClause = functionExpr.contains("RAND") ? "RAND() >= 0" : functionExpr + " IS NOT NULL";
-        assertUpdate("CREATE MATERIALIZED VIEW test_nondeterministic_where_mv AS " +
-                "SELECT id, value, dt FROM test_nondeterministic_where WHERE " + whereClause);
-
-        // Initial refresh
-        assertRefreshAndFullyMaterialized("test_nondeterministic_where_mv", 2);
-
-        // Introduce staleness
-        assertUpdate("INSERT INTO test_nondeterministic_where VALUES (3, 300, DATE '2024-01-02')", 1);
-
-        // Query should fall back to full recompute
-        assertQuery("SELECT id, value FROM test_nondeterministic_where_mv ORDER BY id",
-                "VALUES (1, 100), (2, 200), (3, 300)");
-
-        assertUpdate("DROP MATERIALIZED VIEW test_nondeterministic_where_mv");
-        assertUpdate("DROP TABLE test_nondeterministic_where");
-    }
-
-    /**
-     * Test that non-deterministic functions in aggregation cause fallback to full recompute.
-     */
-    @Test
-    public void testNonDeterministicFunctionInAggregation()
-    {
-        // Create base table
-        assertUpdate("CREATE TABLE test_nondeterministic_agg (id INTEGER, category VARCHAR, value INTEGER, dt DATE) " +
-                "WITH (partitioning = ARRAY['dt'])");
-        assertUpdate("INSERT INTO test_nondeterministic_agg VALUES " +
-                "(1, 'A', 100, DATE '2024-01-01'), " +
-                "(2, 'A', 200, DATE '2024-01-01'), " +
-                "(3, 'B', 300, DATE '2024-01-01')", 3);
-
-        // Create MV with non-deterministic function in aggregation
-        // Use RAND() to create a non-deterministic computed value before aggregation
-        assertUpdate("CREATE MATERIALIZED VIEW test_nondeterministic_agg_mv AS " +
-                "SELECT category, SUM(value * (1 + RAND())) as total FROM test_nondeterministic_agg GROUP BY category");
-
-        // Initial refresh
-        assertRefreshAndFullyMaterialized("test_nondeterministic_agg_mv", 2);
-
-        // Introduce staleness
-        assertUpdate("INSERT INTO test_nondeterministic_agg VALUES (4, 'A', 400, DATE '2024-01-02')", 1);
-
-        // Query should fall back to full recompute
-        // We just verify it returns the expected categories (values will vary due to RAND())
-        assertQuery("SELECT category FROM test_nondeterministic_agg_mv ORDER BY category",
-                "VALUES ('A'), ('B')");
-
-        assertUpdate("DROP MATERIALIZED VIEW test_nondeterministic_agg_mv");
-        assertUpdate("DROP TABLE test_nondeterministic_agg");
+        finally {
+            assertUpdate("DROP TABLE test_time_fn_base");
+        }
     }
 
     @Test

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -61,7 +61,9 @@ import com.facebook.presto.spi.connector.ConnectorTableVersion;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.eventlistener.Column;
 import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.table.Argument;
@@ -120,6 +122,7 @@ import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateVectorIndex;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Cube;
+import com.facebook.presto.sql.tree.CurrentTime;
 import com.facebook.presto.sql.tree.Deallocate;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Delete;
@@ -269,6 +272,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.CallTask.extractParameterValuesInOrder;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.MetadataUtil.getConnectorIdOrThrow;
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
@@ -413,6 +417,14 @@ class StatementAnalyzer
 {
     private static final Logger log = Logger.get(StatementAnalyzer.class);
     private static final int UNION_DISTINCT_FIELDS_WARNING_THRESHOLD = 3;
+    // Time functions are deterministic within a query but vary across refreshes, so they are disallowed in MV definitions
+    private static final Set<QualifiedObjectName> SESSION_TIME_FUNCTIONS = ImmutableSet.of(
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "now"),
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "current_timestamp"),
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "current_date"),
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "current_time"),
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "localtime"),
+            QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "localtimestamp"));
     private final Analysis analysis;
     private final Metadata metadata;
     private final FunctionAndTypeResolver functionAndTypeResolver;
@@ -896,7 +908,45 @@ class StatementAnalyzer
 
             validateBaseTables(analysis.getTableNodes(), node);
 
+            validateDeterministicFunctionsInMV(node);
+
             return createAndAssignScope(node, scope);
+        }
+
+        private void validateDeterministicFunctionsInMV(CreateMaterializedView node)
+        {
+            FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+            // now()/current_timestamp() are FunctionCalls; CURRENT_TIMESTAMP/CURRENT_DATE parse as CurrentTime nodes
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitFunctionCall(FunctionCall functionCall, Void context)
+                {
+                    FunctionHandle functionHandle = analysis.getFunctionHandle(functionCall);
+                    if (functionHandle != null) {
+                        FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(functionHandle);
+                        if (!functionMetadata.isDeterministic() || SESSION_TIME_FUNCTIONS.contains(functionMetadata.getName())) {
+                            throw rejectNonDeterministicInMV(functionCall, functionCall.getName().toString());
+                        }
+                    }
+                    return super.visitFunctionCall(functionCall, context);
+                }
+
+                @Override
+                protected Void visitCurrentTime(CurrentTime currentTime, Void context)
+                {
+                    throw rejectNonDeterministicInMV(currentTime, currentTime.getFunction().getName());
+                }
+            }.process(node.getQuery(), null);
+        }
+
+        private SemanticException rejectNonDeterministicInMV(Node node, String functionName)
+        {
+            return new SemanticException(
+                    NOT_SUPPORTED,
+                    node,
+                    "Non-deterministic function '%s' is not allowed in a materialized view definition",
+                    functionName);
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -2586,6 +2586,30 @@ public class TestAnalyzer
         assertFails(NOT_SUPPORTED, "REFRESH MATERIALIZED VIEW mv1 WHERE a IN (a)");
     }
 
+    @Test
+    public void testCreateMaterializedViewRejectsNonDeterministicFunction()
+    {
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a, rand() r FROM t1");
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a FROM t1 WHERE rand() >= 0");
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a, sum(b * random()) s FROM t1 GROUP BY a");
+    }
+
+    @Test
+    public void testCreateMaterializedViewRejectsSessionTimeFunction()
+    {
+        // now()/current_timestamp() are function calls; CURRENT_TIMESTAMP/CURRENT_DATE are CurrentTime nodes
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a, now() ts FROM t1");
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a, current_timestamp ts FROM t1");
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a, current_date d FROM t1");
+        assertFails(NOT_SUPPORTED, "CREATE MATERIALIZED VIEW s1.mv_nd AS SELECT a FROM t1 WHERE current_timestamp IS NOT NULL");
+    }
+
+    @Test
+    public void testCreateMaterializedViewAllowsDeterministicFunction()
+    {
+        analyze("CREATE MATERIALIZED VIEW s1.mv_det AS SELECT a, abs(b) c FROM t1");
+    }
+
     private Optional<String> refreshScopePredicate(String query)
     {
         Optional<RowExpression> predicate = analyzeAndGetAnalysis(CLIENT_SESSION, query)


### PR DESCRIPTION
Summary:
`CREATE MATERIALIZED VIEW` previously accepted functions whose value cannot be
reproduced across refreshes, so the materialized data could silently diverge from
the defining query. Two classes are now rejected at create time:

- Non-deterministic functions (`rand`, `random`, `uuid`, `shuffle`), i.e. those whose
  `FunctionMetadata.isDeterministic()` is false.
- Session-time functions (`now`, `current_timestamp`, `current_date`, `current_time`,
  `localtime`, `localtimestamp`), which are deterministic within a query but vary across
  refreshes. Presto has no metadata flag for session-dependence, so these are matched by
  their built-in qualified name.

The check runs in the analyzer as a single traversal of the view query. The restriction
is documented in the CREATE MATERIALIZED VIEW reference.

Differential Revision: D113578730

```
== RELEASE NOTES ==

General Changes
* Add validation to reject non-deterministic and session-time functions in ``CREATE MATERIALIZED VIEW`` definitions.
```
