### PR TITLE
feat(optimizer): Gather BATCH RPC input to a single driver in plan shape (#28230)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -890,10 +890,20 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitRPC(RPCNode node, StreamPreferredProperties parentPreferences)
         {
-            // RPCNode benefits from multiple drivers for concurrent RPC dispatch.
-            // For constant-only queries (1 row, no table source), the C++
-            // RPCPlanNodeTranslator::maxDrivers() forces single-driver to avoid
-            // ROUND_ROBIN distribution issues.
+            // BATCH accumulates rows into one large request sized to the backend's
+            // batch limits. Fanning the input round-robin across N drivers would
+            // produce N under-filled batches (and, for the synthetic single-row
+            // constant-args case, leave drivers empty), so require a single
+            // stream: a local GATHER runs the RPC stage single-driver while
+            // upstream scan/filter still run in parallel. The gather is a pipeline breaker, so single-driver no
+            // longer collapses the whole fused pipeline. Concurrency in BATCH
+            // comes from multiple in-flight async batches (congestion window +
+            // per-tier rate limiter), not from driver count.
+            if (node.getStreamingMode() == RPCNode.StreamingMode.BATCH) {
+                return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
+            }
+            // PER_ROW dispatches one RPC per row and benefits from multiple
+            // drivers for concurrent dispatch.
             return planAndEnforceChildren(node, parentPreferences.withDefaultParallelism(session), parentPreferences.withDefaultParallelism(session));
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddLocalExchanges.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddLocalExchanges.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.RuleStatsRecorder;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
+import com.facebook.presto.sql.planner.plan.RPCNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.RPC_FUNCTION_OPTIMIZER_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.RPC_STREAMING_MODE;
+import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
+import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+
+public class TestAddLocalExchanges
+        extends BasePlanTest
+{
+    // Treat the ordinary scalar lower() as an RPC function so RpcFunctionOptimizer
+    // rewrites lower(comment) into an RPCNode over a parallel TPCH table scan. This
+    // lets us assert AddLocalExchanges.visitRPC's plan shape without a real RPC
+    // backend. TASK_CONCURRENCY>1 keeps the scan multi-stream so the BATCH GATHER is
+    // actually inserted (over a single-stream source the GATHER would be a no-op).
+    private void assertRpcPlan(@Language("SQL") String sql, String streamingMode, PlanMatchPattern pattern)
+    {
+        List<PlanOptimizer> optimizers = ImmutableList.of(
+                new RpcFunctionOptimizer(() -> ImmutableSet.of("lower")),
+                new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
+                new PruneUnreferencedOutputs(),
+                new IterativeOptimizer(
+                        getMetadata(),
+                        new RuleStatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getCostCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
+                new AddLocalExchanges(getMetadata(), getQueryRunner().getStatsCalculator(), false));
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(TASK_CONCURRENCY, "4")
+                .setSystemProperty(RPC_FUNCTION_OPTIMIZER_ENABLED, "true")
+                .setSystemProperty(RPC_STREAMING_MODE, streamingMode)
+                .build();
+        assertPlan(sql, session, OPTIMIZED, pattern, optimizers);
+    }
+
+    @Test
+    public void testBatchRpcGathersToSingleStream()
+    {
+        // BATCH: a LocalExchange[SINGLE/GATHER] is inserted between the RPCNode and its
+        // parallel source, so the RPC stage runs single-driver while the scan below
+        // stays parallel (no batch fragmentation across drivers).
+        assertRpcPlan(
+                "SELECT lower(comment) FROM orders",
+                "BATCH",
+                anyTree(
+                        node(RPCNode.class,
+                                exchange(LOCAL, GATHER,
+                                        tableScan("orders")))));
+    }
+
+    @Test
+    public void testPerRowRpcStaysParallel()
+    {
+        // PER_ROW: no single-stream GATHER is forced -- the RPCNode keeps the parallel
+        // distribution of its source.
+        assertRpcPlan(
+                "SELECT lower(comment) FROM orders",
+                "PER_ROW",
+                anyTree(
+                        node(RPCNode.class,
+                                tableScan("orders"))));
+    }
+}


### PR DESCRIPTION
Summary:

velox #18182 (plan-shape for capability-driven RPC dispatch).

`AddLocalExchanges::visitRPC` required a parallel RPC child, forcing a ROUND_ROBIN
local exchange that fanned input across N drivers. For BATCH that fragments one
intended large request into N under-filled batches (and drops rows when input
rows < driver count). For BATCH, require a single stream so a local GATHER runs
the RPC stage single-driver while upstream scan/filter stay parallel; the gather
is a pipeline breaker, so single-driver no longer collapses the whole fused
pipeline. PER_ROW is unchanged.

A separate C++ `maxDrivers=1` clamp (RPCPlanNodeTranslator, NOT part of this
diff) remains a defensive backstop so a BATCH RPC node is never fragmented if a
plan omits the gather (coordinator/worker version skew, or a direct-Velox plan);
with the gather it only bounds the already-isolated RPC factory (scan stays
parallel).

Adds `TestAddLocalExchanges` asserting the BATCH `LocalExchange(SINGLE, GATHER)`
shape above the RPC node over a parallel scan, and that PER_ROW keeps parallel
distribution.

```
== RELEASE NOTES ==

General Changes
* Fix BATCH-mode RPC dispatch dropping and under-batching rows by gathering RPC input to a single driver in the local plan.
```

Reviewed By: sebastianopeluso

Differential Revision: D113347630


