### PR TITLE
test: Migrate RPCPlanConverterTest to RPCNode::call() (#28224)

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2434,40 +2434,47 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   // Parse the result type from the protocol output variable.
   auto resultType = typeParser_.parse(node->outputVariable.type);
 
-  // Extract argument types and constant values from the protocol argument
-  // expressions. The Java planner sends both `arguments` (original
-  // expressions for type/constant extraction) and `argumentColumns`
-  // (column names for runtime reads by RPCOperator).
-  std::vector<TypePtr> argumentTypes;
-  std::vector<VectorPtr> constantInputs;
-  argumentTypes.reserve(node->arguments.size());
-  constantInputs.reserve(node->arguments.size());
-  for (const auto& arg : node->arguments) {
-    auto veloxExpr = exprConverter_.toVeloxExpr(arg);
-    argumentTypes.push_back(veloxExpr->type());
+  // Build the RPC call arguments. The Java planner sends both `arguments`
+  // (original expressions, for type/constant extraction) and `argumentColumns`
+  // (the column names RPCOperator reads at runtime for non-constant args). Each
+  // argument becomes a ConstantTypedExpr (constant literal) or a
+  // FieldAccessTypedExpr (column reference).
+  VELOX_CHECK_EQ(
+      node->arguments.size(),
+      node->argumentColumns.size(),
+      "RPCNode arguments and argumentColumns must have the same size");
+  std::vector<core::TypedExprPtr> callInputs;
+  callInputs.reserve(node->arguments.size());
+  for (size_t i = 0; i < node->arguments.size(); ++i) {
+    auto veloxExpr = exprConverter_.toVeloxExpr(node->arguments[i]);
 
-    // Extract constant value. Unwrap CastTypedExpr if present — the Java
-    // planner wraps string literals in CAST(x AS VARCHAR) which hides the
-    // inner ConstantTypedExpr from a direct dynamic_cast.
-    const core::ITypedExpr* innerExpr = veloxExpr.get();
-    if (auto* castExpr = dynamic_cast<const core::CastTypedExpr*>(innerExpr)) {
+    // Unwrap CastTypedExpr if present — the Java planner wraps string literals
+    // in CAST(x AS VARCHAR) which hides the inner ConstantTypedExpr from a
+    // direct dynamic_cast.
+    core::TypedExprPtr innerExpr = veloxExpr;
+    if (auto* castExpr =
+            dynamic_cast<const core::CastTypedExpr*>(veloxExpr.get())) {
       if (!castExpr->inputs().empty()) {
-        innerExpr = castExpr->inputs()[0].get();
+        innerExpr = castExpr->inputs()[0];
       }
     }
-    if (auto* constExpr =
-            dynamic_cast<const core::ConstantTypedExpr*>(innerExpr)) {
-      constantInputs.push_back(constExpr->toConstantVector(pool_));
+    if (auto constExpr =
+            std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+                innerExpr)) {
+      callInputs.push_back(std::move(constExpr));
     } else {
-      constantInputs.push_back(nullptr);
+      // A column argument is read at runtime by RPCOperator directly from the
+      // source column named argumentColumns[i] (resolved by name to a channel),
+      // so the FieldAccess must carry that source column's actual type. The
+      // argument expression's own type (e.g. an outer CAST target) is not what
+      // the operator reads; using the source-schema type keeps the declared
+      // argument type consistent with the vector actually read, and fails
+      // loudly if the planner ever names a column the source does not produce.
+      callInputs.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              sourceNode->outputType()->findChild(node->argumentColumns[i]),
+              node->argumentColumns[i]));
     }
-  }
-
-  // Read argument column names from the protocol node.
-  std::vector<std::string> argumentColumns;
-  argumentColumns.reserve(node->argumentColumns.size());
-  for (const auto& col : node->argumentColumns) {
-    argumentColumns.push_back(col);
   }
 
   // Determine streaming mode.
@@ -2498,16 +2505,15 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   outputTypes.push_back(resultType);
   auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
 
+  auto call = std::make_shared<core::CallTypedExpr>(
+      resultType, std::move(callInputs), node->functionName);
+
   return std::make_shared<core::RPCNode>(
       node->id,
       sourceNode,
-      node->functionName,
-      resultType,
+      std::move(call),
       node->outputVariable.name,
       std::move(outputType),
-      std::move(argumentColumns),
-      std::move(argumentTypes),
-      std::move(constantInputs),
       veloxStreamingMode,
       dispatchBatchSize);
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
@@ -159,15 +159,72 @@ TEST_F(RPCPlanConverterTest, rpcNodeWithRegisteredFunction) {
   EXPECT_EQ(veloxRpcNode->functionName(), "fb_llm_inference");
   EXPECT_EQ(veloxRpcNode->outputColumn(), "__rpc_result");
 
-  // Verify argumentColumns are passed through.
-  ASSERT_EQ(veloxRpcNode->argumentColumns().size(), 1);
-  EXPECT_EQ(veloxRpcNode->argumentColumns()[0], "comment");
+  // Verify the call argument: a single column reference to "comment", typed
+  // VARCHAR. A variable reference is not a constant, so it becomes a
+  // FieldAccessTypedExpr column argument rather than a ConstantTypedExpr.
+  ASSERT_EQ(veloxRpcNode->call()->inputs().size(), 1);
+  auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      veloxRpcNode->call()->inputs()[0].get());
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->name(), "comment");
+  EXPECT_EQ(field->type()->kind(), TypeKind::VARCHAR);
+}
 
-  // Verify argumentTypes are extracted from argument expressions.
-  ASSERT_EQ(veloxRpcNode->argumentTypes().size(), 1);
-  EXPECT_EQ(veloxRpcNode->argumentTypes()[0]->kind(), TypeKind::VARCHAR);
+// A column argument's FieldAccess must carry the SOURCE column's actual type,
+// not the argument expression's declared type. In production the Java planner
+// hoists the argument expression (e.g. a CAST) into the source column, so the
+// two normally agree; this test forces them to differ (source column "num" is
+// BIGINT while the argument expression is declared VARCHAR) to pin that the
+// converter uses the authoritative source-schema type. RPCOperator reads that
+// column by name at runtime, so a FieldAccess typed from the argument
+// expression would misdeclare the vector actually read.
+TEST_F(RPCPlanConverterTest, columnArgUsesSourceColumnType) {
+  exec_rpc::AsyncRPCFunctionRegistry::testingClear();
+  exec_rpc::AsyncRPCFunctionRegistry::registerFunction(
+      "fb_llm_inference", []() { return nullptr; });
 
-  // Verify constantInputs: arg 0 is a variable reference (nullptr).
-  ASSERT_EQ(veloxRpcNode->constantInputs().size(), 1);
-  EXPECT_EQ(veloxRpcNode->constantInputs()[0], nullptr);
+  // Source produces column "num" of type BIGINT.
+  auto valuesNode = std::make_shared<protocol::ValuesNode>();
+  valuesNode->_type = "com.facebook.presto.sql.planner.plan.ValuesNode";
+  valuesNode->id = "0";
+  protocol::VariableReferenceExpression numVar;
+  numVar.name = "num";
+  numVar.type = "bigint";
+  valuesNode->outputVariables.push_back(numVar);
+
+  // The RPC argument references "num" but with a DIFFERENT declared type
+  // (varchar), as a hoisted CAST(num AS varchar) would present it.
+  // argumentColumns names the source column the operator actually reads.
+  auto rpcNode = std::make_shared<protocol::RPCNode>();
+  rpcNode->_type = "com.facebook.presto.sql.planner.plan.RPCNode";
+  rpcNode->id = "8";
+  rpcNode->source = valuesNode;
+  rpcNode->functionName = "fb_llm_inference";
+  auto arg = std::make_shared<protocol::VariableReferenceExpression>();
+  arg->_type = "variable";
+  arg->name = "num";
+  arg->type = "varchar"; // differs from the source column's BIGINT
+  rpcNode->arguments.push_back(arg);
+  rpcNode->argumentColumns = {"num"};
+  rpcNode->outputVariable.name = "__rpc_result";
+  rpcNode->outputVariable.type = "varchar";
+  rpcNode->streamingMode = protocol::RPCNodeStreamingMode::PER_ROW;
+  rpcNode->dispatchBatchSize = 0;
+
+  VeloxInteractiveQueryPlanConverter converter(queryCtx_.get(), pool_.get());
+  auto veloxPlan = converter.toVeloxQueryPlan(
+      std::dynamic_pointer_cast<protocol::PlanNode>(rpcNode),
+      nullptr,
+      "20260124_042527_00001_gp3te.1.0.0.0");
+  auto veloxRpcNode = std::dynamic_pointer_cast<const core::RPCNode>(veloxPlan);
+  ASSERT_NE(veloxRpcNode, nullptr);
+
+  ASSERT_EQ(veloxRpcNode->call()->inputs().size(), 1);
+  auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      veloxRpcNode->call()->inputs()[0].get());
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->name(), "num");
+  // Authoritative source-column type (BIGINT), NOT the argument's declared
+  // VARCHAR: this is the column RPCOperator reads by name at runtime.
+  EXPECT_EQ(field->type()->kind(), TypeKind::BIGINT);
 }


### PR DESCRIPTION
Summary:

MIGRATE step of the RPCNode expand/migrate/contract migration (see D112860382).
Update the presto-cpp conversion test to read the folded call via
call()->inputs() instead of the legacy argumentColumns()/argumentTypes()/
constantInputs() accessors. Split out of EXPAND so that diff stays velox-only;
this presto-cpp test change rides with the presto-cpp migration and lands before
CONTRACT removes the legacy accessors.

== NO RELEASE NOTE ==

Reviewed By: abhinavmuk04

Differential Revision: D113617918


