### PR TITLE
fix(optimizer): Preserve TRY-wrapped RPC results from output pruning (#28232)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.spi.VariableAllocator;
@@ -46,6 +48,7 @@ import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -361,18 +364,134 @@ public class RpcFunctionOptimizer
             RowExpression rewrittenBody = RowExpressionTreeRewriter.rewriteWith(
                     createRpcRewriter(), body, context);
 
+            // After extracting RPC calls, the body typically reduces to just
+            // a result variable (e.g., TRY(rpc_fn(args)) -> __rpc_result).
+            // Reading a column never throws, so TRY is unnecessary.
+            // Returning the variable directly also avoids creating a bare
+            // lambda with free variables invisible to VariablesExtractor,
+            // which causes PruneUnreferencedOutputs to drop the variable
+            // from intermediate ProjectNodes in multi-RPC chains.
+            if (rewrittenBody instanceof VariableReferenceExpression) {
+                return rewrittenBody;
+            }
+
+            // For complex bodies (e.g., TRY(CAST(rpc_fn(args) AS INT))),
+            // reconstruct a BIND to expose free variables to optimizers.
+            List<VariableReferenceExpression> freeVars = extractFreeVariables(rewrittenBody);
+            // A non-variable body reaching here normally references at least one
+            // free variable: createRpcRewriter replaces every rpc_fn(...) with a
+            // freshly allocated __rpc_result variable (never a lambda parameter).
+            // If a future rewriter/simplification ever yields a non-variable body
+            // with no free variables, degrade gracefully by leaving the TRY
+            // unchanged rather than emitting a captureless lambda (whose result
+            // would be invisible to PruneUnreferencedOutputs) or failing planning.
+            if (freeVars.isEmpty()) {
+                return tryCall;
+            }
+
+            // Dedup free variables by name. A plan variable name maps to a single
+            // type, so this is normally a no-op; it keeps the name-keyed subs map
+            // and the BIND capture list consistent and avoids a duplicate name
+            // that would otherwise throw from ImmutableMap.Builder.build().
+            Map<String, VariableReferenceExpression> uniqueFreeVars = new LinkedHashMap<>();
+            for (VariableReferenceExpression freeVar : freeVars) {
+                uniqueFreeVars.putIfAbsent(freeVar.getName(), freeVar);
+            }
+
+            ImmutableList.Builder<String> paramNames = ImmutableList.builder();
+            ImmutableList.Builder<com.facebook.presto.common.type.Type> paramTypes = ImmutableList.builder();
+            ImmutableMap.Builder<String, RowExpression> subs = ImmutableMap.builder();
+            ImmutableList.Builder<RowExpression> bindArgs = ImmutableList.builder();
+            int paramIndex = 0;
+            for (VariableReferenceExpression freeVar : uniqueFreeVars.values()) {
+                String paramName = "__try_p_" + paramIndex++;
+                paramNames.add(paramName);
+                paramTypes.add(freeVar.getType());
+                subs.put(
+                        freeVar.getName(),
+                        new VariableReferenceExpression(Optional.empty(), paramName, freeVar.getType()));
+                bindArgs.add(freeVar);
+            }
+
+            RowExpression substitutedBody = VariableSubstitutor.substitute(rewrittenBody, subs.build());
             LambdaDefinitionExpression newLambda = new LambdaDefinitionExpression(
                     lambda.getSourceLocation(),
-                    ImmutableList.of(),
-                    ImmutableList.of(),
-                    rewrittenBody);
+                    paramTypes.build(),
+                    paramNames.build(),
+                    substitutedBody);
+
+            bindArgs.add(newLambda);
+            // BIND fully applies every captured free variable to newLambda (one
+            // bind value per lambda parameter), so its result is a zero-arg
+            // function () -> bodyType. Match the canonical pattern in
+            // PlanRemoteProjections.buildLambdaWithBind; the prior tryCall.getType()
+            // (a scalar like INTEGER) mistyped the BIND special form.
+            SpecialFormExpression bind = new SpecialFormExpression(
+                    SpecialFormExpression.Form.BIND,
+                    new FunctionType(ImmutableList.of(), substitutedBody.getType()),
+                    bindArgs.build());
 
             return new CallExpression(
                     tryCall.getSourceLocation(),
                     tryCall.getDisplayName(),
                     tryCall.getFunctionHandle(),
                     tryCall.getType(),
-                    ImmutableList.of(newLambda));
+                    ImmutableList.of(bind));
+        }
+
+        /**
+         * Returns the free variables of {@code expression}: every
+         * VariableReferenceExpression referenced but not bound by an enclosing
+         * lambda. Unlike VariablesExtractor and the default traversal (whose
+         * visitLambda does not recurse into the body), this descends into lambda
+         * bodies while tracking each lambda's parameters as bound -- so a nested
+         * lambda neither hides a genuinely-free variable nor leaks its own
+         * parameters as free. This mirrors VariableSubstitutor's lambda-shadowing
+         * semantics above, so every free variable reported here is exactly one the
+         * substitution rewrites (and therefore one the reconstructed BIND must
+         * capture to keep it visible to PruneUnreferencedOutputs).
+         */
+        private static List<VariableReferenceExpression> extractFreeVariables(RowExpression expression)
+        {
+            ImmutableSet.Builder<VariableReferenceExpression> freeVars = ImmutableSet.builder();
+            expression.accept(new FreeVariableVisitor(), new FreeVariableScope(ImmutableSet.of(), freeVars));
+            return ImmutableList.copyOf(freeVars.build());
+        }
+
+        private static final class FreeVariableScope
+        {
+            private final Set<String> boundNames;
+            private final ImmutableSet.Builder<VariableReferenceExpression> freeVars;
+
+            FreeVariableScope(Set<String> boundNames, ImmutableSet.Builder<VariableReferenceExpression> freeVars)
+            {
+                this.boundNames = boundNames;
+                this.freeVars = freeVars;
+            }
+        }
+
+        private static final class FreeVariableVisitor
+                extends DefaultRowExpressionTraversalVisitor<FreeVariableScope>
+        {
+            @Override
+            public Void visitVariableReference(VariableReferenceExpression reference, FreeVariableScope scope)
+            {
+                if (!scope.boundNames.contains(reference.getName())) {
+                    scope.freeVars.add(reference);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitLambda(LambdaDefinitionExpression lambda, FreeVariableScope scope)
+            {
+                Set<String> innerBound = ImmutableSet.<String>builder()
+                        .addAll(scope.boundNames)
+                        .addAll(lambda.getArguments())
+                        .build();
+                lambda.getBody().accept(this, new FreeVariableScope(innerBound, scope.freeVars));
+                return null;
+            }
         }
 
         private boolean containsRpcFunction(RowExpression expression)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
@@ -22,6 +23,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
@@ -46,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static org.testng.Assert.assertEquals;
@@ -589,6 +592,250 @@ public class TestRpcFunctionOptimizer
 
         return optimizer.optimize(
                 projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+    }
+
+    @Test
+    public void testMultipleTryWrappedRpcCallsSurvivePruning()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("content", VARCHAR);
+        VariableReferenceExpression out1 = variableAllocator.newVariable("topic", VARCHAR);
+        VariableReferenceExpression out2 = variableAllocator.newVariable("objective", VARCHAR);
+        VariableReferenceExpression out3 = variableAllocator.newVariable("audience", VARCHAR);
+
+        // 3 TRY-wrapped RPC calls: TRY(BIND(content, (p) -> rpc(p, ...)))
+        CallExpression tryCall1 = createTryWrappedRpcCall(inputVar, "topic_prompt");
+        CallExpression tryCall2 = createTryWrappedRpcCall(inputVar, "objective_prompt");
+        CallExpression tryCall3 = createTryWrappedRpcCall(inputVar, "audience_prompt");
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder()
+                        .put(out1, tryCall1)
+                        .put(out2, tryCall2)
+                        .put(out3, tryCall3)
+                        .build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult rpcResult = optimizer.optimize(
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+        assertTrue(rpcResult.isOptimizerTriggered());
+
+        int rpcCount = countPlanNodes(rpcResult.getPlanNode(), RPCNode.class);
+        assertEquals(rpcCount, 3, "Should create 3 RPCNodes");
+
+        // Wrap in OutputNode so PruneUnreferencedOutputs has a root
+        // that declares which variables are needed (otherwise it starts
+        // with empty context and prunes everything).
+        PlanNode rpcPlan = rpcResult.getPlanNode();
+        OutputNode outputNode = new OutputNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                rpcPlan,
+                ImmutableList.of("topic", "objective", "audience"),
+                rpcPlan.getOutputVariables());
+
+        PruneUnreferencedOutputs pruner = new PruneUnreferencedOutputs();
+        PlanOptimizerResult pruneResult = pruner.optimize(
+                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+
+        PlanNode prunedPlan = pruneResult.getPlanNode();
+        assertEquals(countPlanNodes(prunedPlan, RPCNode.class), 3,
+                "All 3 RPCNodes must survive pruning");
+
+        // The OutputNode wraps a ProjectNode
+        assertTrue(prunedPlan instanceof OutputNode);
+        PlanNode child = ((OutputNode) prunedPlan).getSource();
+        assertTrue(child instanceof ProjectNode);
+        ProjectNode finalProject = (ProjectNode) child;
+        assertEquals(finalProject.getOutputVariables().size(), 3,
+                "Final projection must output all 3 result variables");
+    }
+
+    @Test
+    public void testTryWrappedRpcReturnsVariableDirectly()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", VARCHAR);
+
+        CallExpression tryCall = createTryWrappedRpcCall(inputVar, "prompt");
+
+        PlanOptimizerResult result = optimizeWithTryCall(idAllocator, variableAllocator, inputVar, outputVar, tryCall);
+        assertTrue(result.isOptimizerTriggered());
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class));
+
+        // The final ProjectNode's expression for outputVar should be
+        // a direct VariableReferenceExpression (the __rpc_result_ variable),
+        // not a TRY(lambda) wrapping it.
+        ProjectNode finalProject = (ProjectNode) result.getPlanNode();
+        RowExpression outputExpr = finalProject.getAssignments().get(outputVar);
+        assertTrue(outputExpr instanceof VariableReferenceExpression,
+                "TRY(rpc_fn(...)) should rewrite to a direct variable reference, not a TRY lambda. Got: " + outputExpr.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testTryWrappedCastRpcReconstructsBind()
+    {
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new VariableAllocator();
+
+        VariableReferenceExpression inputVar = variableAllocator.newVariable("input_col", VARCHAR);
+        VariableReferenceExpression outputVar = variableAllocator.newVariable("output_col", INTEGER);
+
+        // TRY(CAST(rpc_fn(p, ...) AS INTEGER)) as
+        // $internal$try(BIND(input_col, (p) -> CAST(rpc_fn(p, ...) AS INTEGER))).
+        // The body is a CAST (not a bare variable), so this exercises the
+        // extractFreeVariables + BIND-reconstruction branch: the TRY must be
+        // kept (a CAST can throw) but rebuilt as a BIND that exposes
+        // __rpc_result, otherwise PruneUnreferencedOutputs drops it.
+        CallExpression rpcInsideLambda = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(
+                        new VariableReferenceExpression(Optional.empty(), "p", VARCHAR),
+                        varchar("prompt"),
+                        varchar("system"),
+                        varchar("{}")));
+        CallExpression castExpr = new CallExpression(
+                "CAST",
+                createFunctionHandle("CAST"),
+                INTEGER,
+                ImmutableList.of(rpcInsideLambda));
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(VARCHAR),
+                ImmutableList.of("p"),
+                castExpr);
+        SpecialFormExpression bind = new SpecialFormExpression(
+                SpecialFormExpression.Form.BIND,
+                INTEGER,
+                ImmutableList.of(inputVar, lambda));
+        CallExpression tryCall = new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                INTEGER,
+                ImmutableList.of(bind));
+
+        ValuesNode source = new ValuesNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                ImmutableList.of(inputVar),
+                ImmutableList.of(),
+                Optional.empty());
+        ProjectNode projectNode = new ProjectNode(
+                idAllocator.getNextId(),
+                source,
+                Assignments.builder().put(outputVar, tryCall).build());
+
+        RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(
+                () -> ImmutableSet.of("test_rpc_function"));
+        Session session = TestingSession.testSessionBuilder().build();
+
+        PlanOptimizerResult result = optimizer.optimize(
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+
+        assertTrue(result.isOptimizerTriggered());
+        assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class));
+
+        // The complex body must stay wrapped in $internal$try, but rebuilt as a
+        // BIND whose leading argument is the __rpc_result variable (exposed to
+        // VariablesExtractor), not a bare zero-arg lambda that hides it.
+        ProjectNode finalProject = (ProjectNode) result.getPlanNode();
+        RowExpression outputExpr = finalProject.getAssignments().get(outputVar);
+        assertTrue(outputExpr instanceof CallExpression,
+                "Complex TRY body should stay wrapped in $internal$try. Got: " + outputExpr.getClass().getSimpleName());
+        CallExpression tryExpr = (CallExpression) outputExpr;
+        assertEquals(tryExpr.getDisplayName(), "$internal$try");
+        RowExpression tryArg = tryExpr.getArguments().get(0);
+        assertTrue(tryArg instanceof SpecialFormExpression
+                        && ((SpecialFormExpression) tryArg).getForm() == SpecialFormExpression.Form.BIND,
+                "Complex TRY body must be reconstructed as a BIND. Got: " + tryArg.getClass().getSimpleName());
+        List<RowExpression> bindArgs = ((SpecialFormExpression) tryArg).getArguments();
+        assertTrue(bindArgs.get(0) instanceof VariableReferenceExpression,
+                "BIND must expose the rpc result variable as a bound argument. Got: " + bindArgs.get(0).getClass().getSimpleName());
+
+        // The reconstructed BIND fully applies its captured variable(s) to the
+        // lambda, so its type must be the bound function type () -> INTEGER, not
+        // the scalar TRY result type. Regression guard for the BIND mistyping
+        // (previously tryCall.getType()); matches PlanRemoteProjections.
+        RowExpression bindExpr = tryArg;
+        assertTrue(bindExpr.getType() instanceof FunctionType,
+                "Reconstructed BIND must be typed as a FunctionType. Got: " + bindExpr.getType());
+        FunctionType bindType = (FunctionType) bindExpr.getType();
+        assertTrue(bindType.getArgumentTypes().isEmpty(),
+                "Fully-bound BIND must have zero argument types. Got: " + bindType.getArgumentTypes());
+        assertEquals(bindType.getReturnType(), INTEGER,
+                "BIND return type must be the CAST body type INTEGER");
+
+        // And it must survive PruneUnreferencedOutputs.
+        PlanNode rpcPlan = result.getPlanNode();
+        OutputNode outputNode = new OutputNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                rpcPlan,
+                ImmutableList.of("output_col"),
+                rpcPlan.getOutputVariables());
+        PruneUnreferencedOutputs pruner = new PruneUnreferencedOutputs();
+        PlanOptimizerResult pruneResult = pruner.optimize(
+                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+        assertEquals(countPlanNodes(pruneResult.getPlanNode(), RPCNode.class), 1,
+                "RPCNode must survive pruning for a TRY(CAST(rpc_fn())) body");
+    }
+
+    private static CallExpression createTryWrappedRpcCall(VariableReferenceExpression inputVar, String prompt)
+    {
+        CallExpression rpcInsideLambda = new CallExpression(
+                "test_rpc_function",
+                createFunctionHandle("test_rpc_function"),
+                VARCHAR,
+                ImmutableList.of(
+                        new VariableReferenceExpression(Optional.empty(), "p", VARCHAR),
+                        varchar(prompt),
+                        varchar("system"),
+                        varchar("{}")));
+
+        LambdaDefinitionExpression lambda = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(VARCHAR),
+                ImmutableList.of("p"),
+                rpcInsideLambda);
+
+        SpecialFormExpression bind = new SpecialFormExpression(
+                SpecialFormExpression.Form.BIND,
+                VARCHAR,
+                ImmutableList.of(inputVar, lambda));
+
+        return new CallExpression(
+                "$internal$try",
+                createFunctionHandle("$internal$try"),
+                VARCHAR,
+                ImmutableList.of(bind));
+    }
+
+    private static int countPlanNodes(PlanNode node, Class<? extends PlanNode> targetClass)
+    {
+        int count = targetClass.isInstance(node) ? 1 : 0;
+        for (PlanNode child : node.getSources()) {
+            count += countPlanNodes(child, targetClass);
+        }
+        return count;
     }
 
     private static boolean containsPlanNode(PlanNode node, Class<? extends PlanNode> targetClass)


### PR DESCRIPTION
Summary:

When multiple RPC function calls appear in the same SELECT wrapped in TRY(), the intermediate __rpc_result_* variables were pruned by PruneUnreferencedOutputs, causing VeloxUserError: "Field not found: __rpc_result_...".

Root cause: RpcFunctionOptimizer.rewriteTryWithRpcFunction rewrote TRY(BIND(col, (p) -> rpc_fn(p))) into $internal$try(() -> __rpc_result) -- a bare lambda whose free variable __rpc_result is invisible to VariablesExtractor (DefaultRowExpressionTraversalVisitor skips lambda bodies), so PruneUnreferencedOutputs dropped it from intermediate ProjectNodes.

Fix: if the rewritten TRY body is just a VariableReferenceExpression, return it directly (reading a column never throws, so TRY is unnecessary); for complex bodies (e.g. TRY(CAST(rpc_fn() AS INT))), reconstruct a BIND that binds the free variables so they stay visible to the optimizer.

== RELEASE NOTES ==

General Changes
* Fix a query failure (``Field not found``) when multiple remote function calls wrapped in ``TRY()`` appear in the same ``SELECT``. :pr:`28232`

Reviewed By: sebastianopeluso

Differential Revision: D107687595


