### PR TITLE
feat!: Add scan-only raw input data size statistics (#28222)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -256,7 +256,8 @@ public class QueryMonitor
                         0,
                         0,
                         true,
-                        new RuntimeStats()),
+                        new RuntimeStats(),
+                        0L),
                 createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
@@ -470,7 +471,8 @@ public class QueryMonitor
                 queryStats.getCumulativeTotalMemory(),
                 queryStats.getCompletedDrivers(),
                 queryInfo.isFinalQueryInfo(),
-                queryStats.getRuntimeStats());
+                queryStats.getRuntimeStats(),
+                queryStats.getRawInputDataSize().toBytes());
     }
 
     private QueryStatistics createQueryStatistics(BasicQueryInfo basicQueryInfo)
@@ -512,7 +514,8 @@ public class QueryMonitor
                 queryStats.getCumulativeTotalMemory(),
                 queryStats.getCompletedDrivers(),
                 false,
-                new RuntimeStats());
+                new RuntimeStats(),
+                queryStats.getScanRawInputDataSize().toBytes());
     }
 
     private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
@@ -46,6 +46,7 @@ public class BasicStageExecutionStats
             0,
 
             0L,
+            0L,
             0,
 
             0.0,
@@ -77,6 +78,7 @@ public class BasicStageExecutionStats
     private final int runningSplits;
     private final int completedSplits;
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
     private final double cumulativeUserMemory;
     private final double cumulativeTotalMemory;
@@ -108,6 +110,7 @@ public class BasicStageExecutionStats
             int completedSplits,
 
             long rawInputDataSizeInBytes,
+            long scanRawInputDataSizeInBytes,
             long rawInputPositions,
 
             double cumulativeUserMemory,
@@ -140,6 +143,8 @@ public class BasicStageExecutionStats
         this.completedSplits = completedSplits;
         checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
         this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        checkArgument(scanRawInputDataSizeInBytes >= 0, "scanRawInputDataSizeInBytes is negative");
+        this.scanRawInputDataSizeInBytes = scanRawInputDataSizeInBytes;
         this.rawInputPositions = rawInputPositions;
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.cumulativeTotalMemory = cumulativeTotalMemory;
@@ -226,6 +231,11 @@ public class BasicStageExecutionStats
         return rawInputDataSizeInBytes;
     }
 
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
     public long getRawInputPositions()
     {
         return rawInputPositions;
@@ -307,6 +317,7 @@ public class BasicStageExecutionStats
         long totalCpuTime = 0;
 
         long rawInputDataSize = 0;
+        long scanRawInputDataSize = 0;
         long rawInputPositions = 0;
 
         boolean isScheduled = true;
@@ -348,6 +359,7 @@ public class BasicStageExecutionStats
             totalAllocation += stageStats.getTotalAllocationInBytes();
 
             rawInputDataSize += stageStats.getRawInputDataSizeInBytes();
+            scanRawInputDataSize += stageStats.getScanRawInputDataSizeInBytes();
             rawInputPositions += stageStats.getRawInputPositions();
         }
 
@@ -375,6 +387,7 @@ public class BasicStageExecutionStats
                 completedSplits,
 
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
 
                 cumulativeUserMemory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -405,6 +405,7 @@ public class QueryStateMachine
                 stageStats.getCompletedSplits(),
 
                 succinctBytes(stageStats.getRawInputDataSizeInBytes()),
+                succinctBytes(stageStats.getScanRawInputDataSizeInBytes()),
                 stageStats.getRawInputPositions(),
 
                 stageStats.getCumulativeUserMemory(),

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -139,6 +139,7 @@ public class StageExecutionInfo
                 taskStatsAggregator.totalAllocation,
 
                 taskStatsAggregator.rawInputDataSize,
+                taskStatsAggregator.scanRawInputDataSize,
                 taskStatsAggregator.rawInputPositions,
                 taskStatsAggregator.processedInputDataSize,
                 taskStatsAggregator.processedInputPositions,
@@ -278,6 +279,7 @@ public class StageExecutionInfo
         private long totalAllocation;
 
         private long rawInputDataSize;
+        private long scanRawInputDataSize;
         private long rawInputPositions;
 
         private long processedInputDataSize;
@@ -336,6 +338,7 @@ public class StageExecutionInfo
             totalAllocation += taskStats.getTotalAllocationInBytes();
 
             rawInputDataSize += taskStats.getRawInputDataSizeInBytes();
+            scanRawInputDataSize += taskStats.getScanRawInputDataSizeInBytes();
             rawInputPositions += taskStats.getRawInputPositions();
 
             processedInputDataSize += taskStats.getProcessedInputDataSizeInBytes();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -274,6 +274,7 @@ public class StageExecutionStateMachine
         long totalCpuTime = 0;
 
         long rawInputDataSizeInBytes = 0;
+        long scanRawInputDataSizeInBytes = 0;
         long rawInputPositions = 0;
 
         boolean fullyBlocked = true;
@@ -316,6 +317,8 @@ public class StageExecutionStateMachine
 
             totalAllocationInBytes += taskStats.getTotalAllocationInBytes();
 
+            scanRawInputDataSizeInBytes += taskStats.getScanRawInputDataSizeInBytes();
+
             if (containsTableScans) {
                 rawInputDataSizeInBytes += taskStats.getRawInputDataSizeInBytes();
                 rawInputPositions += taskStats.getRawInputPositions();
@@ -346,6 +349,7 @@ public class StageExecutionStateMachine
                 completedSplits,
 
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
 
                 cumulativeUserMemory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -83,6 +83,7 @@ public class StageExecutionStats
     private final long totalAllocationInBytes;
 
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
 
     private final long processedInputDataSizeInBytes;
@@ -147,6 +148,7 @@ public class StageExecutionStats
             @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
             @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("scanRawInputDataSizeInBytes") long scanRawInputDataSizeInBytes,
             @JsonProperty("rawInputPositions") long rawInputPositions,
 
             @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
@@ -223,6 +225,7 @@ public class StageExecutionStats
 
         this.totalAllocationInBytes = (totalAllocationInBytes >= 0) ? totalAllocationInBytes : Long.MAX_VALUE;
         this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
+        this.scanRawInputDataSizeInBytes = (scanRawInputDataSizeInBytes >= 0) ? scanRawInputDataSizeInBytes : Long.MAX_VALUE;
         this.rawInputPositions = (rawInputPositions >= 0) ? rawInputPositions : Long.MAX_VALUE;
 
         this.processedInputDataSizeInBytes = (processedInputDataSizeInBytes >= 0) ? processedInputDataSizeInBytes : Long.MAX_VALUE;
@@ -447,6 +450,12 @@ public class StageExecutionStats
     }
 
     @JsonProperty
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
+    @JsonProperty
     public long getRawInputPositions()
     {
         return rawInputPositions;
@@ -530,6 +539,7 @@ public class StageExecutionStats
                 runningSplits,
                 completedSplits,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 cumulativeUserMemory,
                 cumulativeTotalMemory,
@@ -579,6 +589,7 @@ public class StageExecutionStats
                 new Duration(0, NANOSECONDS),
                 false,
                 ImmutableSet.of(),
+                0L,
                 0L,
                 0L,
                 0,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -464,6 +464,7 @@ public class TaskContext
         long totalAllocation = 0;
 
         long rawInputDataSize = 0;
+        long scanRawInputDataSize = 0;
         long rawInputPositions = 0;
 
         long processedInputDataSize = 0;
@@ -520,7 +521,13 @@ public class TaskContext
             }
 
             physicalWrittenDataSize += pipeline.getPhysicalWrittenDataSizeInBytes();
-            pipeline.getOperatorSummaries().stream().forEach(stats -> mergedRuntimeStats.mergeWith(stats.getRuntimeStats()));
+            for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
+                mergedRuntimeStats.mergeWith(operatorStats.getRuntimeStats());
+                String operatorType = operatorStats.getOperatorType();
+                if (operatorType.equals(TableScanOperator.class.getSimpleName()) || operatorType.equals(ScanFilterAndProjectOperator.class.getSimpleName())) {
+                    scanRawInputDataSize += operatorStats.getRawInputDataSizeInBytes();
+                }
+            }
         }
 
         long startNanos = this.startNanos.get();
@@ -613,6 +620,7 @@ public class TaskContext
                 blockedReasons.build(),
                 totalAllocation,
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
                 processedInputDataSize,
                 processedInputPositions,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -81,6 +81,7 @@ public class TaskStats
     private final long totalAllocationInBytes;
 
     private final long rawInputDataSizeInBytes;
+    private final long scanRawInputDataSizeInBytes;
     private final long rawInputPositions;
 
     private final long processedInputDataSizeInBytes;
@@ -140,6 +141,7 @@ public class TaskStats
                 ImmutableSet.of(),
                 0L,
                 0L,
+                0L,
                 0,
                 0L,
                 0,
@@ -191,6 +193,7 @@ public class TaskStats
                 0L,
                 false,
                 ImmutableSet.of(),
+                0L,
                 0L,
                 0L,
                 0,
@@ -255,6 +258,7 @@ public class TaskStats
             @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
             @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("scanRawInputDataSizeInBytes") long scanRawInputDataSizeInBytes,
             @JsonProperty("rawInputPositions") long rawInputPositions,
 
             @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
@@ -346,6 +350,7 @@ public class TaskStats
         this.totalAllocationInBytes = totalAllocationInBytes;
 
         this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.scanRawInputDataSizeInBytes = scanRawInputDataSizeInBytes;
         this.rawInputPositions = (rawInputPositions >= 0) ? rawInputPositions : Long.MAX_VALUE;
 
         this.processedInputDataSizeInBytes = processedInputDataSizeInBytes;
@@ -732,6 +737,13 @@ public class TaskStats
         return completedNewDrivers;
     }
 
+    @JsonProperty
+    @ThriftField(50)
+    public long getScanRawInputDataSizeInBytes()
+    {
+        return scanRawInputDataSizeInBytes;
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -774,6 +786,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,
@@ -828,6 +841,7 @@ public class TaskStats
                 blockedReasons,
                 totalAllocationInBytes,
                 rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
                 rawInputPositions,
                 processedInputDataSizeInBytes,
                 processedInputPositions,

--- a/presto-main-base/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -72,6 +72,7 @@ public class BasicQueryStats
     private final int completedSplits;
 
     private final DataSize rawInputDataSize;
+    private final DataSize scanRawInputDataSize;
     private final long rawInputPositions;
 
     private final double cumulativeUserMemory;
@@ -115,6 +116,7 @@ public class BasicQueryStats
             int runningSplits,
             int completedSplits,
             DataSize rawInputDataSize,
+            DataSize scanRawInputDataSize,
             long rawInputPositions,
             double cumulativeUserMemory,
             double cumulativeTotalMemory,
@@ -168,6 +170,7 @@ public class BasicQueryStats
         this.completedSplits = completedSplits;
 
         this.rawInputDataSize = requireNonNull(rawInputDataSize);
+        this.scanRawInputDataSize = requireNonNull(scanRawInputDataSize, "scanRawInputDataSize is null");
         this.rawInputPositions = rawInputPositions;
 
         this.cumulativeUserMemory = cumulativeUserMemory;
@@ -214,6 +217,7 @@ public class BasicQueryStats
             @JsonProperty("runningSplits") int runningSplits,
             @JsonProperty("completedSplits") int completedSplits,
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
+            @JsonProperty("scanRawInputDataSize") DataSize scanRawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
@@ -252,6 +256,7 @@ public class BasicQueryStats
                 runningSplits,
                 completedSplits,
                 rawInputDataSize,
+                scanRawInputDataSize,
                 rawInputPositions,
                 cumulativeUserMemory,
                 cumulativeTotalMemory,
@@ -292,6 +297,9 @@ public class BasicQueryStats
                 queryStats.getQueuedSplits(),
                 queryStats.getRunningSplits(),
                 queryStats.getCompletedSplits(),
+                queryStats.getRawInputDataSize(),
+                // rawInputDataSize is already scan-only here (QueryStats.create() filters to
+                // leaf table-scan operators), so reuse it for scanRawInputDataSize.
                 queryStats.getRawInputDataSize(),
                 queryStats.getRawInputPositions(),
                 queryStats.getCumulativeUserMemory(),
@@ -335,6 +343,7 @@ public class BasicQueryStats
                 0,
                 0,
                 0,
+                new DataSize(0, BYTE),
                 new DataSize(0, BYTE),
                 0,
                 0,
@@ -619,5 +628,12 @@ public class BasicQueryStats
     public int getCompletedNewDrivers()
     {
         return completedNewDrivers;
+    }
+
+    @ThriftField(38)
+    @JsonProperty
+    public DataSize getScanRawInputDataSize()
+    {
+        return scanRawInputDataSize;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -145,6 +145,7 @@ public class MockManagedQueryExecution
                         8,
                         9,
                         new DataSize(14, BYTE),
+                        new DataSize(14, BYTE),
                         15,
                         16.0,
                         25.0,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -200,6 +200,7 @@ public class TestNodeScheduler
                     0,
                     0,
                     DataSize.valueOf("1MB"),
+                    DataSize.valueOf("1MB"),
                     0,
                     0,
                     0,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 import static com.facebook.airlift.units.DataSize.Unit.BYTE;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
@@ -429,6 +430,45 @@ public class TestQueryStats
         assertEquals(queryStats.getProcessedInputPositions(), 250);
         assertEquals(queryStats.getOutputDataSize().toBytes(), 5040);
         assertEquals(queryStats.getOutputPositions(), 100);
+    }
+
+    @Test
+    public void testScanRawInputDataSizeExcludesExchangeOnLivePath()
+    {
+        // On the running/live path an exchange-only stage sits on top of a leaf-scan
+        // stage. rawInputDataSize aggregates every stage (so it includes the exchange
+        // input), but scanRawInputDataSize must count the leaf-scan stage only.
+        BasicStageExecutionStats scanStage = basicStageStats(8620L, 8620L, 150L);
+        BasicStageExecutionStats exchangeStage = basicStageStats(5384L, 0L, 100L);
+
+        BasicStageExecutionStats aggregated = BasicStageExecutionStats.aggregateBasicStageStats(
+                ImmutableList.of(exchangeStage, scanStage));
+
+        // rawInputDataSize over-counts by the exchange bytes; scanRawInputDataSize does not.
+        assertEquals(aggregated.getRawInputDataSizeInBytes(), 8620L + 5384L);
+        assertEquals(aggregated.getScanRawInputDataSizeInBytes(), 8620L);
+    }
+
+    private static BasicStageExecutionStats basicStageStats(long rawInputDataSizeInBytes, long scanRawInputDataSizeInBytes, long rawInputPositions)
+    {
+        return new BasicStageExecutionStats(
+                false,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                rawInputDataSizeInBytes,
+                scanRawInputDataSizeInBytes,
+                rawInputPositions,
+                0.0,
+                0.0,
+                0L,
+                0L,
+                new Duration(0, NANOSECONDS),
+                new Duration(0, NANOSECONDS),
+                false,
+                ImmutableSet.of(),
+                0L,
+                OptionalDouble.empty());
     }
 
     @Test
@@ -834,6 +874,7 @@ public class TestQueryStats
                 0L,
 
                 rawInputDataSize,
+                0L,
                 rawInputPositions,
 
                 inputDataSize,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
@@ -71,6 +71,7 @@ public class TestStageExecutionStats
             123L,
 
             19L,
+            17L,
             20,
 
             21L,
@@ -139,6 +140,7 @@ public class TestStageExecutionStats
         assertEquals(actual.getTotalAllocationInBytes(), 123L);
 
         assertEquals(actual.getRawInputDataSizeInBytes(), 19L);
+        assertEquals(actual.getScanRawInputDataSizeInBytes(), 17L);
         assertEquals(actual.getRawInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSizeInBytes(), 21L);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -70,6 +70,7 @@ public class TestTaskStats
             123,
 
             19,
+            17,
             20,
 
             21,
@@ -130,6 +131,7 @@ public class TestTaskStats
         assertEquals(actual.getTotalAllocationInBytes(), 123);
 
         assertEquals(actual.getRawInputDataSizeInBytes(), 19);
+        assertEquals(actual.getScanRawInputDataSizeInBytes(), 17);
         assertEquals(actual.getRawInputPositions(), 20);
 
         assertEquals(actual.getProcessedInputDataSizeInBytes(), 21);

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -769,6 +769,7 @@ public class TestResourceManagerClusterStateProvider
                         15,
                         100,
                         DataSize.valueOf("21GB"),
+                        DataSize.valueOf("21GB"),
                         22,
                         23,
                         24,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
@@ -339,6 +339,7 @@ public class TestPlanPrinter
                 0L,
 
                 rawInputDataSize,
+                0L,
                 rawInputPositions,
 
                 inputDataSize,

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -113,6 +113,8 @@ public class TestEventListenerManager
         assertEquals(generatedEvents.getSplitCompletedEvents().size(), 3);
         generatedEvents.getQueryCreatedEvents().forEach(event -> assertEquals(event, queryCreatedEvent));
         generatedEvents.getQueryCompletedEvents().forEach(event -> assertEquals(event, queryCompletedEvent));
+        generatedEvents.getQueryCompletedEvents().forEach(event ->
+                assertEquals(event.getStatistics().getScanRawInputBytes(), 25000000L));
         generatedEvents.getSplitCompletedEvents().forEach(event -> assertEquals(event, splitCompletedEvent));
 
         tryDeleteFile(tempFile1);
@@ -247,6 +249,7 @@ public class TestEventListenerManager
         long shuffledBytes = 10000000L;
         long shuffledRows = 200000L;
         long totalBytes = 30000000L;
+        long scanRawInputBytes = 25000000L;
         long totalRows = 400000L;
         long outputBytes = 5000000L;
         long outputRows = 60000L;
@@ -294,7 +297,8 @@ public class TestEventListenerManager
                 cumulativeTotalMemory,
                 completedSplits,
                 complete,
-                runtimeStats);
+                runtimeStats,
+                scanRawInputBytes);
     }
 
     private static QueryMetadata createDummyQueryMetadata()

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -278,6 +278,7 @@ public class TestHttpResourceManagerClient
                         new Duration(1, SECONDS),
                         1, 1, 1, 1, 1, 100, 1, 1, 1, 100, 1, 1, 1, 100,
                         new DataSize(1, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
                         1, 1, 1,
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -859,6 +859,7 @@ void PrestoTask::updateExecutionInfoLocked(
 
   prestoTaskStats.rawInputPositions = 0;
   prestoTaskStats.rawInputDataSizeInBytes = 0;
+  prestoTaskStats.scanRawInputDataSizeInBytes = 0;
   prestoTaskStats.processedInputPositions = 0;
   prestoTaskStats.processedInputDataSizeInBytes = 0;
   prestoTaskStats.outputPositions = 0;
@@ -909,6 +910,12 @@ void PrestoTask::updateExecutionInfoLocked(
             firstVeloxOpStats.rawInputPositions;
         prestoTaskStats.rawInputDataSizeInBytes +=
             firstVeloxOpStats.rawInputBytes;
+        // Velox has no fused scan+filter+project (only TableScan and
+        // FilterProject), so a leaf scan is always reported as TableScan.
+        if (firstVeloxOpStats.operatorType == "TableScan") {
+          prestoTaskStats.scanRawInputDataSizeInBytes +=
+              firstVeloxOpStats.rawInputBytes;
+        }
         prestoTaskStats.processedInputPositions +=
             firstVeloxOpStats.inputPositions;
         prestoTaskStats.processedInputDataSizeInBytes +=

--- a/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
+++ b/presto-native-execution/presto_cpp/main/tests/data/TaskInfo.json
@@ -101,6 +101,7 @@
         ],
         "totalAllocationInBytes": 123,
         "rawInputDataSizeInBytes": 456,
+        "scanRawInputDataSizeInBytes": 123,
         "rawInputPositions": 789,
         "processedInputDataSizeInBytes": 123,
         "processedInputPositions": 456,

--- a/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
@@ -1204,6 +1204,9 @@ void toThrift(
   toThrift(proto.queuedNewDrivers, *thrift.queuedNewDrivers_ref());
   toThrift(proto.runningNewDrivers, *thrift.runningNewDrivers_ref());
   toThrift(proto.completedNewDrivers, *thrift.completedNewDrivers_ref());
+  toThrift(
+      proto.scanRawInputDataSizeInBytes,
+      *thrift.scanRawInputDataSizeInBytes_ref());
 }
 void fromThrift(
     const TaskStats& thrift,
@@ -1282,6 +1285,9 @@ void fromThrift(
   fromThrift(*thrift.queuedNewDrivers_ref(), proto.queuedNewDrivers);
   fromThrift(*thrift.runningNewDrivers_ref(), proto.runningNewDrivers);
   fromThrift(*thrift.completedNewDrivers_ref(), proto.completedNewDrivers);
+  fromThrift(
+      *thrift.scanRawInputDataSizeInBytes_ref(),
+      proto.scanRawInputDataSizeInBytes);
 }
 
 void toThrift(

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -451,6 +451,7 @@ struct TaskStats {
   47: i32 queuedNewDrivers;
   48: i32 runningNewDrivers;
   49: i32 completedNewDrivers;
+  50: i64 scanRawInputDataSizeInBytes;
 }
 struct PipelineStats {
   1: i32 pipelineId;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -12035,6 +12035,13 @@ void to_json(json& j, const TaskStats& p) {
       "rawInputDataSizeInBytes");
   to_json_key(
       j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
+  to_json_key(
+      j,
       "rawInputPositions",
       p.rawInputPositions,
       "TaskStats",
@@ -12344,6 +12351,13 @@ void from_json(const json& j, TaskStats& p) {
       "TaskStats",
       "int64_t",
       "rawInputDataSizeInBytes");
+  from_json_key(
+      j,
+      "scanRawInputDataSizeInBytes",
+      p.scanRawInputDataSizeInBytes,
+      "TaskStats",
+      "int64_t",
+      "scanRawInputDataSizeInBytes");
   from_json_key(
       j,
       "rawInputPositions",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2674,6 +2674,7 @@ struct TaskStats {
   List<BlockedReason> blockedReasons = {};
   int64_t totalAllocationInBytes = {};
   int64_t rawInputDataSizeInBytes = {};
+  int64_t scanRawInputDataSizeInBytes = {};
   int64_t rawInputPositions = {};
   int64_t processedInputDataSizeInBytes = {};
   int64_t processedInputPositions = {};

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/PrestoEventData.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/PrestoEventData.java
@@ -119,7 +119,8 @@ public final class PrestoEventData
                 0.0, // cumulativeTotalMemory
                 0, // completedSplits
                 true, // complete
-                new RuntimeStats());
+                new RuntimeStats(),
+                0L);
 
         queryCompleteEvent = new QueryCompletedEvent(
                 queryMetadata,

--- a/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
+++ b/presto-openlineage-event-listener/src/test/java/com/facebook/presto/plugin/openlineage/TestOpenLineageColumnLineage.java
@@ -291,7 +291,7 @@ public class TestOpenLineageColumnLineage
                 Duration.ofSeconds(0), Duration.ofSeconds(0), Duration.ofSeconds(0), Optional.empty(),
                 Duration.ofSeconds(1), Duration.ofSeconds(0),
                 0, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0.0, 0.0, 0, true,
-                new RuntimeStats());
+                new RuntimeStats(), 0L);
 
         return new QueryCompletedEvent(
                 meta, stats, ctx, io,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -61,6 +61,7 @@ public class QueryStatistics
     private final int completedSplits;
     private final boolean complete;
     private final RuntimeStats runtimeStats;
+    private final long scanRawInputBytes;
 
     public QueryStatistics(
             Duration cpuTime,
@@ -97,7 +98,8 @@ public class QueryStatistics
             double cumulativeTotalMemory,
             int completedSplits,
             boolean complete,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long scanRawInputBytes)
     {
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.retriedCpuTime = requireNonNull(retriedCpuTime, "retriedCpuTime is null");
@@ -134,6 +136,7 @@ public class QueryStatistics
         this.completedSplits = completedSplits;
         this.complete = complete;
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.scanRawInputBytes = scanRawInputBytes;
     }
 
     public Duration getCpuTime()
@@ -309,5 +312,10 @@ public class QueryStatistics
     public RuntimeStats getRuntimeStats()
     {
         return runtimeStats;
+    }
+
+    public long getScanRawInputBytes()
+    {
+        return scanRawInputBytes;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -206,6 +206,35 @@ public class TestEventListener
     }
 
     @Test
+    public void testScanRawInputBytes()
+            throws Exception
+    {
+        // Aggregation places a final-aggregation (exchange) stage on top of the lineitem
+        // scan, so scanRawInputBytes must reflect only the leaf-scan raw input, not the
+        // exchange input. Same event/split shape as testNormalQuery.
+        int expectedEvents = 1 + 1 + 1 + SPLITS_PER_NODE + 1 + 1;
+        runQueryAndWaitForEvents("SELECT sum(linenumber) FROM lineitem", expectedEvents);
+
+        // Completed event: scanRawInputBytes must match the query's actual scan-only raw
+        // input (QueryStats.rawInputDataSize is already operator-filtered to leaf scans).
+        QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        QueryStats queryStats = queryRunner.getCoordinator().getQueryManager()
+                .getFullQueryInfo(new QueryId(queryCompletedEvent.getMetadata().getQueryId()))
+                .getQueryStats();
+        assertEquals(
+                queryCompletedEvent.getStatistics().getScanRawInputBytes(),
+                queryStats.getRawInputDataSize().toBytes());
+
+        // Progress event: on the running path totalBytes can include exchange input,
+        // so scan-only raw input must be non-negative and never exceed it.
+        QueryProgressEvent queryProgressEvent = generatedEvents.getQueryProgressEvent();
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getStatistics().getScanRawInputBytes() >= 0);
+        assertTrue(queryProgressEvent.getStatistics().getScanRawInputBytes()
+                <= queryProgressEvent.getStatistics().getTotalBytes());
+    }
+
+    @Test
     public void testPrepareAndExecute()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -104,6 +104,7 @@ public class TestClusterMemoryLeakDetector
                         15,
                         100,
                         DataSize.valueOf("21GB"),
+                        DataSize.valueOf("21GB"),
                         22,
                         23,
                         28,


### PR DESCRIPTION
Summary:

Add a scan-only raw input data size statistic -- the raw input bytes read by
source (leaf table scan) operators only -- and thread it from the workers all
the way to the event-listener SPI. It is distinct from the existing
`rawInputDataSize`, which on the running/aggregated stats path also includes
exchange (shuffle) input.

This PR has three commits:

1. Add `scanRawInputDataSizeInBytes` to `TaskStats` (Java + native). New additive
   field on `TaskStats` (Java, regenerated `presto_protocol`, and
   `presto_thrift` + `ProtocolToThrift`), populated at the worker: `TaskContext`
   (Java) and `PrestoTask` (native) sum raw input bytes over leaf scan operators
   (`TableScanOperator` / `ScanFilterAndProjectOperator`; Velox `TableScan`),
   matching the operator-type filter `QueryStats.create()` already uses for
   completed queries.

2. Add `scanRawInputDataSize` to basic query statistics. Thread the scan-only
   value through the coordinator's basic/live stats path
   (`BasicStageExecutionStats`, `StageExecutionStats`, `StageExecutionInfo`,
   `QueryStateMachine`) onto `BasicQueryStats`, so it is available for running
   queries over REST/Thrift. The per-task scalar is summed unconditionally rather
   than gated on the coarse per-stage `containsTableScans` flag, which lets a
   scan-containing stage's exchange input inflate `rawInputDataSize`.

3. Add `scanRawInputBytes` to the event-listener SPI `QueryStatistics`, populated
   in `QueryMonitor` -- from the scan-only value on the progress (running) path,
   and from `QueryStats`' already-operator-filtered `rawInputDataSize` on the
   completed path.

== Motivation and Context ==

On the running/progress path, `rawInputDataSize` sums all input pipelines
(including exchange sources), so it over-reports exchange/shuffle-heavy queries
by their shuffle bytes. Consumers that need the bytes physically read from source
connectors (monitoring, event listeners, resource accounting) could not obtain
that value. A dedicated scan-only statistic provides it without changing the
semantics of the existing field.

== Impact ==

Additive and backward-compatible. The new field defaults to `0`, so it is
forward/backward compatible across mixed Java/native worker deployments (missing
-> 0, unknown -> ignored); existing statistics are unchanged. Callers that
construct the SPI `QueryStatistics` directly must pass the new final argument.

```
== RELEASE NOTES ==

General Changes
* Add ``scanRawInputDataSizeInBytes`` to task statistics, reporting the raw input data size read by table scan operators.
* Add ``scanRawInputDataSize`` to basic query statistics.

SPI Changes
* Add ``getScanRawInputBytes`` to ``QueryStatistics``. Note: this adds a required constructor argument; plugins that construct ``QueryStatistics`` directly must be updated.
```

Differential Revision: D113461498


