### PR TITLE
fix(analyzer): Reject non-hashable argument types for approx_distinct (#28227)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -39,6 +39,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.type.TypeCalculation.calculateLiteralValue;
@@ -671,7 +673,7 @@ public class SignatureBinder
         public SolverReturnStatus update(BoundVariables.Builder bindings)
         {
             if (!bindings.containsTypeVariable(typeParameter)) {
-                if (!typeVariableConstraint.canBind(actualType)) {
+                if (!typeVariableConstraint.canBind(actualType) || !satisfiesHashableConstraint(actualType)) {
                     return SolverReturnStatus.UNSOLVABLE;
                 }
                 bindings.setTypeVariable(typeParameter, actualType);
@@ -682,7 +684,7 @@ public class SignatureBinder
             if (!commonSuperType.isPresent()) {
                 return SolverReturnStatus.UNSOLVABLE;
             }
-            if (!typeVariableConstraint.canBind(commonSuperType.get())) {
+            if (!typeVariableConstraint.canBind(commonSuperType.get()) || !satisfiesHashableConstraint(commonSuperType.get())) {
                 // This check must not be skipped even if commonSuperType is equal to originalType
                 return SolverReturnStatus.UNSOLVABLE;
             }
@@ -691,6 +693,22 @@ public class SignatureBinder
             }
             bindings.setTypeVariable(typeParameter, commonSuperType.get());
             return SolverReturnStatus.CHANGED;
+        }
+
+        // Enforced here, not in canBind, because it needs the operator registry that canBind(Type) can't reach.
+        private boolean satisfiesHashableConstraint(Type type)
+        {
+            // Supported specializations that don't require an XX_HASH_64 operator.
+            if (!typeVariableConstraint.isHashableRequired() || UNKNOWN.equals(type) || BOOLEAN.equals(type)) {
+                return true;
+            }
+            try {
+                functionAndTypeManager.resolveOperator(XX_HASH_64, fromTypes(type));
+                return true;
+            }
+            catch (OperatorNotFoundException e) {
+                return false;
+            }
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
@@ -56,6 +56,7 @@ import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.common.type.StandardTypes.PARAMETRIC_TYPES;
 import static com.facebook.presto.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
@@ -74,6 +75,7 @@ public class FunctionsParserHelper
 {
     private static final Set<OperatorType> COMPARABLE_TYPE_OPERATORS = ImmutableSet.of(EQUAL, NOT_EQUAL, HASH_CODE);
     private static final Set<OperatorType> ORDERABLE_TYPE_OPERATORS = ImmutableSet.of(LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, BETWEEN);
+    private static final Set<OperatorType> HASHABLE_TYPE_OPERATORS = ImmutableSet.of(XX_HASH_64);
 
     private FunctionsParserHelper()
     {}
@@ -92,6 +94,7 @@ public class FunctionsParserHelper
     {
         Set<String> orderableRequired = new HashSet<>();
         Set<String> comparableRequired = new HashSet<>();
+        Set<String> hashableRequired = new HashSet<>();
         for (ImplementationDependency dependency : dependencies) {
             if (dependency instanceof OperatorImplementationDependency) {
                 OperatorType operator = ((OperatorImplementationDependency) dependency).getOperator();
@@ -109,6 +112,9 @@ public class FunctionsParserHelper
                 if (ORDERABLE_TYPE_OPERATORS.contains(operator)) {
                     orderableRequired.add(argumentType);
                 }
+                if (HASHABLE_TYPE_OPERATORS.contains(operator)) {
+                    hashableRequired.add(argumentType);
+                }
             }
         }
         ImmutableList.Builder<TypeVariableConstraint> typeVariableConstraints = ImmutableList.builder();
@@ -116,14 +122,15 @@ public class FunctionsParserHelper
             String name = typeParameter.value();
             String variadicBound = typeParameter.boundedBy().isEmpty() ? null : typeParameter.boundedBy();
             checkArgument(variadicBound == null || PARAMETRIC_TYPES.contains(variadicBound), "boundedBy must be a parametric type, got %s", variadicBound);
+            boolean hashable = hashableRequired.contains(name);
             if (orderableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, variadicBound, false));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, variadicBound, false, hashable));
             }
             else if (comparableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, variadicBound, false));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, variadicBound, false, hashable));
             }
             else {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, variadicBound, false));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, variadicBound, false, hashable));
             }
         }
         return typeVariableConstraints.build();

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
 import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceManager;
 import com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation;
 import com.facebook.presto.operator.scalar.CustomFunctions;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.function.Parameter;
@@ -45,6 +46,7 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +63,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
@@ -78,6 +81,7 @@ import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -541,6 +545,76 @@ public class TestFunctionAndTypeManager
                         functionSignature(ImmutableList.of("integer"), "integer"))
                 .forParameters("unknown")
                 .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+    }
+
+    @Test
+    public void testApproxDistinctRejectsNonHashableArgument()
+    {
+        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "map(bigint,bigint)");
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "array(bigint)");
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "row(bigint)");
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "map(bigint,bigint)", "double");
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "array(bigint)", "double");
+        assertFunctionNotFound(functionAndTypeManager, "approx_distinct", "row(bigint)", "double");
+    }
+
+    @Test
+    public void testApproxDistinctResolvesHashableArgument()
+    {
+        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "bigint");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "varchar");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "uuid");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "ipaddress");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "tinyint");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "smallint");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "integer");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "real");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "double");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "decimal(10,2)");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "decimal(38,2)");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "date");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "timestamp");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "timestamp with time zone");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "varbinary");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "char(10)");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "bigint", "double");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "varchar", "double");
+        assertFunctionResolves(functionAndTypeManager, "approx_distinct", "unknown");
+    }
+
+    @Test
+    public void testHashableConstraintAppliesToSfmAggregations()
+    {
+        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+
+        assertFunctionResolves(functionAndTypeManager, "noisy_approx_distinct_sfm", "bigint", "double", "bigint", "bigint");
+        assertFunctionResolves(functionAndTypeManager, "noisy_approx_set_sfm", "bigint", "double", "bigint", "bigint");
+        assertFunctionNotFound(functionAndTypeManager, "noisy_approx_distinct_sfm", "map(bigint,bigint)", "double", "bigint", "bigint");
+        assertFunctionNotFound(functionAndTypeManager, "noisy_approx_set_sfm", "map(bigint,bigint)", "double", "bigint", "bigint");
+    }
+
+    private static void assertFunctionResolves(FunctionAndTypeManager functionAndTypeManager, String name, String... argumentTypes)
+    {
+        assertNotNull(functionAndTypeManager.lookupFunction(name, fromTypeSignatures(
+                Arrays.stream(argumentTypes).map(TypeSignature::parseTypeSignature).collect(toImmutableList()))));
+    }
+
+    private static void assertFunctionNotFound(FunctionAndTypeManager functionAndTypeManager, String name, String... argumentTypes)
+    {
+        try {
+            functionAndTypeManager.lookupFunction(name, fromTypeSignatures(
+                    Arrays.stream(argumentTypes).map(TypeSignature::parseTypeSignature).collect(toImmutableList())));
+            fail(format("Expected %s(%s) to not resolve", name, String.join(", ", argumentTypes)));
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), FUNCTION_NOT_FOUND.toErrorCode());
+            assertTrue(e.getMessage().contains(name), e.getMessage());
+            assertTrue(e.getMessage().contains(":hashable"), e.getMessage());
+        }
     }
 
     private SignatureBuilder functionSignature(String... argumentTypes)

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.function.Signature.comparableTypeParameter;
+import static com.facebook.presto.spi.function.Signature.hashableTypeParameter;
 import static com.facebook.presto.spi.function.Signature.orderableTypeParameter;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.facebook.presto.spi.function.Signature.withVariadicBound;
@@ -1091,6 +1092,62 @@ public class TestSignatureBinder
         catch (RuntimeException e) {
             // Expected
         }
+    }
+
+    @Test
+    public void testBindHashableTypeParameter()
+    {
+        Signature function = functionSignature()
+                .returnType(parseTypeSignature(StandardTypes.BOOLEAN))
+                .argumentTypes(parseTypeSignature("T"))
+                .typeVariableConstraints(ImmutableList.of(hashableTypeParameter("T")))
+                .build();
+
+        assertThat(function)
+                .boundTo("bigint")
+                .succeeds();
+
+        assertThat(function)
+                .boundTo("varchar")
+                .succeeds();
+
+        assertThat(function)
+                .boundTo("boolean")
+                .succeeds();
+
+        // map is comparable but not hashable, which a comparable constraint would miss.
+        assertThat(function)
+                .boundTo("map(bigint,bigint)")
+                .fails();
+
+        assertThat(function)
+                .boundTo("array(bigint)")
+                .fails();
+
+        assertThat(function)
+                .boundTo("row(bigint)")
+                .fails();
+    }
+
+    @Test
+    public void testBindHashableTypeParameterCommonSuperType()
+    {
+        Signature function = functionSignature()
+                .returnType(parseTypeSignature(StandardTypes.BOOLEAN))
+                .argumentTypes(parseTypeSignature("T"), parseTypeSignature("T"))
+                .typeVariableConstraints(ImmutableList.of(hashableTypeParameter("T")))
+                .build();
+
+        assertThat(function)
+                .boundTo("bigint", "integer")
+                .withCoercion()
+                .succeeds();
+
+        // The hashable check also runs on the common supertype, not only the first bind.
+        assertThat(function)
+                .boundTo("unknown", "map(bigint,bigint)")
+                .withCoercion()
+                .fails();
     }
 
     private static void assertThat(String typeSignature, BoundVariables boundVariables, String expectedTypeSignature)

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/Combinations.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/Combinations.json
@@ -19,6 +19,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "__user_t1",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/ElementAt.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/ElementAt.json
@@ -19,6 +19,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -46,6 +47,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -73,6 +75,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "v",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -80,6 +83,7 @@
         },
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "k",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/Lead.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/Lead.json
@@ -18,6 +18,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -45,6 +46,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -73,6 +75,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/SetAgg.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/SetAgg.json
@@ -22,6 +22,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "t",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/TransformKeys.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/TransformKeys.json
@@ -19,6 +19,7 @@
       "typeVariableConstraints": [
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "v",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -26,6 +27,7 @@
         },
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "k2",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,
@@ -33,6 +35,7 @@
         },
         {
           "comparableRequired": false,
+          "hashableRequired": false,
           "name": "k1",
           "nonDecimalNumericRequired": false,
           "orderableRequired": false,

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -1874,6 +1874,13 @@ void to_json(json& j, const TypeVariableConstraint& p) {
       "TypeVariableConstraint",
       "bool",
       "nonDecimalNumericRequired");
+  to_json_key(
+      j,
+      "hashableRequired",
+      p.hashableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "hashableRequired");
 }
 
 void from_json(const json& j, TypeVariableConstraint& p) {
@@ -1906,6 +1913,13 @@ void from_json(const json& j, TypeVariableConstraint& p) {
       "TypeVariableConstraint",
       "bool",
       "nonDecimalNumericRequired");
+  from_json_key(
+      j,
+      "hashableRequired",
+      p.hashableRequired,
+      "TypeVariableConstraint",
+      "bool",
+      "hashableRequired");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -631,6 +631,7 @@ struct TypeVariableConstraint {
   bool orderableRequired = {};
   String variadicBound = {};
   bool nonDecimalNumericRequired = {};
+  bool hashableRequired = {};
   String boundedBy = {};
 };
 void to_json(json& j, const TypeVariableConstraint& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/TypeVariableConstraint.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/TypeVariableConstraint.hpp.inc
@@ -19,6 +19,7 @@ struct TypeVariableConstraint {
   bool orderableRequired = {};
   String variadicBound = {};
   bool nonDecimalNumericRequired = {};
+  bool hashableRequired = {};
   String boundedBy = {};
 };
 void to_json(json& j, const TypeVariableConstraint& p);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
@@ -206,6 +206,11 @@ public final class Signature
         return new TypeVariableConstraint(name, false, false, null, true);
     }
 
+    public static TypeVariableConstraint hashableTypeParameter(String name)
+    {
+        return new TypeVariableConstraint(name, false, false, null, false, true);
+    }
+
     public static LongVariableConstraint longVariableExpression(String variable, String expression)
     {
         return new LongVariableConstraint(variable, expression);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -34,6 +34,17 @@ public class TypeVariableConstraint
     private final boolean orderableRequired;
     private final String variadicBound;
     private final boolean nonDecimalNumericRequired;
+    private final boolean hashableRequired;
+
+    public TypeVariableConstraint(
+            String name,
+            boolean comparableRequired,
+            boolean orderableRequired,
+            String variadicBound,
+            boolean nonDecimalNumericRequired)
+    {
+        this(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, false);
+    }
 
     @ThriftConstructor
     @JsonCreator
@@ -42,13 +53,15 @@ public class TypeVariableConstraint
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
             @JsonProperty("variadicBound") @Nullable String variadicBound,
-            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired)
+            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired,
+            @JsonProperty("hashableRequired") boolean hashableRequired)
     {
         this.name = name;
         this.comparableRequired = comparableRequired;
         this.orderableRequired = orderableRequired;
         this.variadicBound = (Objects.equals(variadicBound, "")) ? null : variadicBound;
         this.nonDecimalNumericRequired = nonDecimalNumericRequired;
+        this.hashableRequired = hashableRequired;
     }
 
     @ThriftField(1)
@@ -86,6 +99,13 @@ public class TypeVariableConstraint
         return nonDecimalNumericRequired;
     }
 
+    @ThriftField(6)
+    @JsonProperty
+    public boolean isHashableRequired()
+    {
+        return hashableRequired;
+    }
+
     public boolean canBind(Type type)
     {
         if (comparableRequired && !type.isComparable()) {
@@ -119,6 +139,9 @@ public class TypeVariableConstraint
         if (nonDecimalNumericRequired) {
             value += ":nonDecimalNumeric";
         }
+        if (hashableRequired) {
+            value += ":hashable";
+        }
         return value;
     }
 
@@ -135,6 +158,7 @@ public class TypeVariableConstraint
         return comparableRequired == that.comparableRequired &&
                 orderableRequired == that.orderableRequired &&
                 nonDecimalNumericRequired == that.nonDecimalNumericRequired &&
+                hashableRequired == that.hashableRequired &&
                 Objects.equals(name, that.name) &&
                 Objects.equals(variadicBound, that.variadicBound);
     }
@@ -142,6 +166,6 @@ public class TypeVariableConstraint
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired);
+        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, hashableRequired);
     }
 }


### PR DESCRIPTION
Summary:

## Description
approx_distinct declares an unbounded type parameter `T`, so a `MAP`, `ARRAY`, or `ROW` argument binds during analysis and passes EXPLAIN, then fails later: at execution on a native worker with `Aggregate function signature is not supported`, or at Java specialization with `FUNCTION_IMPLEMENTATION_MISSING`. For example, `approx_distinct(map(bigint, bigint))` is accepted at analysis but has no implementation anywhere.

approx_distinct requires an `XX_HASH_64` operator on `T` (the value is hashed into the sketch), but that requirement was only enforced at specialization. This change auto-derives a `hashableRequired` type-variable constraint from `OperatorDependency(XX_HASH_64)` — the same way the `comparable` and `orderable` constraints are derived from their operator dependencies — and enforces it in `SignatureBinder`. Any aggregation whose type variable carries the `XX_HASH_64` dependency now rejects a non-hashable type at analysis:

    Unexpected parameters (map(bigint,bigint), double) for function approx_distinct.
    Expected: approx_distinct(T, double) T:hashable

`UNKNOWN` and `BOOLEAN` are exempt — they are the supported specializations that do not use `XX_HASH_64`.

## Motivation and Context
approx_distinct over a complex type resolves at analysis but has no implementation on any engine, producing a false-green EXPLAIN and a late, confusing failure. Rejecting it at analysis fails fast with a clear, actionable error.

## Impact
approx_distinct over `MAP`/`ARRAY`/`ROW` (and any other type lacking an `XX_HASH_64` operator) now fails at analysis with a clear `T:hashable` error instead of failing late at execution. All currently-supported argument types are unaffected. The same constraint is derived for any aggregation that declares the `XX_HASH_64` dependency on its type variable.

## Test Plan
CI

## Contributor checklist
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D113714500


