### PR TITLE
fix(plugin-iceberg): Fix Iceberg ANALYZE failure when column names in metadata are not lowercase for Hive catalog

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -655,12 +655,12 @@ public class IcebergHiveMetadata
 
         List<Column> partitionColumns = table.getPartitionColumns();
         List<String> partitionColumnNames = partitionColumns.stream()
-                .map(Column::getName)
+                .map(column -> column.getName().toLowerCase(ENGLISH))
                 .collect(toImmutableList());
         List<HiveColumnHandle> hiveColumnHandles = hiveColumnHandles(table);
         Map<String, Type> columnTypes = hiveColumnHandles.stream()
                 .filter(columnHandle -> !columnHandle.isHidden())
-                .collect(toImmutableMap(HiveColumnHandle::getName, column -> column.getHiveType().getType(typeManager)));
+                .collect(toImmutableMap(column -> column.getName().toLowerCase(ENGLISH), column -> column.getHiveType().getType(typeManager)));
 
         Map<List<String>, ComputedStatistics> computedStatisticsMap = createComputedStatisticsToPartitionMap(computedStatistics, partitionColumnNames, columnTypes);
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergAnalyzeUppercaseColumns.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergAnalyzeUppercaseColumns.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.parquet.Parquet;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.UUID;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static java.lang.String.format;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Abstract base class for E2E tests that verify ANALYZE succeeds on Iceberg tables
+ * whose schemas were written by an external engine (e.g. Spark) for both unpartitioned and identity-partitioned tables.
+ */
+public abstract class AbstractTestIcebergAnalyzeUppercaseColumns
+        extends AbstractTestQueryFramework
+{
+    protected static final String TEST_SCHEMA = "tpch";
+
+    /**
+     * Rows written into the partitioned table: {id, value, region}.
+     * Three partitions with deliberately mixed casing on the partition value:
+     * all-uppercase, all-lowercase, mixed — one row each.
+     */
+    protected static final Object[][] PARTITIONED_TABLE_ROWS = {
+        {1, "alpha", "US-EAST"},
+        {2, "beta", "eu-west"},
+        {3, "gamma", "Ap-South"},
+    };
+
+    protected abstract String getTableName();
+
+    protected abstract String getPartitionedTableName();
+
+    protected abstract File getHadoopWarehouseLocation();
+
+    @Test
+    public void testAnalyzeSucceeds()
+    {
+        assertQuerySucceeds(format("ANALYZE %s.%s", TEST_SCHEMA, getTableName()));
+    }
+
+    @Test(dependsOnMethods = "testAnalyzeSucceeds")
+    public void testShowStatsAfterAnalyze()
+    {
+        assertQuerySucceeds(format("ANALYZE %s.%s", TEST_SCHEMA, getTableName()));
+
+        MaterializedResult stats = getQueryRunner().execute(format("SHOW STATS FOR %s.%s", TEST_SCHEMA, getTableName()));
+        List<MaterializedRow> rows = stats.getMaterializedRows();
+
+        // Presto lowercases column names; find the 'id' row.
+        MaterializedRow idRow = rows.stream()
+                .filter(row -> "id".equalsIgnoreCase((String) row.getField(0)))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(idRow, "SHOW STATS FOR must return a row for the 'id' column after ANALYZE");
+
+        // distinct_values_count is field index 2; it must be non-null after ANALYZE.
+        assertNotNull(idRow.getField(2), "distinct_values_count for 'id' must be populated after ANALYZE " +
+                        "on a table whose schema has uppercase column names");
+    }
+
+    @Test
+    public void testSelectFromTable()
+    {
+        assertQuery(format("SELECT count(*) FROM %s.%s", TEST_SCHEMA, getTableName()), "VALUES (3)");
+    }
+
+    @Test(dependsOnMethods = "testAnalyzeSucceeds")
+    public void testQueryWithFilterAfterAnalyzeOnUppercaseColumnsTable()
+    {
+        assertQuery(format("SELECT id FROM %s.%s WHERE id > 1 ORDER BY id", TEST_SCHEMA, getTableName()), "VALUES (2), (3)");
+    }
+
+    /**
+     * Load an Iceberg HadoopCatalog pointing at the "external" warehouse directory.
+     * This simulates an external engine (Spark, Flink, …) that can write tables with
+     * uppercase column names.
+     */
+    protected Catalog loadHadoopCatalog()
+    {
+        return CatalogUtil.loadCatalog(
+                HadoopCatalog.class.getName(),
+                "hadoop_test",
+                ImmutableMap.of("warehouse", getHadoopWarehouseLocation().toURI().toString()),
+                new Configuration());
+    }
+
+    /**
+     * Write a single record to the table as a new Parquet data file and commit it as
+     * a new snapshot — the same write path used by Spark internally.
+     * Supports both unpartitioned and identity-partitioned tables.
+     */
+    protected static void writeRecord(Table table, Record record)
+            throws Exception
+    {
+        String filename = "data-" + UUID.randomUUID() + ".parquet";
+        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
+                table.location(), "data/" + filename);
+
+        DataWriter<Record> writer = Parquet
+                .writeData(HadoopOutputFile.fromPath(filePath, new Configuration()))
+                .forTable(table)
+                .createWriterFunc(GenericParquetWriter::create)
+                .withPartition(partitionKeyFor(table, record))
+                .overwrite()
+                .build();
+        try {
+            writer.write(record);
+        }
+        finally {
+            writer.close();
+        }
+
+        table.newAppend()
+                .appendFile(writer.toDataFile())
+                .commit();
+    }
+
+    /**
+     * Write a single record to a partitioned table using an explicit pre-built
+     * {@code partitionRecord} ({@link GenericRecord} over the partition type).
+     * This variant is used when the caller needs to control the exact partition
+     * struct — for example, to exercise mixed-case partition values written by
+     * an external engine.
+     */
+    protected static void writePartitionedRecord(Table table, PartitionSpec spec, GenericRecord partitionRecord, Record record)
+            throws Exception
+    {
+        String filename = "data-" + UUID.randomUUID() + ".parquet";
+        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
+                table.location(), "data/" + filename);
+
+        DataWriter<Record> writer = Parquet
+                .writeData(HadoopOutputFile.fromPath(filePath, new Configuration()))
+                .forTable(table)
+                .createWriterFunc(GenericParquetWriter::create)
+                .withPartition(partitionRecord)
+                .overwrite()
+                .build();
+        try {
+            writer.write(record);
+        }
+        finally {
+            writer.close();
+        }
+
+        table.newAppend()
+                .appendFile(writer.toDataFile())
+                .commit();
+    }
+
+    /**
+     * Compute the {@link StructLike} partition key for a record.
+     * For unpartitioned tables this returns {@code null}, which {@code DataWriter} accepts.
+     * For partitioned tables the key is built by extracting the identity-partition field
+     * values from the record in the order they appear in the partition spec.
+     */
+    protected static StructLike partitionKeyFor(Table table, Record record)
+    {
+        if (table.spec().isUnpartitioned()) {
+            return null;
+        }
+        PartitionKey partitionKey = new PartitionKey(table.spec(), table.schema());
+        partitionKey.partition(record);
+        return partitionKey;
+    }
+
+    protected static Schema createUnpartitionedSchema()
+    {
+        return new Schema(
+                org.apache.iceberg.types.Types.NestedField.required(1, "ID", org.apache.iceberg.types.Types.IntegerType.get()),
+                org.apache.iceberg.types.Types.NestedField.optional(2, "VALUE", org.apache.iceberg.types.Types.StringType.get()));
+    }
+
+    protected static Schema createPartitionedSchema()
+    {
+        return new Schema(
+                org.apache.iceberg.types.Types.NestedField.required(1, "ID", org.apache.iceberg.types.Types.IntegerType.get()),
+                org.apache.iceberg.types.Types.NestedField.optional(2, "VALUE", org.apache.iceberg.types.Types.StringType.get()),
+                org.apache.iceberg.types.Types.NestedField.required(3, "REGION", org.apache.iceberg.types.Types.StringType.get()));
+    }
+
+    protected void registerTable(String tableName, String tableLocation)
+    {
+        assertQuerySucceeds(format("CALL %s.system.register_table('%s', '%s', '%s')", ICEBERG_CATALOG, TEST_SCHEMA, tableName, tableLocation));
+    }
+
+    protected void unregisterTableQuietly(String tableName)
+    {
+        try {
+            assertQuerySucceeds(format("CALL %s.system.unregister_table('%s', '%s')", ICEBERG_CATALOG, TEST_SCHEMA, tableName));
+        }
+        catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Write three rows to an unpartitioned table with uppercase ID/VALUE columns and
+     * register it in the Presto catalog.
+     */
+    protected void setupUnpartitionedTable(Catalog hadoopCatalog, String tableName)
+            throws Exception
+    {
+        Schema schema = createUnpartitionedSchema();
+        Table table = hadoopCatalog.createTable(
+                org.apache.iceberg.catalog.TableIdentifier.of(TEST_SCHEMA, tableName),
+                schema,
+                PartitionSpec.unpartitioned());
+
+        writeRecord(table, GenericRecord.create(schema).copy("ID", 1, "VALUE", "one"));
+        table.refresh();
+        writeRecord(table, GenericRecord.create(schema).copy("ID", 2, "VALUE", "two"));
+        table.refresh();
+        writeRecord(table, GenericRecord.create(schema).copy("ID", 3, "VALUE", "three"));
+
+        registerTable(tableName, table.location());
+    }
+
+    /**
+     * Creates a table with uppercase columns {@code ID}, {@code VALUE} and {@code REGION},
+     * identity-partitioned on {@code REGION}, writes one row into each of three partitions
+     * with deliberately mixed-case values ({@link #PARTITIONED_TABLE_ROWS}), then registers
+     * the table in the Presto catalog.
+     */
+    protected void setupPartitionedTable(Catalog hadoopCatalog, String tableName)
+            throws Exception
+    {
+        Schema schema = createPartitionedSchema();
+        PartitionSpec spec = PartitionSpec.builderFor(schema).identity("REGION").build();
+        Table table = hadoopCatalog.createTable(
+                org.apache.iceberg.catalog.TableIdentifier.of(TEST_SCHEMA, tableName),
+                schema,
+                spec);
+
+        for (Object[] row : PARTITIONED_TABLE_ROWS) {
+            Record record = GenericRecord.create(schema).copy("ID", row[0], "VALUE", row[1], "REGION", row[2]);
+            GenericRecord partitionRecord = GenericRecord.create(spec.partitionType());
+            partitionRecord.setField("REGION", row[2]);
+            writePartitionedRecord(table, spec, partitionRecord, record);
+            table.refresh();
+        }
+
+        registerTable(tableName, table.location());
+    }
+
+    @Test
+    public void testAnalyzeSucceedsOnPartitionedTable()
+    {
+        assertQuerySucceeds(format("ANALYZE %s.%s", TEST_SCHEMA, getPartitionedTableName()));
+    }
+
+    @Test(dependsOnMethods = "testAnalyzeSucceedsOnPartitionedTable")
+    public void testShowStatsAfterAnalyzeOnPartitionedTable()
+    {
+        assertQuerySucceeds(format("ANALYZE %s.%s", TEST_SCHEMA, getPartitionedTableName()));
+
+        MaterializedResult stats = getQueryRunner().execute(format("SHOW STATS FOR %s.%s", TEST_SCHEMA, getPartitionedTableName()));
+        List<MaterializedRow> rows = stats.getMaterializedRows();
+
+        MaterializedRow idRow = rows.stream()
+                .filter(row -> "id".equalsIgnoreCase((String) row.getField(0)))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(idRow, "SHOW STATS FOR must return a row for the 'id' column after ANALYZE on partitioned table");
+        assertNotNull(idRow.getField(2), "distinct_values_count for 'id' must be populated after ANALYZE " +
+                        "on a partitioned catalog table with uppercase column names");
+    }
+
+    @Test
+    public void testSelectFromPartitionedTable()
+    {
+        assertQuery(format("SELECT count(*) FROM %s.%s", TEST_SCHEMA, getPartitionedTableName()), "VALUES (3)");
+        assertQuery(format("SELECT id FROM %s.%s WHERE region = 'US-EAST'", TEST_SCHEMA, getPartitionedTableName()), "VALUES (1)");
+        assertQuery(format("SELECT id FROM %s.%s WHERE region = 'eu-west'", TEST_SCHEMA, getPartitionedTableName()), "VALUES (2)");
+        assertQuery(format("SELECT id FROM %s.%s WHERE region = 'Ap-South'", TEST_SCHEMA, getPartitionedTableName()), "VALUES (3)");
+    }
+
+    @Test(dependsOnMethods = "testAnalyzeSucceedsOnPartitionedTable")
+    public void testQueryWithFilterAfterAnalyzeOnPartitioned()
+    {
+        assertQuery(format("SELECT id FROM %s.%s WHERE region IN ('US-EAST', 'Ap-South') ORDER BY id", TEST_SCHEMA, getPartitionedTableName()), "VALUES (1), (3)");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveAnalyzeUppercaseColumns.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveAnalyzeUppercaseColumns.java
@@ -11,9 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg.rest;
+package com.facebook.presto.iceberg.hive;
 
-import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.presto.iceberg.AbstractTestIcebergAnalyzeUppercaseColumns;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
@@ -24,32 +23,25 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Optional;
 
-import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
-import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 
 /**
- * E2E test verifying that ANALYZE succeeds on Iceberg tables whose schemas were written
- * by an external engine (e.g. Spark on Hadoop) with uppercase column names, then
- * registered into a Presto REST catalog via the {@code register_table} procedure.
- * Covers both unpartitioned and identity-partitioned tables; the partitioned variant
- * exercises mixed-case partition values (all-upper, all-lower, mixed).
+ * E2E tests verifying that ANALYZE succeeds on Iceberg tables registered into a Presto
+ * Hive-metastore catalog whose schemas were written by an external engine (e.g. Spark)
+ * with uppercase column names — for both unpartitioned and identity-partitioned tables.
  */
 @Test
-public class TestIcebergRestAnalyzeUppercaseColumns
+public class TestIcebergHiveAnalyzeUppercaseColumns
         extends AbstractTestIcebergAnalyzeUppercaseColumns
 {
-    private static final String TABLE_NAME = "test_rest_uppercase_columns";
-    private static final String PARTITIONED_TABLE = "test_rest_uppercase_columns_partitioned";
+    private static final String TABLE_NAME = "test_hive_uppercase_columns";
+    private static final String PARTITIONED_TABLE_NAME = "test_hive_uppercase_columns_partitioned";
 
-    private File restWarehouseLocation;
+    /** Separate temp dir used as the "external" Hadoop warehouse (simulates Spark). */
     private File hadoopWarehouseLocation;
-    private TestingHttpServer restServer;
-    private String serverUri;
 
     @Override
     protected String getTableName()
@@ -60,7 +52,7 @@ public class TestIcebergRestAnalyzeUppercaseColumns
     @Override
     protected String getPartitionedTableName()
     {
-        return PARTITIONED_TABLE;
+        return PARTITIONED_TABLE_NAME;
     }
 
     @Override
@@ -73,20 +65,14 @@ public class TestIcebergRestAnalyzeUppercaseColumns
     public void init()
             throws Exception
     {
-        // Separate temp dirs: REST catalog warehouse vs. the "external" Hadoop warehouse
-        restWarehouseLocation = Files.newTemporaryFolder();
         hadoopWarehouseLocation = Files.newTemporaryFolder();
-
-        restServer = getRestServer(restWarehouseLocation.getAbsolutePath());
-        restServer.start();
-        serverUri = restServer.getBaseUrl().toString();
 
         super.init();
         assertQuerySucceeds("CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
 
         Catalog hadoopCatalog = loadHadoopCatalog();
         setupUnpartitionedTable(hadoopCatalog, TABLE_NAME);
-        setupPartitionedTable(hadoopCatalog, PARTITIONED_TABLE);
+        setupPartitionedTable(hadoopCatalog, PARTITIONED_TABLE_NAME);
     }
 
     @AfterClass
@@ -94,11 +80,7 @@ public class TestIcebergRestAnalyzeUppercaseColumns
             throws Exception
     {
         unregisterTableQuietly(TABLE_NAME);
-        unregisterTableQuietly(PARTITIONED_TABLE);
-        if (restServer != null) {
-            restServer.stop();
-        }
-        deleteRecursively(restWarehouseLocation.toPath(), ALLOW_INSECURE);
+        unregisterTableQuietly(PARTITIONED_TABLE_NAME);
         deleteRecursively(hadoopWarehouseLocation.toPath(), ALLOW_INSECURE);
     }
 
@@ -107,9 +89,8 @@ public class TestIcebergRestAnalyzeUppercaseColumns
             throws Exception
     {
         return IcebergQueryRunner.builder()
-                .setCatalogType(REST)
-                .setExtraConnectorProperties(restConnectorProperties(serverUri))
-                .setDataDirectory(Optional.of(restWarehouseLocation.toPath()))
+                .setCatalogType(HIVE)
+                .setCreateTpchTables(false)
                 .build()
                 .getQueryRunner();
     }


### PR DESCRIPTION
Fix NullPointerException in `IcebergHiveMetadata.finishStatisticsCollection` when running ANALYZE on a Hive-catalog Iceberg table whose column names are stored in non-lowercase form in the Hive metastore 

## Description
ANALYZE on Iceberg tables using the Hive metastore catalog failed with a NullPointerException when the table schema was written by an external engine (e.g. Spark, Flink) that stored column names in non-lowercase form:

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "type" is null
    at com.facebook.presto.hive.metastore.Statistics.setMinMax(Statistics.java:404)
    at com.facebook.presto.hive.metastore.Statistics.createHiveColumnStatistics(Statistics.java:362)
    at com.facebook.presto.hive.metastore.Statistics.lambda$fromComputedStatistics$5(Statistics.java:334)
    ...
    at com.facebook.presto.iceberg.IcebergHiveMetadata.finishStatisticsCollection(IcebergHiveMetadata.java:671)
    ...
```

## Motivation and Context
In `IcebergHiveMetadata.finishStatisticsCollection`, a columnTypes map (Map<String, Type>) is built from the Hive metastore table's HiveColumnHandle objects, keyed by the column name exactly as stored in HMS.

When the table was registered from an externally-written Iceberg table (via register_table), HMS column names are stored from the Iceberg schema — i.e. "ID", "VALUE" (uppercase).

## Impact
- ANALYZE on Hive-catalog Iceberg tables with uppercase column names
- ANALYZE on Hive-catalog Iceberg tables with identity-partitioned uppercase partition column

## Test Plan
Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix ANALYZE statistics collection for Hive-catalog Iceberg tables whose column names are stored in non-lowercase form and add regression coverage for uppercase schemas.

Bug Fixes:
- Normalize Hive metastore partition and column names to lowercase when building column type and partition mappings used during Iceberg ANALYZE statistics collection to avoid NullPointerExceptions for non-lowercase columns.

Tests:
- Add end-to-end tests that register externally created Iceberg tables with uppercase column names, both unpartitioned and identity-partitioned, and verify ANALYZE, SHOW STATS, and filtered queries work correctly.