### PR TITLE
fix(plugin-native-sidecar): Rewrite literal LIKE predicates to equality for connector pushdown

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
@@ -37,6 +37,8 @@ public interface FunctionAndTypeResolver
 
     FunctionHandle lookupFunction(String functionName, List<TypeSignatureProvider> fromTypes);
 
+    FunctionHandle lookupJavaBuiltInFunction(String functionName, List<TypeSignatureProvider> fromTypes);
+
     FunctionHandle resolveFunction(
             Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions,
             Optional<TransactionId> transactionId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -259,6 +259,12 @@ public class FunctionAndTypeManager
             }
 
             @Override
+            public FunctionHandle lookupJavaBuiltInFunction(String functionName, List<TypeSignatureProvider> fromTypes)
+            {
+                return FunctionAndTypeManager.this.lookupFunction(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, functionName), fromTypes);
+            }
+
+            @Override
             public FunctionHandle resolveFunction(
                     Optional<Map<SqlFunctionId, SqlInvokedFunction>> sessionFunctions,
                     Optional<TransactionId> transactionId,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -459,6 +459,12 @@ public final class FunctionResolution
     }
 
     @Override
+    public FunctionHandle lookupJavaBuiltInFunction(String functionName, List<Type> inputTypes)
+    {
+        return functionAndTypeResolver.lookupJavaBuiltInFunction(functionName, fromTypes(inputTypes));
+    }
+
+    @Override
     public FunctionHandle lookupFunction(String catalog, String schema, String functionName, List<Type> inputTypes)
     {
         return functionAndTypeResolver.resolveFunction(Optional.empty(), Optional.empty(), QualifiedObjectName.valueOf(catalog, schema, functionName), fromTypes(inputTypes));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -123,7 +123,7 @@ public final class FunctionResolution
     @Override
     public boolean isLikeFunction(FunctionHandle functionHandle)
     {
-        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "LIKE"));
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().getObjectName().equalsIgnoreCase("LIKE");
     }
 
     @Override

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMEN
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
@@ -90,9 +91,11 @@ public class NativeExpressionOptimizer
     @Override
     public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
-        // Rewrite literal LIKE predicates (no real wildcards) to equality before the sidecar
-        // pipeline, enabling connector predicate pushdown. On the native execution path,
-        // RowExpressionInterpreter.tryHandleLike is never invoked, so this visitor fills that gap.
+        // Rewrite LIKE predicates before sending to the sidecar:
+        //   col LIKE '%' [ESCAPE c]  →  col IS NOT NULL   (match-all pattern)
+        //   col LIKE 'literal'       →  col = 'literal'   (no real wildcards)
+        // On the native execution path RowExpressionInterpreter.tryHandleLike is never invoked,
+        // so this visitor fills that gap and enables connector predicate pushdown.
         expression = expression.accept(likeToEqualityVisitor, null);
 
         // Collect expressions to optimize
@@ -520,16 +523,21 @@ public class NativeExpressionOptimizer
     }
 
     /**
-     * Rewrites literal LIKE predicates to equality checks throughout the expression tree,
-     * enabling connector predicate pushdown on the native execution path.
+     * Rewrites LIKE predicates throughout the expression tree to simpler forms, enabling
+     * connector predicate pushdown on the native execution path.
      * <p>
-     * Because {@code supportsLikePatternFunction()} is false in native mode, the optimizer always emits
-     * the raw VARCHAR forms:
+     * Three rewrites are performed :
+     * <ol>
+     *   <li><b>Match-all</b>: {@code col LIKE '%' [ESCAPE c]} → {@code col IS NOT NULL}</li>
+     *   <li><b>Literal equality</b>: {@code col LIKE 'no_wildcards' [ESCAPE c]} → {@code col = 'unescaped'}</li>
+     *   <li><b>No rewrite</b>: pattern contains real wildcards, non-constant args, or non-varchar column — left unchanged.</li>
+     * </ol>
+     * Because {@code supportsLikePatternFunction()} is false in native mode, the optimizer always
+     * emits the raw VARCHAR forms:
      * <ul>
      *   <li>2-arg: {@code LIKE(col, patternConst)} — no ESCAPE clause</li>
      *   <li>3-arg: {@code LIKE(col, patternConst, escapeConst)} — with ESCAPE clause</li>
      * </ul>
-     * <p>
      * This mirrors {@code RowExpressionInterpreter.tryHandleLike}, which is never invoked on
      * the native execution path.
      */
@@ -562,14 +570,7 @@ public class NativeExpressionOptimizer
                 return visited;
             }
 
-            // Returns null if the call cannot be rewritten (non-constant args, real wildcards,
-            // non-varchar column, or null escape constant).
-            Slice unescapedLiteral = extractUnescapedLiteral(visited.getArguments());
-            if (unescapedLiteral == null) {
-                return visited;
-            }
-
-            return buildEquality(visited, visited.getArguments().get(0), unescapedLiteral);
+            return tryRewriteLike(visited);
         }
 
         @Override
@@ -607,42 +608,90 @@ public class NativeExpressionOptimizer
         }
 
         /**
-         * Validates the LIKE call arguments and returns the unescaped literal to compare against,
-         * or null if the call cannot be rewritten to equality (non-constant args, non-varchar
-         * column, null escape constant, or the pattern contains real wildcards).
+         * Attempts to rewrite a confirmed LIKE call to a simpler form, performing all argument
+         * validation exactly once and dispatching to the right rewrite:
+         * <ul>
+         *   <li>{@code col LIKE '%' [ESCAPE c]} — pattern is pure match-all → {@code col IS NOT NULL}</li>
+         *   <li>{@code col LIKE 'literal'} (no real wildcards) → {@code col = 'literal'}</li>
+         *   <li>anything else — non-constant args, wildcards, non-varchar col → original call unchanged</li>
+         * </ul>
          */
-        private Slice extractUnescapedLiteral(List<RowExpression> args)
+        private RowExpression tryRewriteLike(CallExpression call)
         {
+            List<RowExpression> args = call.getArguments();
             if (args.size() < 2 || args.size() > 3) {
-                return null;
+                return call;
             }
             if (!(args.get(0).getType() instanceof VarcharType)) {
-                return null;
+                return call;
             }
             if (!(args.get(1) instanceof ConstantExpression)
                     || !(((ConstantExpression) args.get(1)).getValue() instanceof Slice)) {
-                return null; // non-constant or null pattern — leave null-propagation to runtime
+                return call; // non-constant or null pattern — leave null-propagation to runtime
             }
             if (args.size() == 3
                     && (!(args.get(2) instanceof ConstantExpression)
                     || !(((ConstantExpression) args.get(2)).getValue() instanceof Slice))) {
-                return null; // non-constant or null escape — leave null-propagation to runtime
+                return call; // non-constant or null escape — leave null-propagation to runtime
             }
 
             Slice pattern = (Slice) ((ConstantExpression) args.get(1)).getValue();
             Slice escape = args.size() == 3 ? (Slice) ((ConstantExpression) args.get(2)).getValue() : null;
 
-            if (hasLikeWildcards(pattern, escape)) {
-                return null;
+            // col LIKE '%' [ESCAPE c] matches every non-null value — rewrite to IS NOT NULL.
+            if (isMatchAll(pattern, escape)) {
+                return buildIsNotNull(call, args.get(0));
             }
 
-            return stripEscapes(pattern, escape);
+            if (hasLikeWildcards(pattern, escape)) {
+                return call;
+            }
+
+            return buildEquality(call, args.get(0), stripEscapes(pattern, escape));
+        }
+
+        /**
+         * Returns true when the pattern is a single unescaped {@code '%'}, i.e. it matches any
+         * non-null string. The escape character (if present) is validated but cannot affect the
+         * result because {@code '%'} is the only character in the pattern.
+         */
+        private boolean isMatchAll(Slice pattern, Slice escape)
+        {
+            String stringPattern = pattern.toStringUtf8();
+            if (!stringPattern.equals("%")) {
+                return false;
+            }
+            if (escape != null) {
+                String stringEscape = escape.toStringUtf8();
+                checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+            }
+            return true;
+        }
+
+        /**
+         * Builds {@code NOT(IS_NULL(col))} — the row-expression equivalent of {@code col IS NOT NULL}.
+         * Uses {@code lookupJavaBuiltInFunction()} directly to guarantee the built-in
+         * {@code presto.default.not} handle, enabling pushdown when the default namespace is
+         * overridden to {@code native.default}.
+         */
+        private RowExpression buildIsNotNull(CallExpression originalCall, RowExpression col)
+        {
+            RowExpression isNull = new SpecialFormExpression(
+                    originalCall.getSourceLocation(),
+                    IS_NULL,
+                    BooleanType.BOOLEAN,
+                    ImmutableList.of(col));
+            return new CallExpression(
+                    originalCall.getSourceLocation(),
+                    "not",
+                    resolution.lookupJavaBuiltInFunction("not", ImmutableList.of(BooleanType.BOOLEAN)),
+                    BooleanType.BOOLEAN,
+                    ImmutableList.of(isNull));
         }
 
         /**
          * Returns true if the pattern contains any unescaped '%' or '_' wildcard.
-         * Mirrors {@code LikeFunctions.isLikePattern} but returns true for malformed escape
-         * instead of throwing, leaving error handling to the runtime.
+         * Mirrors {@code LikeFunctions.isLikePattern}.
          */
         private boolean hasLikeWildcards(Slice pattern, Slice escape)
         {

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -13,10 +13,15 @@
  */
 package com.facebook.presto.sidecar.expressions;
 
+import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.FunctionMetadata;
@@ -34,6 +39,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -46,6 +53,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.common.Utils.checkArgument;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
@@ -62,6 +71,7 @@ public class NativeExpressionOptimizer
     private final StandardFunctionResolution resolution;
     private final NativeSidecarExpressionInterpreter rowExpressionInterpreterService;
     private final CastInsertionVisitor castInsertionVisitor;
+    private final LikeToEqualityVisitor likeToEqualityVisitor;
 
     @Inject
     public NativeExpressionOptimizer(
@@ -74,11 +84,17 @@ public class NativeExpressionOptimizer
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.resolution = requireNonNull(resolution, "resolution is null");
         this.castInsertionVisitor = new CastInsertionVisitor(resolution, requireNonNull(typeManager, "typeManager is null"));
+        this.likeToEqualityVisitor = new LikeToEqualityVisitor(resolution);
     }
 
     @Override
     public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
+        // Rewrite literal LIKE predicates (no real wildcards) to equality before the sidecar
+        // pipeline, enabling connector predicate pushdown. On the native execution path,
+        // RowExpressionInterpreter.tryHandleLike is never invoked, so this visitor fills that gap.
+        expression = expression.accept(likeToEqualityVisitor, null);
+
         // Collect expressions to optimize
         CollectingVisitor collectingVisitor = new CollectingVisitor(functionMetadataManager, level, resolution);
         expression = expression.accept(castInsertionVisitor, null);
@@ -503,6 +519,221 @@ public class NativeExpressionOptimizer
         }
     }
 
+    /**
+     * Rewrites literal LIKE predicates to equality checks throughout the expression tree,
+     * enabling connector predicate pushdown on the native execution path.
+     * <p>
+     * Because {@code supportsLikePatternFunction()} is false in native mode, the optimizer always emits
+     * the raw VARCHAR forms:
+     * <ul>
+     *   <li>2-arg: {@code LIKE(col, patternConst)} — no ESCAPE clause</li>
+     *   <li>3-arg: {@code LIKE(col, patternConst, escapeConst)} — with ESCAPE clause</li>
+     * </ul>
+     * <p>
+     * This mirrors {@code RowExpressionInterpreter.tryHandleLike}, which is never invoked on
+     * the native execution path.
+     */
+    private static class LikeToEqualityVisitor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final StandardFunctionResolution resolution;
+
+        public LikeToEqualityVisitor(StandardFunctionResolution resolution)
+        {
+            this.resolution = requireNonNull(resolution, "resolution is null");
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            // Recurse into all arguments first — this covers NOT (a CallExpression) and any
+            // other call that may contain a LIKE node somewhere inside it.
+            List<RowExpression> processedArgs = call.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+            CallExpression visited = new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    processedArgs);
+
+            if (!resolution.isLikeFunction(visited.getFunctionHandle())) {
+                return visited;
+            }
+
+            // Returns null if the call cannot be rewritten (non-constant args, real wildcards,
+            // non-varchar column, or null escape constant).
+            Slice unescapedLiteral = extractUnescapedLiteral(visited.getArguments());
+            if (unescapedLiteral == null) {
+                return visited;
+            }
+
+            return buildEquality(visited, visited.getArguments().get(0), unescapedLiteral);
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> processedArgs = specialForm.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+            return new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), processedArgs);
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            RowExpression processedBody = lambda.getBody().accept(this, context);
+            return new LambdaDefinitionExpression(lambda.getSourceLocation(), lambda.getArgumentTypes(), lambda.getArguments(), processedBody);
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression variable, Void context)
+        {
+            return variable;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression constant, Void context)
+        {
+            return constant;
+        }
+
+        @Override
+        public RowExpression visitExpression(RowExpression expression, Void context)
+        {
+            return expression;
+        }
+
+        /**
+         * Validates the LIKE call arguments and returns the unescaped literal to compare against,
+         * or null if the call cannot be rewritten to equality (non-constant args, non-varchar
+         * column, null escape constant, or the pattern contains real wildcards).
+         */
+        private Slice extractUnescapedLiteral(List<RowExpression> args)
+        {
+            if (args.size() < 2 || args.size() > 3) {
+                return null;
+            }
+            if (!(args.get(0).getType() instanceof VarcharType)) {
+                return null;
+            }
+            if (!(args.get(1) instanceof ConstantExpression)
+                    || !(((ConstantExpression) args.get(1)).getValue() instanceof Slice)) {
+                return null; // non-constant or null pattern — leave null-propagation to runtime
+            }
+            if (args.size() == 3
+                    && (!(args.get(2) instanceof ConstantExpression)
+                    || !(((ConstantExpression) args.get(2)).getValue() instanceof Slice))) {
+                return null; // non-constant or null escape — leave null-propagation to runtime
+            }
+
+            Slice pattern = (Slice) ((ConstantExpression) args.get(1)).getValue();
+            Slice escape = args.size() == 3 ? (Slice) ((ConstantExpression) args.get(2)).getValue() : null;
+
+            if (hasLikeWildcards(pattern, escape)) {
+                return null;
+            }
+
+            return stripEscapes(pattern, escape);
+        }
+
+        /**
+         * Returns true if the pattern contains any unescaped '%' or '_' wildcard.
+         * Mirrors {@code LikeFunctions.isLikePattern} but returns true for malformed escape
+         * instead of throwing, leaving error handling to the runtime.
+         */
+        private boolean hasLikeWildcards(Slice pattern, Slice escape)
+        {
+            String stringPattern = pattern.toStringUtf8();
+            if (escape == null) {
+                return stringPattern.contains("%") || stringPattern.contains("_");
+            }
+
+            String stringEscape = escape.toStringUtf8();
+            checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+
+            char escapeChar = stringEscape.charAt(0);
+            boolean escaped = false;
+            boolean hasWildcards = false;
+            for (int currentChar : stringPattern.codePoints().toArray()) {
+                if (!escaped && currentChar == escapeChar) {
+                    escaped = true;
+                }
+                else if (escaped) {
+                    checkEscape(currentChar == '%' || currentChar == '_' || currentChar == escapeChar);
+                    escaped = false;
+                }
+                else if (currentChar == '%' || currentChar == '_') {
+                    hasWildcards = true;
+                }
+            }
+            checkEscape(!escaped);
+            return hasWildcards;
+        }
+
+        /**
+         * Strips escape prefixes from a pattern that has no wildcards, returning the literal string.
+         * Mirrors {@code LikeFunctions.unescapeLiteralLikePattern}.
+         */
+        private Slice stripEscapes(Slice pattern, Slice escape)
+        {
+            if (escape == null) {
+                return pattern;
+            }
+
+            String stringEscape = escape.toStringUtf8();
+            checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+            char escapeChar = stringEscape.charAt(0);
+            String stringPattern = pattern.toStringUtf8();
+            StringBuilder unescapedPattern = new StringBuilder(stringPattern.length());
+            boolean escaped = false;
+            for (int currentChar : stringPattern.codePoints().toArray()) {
+                if (!escaped && currentChar == escapeChar) {
+                    escaped = true;
+                }
+                else {
+                    unescapedPattern.append(Character.toChars(currentChar));
+                    escaped = false;
+                }
+            }
+            return Slices.utf8Slice(unescapedPattern.toString());
+        }
+
+        /**
+         * Builds EQUAL(col, literal), widening both sides to a common varchar type if needed.
+         */
+        private RowExpression buildEquality(CallExpression originalCall, RowExpression col, Slice literal)
+        {
+            VarcharType colType = (VarcharType) col.getType();
+            VarcharType literalType = createVarcharType(literal.length());
+            Type commonType = (colType.isUnbounded() || literalType.isUnbounded())
+                    ? VarcharType.createUnboundedVarcharType()
+                    : createVarcharType(Math.max(colType.getLengthSafe(), literalType.getLengthSafe()));
+
+            RowExpression lhs = widen(col, colType, commonType);
+            RowExpression rhs = widen(
+                    new ConstantExpression(originalCall.getArguments().get(1).getSourceLocation(), literal, literalType),
+                    literalType, commonType);
+
+            return new CallExpression(
+                    originalCall.getSourceLocation(), "EQUAL",
+                    resolution.comparisonFunction(OperatorType.EQUAL, commonType, commonType),
+                    BooleanType.BOOLEAN,
+                    ImmutableList.of(lhs, rhs));
+        }
+
+        private RowExpression widen(RowExpression expr, Type from, Type to)
+        {
+            if (from.equals(to)) {
+                return expr;
+            }
+            return new CallExpression(expr.getSourceLocation(), "CAST",
+                    resolution.lookupCast("CAST", from, to), to, ImmutableList.of(expr));
+        }
+    }
+
     private static RowExpression toRowExpression(Optional<SourceLocation> sourceLocation, Object object, Type type)
     {
         requireNonNull(type, "type is null");
@@ -558,5 +789,17 @@ public class NativeExpressionOptimizer
         }
 
         return false;
+    }
+
+    private static void checkCondition(boolean condition, ErrorCodeSupplier errorCode, String formatString, Object... args)
+    {
+        if (!condition) {
+            throw new PrestoException(errorCode, format(formatString, args));
+        }
+    }
+
+    private static void checkEscape(boolean condition)
+    {
+        checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -870,6 +870,37 @@ public class TestNativeSidecarPlugin
 
         // Verify UNKNOWN type expressions produce a structured error instead of crashing the sidecar.
         assertQueryFails(session, "SELECT array_except(ARRAY[], ARRAY[])", ".*Errors encountered while optimizing expressions\\..*", true);
+
+        // LikeToEqualityVisitor must rewrite LIKE with no real wildcards into a constant equality, enabling
+        // connector predicate pushdown (ScanFilterProject). We assert structural properties of the native
+        // EXPLAIN directly — PlanNodeIds and cost estimates differ between runners, so cross-runner string
+        // comparison is not viable.
+
+        // Escaped '_': LIKE 'curre\_nt' ESCAPE '\' → equality on 'curre_nt'
+        @Language("SQL") String likeEscapeQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'curre\\_nt' ESCAPE '\\'";
+        String likeEscapePlan = (String) computeActual(session, likeEscapeQuery).getOnlyValue();
+        assertTrue(likeEscapePlan.contains("ScanFilterProject"),
+                "Expected ScanFilterProject (predicate pushed into scan), but got:\n" + likeEscapePlan);
+        assertFalse(likeEscapePlan.contains("- Filter[") && likeEscapePlan.contains("LIKE"),
+                "Expected no Filter+LIKE node above the scan, but got:\n" + likeEscapePlan);
+        assertTrue(likeEscapePlan.contains("VARCHAR'curre_nt'"),
+                "Expected constant VARCHAR'curre_nt' in the scan projection, but got:\n" + likeEscapePlan);
+
+        // Escaped '%': LIKE '100\%' ESCAPE '\' → equality on '100%'
+        @Language("SQL") String likeEscapePercentQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_name LIKE '100\\%' ESCAPE '\\'";
+        String likeEscapePercentPlan = (String) computeActual(session, likeEscapePercentQuery).getOnlyValue();
+        assertTrue(likeEscapePercentPlan.contains("ScanFilterProject"),
+                "Expected ScanFilterProject (predicate pushed into scan), but got:\n" + likeEscapePercentPlan);
+        assertFalse(likeEscapePercentPlan.contains("- Filter[") && likeEscapePercentPlan.contains("LIKE"),
+                "Expected no Filter+LIKE node above the scan, but got:\n" + likeEscapePercentPlan);
+        assertTrue(likeEscapePercentPlan.contains("VARCHAR'100%'"),
+                "Expected constant VARCHAR'100%' in the scan projection, but got:\n" + likeEscapePercentPlan);
+
+        // Real wildcard: LIKE '%' must NOT be rewritten — LIKE must remain in the plan.
+        @Language("SQL") String likeWildcardQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%'";
+        String likeWildcardPlan = (String) computeActual(session, likeWildcardQuery).getOnlyValue();
+        assertTrue(likeWildcardPlan.contains("LIKE"),
+                "Expected LIKE to be preserved in the plan for a real wildcard, but got:\n" + likeWildcardPlan);
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -896,11 +896,35 @@ public class TestNativeSidecarPlugin
         assertTrue(likeEscapePercentPlan.contains("VARCHAR'100%'"),
                 "Expected constant VARCHAR'100%' in the scan projection, but got:\n" + likeEscapePercentPlan);
 
-        // Real wildcard: LIKE '%' must NOT be rewritten — LIKE must remain in the plan.
-        @Language("SQL") String likeWildcardQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%'";
-        String likeWildcardPlan = (String) computeActual(session, likeWildcardQuery).getOnlyValue();
-        assertTrue(likeWildcardPlan.contains("LIKE"),
-                "Expected LIKE to be preserved in the plan for a real wildcard, but got:\n" + likeWildcardPlan);
+        // LIKE '%' (no escape) — match-all → IS NOT NULL: LIKE must vanish and IS_NULL must appear.
+        @Language("SQL") String likeMatchAllQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%'";
+        String likeMatchAllPlan = (String) computeActual(session, likeMatchAllQuery).getOnlyValue();
+        assertFalse(likeMatchAllPlan.contains("LIKE"),
+                "Expected LIKE '%' to be rewritten away (IS NOT NULL), but LIKE remained in the plan:\n" + likeMatchAllPlan);
+        assertTrue(likeMatchAllPlan.contains("IS_NULL") || likeMatchAllPlan.contains("not"),
+                "Expected IS_NULL / not node from IS NOT NULL rewrite, but got:\n" + likeMatchAllPlan);
+
+        // LIKE '%' ESCAPE '\' — match-all with escape → IS NOT NULL: same as above.
+        @Language("SQL") String likeMatchAllEscapeQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%' ESCAPE '\\'";
+        String likeMatchAllEscapePlan = (String) computeActual(session, likeMatchAllEscapeQuery).getOnlyValue();
+        assertFalse(likeMatchAllEscapePlan.contains("LIKE"),
+                "Expected LIKE '%' ESCAPE '\\' to be rewritten away (IS NOT NULL), but LIKE remained in the plan:\n" + likeMatchAllEscapePlan);
+        assertTrue(likeMatchAllEscapePlan.contains("IS_NULL") || likeMatchAllEscapePlan.contains("not"),
+                "Expected IS_NULL / not node from IS NOT NULL rewrite, but got:\n" + likeMatchAllEscapePlan);
+
+        // --- Negative cases for IS NOT NULL branch: patterns that are NOT pure match-all must preserve LIKE ---
+
+        // '%%' — two unescaped '%' chars — not match-all, LIKE must remain
+        @Language("SQL") String likeDoublePercentQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%%'";
+        String likeDoublePercentPlan = (String) computeActual(session, likeDoublePercentQuery).getOnlyValue();
+        assertTrue(likeDoublePercentPlan.contains("LIKE"),
+                "Expected LIKE '%%' to be preserved (not IS NOT NULL), but LIKE was rewritten:\n" + likeDoublePercentPlan);
+
+        // '%abc%' — '%' is not the only character — LIKE must remain
+        @Language("SQL") String likeContainsQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%abc%'";
+        String likeContainsPlan = (String) computeActual(session, likeContainsQuery).getOnlyValue();
+        assertTrue(likeContainsPlan.contains("LIKE"),
+                "Expected LIKE '%abc%' to be preserved (not IS NOT NULL), but LIKE was rewritten:\n" + likeContainsPlan);
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionOptimizer.java
@@ -144,6 +144,55 @@ public class TestNativeExpressionOptimizer
                 session);
     }
 
+    @Test
+    public void testLikeToEqualityRewrite()
+    {
+        // escaped '_' is a literal, not a wildcard — must rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE 'curre\\_nt' ESCAPE '\\'",
+                "unbound_string = CAST('curre_nt' AS VARCHAR)");
+
+        // Escaped '%' is a literal — rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE '100\\%' ESCAPE '\\'",
+                "unbound_string = CAST('100%' AS VARCHAR)");
+
+        // Escaped '_' and escaped escapeChar in same pattern
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a#_##b' ESCAPE '#'",
+                "unbound_string = CAST('a_#b' AS VARCHAR)");
+
+        // No escape clause, no wildcards — rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc'",
+                "unbound_string = CAST('abc' AS VARCHAR)");
+
+        // Real '%' wildcard — must NOT rewrite, leave as LIKE
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc%' ESCAPE '\\'",
+                "unbound_string LIKE 'abc%' ESCAPE '\\'");
+
+        // Real unescaped '_' wildcard — must NOT rewrite
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a_b' ESCAPE '\\'",
+                "unbound_string LIKE 'a_b' ESCAPE '\\'");
+
+        // Escaped '_' but also an unescaped '_' — has real wildcard, must NOT rewrite
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a#__b' ESCAPE '#'",
+                "unbound_string LIKE 'a#__b' ESCAPE '#'");
+
+        // LIKE inside AND — nested rewrite must fire
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc' AND unbound_string LIKE 'x\\_y' ESCAPE '\\'",
+                "unbound_string = CAST('abc' AS VARCHAR) AND unbound_string = CAST('x_y' AS VARCHAR)");
+
+        // LIKE inside NOT — nested rewrite via CallExpression recursion must fire
+        assertOptimizedEquals(
+                "NOT (unbound_string LIKE 'abc')",
+                "NOT (unbound_string = CAST('abc' AS VARCHAR))");
+    }
+
     private void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
     {
         assertOptimizedEquals(actual, expected, TEST_SESSION);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -98,6 +98,8 @@ public interface StandardFunctionResolution
 
     FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes);
 
+    FunctionHandle lookupJavaBuiltInFunction(String functionName, List<Type> inputTypes);
+
     FunctionHandle lookupFunction(String catalog, String schema, String functionName, List<Type> inputTypes);
 
     boolean isArrayConstructor(FunctionHandle functionHandle);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Rewrite literal LIKE predicates without real wildcards to equality comparisons in the native sidecar expression optimizer to enable connector predicate pushdown while preserving wildcard semantics when present.

Enhancements:
- Relax LIKE function detection to match functions named LIKE case-insensitively across namespaces.

Tests:
- Add unit tests for the LikeToEqualityVisitor to validate correct rewriting of LIKE expressions with and without escapes.
- Add native sidecar integration tests asserting that LIKE predicates without wildcards are pushed down into ScanFilterProject nodes and that real wildcard patterns remain as LIKE in query plans.