### PR TITLE
fix: Fix unnest rows error message in AbstractTestArrowFederationNativeQueries

### DIFF
--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
@@ -39,7 +39,7 @@ import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 public abstract class AbstractTestArrowFederationNativeQueries
         extends AbstractTestDistributedQueries
 {
-    private final @Language("RegExp") String unnestRowsInvalidFieldError = "Field not found: field(?:_\\d+)?. Available fields are: field.*";
+    private final @Language("RegExp") String unnestRowsError = ".*UnnestNode requires one name per array column and two per map column.*";
 
     protected BufferAllocator allocator;
     protected FlightShimProducer producer;
@@ -443,18 +443,18 @@ public abstract class AbstractTestArrowFederationNativeQueries
     public void testDuplicateUnnestRows()
     {
         assertQueryFails("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)]) AS r(r1, r2, r3, r4)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
         assertQueryFails("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)], ARRAY[row(10, 13, 15), row(23, 25, 20)]) AS r(r1, r2, r3, r4, r5, r6, r7)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
         assertQueryFails("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)]) WITH ORDINALITY AS r(r1, r2, r3, r4, ord)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
         assertQueryFails("SELECT * from (select * FROM (values 1) as t(k)) CROSS JOIN unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)], ARRAY[row(10, 13, 15), row(23, 25, 20)]) WITH ORDINALITY AS r(r1, r2, r3, r4, r5, r6, r7, ord)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
 
         assertQueryFails("SELECT * from unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)]) AS r(r1, r2, r3, r4)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
         assertQueryFails("SELECT * from unnest(ARRAY[row(2, 3), row(3, 5)], ARRAY[row(2, 3), row(3, 5)]) WITH ORDINALITY AS r(r1, r2, r3, r4, ord)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
     }
 
     /// Presto C++ only supports legacy unnest and this test relies on non-legacy behavior of unnest operator for
@@ -471,7 +471,7 @@ public abstract class AbstractTestArrowFederationNativeQueries
                         "UNION ALL " +
                         "SELECT ARRAY[CAST(row(null, 2) AS ROW(INTEGER, INTEGER))])) " +
                         "CROSS JOIN unnest(agg_result) as r(c1, c2)",
-                unnestRowsInvalidFieldError, true);
+                unnestRowsError, true);
     }
 
     /// The integer overflow error message differs in Presto and Velox.


### PR DESCRIPTION
## Description
The error message for the unnest rows failure has changed. This is not specific to the Arrow Federation connector — the same failure occurs for normal queries in Prestissimo.

Updated the expected error string in the affected test cases to match the new message. The underlying issue is tracked in [#20643](https://github.com/prestodb/presto/issues/20643), which has been updated with a comment noting the message change.

## Motivation and Context
Resolves: https://github.com/prestodb/presto/issues/28205

## Impact
No impact

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Align Arrow federation native query tests with updated unnest error message.

Bug Fixes:
- Update unnest rows error expectation to match current error message in Arrow federation native query tests.

Tests:
- Adjust duplicate unnest rows test cases to assert the new generic unnest error message instead of the previous invalid field message.

## Summary by Sourcery

Align Arrow federation native query tests with the updated unnest rows error message.

Bug Fixes:
- Update unnest-related failure expectations to match the current generic unnest error message for invalid row naming.

Tests:
- Adjust Arrow federation native query tests to assert the new unnest rows error message across duplicate and set-union unnest scenarios.