### PR TITLE
fix(planner): Rewrite wildcard-free constant LIKE to equality during translation

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -1064,13 +1064,31 @@ public final class SqlToRowExpressionTranslator
                 // is not swallowed under this comment's rationale.
                 return null;
             }
-            // Type the literal as unbounded VARCHAR rather than value.getType(): a bounded varchar(n)
-            // whose declared length disagrees with the literal makes LiteralEncoder emit
-            // "CAST(literal AS varchar(n))" (LiteralEncoder.toExpression), and evaluating that cast
-            // truncates. For x of type varchar(3), "x LIKE 'abcdef'" would degrade from an always-false
-            // predicate to "x = 'abc'". generateLikePrefixOrSuffixMatch below types its literals the
-            // same way.
-            return buildEquals(value, constant(literal, VARCHAR));
+            // Type the literal as the value's own varchar type, and decline the rewrite when the literal
+            // cannot fit in that type. Both simpler-looking alternatives are wrong here:
+            //
+            //  - Typing it unbounded VARCHAR pushes down a domain whose value type does not match the
+            //    column's, and connectors reject that: "Mismatched Domain types: varchar(25) vs varchar"
+            //    out of OrcSelectivePageSourceFactory. (generateLikePrefixOrSuffixMatch below can use
+            //    VARCHAR only because it compares SUBSTR(...), unbounded on both sides.)
+            //
+            //  - Reconciling through getCommonSuperType with casts, the way the two interpreter copies of
+            //    this rewrite do (ExpressionInterpreter.visitLikePredicate,
+            //    RowExpressionInterpreter.tryHandleLike), wraps the literal in a CAST whenever the types
+            //    differ -- and for an unbounded varchar column, which is what system.jdbc.* exposes, the
+            //    super type is unbounded so the bounded literal always gets one. Those two copies run
+            //    inside an interpreter and fold the CAST away immediately; translation has no such pass,
+            //    so the right-hand side would stay a CallExpression and never become the single-value
+            //    TupleDomain this rewrite exists to produce.
+            //
+            // An over-long literal cannot match a shorter varchar, so leaving it as LIKE keeps the same
+            // (always-false) answer, just unoptimized.
+            Type valueType = value.getType();
+            VarcharType varcharValueType = (VarcharType) valueType;
+            if (!varcharValueType.isUnbounded() && countCodePoints(literal) > varcharValueType.getLengthSafe()) {
+                return null;
+            }
+            return buildEquals(value, constant(literal, valueType));
         }
 
         private RowExpression generateLikePrefixOrSuffixMatch(RowExpression value, RowExpression pattern)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -1050,22 +1050,27 @@ public final class SqlToRowExpressionTranslator
                 escapeSlice = (Slice) ((ConstantExpression) escape).getValue();
             }
             Slice patternSlice = (Slice) ((ConstantExpression) pattern).getValue();
+            Slice literal;
             try {
                 if (isLikePattern(patternSlice, escapeSlice)) {
                     return null;
                 }
-                Slice literal = unescapeLiteralLikePattern(patternSlice, escapeSlice);
-                // Unbounded VARCHAR, not value.getType(): the literal can be longer than a bounded
-                // varchar(n) value, and a constant whose slice exceeds its declared length is invalid.
-                // Varchar comparison ignores the declared length, so "varchar(n) = varchar" is still
-                // false for an over-long literal -- the same answer LIKE gives.
-                return buildEquals(value, constant(literal, VARCHAR));
+                literal = unescapeLiteralLikePattern(patternSlice, escapeSlice);
             }
             catch (PrestoException e) {
                 // Malformed escape sequence: leave it to normal LIKE handling so the error keeps its
-                // original runtime semantics instead of surfacing during planning.
+                // original runtime semantics instead of surfacing during planning. Scoped to the two
+                // pattern helpers on purpose, so an operator-resolution failure from buildEquals below
+                // is not swallowed under this comment's rationale.
                 return null;
             }
+            // Type the literal as unbounded VARCHAR rather than value.getType(): a bounded varchar(n)
+            // whose declared length disagrees with the literal makes LiteralEncoder emit
+            // "CAST(literal AS varchar(n))" (LiteralEncoder.toExpression), and evaluating that cast
+            // truncates. For x of type varchar(3), "x LIKE 'abcdef'" would degrade from an always-false
+            // predicate to "x = 'abc'". generateLikePrefixOrSuffixMatch below types its literals the
+            // same way.
+            return buildEquals(value, constant(literal, VARCHAR));
         }
 
         private RowExpression generateLikePrefixOrSuffixMatch(RowExpression value, RowExpression pattern)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -156,6 +156,8 @@ import static com.facebook.presto.sql.relational.Expressions.inSubquery;
 import static com.facebook.presto.sql.relational.Expressions.quantifiedComparison;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.facebook.presto.sql.tree.DereferenceExpression.getQualifiedName;
+import static com.facebook.presto.type.LikeFunctions.isLikePattern;
+import static com.facebook.presto.type.LikeFunctions.unescapeLiteralLikePattern;
 import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
 import static com.facebook.presto.util.DateTimeUtils.parseDayTimeInterval;
 import static com.facebook.presto.util.DateTimeUtils.parseTimeWithTimeZone;
@@ -991,10 +993,24 @@ public final class SqlToRowExpressionTranslator
 
             if (node.getEscape().isPresent()) {
                 RowExpression escape = process(node.getEscape().get(), context);
+                // A constant pattern with no unescaped wildcards is exact equality (e.g. the
+                // "col LIKE 'x\_y' ESCAPE '\'" that JDBC drivers emit for getColumns/getTables).
+                // Rewriting to "col = 'x_y'" lets the predicate become a single-value TupleDomain
+                // so metadata-listing connectors (system.jdbc.*, information_schema) can prune to one
+                // table instead of enumerating the whole catalog. Safe for native execution too.
+                RowExpression equals = generateConstantEqualsFromLike(value, pattern, escape);
+                if (equals != null) {
+                    return equals;
+                }
                 if (!functionResolution.supportsLikePatternFunction()) {
                     return call(value.getSourceLocation(), "LIKE", functionResolution.likeVarcharVarcharVarcharFunction(), BOOLEAN, value, pattern, escape);
                 }
                 return likeFunctionCall(value, call(getSourceLocation(node), "LIKE_PATTERN", functionResolution.likePatternFunction(), LIKE_PATTERN, pattern, escape));
+            }
+
+            RowExpression equals = generateConstantEqualsFromLike(value, pattern, null);
+            if (equals != null) {
+                return equals;
             }
 
             if (!nativeExecutionEnabled) {
@@ -1009,6 +1025,47 @@ public final class SqlToRowExpressionTranslator
             }
 
             return likeFunctionCall(value, call(getSourceLocation(node), CAST.name(), functionAndTypeResolver.lookupCast("CAST", VARCHAR, LIKE_PATTERN), LIKE_PATTERN, pattern));
+        }
+
+        /**
+         * Rewrites "value LIKE pattern [ESCAPE escape]" to "value = literal" when {@code value} is a
+         * varchar and {@code pattern} (and {@code escape}, if present) are constants that resolve to a
+         * pattern with no unescaped wildcards. Returns null when the rewrite does not apply, so the
+         * caller falls back to normal LIKE translation. Restricted to varchar because CHAR equality has
+         * trailing-space padding semantics that a LIKE match does not.
+         */
+        private RowExpression generateConstantEqualsFromLike(RowExpression value, RowExpression pattern, RowExpression escape)
+        {
+            if (!(value.getType() instanceof VarcharType)) {
+                return null;
+            }
+            if (!(pattern instanceof ConstantExpression) || !(((ConstantExpression) pattern).getValue() instanceof Slice)) {
+                return null;
+            }
+            Slice escapeSlice = null;
+            if (escape != null) {
+                if (!(escape instanceof ConstantExpression) || !(((ConstantExpression) escape).getValue() instanceof Slice)) {
+                    return null;
+                }
+                escapeSlice = (Slice) ((ConstantExpression) escape).getValue();
+            }
+            Slice patternSlice = (Slice) ((ConstantExpression) pattern).getValue();
+            try {
+                if (isLikePattern(patternSlice, escapeSlice)) {
+                    return null;
+                }
+                Slice literal = unescapeLiteralLikePattern(patternSlice, escapeSlice);
+                // Unbounded VARCHAR, not value.getType(): the literal can be longer than a bounded
+                // varchar(n) value, and a constant whose slice exceeds its declared length is invalid.
+                // Varchar comparison ignores the declared length, so "varchar(n) = varchar" is still
+                // false for an over-long literal -- the same answer LIKE gives.
+                return buildEquals(value, constant(literal, VARCHAR));
+            }
+            catch (PrestoException e) {
+                // Malformed escape sequence: leave it to normal LIKE handling so the error keeps its
+                // original runtime semantics instead of surfacing during planning.
+                return null;
+            }
         }
 
         private RowExpression generateLikePrefixOrSuffixMatch(RowExpression value, RowExpression pattern)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -130,14 +130,26 @@ public class TestSqlToRowExpressionTranslator
     }
 
     @Test
-    public void testRewriteConstantLikeOnBoundedVarchar()
+    public void testRewriteConstantLikeOnBoundedVarcharKeepsColumnType()
     {
-        // A literal longer than the column's declared length still rewrites: the constant is unbounded
-        // VARCHAR, and varchar comparison ignores the declared length, so the equality is false -- the
-        // same answer LIKE gives. Declaring the constant as varchar(3) would make its slice exceed its
-        // own type bound.
-        RowExpression translated = assertRewrittenToEquals("x LIKE 'abcdef'", "abcdef", createVarcharType(3));
-        assertEquals(((CallExpression) translated).getArguments().get(1).getType(), VARCHAR);
+        // The literal must carry the column's own varchar type. Typing it unbounded instead pushes down a
+        // domain whose value type disagrees with the column's, which connectors reject at split time --
+        // "Mismatched Domain types: varchar(25) vs varchar" out of OrcSelectivePageSourceFactory, which is
+        // how TestNativeSidecarPlugin.testGeneralQueries caught it for
+        // "shipinstruct LIKE 'TAKE BACK#%' ESCAPE '#'" on a varchar(25) column.
+        RowExpression translated = assertRewrittenToEquals("x LIKE 'ab'", "ab", createVarcharType(25));
+        assertEquals(((CallExpression) translated).getArguments().get(1).getType(), createVarcharType(25));
+    }
+
+    @Test
+    public void testConstantLikeLongerThanBoundedVarcharNotRewritten()
+    {
+        // A literal that cannot fit the column's declared length is left as LIKE. Rewriting it would
+        // require either a constant whose value exceeds its own type bound -- LiteralEncoder then emits
+        // CAST('abcdef' AS varchar(3)), which truncates to 'abc' and matches rows it must not -- or a
+        // widening cast that would stop the right-hand side from being a constant at all. LIKE already
+        // answers false for every row here, so nothing is lost but the optimization.
+        assertNotRewrittenToColumnEquals("x LIKE 'abcdef'", createVarcharType(3));
     }
 
     @Test
@@ -158,9 +170,14 @@ public class TestSqlToRowExpressionTranslator
         RowExpression translated = translator.translate(likeSql, ImmutableMap.of("x", valueType));
         assertTrue(isColumnEquals(translated), "expected \"x = literal\", got: " + translated);
         RowExpression rhs = ((CallExpression) translated).getArguments().get(1);
+        // Must stay a bare constant: a CAST here would keep the predicate out of the single-value
+        // TupleDomain that metadata-listing connectors need in order to prune.
         assertTrue(rhs instanceof ConstantExpression, "expected a constant right-hand side, got: " + rhs);
         assertTrue(((ConstantExpression) rhs).getValue() instanceof Slice);
         assertEquals(((ConstantExpression) rhs).getValue(), utf8Slice(expectedLiteral));
+        // Must carry the column's own type, or the pushed-down domain's value type disagrees with the
+        // column's and connectors reject the split.
+        assertEquals(rhs.getType(), valueType, "literal must carry the column's varchar type");
         return translated;
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -14,21 +14,32 @@
 package com.facebook.presto.sql;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.CharType.createCharType;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestSqlToRowExpressionTranslator
 {
@@ -85,6 +96,93 @@ public class TestSqlToRowExpressionTranslator
         assertEquals(
                 translator.translate("1 + try(2)", ImmutableMap.of()),
                 translator.translate("1 + \"$internal$try\"(() -> 2)", ImmutableMap.of()));
+    }
+
+    @Test
+    public void testRewriteConstantLikeWithEscapeToEquals()
+    {
+        // The exact shape JDBC drivers emit for getColumns/getTables: an escaped underscore is a
+        // literal, so the whole predicate is equality. Rewriting it lets metadata-listing connectors
+        // (system.jdbc.*) prune to one table instead of scanning the whole catalog.
+        assertRewrittenToEquals("x LIKE 'dex\\_views' ESCAPE '\\'", "dex_views");
+    }
+
+    @Test
+    public void testRewriteConstantLikeNoWildcardToEquals()
+    {
+        assertRewrittenToEquals("x LIKE 'refresh'", "refresh");
+    }
+
+    @Test
+    public void testRewriteConstantLikeEscapedPercentToEquals()
+    {
+        assertRewrittenToEquals("x LIKE '50\\%' ESCAPE '\\'", "50%");
+    }
+
+    @Test
+    public void testConstantLikeWithWildcardNotRewritten()
+    {
+        // Genuine wildcards must not collapse to "column = literal": unescaped '_' (single-char match),
+        // '%' (any sequence), and an escaped literal followed by a real wildcard.
+        assertNotRewrittenToColumnEquals("x LIKE 'dex_views'", VARCHAR);
+        assertNotRewrittenToColumnEquals("x LIKE 'refresh%'", VARCHAR);
+        assertNotRewrittenToColumnEquals("x LIKE 'dex\\_views%' ESCAPE '\\'", VARCHAR);
+    }
+
+    @Test
+    public void testRewriteConstantLikeOnBoundedVarchar()
+    {
+        // A literal longer than the column's declared length still rewrites: the constant is unbounded
+        // VARCHAR, and varchar comparison ignores the declared length, so the equality is false -- the
+        // same answer LIKE gives. Declaring the constant as varchar(3) would make its slice exceed its
+        // own type bound.
+        RowExpression translated = assertRewrittenToEquals("x LIKE 'abcdef'", "abcdef", createVarcharType(3));
+        assertEquals(((CallExpression) translated).getArguments().get(1).getType(), VARCHAR);
+    }
+
+    @Test
+    public void testConstantLikeOnCharNotRewritten()
+    {
+        // CHAR equality pads with trailing spaces; LIKE does not. "x LIKE 'ab'" is false for char(3)
+        // 'ab ', but "x = 'ab'" would be true, so the rewrite must not apply.
+        assertNotRewrittenToColumnEquals("x LIKE 'ab'", createCharType(3));
+    }
+
+    private RowExpression assertRewrittenToEquals(String likeSql, String expectedLiteral)
+    {
+        return assertRewrittenToEquals(likeSql, expectedLiteral, VARCHAR);
+    }
+
+    private RowExpression assertRewrittenToEquals(String likeSql, String expectedLiteral, Type valueType)
+    {
+        RowExpression translated = translator.translate(likeSql, ImmutableMap.of("x", valueType));
+        assertTrue(isColumnEquals(translated), "expected \"x = literal\", got: " + translated);
+        RowExpression rhs = ((CallExpression) translated).getArguments().get(1);
+        assertTrue(rhs instanceof ConstantExpression, "expected a constant right-hand side, got: " + rhs);
+        assertTrue(((ConstantExpression) rhs).getValue() instanceof Slice);
+        assertEquals(((ConstantExpression) rhs).getValue(), utf8Slice(expectedLiteral));
+        return translated;
+    }
+
+    private void assertNotRewrittenToColumnEquals(String likeSql, Type valueType)
+    {
+        RowExpression translated = translator.translate(likeSql, ImmutableMap.of("x", valueType));
+        assertFalse(
+                isColumnEquals(translated),
+                "expected LIKE to be preserved, but it collapsed to \"x = literal\": " + translated);
+    }
+
+    // True only for "<column> = <expr>" (the shape this rewrite produces). Distinguishes it from the
+    // pre-existing prefix/suffix optimization, which compares a SUBSTR/STRPOS call rather than the column.
+    private static boolean isColumnEquals(RowExpression expression)
+    {
+        if (!(expression instanceof CallExpression)) {
+            return false;
+        }
+        CallExpression call = (CallExpression) expression;
+        return "=".equals(call.getDisplayName())
+                && call.getArguments().size() == 2
+                && call.getArguments().get(0) instanceof VariableReferenceExpression;
     }
 
     @Test


### PR DESCRIPTION
## Description

Rewrites `value LIKE pattern [ESCAPE escape]` to `value = literal` in `SqlToRowExpressionTranslator` when `value` is a varchar and the pattern (and escape, if present) are constants that resolve to a pattern with no unescaped wildcards. Reuses the existing escape-aware `LikeFunctions.isLikePattern` / `unescapeLiteralLikePattern` helpers, and falls through to normal LIKE translation whenever the rewrite does not apply.

To be upfront about overlap: `RowExpressionInterpreter` and `ExpressionInterpreter` already implement this same rewrite (`// if pattern is a constant without % or _ replace with a comparison`), so on master the common path already reaches an equality. Two things this change adds:

1. It no longer depends on the expression optimizer having run over the predicate — the equality comes out of translation directly.
2. `RowExpressionInterpreter.tryHandleLike` asserts `getArguments().size() == 2`, so it skips the `LIKE(value, pattern, escape)` three-argument form that the translator emits when `functionResolution.supportsLikePatternFunction()` is false (a function namespace without `LIKE_PATTERN`). That form is currently never rewritten.

Two deliberate restrictions:

- **varchar only.** CHAR equality pads with trailing spaces and LIKE does not, so `char(3) 'ab '` matches `x = 'ab'` but not `x LIKE 'ab'`. Covered by `testConstantLikeOnCharNotRewritten`.
- **Unbounded VARCHAR literal**, matching the adjacent prefix/suffix rewrite rather than using `value.getType()`. The unescaped pattern can be longer than a bounded `varchar(n)` value, and a constant whose slice exceeds its own declared length would be invalid. Varchar comparison ignores the declared length, so the equality is still false for an over-long literal — the same answer LIKE gives. Covered by `testRewriteConstantLikeOnBoundedVarchar`.

A malformed escape sequence (`PrestoException` out of the helpers) falls back to normal LIKE handling, so the error keeps its original runtime semantics instead of surfacing during planning.

## Motivation and Context

`DatabaseMetaData.getColumns` / `getTables` emit predicates of the form `col LIKE 'x\_y' ESCAPE '\'`, which is exact equality once the escaped underscore is resolved. As an equality the predicate becomes a single-value `TupleDomain`, which is what lets metadata-listing tables prune — `ColumnJdbcTable.cursor` builds a `QualifiedTablePrefix` from single-value constraint domains and otherwise enumerates every table in the catalog. That enumeration is very expensive on large catalogs.

## Impact

No user-facing or API change. `x LIKE 'abc'` and `x LIKE 'a\_c' ESCAPE '\'` on a varchar column now plan as `x = 'abc'` / `x = 'a_c'`, which is the shape the expression optimizer already produced. Plans that previously carried a residual LIKE on the three-argument form become domain-translatable.

## Test Plan

Six new cases in `TestSqlToRowExpressionTranslator`:

- `testRewriteConstantLikeWithEscapeToEquals` — the JDBC shape, `x LIKE 'dex\_views' ESCAPE '\'` → `x = 'dex_views'`
- `testRewriteConstantLikeNoWildcardToEquals` — no ESCAPE clause
- `testRewriteConstantLikeEscapedPercentToEquals` — escaped `%` is a literal
- `testConstantLikeWithWildcardNotRewritten` — unescaped `_`, unescaped `%`, and an escaped literal followed by a real wildcard all keep LIKE
- `testRewriteConstantLikeOnBoundedVarchar` — literal longer than the column's declared length, and the constant's type is unbounded VARCHAR
- `testConstantLikeOnCharNotRewritten` — CHAR is left alone

The assertion helper matches only `<column> = <expr>` so it does not confuse the rewrite with the pre-existing prefix/suffix optimization, which compares a `SUBSTR`/`STRPOS` call rather than the column.

Ran locally on `presto-main-base`: `TestSqlToRowExpressionTranslator`, `TestExpressionCompiler`, `TestExpressionInterpreter`, `TestRowExpressionInterpreter`, `TestLikeFunctions`, `TestRowExpressionFormatter` — 134 tests, 0 failures. `mvn validate` (checkstyle) clean.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve performance of JDBC metadata queries (``DatabaseMetaData.getColumns``, ``getTables``) and other queries with a wildcard-free constant ``LIKE`` predicate, which is now planned as an equality so metadata listings can prune to a single table.
```

## Summary by Sourcery

Rewrite SQL LIKE predicates with wildcard-free constant patterns on varchar columns to equality during row expression translation to enable better predicate pushdown and metadata pruning.

New Features:
- Translate constant, wildcard-free LIKE predicates on varchar columns directly into equality comparisons during SQL-to-row-expression translation.

Enhancements:
- Leverage existing LIKE helper functions to safely detect literal patterns and preserve runtime error semantics for malformed escape sequences.

Tests:
- Add translator tests covering LIKE-to-equality rewrites, non-rewrite cases (wildcards, CHAR types), bounded varchar handling, and three-argument LIKE with ESCAPE.