### PR TITLE
fix: ClassNotFoundException: S3AFileSystem on partitioned Delta Lake tables

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
@@ -31,6 +31,7 @@ import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import jakarta.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -185,7 +186,9 @@ public class DeltaClient
             if (!fileSystem.isDirectory(tableLocation)) {
                 return Optional.empty();
             }
-            return Optional.of(DefaultEngine.create(fileSystem.getConf()));
+            Configuration conf = hdfsEnvironment.getConfiguration(hdfsContext, tableLocation);
+            conf.setClassLoader(Thread.currentThread().getContextClassLoader());
+            return Optional.of(DefaultEngine.create(conf));
         }
         catch (IOException ioException) {
             throw new PrestoException(DeltaErrorCode.DELTA_ERROR_LOADING_METADATA,

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
@@ -186,9 +186,9 @@ public class DeltaClient
             if (!fileSystem.isDirectory(tableLocation)) {
                 return Optional.empty();
             }
-Configuration conf = new Configuration(hdfsEnvironment.getConfiguration(hdfsContext, tableLocation));
-conf.setClassLoader(DeltaClient.class.getClassLoader());
-return Optional.of(DefaultEngine.create(conf));
+            Configuration conf = new Configuration(hdfsEnvironment.getConfiguration(hdfsContext, tableLocation));
+            conf.setClassLoader(DeltaClient.class.getClassLoader());
+            return Optional.of(DefaultEngine.create(conf));
         }
         catch (IOException ioException) {
             throw new PrestoException(DeltaErrorCode.DELTA_ERROR_LOADING_METADATA,

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
@@ -186,9 +186,9 @@ public class DeltaClient
             if (!fileSystem.isDirectory(tableLocation)) {
                 return Optional.empty();
             }
-            Configuration conf = hdfsEnvironment.getConfiguration(hdfsContext, tableLocation);
-            conf.setClassLoader(Thread.currentThread().getContextClassLoader());
-            return Optional.of(DefaultEngine.create(conf));
+Configuration conf = new Configuration(hdfsEnvironment.getConfiguration(hdfsContext, tableLocation));
+conf.setClassLoader(DeltaClient.class.getClassLoader());
+return Optional.of(DefaultEngine.create(conf));
         }
         catch (IOException ioException) {
             throw new PrestoException(DeltaErrorCode.DELTA_ERROR_LOADING_METADATA,


### PR DESCRIPTION
## Description

Presto throws a `ClassNotFoundException: S3AFileSystem` when querying **partitioned Delta Lake tables** stored on S3. The failure occurs during query analysis inside the Delta connector, specifically when the Delta Kernel attempts to resolve the S3A filesystem while replaying the Delta transaction log for partitioned tables.

### Root Cause

The issue originates in `DeltaClient.loadDeltaEngine()`, where the Delta Kernel is initialized using:

```java
DefaultEngine.create(fileSystem.getConf())
```

The `Configuration` returned by `fileSystem.getConf()` does not retain an explicit `ClassLoader` reference. During partitioned table processing, the Delta Kernel internally constructs `s3a://` paths for partition directories and invokes `Path.getFileSystem(conf)` on its own thread. As a result, Hadoop falls back to the **system classloader**, which does not include the `S3AFileSystem` implementation.

The `S3AFileSystem` class is available only through the **Presto plugin classloader**, causing the following exception:

```text
ClassNotFoundException:
org.apache.hadoop.fs.s3a.S3AFileSystem
```

### Solution

This change updates `DeltaClient.loadDeltaEngine()` to:

- Obtain the Hadoop `Configuration` using `hdfsEnvironment.getConfiguration()`, ensuring all connector-level filesystem settings (S3A, GCS, and ADLS) are applied.
- Explicitly associate the Presto plugin classloader with the `Configuration` before passing it to `DefaultEngine.create()`.

## Motivation and Context

Address the issue https://github.com/prestodb/presto/issues/28228

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

<img width="1824" height="768" alt="image" src="https://github.com/user-attachments/assets/7cfff8c3-3f74-45a9-bc50-005cb097f596" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix ClassNotFoundException for S3AFileSystem when querying partitioned Delta Lake tables stored on S3.

```

## Summary by Sourcery

Ensure the Delta connector initializes the Delta Kernel with a Hadoop configuration that has the correct classloader so S3A-backed partitioned Delta Lake tables can be queried successfully.

Bug Fixes:
- Fix ClassNotFoundException when querying partitioned Delta Lake tables on S3 by using a connector-aware Hadoop configuration with the appropriate classloader for the Delta Kernel.

Enhancements:
- Align Delta Kernel initialization with the connector’s HDFS environment configuration to consistently apply filesystem settings across backends.