### PR TITLE
feat: Add scanRawInputDataSize to basic query statistics (#28221)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
@@ -46,6 +46,7 @@ public class BasicStageExecutionStats
             0,
 
             0L,
+            0L,
             0,
 
             0.0,
@@ -77,6 +78,7 @@ public class BasicStageExecutionStats
     private final int runningSplits;
     private final int completedSplits;
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
     private final double cumulativeUserMemory;
     private final double cumulativeTotalMemory;
@@ -108,6 +110,7 @@ public class BasicStageExecutionStats
             int completedSplits,
 
             long rawInputDataSizeInBytes,
+            long scanRawInputDataSizeInBytes,
             long rawInputPositions,
 
             double cumulativeUserMemory,
@@ -140,6 +143,8 @@ public class BasicStageExecutionStats
         this.completedSplits = completedSplits;
         checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
         this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        checkArgument(scanRawInputDataSizeInBytes >= 0, "scanRawInputDataSizeInBytes is negative");
+        this.scanRawInputDataSizeInBytes = scanRawInputDataSizeInBytes;
         this.rawInputPositions = rawInputPositions;
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.cumulativeTotalMemory = cumulativeTotalMemory;
@@ -226,6 +231,11 @@ public class BasicStageExecutionStats
         return rawInputDataSizeInBytes;
     }
 
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
     public long getRawInputPositions()
     {
         return rawInputPositions;
@@ -307,6 +317,7 @@ public class BasicStageExecutionStats
         long totalCpuTime = 0;
 
         long rawInputDataSize = 0;
+        long scanRawInputDataSize = 0;
         long rawInputPositions = 0;
 
         boolean isScheduled = true;
@@ -348,6 +359,7 @@ public class BasicStageExecutionStats
             totalAllocation += stageStats.getTotalAllocationInBytes();
 
             rawInputDataSize += stageStats.getRawInputDataSizeInBytes();
+            scanRawInputDataSize += stageStats.getScanRawInputDataSizeInBytes();
             rawInputPositions += stageStats.getRawInputPositions();
         }
 
@@ -375,6 +387,7 @@ public class BasicStageExecutionStats
                 completedSplits,
 
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
 
                 cumulativeUserMemory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -405,6 +405,7 @@ public class QueryStateMachine
                 stageStats.getCompletedSplits(),
 
                 succinctBytes(stageStats.getRawInputDataSizeInBytes()),
+                succinctBytes(stageStats.getScanRawInputDataSizeInBytes()),
                 stageStats.getRawInputPositions(),
 
                 stageStats.getCumulativeUserMemory(),

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -139,6 +139,7 @@ public class StageExecutionInfo
                 taskStatsAggregator.totalAllocation,
 
                 taskStatsAggregator.rawInputDataSize,
+                taskStatsAggregator.scanRawInputDataSize,
                 taskStatsAggregator.rawInputPositions,
                 taskStatsAggregator.processedInputDataSize,
                 taskStatsAggregator.processedInputPositions,
@@ -278,6 +279,7 @@ public class StageExecutionInfo
         private long totalAllocation;
 
         private long rawInputDataSize;
+        private long scanRawInputDataSize;
         private long rawInputPositions;
 
         private long processedInputDataSize;
@@ -336,6 +338,7 @@ public class StageExecutionInfo
             totalAllocation += taskStats.getTotalAllocationInBytes();
 
             rawInputDataSize += taskStats.getRawInputDataSizeInBytes();
+            scanRawInputDataSize += taskStats.getScanRawInputDataSizeInBytes();
             rawInputPositions += taskStats.getRawInputPositions();
 
             processedInputDataSize += taskStats.getProcessedInputDataSizeInBytes();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -274,6 +274,7 @@ public class StageExecutionStateMachine
         long totalCpuTime = 0;
 
         long rawInputDataSizeInBytes = 0;
+        long scanRawInputDataSizeInBytes = 0;
         long rawInputPositions = 0;
 
         boolean fullyBlocked = true;
@@ -316,6 +317,11 @@ public class StageExecutionStateMachine
 
             totalAllocationInBytes += taskStats.getTotalAllocationInBytes();
 
+            // Scan-only raw input is already leaf-filtered per task, so it is summed
+            // unconditionally (non-scan tasks contribute 0) rather than gated on the
+            // coarse per-stage containsTableScans flag that inflates rawInputDataSizeInBytes.
+            scanRawInputDataSizeInBytes += taskStats.getScanRawInputDataSizeInBytes();
+
             if (containsTableScans) {
                 rawInputDataSizeInBytes += taskStats.getRawInputDataSizeInBytes();
                 rawInputPositions += taskStats.getRawInputPositions();
@@ -346,6 +352,7 @@ public class StageExecutionStateMachine
                 completedSplits,
 
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
 
                 cumulativeUserMemory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -83,6 +83,7 @@ public class StageExecutionStats
     private final long totalAllocationInBytes;
 
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
 
     private final long processedInputDataSizeInBytes;
@@ -147,6 +148,7 @@ public class StageExecutionStats
             @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
             @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("scanRawInputDataSizeInBytes") long scanRawInputDataSizeInBytes,
             @JsonProperty("rawInputPositions") long rawInputPositions,
 
             @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
@@ -223,6 +225,7 @@ public class StageExecutionStats
 
         this.totalAllocationInBytes = (totalAllocationInBytes >= 0) ? totalAllocationInBytes : Long.MAX_VALUE;
         this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
+        this.scanRawInputDataSizeInBytes = (scanRawInputDataSizeInBytes >= 0) ? scanRawInputDataSizeInBytes : Long.MAX_VALUE;
         this.rawInputPositions = (rawInputPositions >= 0) ? rawInputPositions : Long.MAX_VALUE;
 
         this.processedInputDataSizeInBytes = (processedInputDataSizeInBytes >= 0) ? processedInputDataSizeInBytes : Long.MAX_VALUE;
@@ -447,6 +450,12 @@ public class StageExecutionStats
     }
 
     @JsonProperty
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
+    @JsonProperty
     public long getRawInputPositions()
     {
         return rawInputPositions;
@@ -530,6 +539,7 @@ public class StageExecutionStats
                 runningSplits,
                 completedSplits,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 cumulativeUserMemory,
                 cumulativeTotalMemory,
@@ -579,6 +589,7 @@ public class StageExecutionStats
                 new Duration(0, NANOSECONDS),
                 false,
                 ImmutableSet.of(),
+                0L,
                 0L,
                 0L,
                 0,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -464,6 +464,7 @@ public class TaskContext
         long totalAllocation = 0;
 
         long rawInputDataSize = 0;
+        long scanRawInputDataSize = 0;
         long rawInputPositions = 0;
 
         long processedInputDataSize = 0;
@@ -520,7 +521,15 @@ public class TaskContext
             }
 
             physicalWrittenDataSize += pipeline.getPhysicalWrittenDataSizeInBytes();
-            pipeline.getOperatorSummaries().stream().forEach(stats -> mergedRuntimeStats.mergeWith(stats.getRuntimeStats()));
+            for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
+                mergedRuntimeStats.mergeWith(operatorStats.getRuntimeStats());
+                // Scan-only raw input: leaf table scans exclude exchange/shuffle bytes,
+                // matching the operator-filtered rawInputDataSize in QueryStats.create().
+                String operatorType = operatorStats.getOperatorType();
+                if (operatorType.equals(TableScanOperator.class.getSimpleName()) || operatorType.equals(ScanFilterAndProjectOperator.class.getSimpleName())) {
+                    scanRawInputDataSize += operatorStats.getRawInputDataSizeInBytes();
+                }
+            }
         }
 
         long startNanos = this.startNanos.get();
@@ -613,6 +622,7 @@ public class TaskContext
                 blockedReasons.build(),
                 totalAllocation,
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
                 processedInputDataSize,
                 processedInputPositions,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -81,6 +81,7 @@ public class TaskStats
     private final long totalAllocationInBytes;
 
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
 
     private final long processedInputDataSizeInBytes;
@@ -140,6 +141,7 @@ public class TaskStats
                 ImmutableSet.of(),
                 0L,
                 0L,
+                0L,
                 0,
                 0L,
                 0,
@@ -191,6 +193,7 @@ public class TaskStats
                 0L,
                 false,
                 ImmutableSet.of(),
+                0L,
                 0L,
                 0L,
                 0,
@@ -255,6 +258,7 @@ public class TaskStats
             @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
             @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("scanRawInputDataSizeInBytes") long scanRawInputDataSizeInBytes,
             @JsonProperty("rawInputPositions") long rawInputPositions,
 
             @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
@@ -346,6 +350,7 @@ public class TaskStats
         this.totalAllocationInBytes = totalAllocationInBytes;
 
         this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.scanRawInputDataSizeInBytes = scanRawInputDataSizeInBytes;
         this.rawInputPositions = (rawInputPositions >= 0) ? rawInputPositions : Long.MAX_VALUE;
 
         this.processedInputDataSizeInBytes = processedInputDataSizeInBytes;
@@ -732,6 +737,16 @@ public class TaskStats
         return completedNewDrivers;
     }
 
+    /**
+     * Sum of leaf table-scan (TableScan/ScanFilterAndProject) raw input bytes; excludes exchange/shuffle. Populated by workers.
+     */
+    @JsonProperty
+    @ThriftField(50)
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -774,6 +789,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,
@@ -828,6 +844,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,

--- a/presto-main-base/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -72,6 +72,7 @@ public class BasicQueryStats
     private final int completedSplits;
 
     private final DataSize rawInputDataSize;
+    private final DataSize scanRawInputDataSize;
     private final long rawInputPositions;
 
     private final double cumulativeUserMemory;
@@ -115,6 +116,7 @@ public class BasicQueryStats
             int runningSplits,
             int completedSplits,
             DataSize rawInputDataSize,
+            DataSize scanRawInputDataSize,
             long rawInputPositions,
             double cumulativeUserMemory,
             double cumulativeTotalMemory,
@@ -168,6 +170,7 @@ public class BasicQueryStats
         this.completedSplits = completedSplits;
 
         this.rawInputDataSize = requireNonNull(rawInputDataSize);
+        this.scanRawInputDataSize = requireNonNull(scanRawInputDataSize, "scanRawInputDataSize is null");
         this.rawInputPositions = rawInputPositions;
 
         this.cumulativeUserMemory = cumulativeUserMemory;
@@ -214,6 +217,7 @@ public class BasicQueryStats
             @JsonProperty("runningSplits") int runningSplits,
             @JsonProperty("completedSplits") int completedSplits,
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
+            @JsonProperty("scanRawInputDataSize") DataSize scanRawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
@@ -252,6 +256,7 @@ public class BasicQueryStats
                 runningSplits,
                 completedSplits,
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
                 cumulativeUserMemory,
                 cumulativeTotalMemory,
@@ -292,6 +297,9 @@ public class BasicQueryStats
                 queryStats.getQueuedSplits(),
                 queryStats.getRunningSplits(),
                 queryStats.getCompletedSplits(),
+                queryStats.getRawInputDataSize(),
+                // QueryStats.rawInputDataSize is already operator-filtered to leaf scans
+                // (see QueryStats.create()), so it is the scan-only value for finished queries.
                 queryStats.getRawInputDataSize(),
                 queryStats.getRawInputPositions(),
                 queryStats.getCumulativeUserMemory(),
@@ -335,6 +343,7 @@ public class BasicQueryStats
                 0,
                 0,
                 0,
+                new DataSize(0, BYTE),
                 new DataSize(0, BYTE),
                 0,
                 0,
@@ -619,5 +628,12 @@ public class BasicQueryStats
     public int getCompletedNewDrivers()
     {
         return completedNewDrivers;
+    }
+
+    @ThriftField(38)
+    @JsonProperty
+    public DataSize getScanRawInputDataSize()
+    {
+        return scanRawInputDataSize;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -145,6 +145,7 @@ public class MockManagedQueryExecution
                         8,
                         9,
                         new DataSize(14, BYTE),
+                        new DataSize(14, BYTE),
                         15,
                         16.0,
                         25.0,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -200,6 +200,7 @@ public class TestNodeScheduler
                     0,
                     0,
                     DataSize.valueOf("1MB"),
+                    DataSize.valueOf("1MB"),
                     0,
                     0,
                     0,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -834,6 +834,7 @@ public class TestQueryStats
                 0L,
 
                 rawInputDataSize,
+                0L,
                 rawInputPositions,
 
                 inputDataSize,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
@@ -71,6 +71,7 @@ public class TestStageExecutionStats
             123L,
 
             19L,
+            17L,
             20,
 
             21L,
@@ -139,6 +140,7 @@ public class TestStageExecutionStats
         assertEquals(actual.getTotalAllocationInBytes(), 123L);
 
         assertEquals(actual.getRawInputDataSizeInBytes(), 19L);
+        assertEquals(actual.getScanRawInputDataSizeInBytes(), 17L);
         assertEquals(actual.getRawInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSizeInBytes(), 21L);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -70,6 +70,7 @@ public class TestTaskStats
             123,
 
             19,
+            17,
             20,
 
             21,
@@ -130,6 +131,7 @@ public class TestTaskStats
         assertEquals(actual.getTotalAllocationInBytes(), 123);
 
         assertEquals(actual.getRawInputDataSizeInBytes(), 19);
+        assertEquals(actual.getScanRawInputDataSizeInBytes(), 17);
         assertEquals(actual.getRawInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSizeInBytes(), 21);

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -769,6 +769,7 @@ public class TestResourceManagerClusterStateProvider
                         15,
                         100,
                         DataSize.valueOf("21GB"),
+                        DataSize.valueOf("21GB"),
                         22,
                         23,
                         24,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
@@ -339,6 +339,7 @@ public class TestPlanPrinter
                 0L,
 
                 rawInputDataSize,
+                0L,
                 rawInputPositions,
 
                 inputDataSize,

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -278,6 +278,7 @@ public class TestHttpResourceManagerClient
                         new Duration(1, SECONDS),
                         1, 1, 1, 1, 1, 100, 1, 1, 1, 100, 1, 1, 1, 100,
                         new DataSize(1, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
                         1, 1, 1,
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -859,6 +859,7 @@ void PrestoTask::updateExecutionInfoLocked(
 
   prestoTaskStats.rawInputPositions = 0;
   prestoTaskStats.rawInputDataSizeInBytes = 0;
+  prestoTaskStats.scanRawInputDataSizeInBytes = 0;
   prestoTaskStats.processedInputPositions = 0;
   prestoTaskStats.processedInputDataSizeInBytes = 0;
   prestoTaskStats.outputPositions = 0;
@@ -909,6 +910,14 @@ void PrestoTask::updateExecutionInfoLocked(
             firstVeloxOpStats.rawInputPositions;
         prestoTaskStats.rawInputDataSizeInBytes +=
             firstVeloxOpStats.rawInputBytes;
+        // Scan-only raw input: count only leaf TableScan sources, excluding the
+        // Exchange/Merge shuffle inputs that inflate rawInputDataSizeInBytes.
+        // The task-level source is operatorStats[0] (the scan itself), never
+        // the FilterProject copy made at the per-operator level below.
+        if (firstVeloxOpStats.operatorType == "TableScan") {
+          prestoTaskStats.scanRawInputDataSizeInBytes +=
+              firstVeloxOpStats.rawInputBytes;
+        }
         prestoTaskStats.processedInputPositions +=
             firstVeloxOpStats.inputPositions;
         prestoTaskStats.processedInputDataSizeInBytes +=

--- a/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
+++ b/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
@@ -101,6 +101,7 @@
         ],
         "totalAllocationInBytes": 123,
         "rawInputDataSizeInBytes": 456,
+        "scanRawInputDataSizeInBytes": 123,
         "rawInputPositions": 789,
         "processedInputDataSizeInBytes": 123,
         "processedInputPositions": 456,

--- a/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
@@ -1204,6 +1204,9 @@ void toThrift(
   toThrift(proto.queuedNewDrivers, *thrift.queuedNewDrivers_ref());
   toThrift(proto.runningNewDrivers, *thrift.runningNewDrivers_ref());
   toThrift(proto.completedNewDrivers, *thrift.completedNewDrivers_ref());
+  toThrift(
+      proto.scanRawInputDataSizeInBytes,
+      *thrift.scanRawInputDataSizeInBytes_ref());
 }
 void fromThrift(
     const TaskStats& thrift,
@@ -1282,6 +1285,9 @@ void fromThrift(
   fromThrift(*thrift.queuedNewDrivers_ref(), proto.queuedNewDrivers);
   fromThrift(*thrift.runningNewDrivers_ref(), proto.runningNewDrivers);
   fromThrift(*thrift.completedNewDrivers_ref(), proto.completedNewDrivers);
+  fromThrift(
+      *thrift.scanRawInputDataSizeInBytes_ref(),
+      proto.scanRawInputDataSizeInBytes);
 }
 
 void toThrift(

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -451,6 +451,7 @@ struct TaskStats {
   47: i32 queuedNewDrivers;
   48: i32 runningNewDrivers;
   49: i32 completedNewDrivers;
+  50: i64 scanRawInputDataSizeInBytes;
 }
 struct PipelineStats {
   1: i32 pipelineId;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -12035,6 +12035,13 @@ void to_json(json& j, const TaskStats& p) {
       "rawInputDataSizeInBytes");
   to_json_key(
       j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
+  to_json_key(
+      j,
       "rawInputPositions",
       p.rawInputPositions,
       "TaskStats",
@@ -12344,6 +12351,13 @@ void from_json(const json& j, TaskStats& p) {
       "TaskStats",
       "int64_t",
       "rawInputDataSizeInBytes");
+  from_json_key(
+      j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
   from_json_key(
       j,
       "rawInputPositions",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2674,6 +2674,7 @@ struct TaskStats {
   List<BlockedReason> blockedReasons = {};
   int64_t totalAllocationInBytes = {};
   int64_t rawInputDataSizeInBytes = {};
+  int64_t scanRawInputDataSizeInBytes = {};
   int64_t rawInputPositions = {};
   int64_t processedInputDataSizeInBytes = {};
   int64_t processedInputPositions = {};

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -104,6 +104,7 @@ public class TestClusterMemoryLeakDetector
                         15,
                         100,
                         DataSize.valueOf("21GB"),
+                        DataSize.valueOf("21GB"),
                         22,
                         23,
                         28,


### PR DESCRIPTION
Summary:

Aggregate `scanRawInputDataSizeInBytes` through the coordinator's basic/live
statistics path so it is available for running queries, alongside the existing
`rawInputDataSizeInBytes`.

- `BasicStageExecutionStats`: new `scanRawInputDataSizeInBytes` field, summed in
  `aggregateBasicStageStats()`.
- `StageExecutionStateMachine.getBasicStageStats()`: sums the per-task scan-only
  scalar. Because the scalar is already filtered to leaf scans per task, it is
  summed unconditionally rather than gated on the coarse per-stage
  `containsTableScans` flag used for `rawInputDataSizeInBytes`.
- `StageExecutionStats.toBasicStageStats()` (finished-stage path): derives the
  scan-only value from the stage `operatorSummaries` using the same leaf-scan
  filter, so scan bytes from completed upstream stages are not lost while the
  query is still running.
- `BasicQueryStats`: new `scanRawInputDataSize` field (Thrift field 38). The
  `QueryStats`-based constructor maps it from `getRawInputDataSize()`, which is
  already operator-filtered (scan-only) for completed queries.
- `QueryStateMachine.getBasicQueryInfo()`: threads the aggregated value through.

The existing `rawInputDataSize` is unchanged.

== Motivation and Context ==

`BasicQueryStats` / `BasicStageExecutionStats` power the live view of a running
query (REST and Thrift). Propagating the scan-only statistic through this path
makes it observable for in-flight queries, not just completed ones.

== Impact ==

Additive fields on `BasicStageExecutionStats` and `BasicQueryStats`
(`scanRawInputDataSize` is Thrift field 38 on `BasicQueryStats`). No change to
existing fields.

== RELEASE NOTES ==

General Changes
* Add ``scanRawInputDataSize`` to basic query statistics.

Differential Revision: D113461500
