### PR TITLE
perf(planner): Colocated row-id join and no re-rank in optimize_top_n_using_row_id

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -20,14 +20,16 @@ import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DataOrganizationSpecification;
+import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
-import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.TopNNode.Step;
@@ -48,7 +50,8 @@ import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.getOptimizeTopNUsingRowIdMinColumnSavings;
 import static com.facebook.presto.SystemSessionProperties.isOptimizeTopNUsingRowIdEnabled;
-import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.plan.JoinDistributionType.PARTITIONED;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.sql.planner.PlannerUtils.addColumnToTableScan;
 import static com.facebook.presto.sql.planner.PlannerUtils.addPassThroughVariable;
 import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
@@ -56,6 +59,7 @@ import static com.facebook.presto.sql.planner.PlannerUtils.findTableScanNode;
 import static com.facebook.presto.sql.planner.PlannerUtils.isDeterministicScanFilterProject;
 import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProject;
 import static com.facebook.presto.sql.planner.PlannerUtils.restrictOutput;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
@@ -68,24 +72,27 @@ import static java.util.Objects.requireNonNull;
  *
  * Into:
  *   TopN(N, orderBy=[a, b])
- *     └─ Project(remove $row_id, semi_mark)
- *       └─ Filter(semi_mark = true)
- *         └─ SemiJoin(source=$row_id, filtering=$row_id_clone, output=semi_mark)
- *           ├─ Source_with_row_id(a, b, c, d, e, ..., $row_id)
- *           └─ TopN(N, orderBy=[a_clone, b_clone])
- *               └─ ClonedSource(a_clone, b_clone, $row_id_clone)
+ *     └─ InnerJoin($row_id = $row_id_clone)
+ *       ├─ Source_with_row_id(a, b, c, d, e, ..., $row_id)
+ *       └─ TopN(N, orderBy=[a_clone, b_clone])
+ *           └─ ClonedSource(a_clone, b_clone, $row_id_clone)
  *
- * The inner TopN sorts only the narrow clone (sort keys + $row_id).
- * The SemiJoin filters the full scan to only the N matching rows.
+ * The inner TopN sorts only the narrow clone (sort keys + $row_id). $row_id is the table's unique
+ * column, so joining the wide source back to the narrow winners on it is strictly 1:1 — an INNER join
+ * keeps exactly the N matching rows (what a SemiJoin would), while being eligible for a colocated /
+ * grouped join on the shared $row_id partitioning (avoiding the broadcast a SemiJoin was forced into).
  * The outer TopN re-sorts only N rows (cheap).
  *
- * The same rewrite is also applied to {@link TopNRowNumberNode} (the
+ * The same rewrite is applied to {@link TopNRowNumberNode} (the
  * row_number()/rank()/dense_rank() OVER (PARTITION BY ... ORDER BY ...) with
  * WHERE rn &lt;= N pattern, produced by {@link WindowFilterPushDown}). There the
- * narrow key set is partitionBy ∪ orderBy: the inner TopNRowNumber selects, per
- * partition, the same $row_id set, the SemiJoin restricts the wide scan to those
- * rows, and the outer TopNRowNumber recomputes the ranking column over only the
- * kept rows.
+ * narrow key set is partitionBy ∪ orderBy: the inner TopNRowNumber selects, per partition, the same
+ * $row_id set and assigns each kept row its ranking value, and the INNER join restricts the wide scan to
+ * those rows. Because the ranking is a pure function of the partition/order keys (identical on the narrow
+ * clone and the wide source) and the join is 1:1, the inner ranking value is already the final ranking
+ * for every kept row. So there is NO outer TopNRowNumber at all: the inner ranking is carried through the
+ * join and surfaced by a Project as the ranking variable — eliminating a redundant re-rank and the wide
+ * re-shuffle it would force, for every maxRowCountPerPartition.
  */
 public class OptimizeTopNUsingRowId
         implements PlanOptimizer
@@ -251,37 +258,35 @@ public class OptimizeTopNUsingRowId
                     clonedOrderingScheme,
                     Step.SINGLE);
 
-            // 4. Build SemiJoinNode: source=$row_id from augmented original, filtering=$row_id_clone from inner TopN
-            //    For small N (<= 100K), broadcast the TopN result to all workers to avoid a full repartition.
-            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
-            Optional<SemiJoinNode.DistributionType> semiJoinDistribution = node.getCount() <= 100_000
-                    ? Optional.of(SemiJoinNode.DistributionType.REPLICATED)
-                    : Optional.empty();
-            SemiJoinNode semiJoinNode = new SemiJoinNode(
+            // 4. INNER join the wide source back to the narrow winners on the unique $row_id. Because $row_id is
+            //    unique (and never null) the join is strictly 1:1, so it keeps exactly the rows a SemiJoin would —
+            //    but as a JoinNode it is eligible for a colocated/grouped join on the shared $row_id partitioning
+            //    (the SemiJoin path was forced REPLICATED, i.e. broadcast). Force PARTITIONED so both sides
+            //    partition on $row_id, enabling a colocated/grouped join when the connector is co-bucketed on
+            //    $row_id. Output only the left (wide) columns.
+            JoinNode rowIdJoin = new JoinNode(
                     node.getSourceLocation(),
                     idAllocator.getNextId(),
                     Optional.empty(),
+                    INNER,
                     augmentedSource,
                     innerTopN,
-                    rowIdVar,
-                    clonedRowIdVar,
-                    semiJoinOutput,
+                    ImmutableList.of(new EquiJoinClause(rowIdVar, clonedRowIdVar)),
+                    augmentedSource.getOutputVariables(),
                     Optional.empty(),
                     Optional.empty(),
-                    semiJoinDistribution,
+                    Optional.empty(),
+                    Optional.of(PARTITIONED),
                     ImmutableMap.of());
 
-            // 5. Filter on semi_mark = true
-            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
-
-            // 6. Build outer TopN with original ordering scheme over the filtered result.
-            // Don't project away $row_id and semiJoinOutput here — PruneUnreferencedOutputs will handle it.
-            // Projecting them away here would break StreamPropertyDerivations' unique column consistency check.
+            // 5. Build outer TopN with original ordering scheme over the joined result to establish sorted order.
+            // Don't project away $row_id here — PruneUnreferencedOutputs will handle it.
+            // Projecting it away here would break StreamPropertyDerivations' unique column consistency check.
             TopNNode outerTopN = new TopNNode(
                     node.getSourceLocation(),
                     idAllocator.getNextId(),
                     Optional.empty(),
-                    filtered,
+                    rowIdJoin,
                     node.getCount(),
                     node.getOrderingScheme(),
                     Step.SINGLE);
@@ -420,46 +425,46 @@ public class OptimizeTopNUsingRowId
                     false,
                     Optional.empty());
 
-            // 4. Build SemiJoinNode: source=$row_id from augmented original, filtering=$row_id_clone from inner node.
-            //    For small N (<= 100K), broadcast the inner result to all workers to avoid a full repartition.
-            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
-            Optional<SemiJoinNode.DistributionType> semiJoinDistribution = node.getMaxRowCountPerPartition() <= 100_000
-                    ? Optional.of(SemiJoinNode.DistributionType.REPLICATED)
-                    : Optional.empty();
-            SemiJoinNode semiJoinNode = new SemiJoinNode(
+            // 4. INNER join the wide source back to the narrow per-partition winners on the unique $row_id.
+            //    Because $row_id is unique (and never null) the join is strictly 1:1, so it keeps exactly the rows
+            //    a SemiJoin would — but as a JoinNode it is eligible for a colocated/grouped join on the shared
+            //    $row_id partitioning (the SemiJoin path was forced REPLICATED, i.e. broadcast). Force PARTITIONED
+            //    so both sides partition on $row_id, enabling a colocated/grouped join when the connector is
+            //    co-bucketed on $row_id. Output the left (wide) columns plus the inner ranking value, which is
+            //    reused below instead of being recomputed.
+            List<VariableReferenceExpression> joinOutputs = ImmutableList.<VariableReferenceExpression>builder()
+                    .addAll(augmentedSource.getOutputVariables())
+                    .add(innerRowNumberVar)
+                    .build();
+            JoinNode rowIdJoin = new JoinNode(
                     node.getSourceLocation(),
                     idAllocator.getNextId(),
                     Optional.empty(),
+                    INNER,
                     augmentedSource,
                     innerTopNRowNumber,
-                    rowIdVar,
-                    clonedRowIdVar,
-                    semiJoinOutput,
+                    ImmutableList.of(new EquiJoinClause(rowIdVar, clonedRowIdVar)),
+                    joinOutputs,
                     Optional.empty(),
                     Optional.empty(),
-                    semiJoinDistribution,
+                    Optional.empty(),
+                    Optional.of(PARTITIONED),
                     ImmutableMap.of());
 
-            // 5. Filter on semiJoinOutput = true
-            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
-
-            // 6. Build outer TopNRowNumber over the filtered result, reusing the original specification.
-            // Don't project away $row_id and semiJoinOutput here — PruneUnreferencedOutputs will handle it.
-            // Projecting them away here would break StreamPropertyDerivations' unique column consistency check.
-            TopNRowNumberNode outerTopNRowNumber = new TopNRowNumberNode(
-                    node.getSourceLocation(),
-                    idAllocator.getNextId(),
-                    Optional.empty(),
-                    filtered,
-                    node.getSpecification(),
-                    node.getRankingFunction(),
-                    node.getRowNumberVariable(),
-                    node.getMaxRowCountPerPartition(),
-                    false,
-                    node.getHashVariable());
-
+            // 5. The join key is the table's unique column ($row_id), so the join-back is strictly 1:1 and the
+            // inner TopNRowNumber has already assigned the final ranking value to every kept row — the ranking is
+            // a pure function of the partition/order keys, which are identical on the narrow clone and the wide
+            // source — and has already restricted each partition to rank <= maxRowCountPerPartition. So the outer
+            // TopNRowNumber that recomputes the ranking and re-limits is entirely redundant, and it forces a wide
+            // re-shuffle. Replace it with a projection that surfaces the inner ranking as the node's ranking
+            // variable. Keep $row_id so StreamPropertyDerivations' unique-column consistency check still holds;
+            // PruneUnreferencedOutputs drops the unused columns later.
+            Assignments rankingProjection = Assignments.builder()
+                    .putAll(identityAssignments(augmentedSource.getOutputVariables()))
+                    .put(node.getRowNumberVariable(), innerRowNumberVar)
+                    .build();
             planChanged = true;
-            return outerTopNRowNumber;
+            return new ProjectNode(idAllocator.getNextId(), rowIdJoin, rankingProjection);
         }
 
         private static PlanNode replaceSource(TopNRowNumberNode node, PlanNode newSource)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeTopNUsingRowId.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -52,10 +51,11 @@ import java.util.Optional;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
-import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
@@ -98,7 +98,8 @@ public class TestOptimizeTopNUsingRowId
     public void testBasicRewrite()
     {
         // lineitem has 16 columns, sorting by 1 gives savings of 15 >= 10 threshold.
-        // With unique column available, the optimization should produce SemiJoin plan.
+        // With unique column available, the optimization should produce an INNER join on $row_id
+        // (1:1, colocation-eligible) between the wide source and the narrow-TopN winners.
         assertPlanWithSession(
                 "SELECT * FROM lineitem ORDER BY orderkey LIMIT 10",
                 enabledSession(),
@@ -106,13 +107,11 @@ public class TestOptimizeTopNUsingRowId
                 output(
                         topN(10, ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST)),
                                 anyTree(
-                                        node(FilterNode.class,
+                                        join(INNER, ImmutableList.of(equiJoinClause("ROW_ID", "ROW_ID_CLONE")),
                                                 anyTree(
-                                                        semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
-                                                                anyTree(
-                                                                        tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey", "ROW_ID", "$row_id"))),
-                                                                anyTree(
-                                                                        tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))))));
+                                                        tableScan("lineitem", ImmutableMap.of("ORDERKEY", "orderkey", "ROW_ID", "$row_id"))),
+                                                anyTree(
+                                                        tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))));
     }
 
     @Test
@@ -173,39 +172,55 @@ public class TestOptimizeTopNUsingRowId
                 output(
                         topN(5, ImmutableList.of(sort("NAME", ASCENDING, LAST)),
                                 anyTree(
-                                        node(FilterNode.class,
+                                        join(INNER, ImmutableList.of(equiJoinClause("ROW_ID", "ROW_ID_CLONE")),
                                                 anyTree(
-                                                        semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
-                                                                anyTree(
-                                                                        tableScan("nation", ImmutableMap.of("NAME", "name", "ROW_ID", "$row_id"))),
-                                                                anyTree(
-                                                                        tableScan("nation", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))))));
+                                                        tableScan("nation", ImmutableMap.of("NAME", "name", "ROW_ID", "$row_id"))),
+                                                anyTree(
+                                                        tableScan("nation", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))));
     }
 
     @Test
     public void testTopNRowNumberBasicRewrite()
     {
         // lineitem has 16 columns; row_number() partitioned by orderkey ordered by linenumber
-        // narrows to 2 key columns, savings of 14 >= 10 threshold. With a unique column available,
-        // the optimization should produce an outer TopNRowNumber over a SemiJoin whose build side
-        // is an inner (narrow) TopNRowNumber.
+        // narrows to 2 key columns, savings of 14 >= 10 threshold. Even with rn <= 2 (more than one row per
+        // partition) the inner TopNRowNumber has already assigned the final ranks, so there is NO outer
+        // TopNRowNumber: the rewrite produces an INNER $row_id join whose build side is the inner (narrow)
+        // TopNRowNumber, with the inner ranking carried through and surfaced by a Project.
         assertPlanWithSession(
                 "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 2",
                 enabledSession(),
                 true,
                 output(
-                        anyTree(
-                                topNRowNumber(outer -> outer.partial(false),
-                                        anyTree(
-                                                node(FilterNode.class,
-                                                        anyTree(
-                                                                semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
-                                                                        anyTree(
-                                                                                tableScan("lineitem", ImmutableMap.of("ROW_ID", "$row_id"))),
-                                                                        anyTree(
-                                                                                topNRowNumber(inner -> inner.partial(false),
-                                                                                        anyTree(
-                                                                                                tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id")))))))))))));
+                        join(INNER, ImmutableList.of(equiJoinClause("ROW_ID", "ROW_ID_CLONE")),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("ROW_ID", "$row_id"))),
+                                anyTree(
+                                        topNRowNumber(inner -> inner.partial(false),
+                                                anyTree(
+                                                        tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))));
+    }
+
+    @Test
+    public void testTopNRowNumberDropsOuterForSingleRowPerPartition()
+    {
+        // rn <= 1 (one row per partition): because the join key is the unique $row_id, the join-back is 1:1 and
+        // the inner (narrow) TopNRowNumber has already selected the winning row per partition and assigned its
+        // rank. The outer TopNRowNumber (and the wide re-shuffle it forces) is redundant; the inner ranking is
+        // carried through the join and surfaced by a Project. The only non-partial TopNRowNumber left is the
+        // inner one, on the join build side (same shape as testTopNRowNumberBasicRewrite, which covers rn <= 2).
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT *, row_number() OVER (PARTITION BY orderkey ORDER BY linenumber) rn FROM lineitem) WHERE rn <= 1",
+                enabledSession(),
+                true,
+                output(
+                        join(INNER, ImmutableList.of(equiJoinClause("ROW_ID", "ROW_ID_CLONE")),
+                                anyTree(
+                                        tableScan("lineitem", ImmutableMap.of("ROW_ID", "$row_id"))),
+                                anyTree(
+                                        topNRowNumber(inner -> inner.partial(false),
+                                                anyTree(
+                                                        tableScan("lineitem", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))))));
     }
 
     @Test
@@ -244,7 +259,7 @@ public class TestOptimizeTopNUsingRowId
     {
         // Unpartitioned row_number() over the wide orders table (9 columns). With a low
         // column-savings threshold the rewrite fires, producing the $row_id / $row_id_clone
-        // SemiJoin (the outer/inner TopNRowNumber nesting is asserted in testTopNRowNumberBasicRewrite).
+        // INNER join (the outer/inner TopNRowNumber nesting is asserted in testTopNRowNumberBasicRewrite).
         Session lowThreshold = Session.builder(getQueryRunner().getDefaultSession())
                 .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID, "true")
                 .setSystemProperty(OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS, "1")
@@ -255,12 +270,11 @@ public class TestOptimizeTopNUsingRowId
                 lowThreshold,
                 true,
                 output(
-                        anyTree(
-                                semiJoin("ROW_ID", "ROW_ID_CLONE", "SEMI_JOIN_OUTPUT",
-                                        anyTree(
-                                                tableScan("orders", ImmutableMap.of("ROW_ID", "$row_id"))),
-                                        anyTree(
-                                                tableScan("orders", ImmutableMap.of("ROW_ID_CLONE", "$row_id")))))));
+                        join(INNER, ImmutableList.of(equiJoinClause("ROW_ID", "ROW_ID_CLONE")),
+                                anyTree(
+                                        tableScan("orders", ImmutableMap.of("ROW_ID", "$row_id"))),
+                                anyTree(
+                                        tableScan("orders", ImmutableMap.of("ROW_ID_CLONE", "$row_id"))))));
     }
 
     private Session enabledSession()


### PR DESCRIPTION
## Description

Improves the `optimize_top_n_using_row_id` optimization (gated by the existing, default-off `optimize_top_n_using_row_id` session property).

The optimization late-materializes the wide rows for the selected `$row_id` set. Previously it fetched them with a broadcast (`REPLICATED`) semi join and then re-applied the `TopN` / `TopNRowNumber` over the joined result.

Since `$row_id` is a unique, non-null column, the join back to the narrow winners is strictly 1:1. This PR:

- Replaces the semi join with an **`INNER` join on `$row_id` using `PARTITIONED` distribution**, so it is eligible for a colocated / grouped join on the shared `$row_id` partitioning instead of broadcasting the build side.
- **Drops the outer `TopNRowNumber` entirely.** The inner (narrow) `TopNRowNumber` has already assigned the final ranking value to every kept row and limited each partition, so with a 1:1 join the ranking is simply carried through and surfaced by a projection rather than recomputed over the wide rows — which also removes a wide re-shuffle.

The plain `TopN` path keeps its outer `TopN` only to re-establish the sorted order of the fetched rows.

## Motivation and Context

For a top-N-per-partition / dedup-by-latest over a wide table, the previous plan broadcast the winners and re-ranked the wide rows, forcing an extra shuffle of the wide side. The unique `$row_id` makes the join-back 1:1, so the re-rank is redundant and the join can be colocated, eliminating the broadcast and the wide re-shuffle.

## Test Plan

- Unit (plan shape): `TestOptimizeTopNUsingRowId` — updated to assert the `INNER $row_id` join and that no outer `TopNRowNumber` remains (asserted directly under `Output`, so a reappearing outer node fails the test); covers `TopN`, and `TopNRowNumber` for `maxRowCountPerPartition` = 1 and > 1, partitioned and unpartitioned.
- End-to-end (enabled vs disabled, same SQL): `TestLocalQueries#testOptimizeTopNUsingRowId` and `#testOptimizeTopNRowNumberUsingRowId`.
- Full `TestLocalQueries` suite (542 tests) passes; `mvn validate` (checkstyle) clean.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve the performance of the ``optimize_top_n_using_row_id`` optimization by using a colocation-friendly join and removing a redundant re-ranking step.
```

## Summary by Sourcery

Improve the optimize_top_n_using_row_id planner optimization to use a colocated INNER join on row_id and avoid redundant re-ranking for TopNRowNumber plans.

Enhancements:
- Replace the broadcast SemiJoin in optimize_top_n_using_row_id with a PARTITIONED INNER join on the unique row_id to enable colocated/grouped joins and avoid broadcasting the build side.
- Eliminate the outer TopNRowNumber node by reusing the inner TopNRowNumber ranking through a projection when joining wide rows back to narrow winners, removing redundant ranking and a wide reshuffle.

Tests:
- Update and extend planner tests to assert the new INNER row_id join shape and the absence of an outer TopNRowNumber, including new coverage for single-row-per-partition cases and unpartitioned row_number rewrites.