### PR TITLE
fix(planner): Guard early-out join rules against missing logical properties

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToLeftEarlyOutJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToLeftEarlyOutJoin.java
@@ -160,7 +160,11 @@ public class TransformDistinctInnerJoinToLeftEarlyOutJoin
 
     private boolean canAggregationBePushedDown(AggregationNode aggregationNode, JoinNode joinNode, Context context)
     {
-        if (!context.getLogicalPropertiesProvider().isPresent()) {
+        // getAggregationProperties() below requires the aggregation's source group to carry logical
+        // properties; these are not derivable for every plan shape, so bail out when they are absent
+        // instead of throwing (matches the guard used by RemoveRedundant* and the right early-out rule).
+        if (!context.getLogicalPropertiesProvider().isPresent() ||
+                !Util.hasLogicalProperties(aggregationNode.getSource())) {
             return false;
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToRightEarlyOutJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToRightEarlyOutJoin.java
@@ -145,8 +145,12 @@ public class TransformDistinctInnerJoinToRightEarlyOutJoin
 
     private boolean canAggregationBePushedDown(AggregationNode aggregationNode, JoinNode joinNode, Context context)
     {
+        // getAggregationProperties() below requires the aggregation's source group to carry logical
+        // properties; these are not derivable for every plan shape, so bail out when they are absent
+        // instead of throwing.
         if (!context.getLogicalPropertiesProvider().isPresent() ||
-                !((GroupReference) joinNode.getLeft()).getLogicalProperties().isPresent()) {
+                !Util.hasLogicalProperties(aggregationNode.getSource()) ||
+                !Util.hasLogicalProperties(joinNode.getLeft())) {
             return false;
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Util.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/Util.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -43,6 +44,15 @@ class Util
 {
     private Util()
     {
+    }
+
+    /**
+     * Returns true if the given plan node is a memo group reference whose logical properties have been derived.
+     * Callers that consult logical properties must guard on this, as properties are not derivable for every plan shape.
+     */
+    public static boolean hasLogicalProperties(PlanNode node)
+    {
+        return node instanceof GroupReference && ((GroupReference) node).getLogicalProperties().isPresent();
     }
 
     /**

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.query;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.JoinNode;
@@ -30,6 +31,10 @@ import org.testng.annotations.Test;
 
 import java.util.function.Consumer;
 
+import static com.facebook.presto.SystemSessionProperties.EXPLOIT_CONSTRAINTS;
+import static com.facebook.presto.SystemSessionProperties.IN_PREDICATES_AS_INNER_JOINS_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.VERBOSE_OPTIMIZER_INFO_ENABLED;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
@@ -63,6 +68,40 @@ public class TestSubqueries
     {
         assertions.close();
         assertions = null;
+    }
+
+    // Session that makes the distinct-inner-join early-out rules eligible, with verbose optimizer info
+    // forcing the rules to be evaluated even when they would otherwise be skipped.
+    private Session earlyOutJoinSession()
+    {
+        return Session.builder(assertions.getQueryRunner().getDefaultSession())
+                .setSystemProperty(EXPLOIT_CONSTRAINTS, "true")
+                .setSystemProperty(IN_PREDICATES_AS_INNER_JOINS_ENABLED, "true")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "AUTOMATIC")
+                .setSystemProperty(VERBOSE_OPTIMIZER_INFO_ENABLED, "true")
+                .build();
+    }
+
+    @Test
+    public void testDistinctInnerJoinEarlyOutWithAntiJoinAndVerboseOptimizerInfo()
+    {
+        // Exercises TransformDistinctInnerJoinTo{Left,Right}EarlyOutJoin end to end on a distinct
+        // aggregation over inner joins combined with an anti-join, under the session configuration that
+        // makes these rules eligible (exploit_constraints + in_predicates_as_inner_joins + AUTOMATIC join
+        // reordering) with verbose_optimizer_info_enabled forcing the rules to be evaluated. Guards the
+        // guard added to canAggregationBePushedDown so the rules bail out gracefully rather than throwing.
+        assertions.assertQuery(
+                earlyOutJoinSession(),
+                "WITH " +
+                        "  deleted AS (SELECT k FROM (VALUES 2, 4) t(k) GROUP BY k), " +
+                        "  u2url AS (SELECT uid, url FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c'), (1, 'd')) n(uid, url)), " +
+                        "  users AS (SELECT uid FROM u2url GROUP BY uid), " +
+                        "  users_filtered AS (SELECT users.uid FROM users LEFT JOIN deleted ON users.uid = deleted.k WHERE deleted.k IS NULL), " +
+                        "  url2p AS (SELECT url, p FROM (VALUES ('a', 100), ('b', 200), ('c', 300), ('d', 400)) m(url, p)) " +
+                        "SELECT u.uid, count(*) cnt " +
+                        "FROM (u2url u INNER JOIN users_filtered f ON u.uid = f.uid) INNER JOIN url2p ON u.url = url2p.url " +
+                        "GROUP BY u.uid",
+                "VALUES (1, BIGINT '2'), (3, BIGINT '1')");
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG)


### PR DESCRIPTION
## Description

`TransformDistinctInnerJoinToLeftEarlyOutJoin` and `TransformDistinctInnerJoinToRightEarlyOutJoin` call `LogicalPropertiesProviderImpl.getAggregationProperties(aggregationNode)`, which **requires the aggregation's source group to carry logical properties and throws `IllegalStateException` ("Expected source PlanNode to be a GroupReference with LogicalProperties") otherwise**. Logical properties are not derivable for every plan shape, so a distinct aggregation over an inner join whose source group lacks them crashed query planning before a plan was produced.

This adds a guard so the rules **bail out of the transformation (`return false`) when the source group has no logical properties**, instead of throwing.

### This mirrors the guard already used across the codebase (should make review easy)

Every other consumer of logical properties in these iterative rules already checks `getLogicalProperties().isPresent()` before accessing them. This PR simply brings the two early-out rules in line with that established, already-reviewed pattern:

- `RemoveRedundantDistinct`, `RemoveRedundantDistinctLimit`, `RemoveRedundantLimit`, `RemoveRedundantSort`, `RemoveRedundantSortColumns`, `RemoveRedundantTopN`, `RemoveRedundantTopNColumns` — all guard `((GroupReference) node.getSource()).getLogicalProperties().isPresent()` before use.
- `TransformDistinctInnerJoinToRightEarlyOutJoin` already guarded `joinNode.getLeft()`'s properties — but **not** the aggregation's own source group, which is what `getAggregationProperties()` actually dereferences.
- `TransformDistinctInnerJoinToLeftEarlyOutJoin` had **no** such guard at all.

The fix is a one-line `||` clause in each rule's `canAggregationBePushedDown`, identical in spirit to the existing checks.

## Motivation and Context

A distinct-aggregation-over-inner-join plan (e.g. produced from `IN` predicates with `in_predicates_as_inner_joins_enabled` + `exploit_constraints` + `AUTOMATIC` join reordering) can reach these rules with a source group that has no derivable logical properties. Instead of the rule declining to fire, the transformation threw and failed the whole query during logical optimization (no plan produced, 0 CPU). `verbose_optimizer_info_enabled` widens the exposure because it evaluates the rule even when it is otherwise skipped.

## Impact

Queries that previously failed during planning now plan and execute normally (the early-out transformation simply does not fire for that sub-plan). There is no behavior change when logical properties are present.

## Test Plan

- New e2e test `TestSubqueries#testDistinctInnerJoinEarlyOutWithAntiJoinAndVerboseOptimizerInfo` (also runs via `TestSubqueriesWithEarlyOutJoinTransformationsEnabled`) exercises both rules end to end on a distinct + anti-join + multi-join query under `exploit_constraints` + `in_predicates_as_inner_joins_enabled` + `AUTOMATIC` reordering + `verbose_optimizer_info_enabled`, verifying correct results.
- Existing unit tests `TestTransformDistinctInnerJoinToLeftEarlyOutJoin`, `TestTransformDistinctInnerJoinToRightEarlyOutJoin`, `TestEarlyOutJoins` pass unchanged.
- `mvn validate` (checkstyle) clean on `presto-main-base`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality. (N/A — no new properties or user-facing surface.)
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores). (N/A — no new dependencies.)

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix a query failure that could occur during planning for some queries with a distinct aggregation over an inner join.
```
