### PR TITLE
feat(native): Expose hash_probe_finish_early_on_empty_build session property

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -150,6 +150,18 @@ This should only be used for debugging purposes.
 Temporary flag to control whether selective Nimble reader should be used in this
 query or not.
 
+``native_hash_probe_finish_early_on_empty_build``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. When the hash join build side is empty and the join type cannot produce output
+without matched build rows, finish the hash probe operator immediately and close the probe-side
+``ExchangeClient``. This cancels upstream producer tasks whose output would otherwise be received and
+dropped. Applies to inner, left semi filter, right semi filter, right, and non-null-aware right semi
+project joins.
+
 ``native_join_spill_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -46,6 +46,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_AGGREGATION_SPILL_FILE_CREATE_CONFIG = "native_aggregation_spill_file_create_config";
     public static final String NATIVE_HASH_JOIN_SPILL_FILE_CREATE_CONFIG = "native_hash_join_spill_file_create_config";
     public static final String NATIVE_JOIN_SPILL_ENABLED = "native_join_spill_enabled";
+    public static final String NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD = "native_hash_probe_finish_early_on_empty_build";
     public static final String NATIVE_WINDOW_SPILL_ENABLED = "native_window_spill_enabled";
     public static final String NATIVE_WRITER_SPILL_ENABLED = "native_writer_spill_enabled";
     public static final String NATIVE_WRITER_FLUSH_THRESHOLD_BYTES = "native_writer_flush_threshold_bytes";
@@ -180,6 +181,14 @@ public class NativeWorkerSessionPropertyProvider
                         NATIVE_JOIN_SPILL_ENABLED,
                         "Native Execution only. Enable join spilling on native engine",
                         false,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD,
+                        "Native Execution only. When the hash join build side is empty and the join type " +
+                                "cannot produce output without matched build rows, finish the hash probe operator " +
+                                "immediately and close the probe-side ExchangeClient. This cancels upstream producer " +
+                                "tasks whose output would otherwise be received and dropped.",
+                        true,
                         !nativeExecution),
                 booleanProperty(
                         NATIVE_WINDOW_SPILL_ENABLED,

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -42,6 +42,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_AGGREGATION_SPILL_FILE_CREATE_CONFIG = "native_aggregation_spill_file_create_config";
     public static final String NATIVE_HASH_JOIN_SPILL_FILE_CREATE_CONFIG = "native_hash_join_spill_file_create_config";
     public static final String NATIVE_JOIN_SPILL_ENABLED = "native_join_spill_enabled";
+    public static final String NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD = "native_hash_probe_finish_early_on_empty_build";
     public static final String NATIVE_WINDOW_SPILL_ENABLED = "native_window_spill_enabled";
     public static final String NATIVE_WRITER_SPILL_ENABLED = "native_writer_spill_enabled";
     public static final String NATIVE_WRITER_FLUSH_THRESHOLD_BYTES = "native_writer_flush_threshold_bytes";
@@ -174,6 +175,14 @@ public class NativeWorkerSessionPropertyProvider
                         NATIVE_JOIN_SPILL_ENABLED,
                         "Native Execution only. Enable join spilling on native engine",
                         false,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD,
+                        "Native Execution only. When the hash join build side is empty and the join type " +
+                                "cannot produce output without matched build rows, finish the hash probe operator " +
+                                "immediately and close the probe-side ExchangeClient. This cancels upstream producer " +
+                                "tasks whose output would otherwise be received and dropped.",
+                        true,
                         !nativeExecution),
                 booleanProperty(
                         NATIVE_WINDOW_SPILL_ENABLED,

--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -43,6 +43,14 @@ void updateVeloxConfigsWithSpecialCases(
     configStrings.emplace(
         velox::core::QueryConfig::kDriverCpuTimeSliceLimitMs, "1000");
   }
+  // Presto native default is on; Velox's own QueryConfig default is off, and
+  // the coordinator only serializes properties the user explicitly set.
+  it = configStrings.find(
+      velox::core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild);
+  if (it == configStrings.end()) {
+    configStrings.emplace(
+        velox::core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild, "true");
+  }
 }
 
 void updateFromSessionConfigs(

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -204,6 +204,18 @@ SessionProperties::SessionProperties() {
       util::boolToLowerCaseString(c.joinSpillEnabled()));
 
   addSessionProperty(
+      kHashProbeFinishEarlyOnEmptyBuild,
+      "Native Execution only. When the hash join build side is empty and the "
+      "join type cannot produce output without matched build rows, finish "
+      "the hash probe operator immediately and close the probe-side "
+      "ExchangeClient. This cancels upstream producer tasks whose output "
+      "would otherwise be received and dropped.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kHashProbeFinishEarlyOnEmptyBuild,
+      "true");
+
+  addSessionProperty(
       kWindowSpillEnabled,
       "Native Execution only. Enable window spilling on native engine",
       BOOLEAN(),

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
@@ -51,6 +51,14 @@ class SessionProperties : public SessionPropertiesProvider {
   /// Enable join spilling on native engine.
   static constexpr const char* kJoinSpillEnabled = "native_join_spill_enabled";
 
+  /// Finish hash probe early on empty build for join types where an empty
+  /// build guarantees no join output (inner, left/right semi filter, right,
+  /// non-null-aware right semi project). When enabled, HashProbe also closes
+  /// the probe-side ExchangeClient, which sends abortResults to upstream
+  /// producer tasks so they stop generating output that would be discarded.
+  static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
+      "native_hash_probe_finish_early_on_empty_build";
+
   /// The maximum allowed spilling level for hash join build.
   static constexpr const char* kMaxSpillLevel = "native_max_spill_level";
 

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -59,6 +59,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
        core::QueryConfig::kHashJoinSpillFileCreateConfig},
       {SessionProperties::kJoinSpillEnabled,
        core::QueryConfig::kJoinSpillEnabled},
+      {SessionProperties::kHashProbeFinishEarlyOnEmptyBuild,
+       core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild},
       {SessionProperties::kWindowSpillEnabled,
        core::QueryConfig::kWindowSpillEnabled},
       {SessionProperties::kWriterSpillEnabled,

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -854,6 +854,12 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
       veloxConfigs.count(core::QueryConfig::kDriverCpuTimeSliceLimitMs) > 0);
   EXPECT_EQ(
       "1000", veloxConfigs.at(core::QueryConfig::kDriverCpuTimeSliceLimitMs));
+  EXPECT_TRUE(
+      veloxConfigs.count(core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild) >
+      0);
+  EXPECT_EQ(
+      "true",
+      veloxConfigs.at(core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild));
 
   // Verify session-specific configs
   EXPECT_TRUE(veloxConfigs.count(core::QueryConfig::kSessionStartTime) > 0);
@@ -868,6 +874,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
     }
   }
   expectedExactConfigs += 1; // kDriverCpuTimeSliceLimitMs
+  expectedExactConfigs += 1; // kHashProbeFinishEarlyOnEmptyBuild
   expectedExactConfigs += 1; // kSessionStartTime
   expectedExactConfigs += 1; // kSessionTimezone (always added)
 

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestNativeHashProbeFinishEarlyOnEmptyBuild.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestNativeHashProbeFinishEarlyOnEmptyBuild.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.operator.OperatorStats;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.sessionpropertyproviders.NativeWorkerSessionPropertyProvider.NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * End-to-end coverage of {@code native_hash_probe_finish_early_on_empty_build}. The flag applies
+ * only to join types for which Velox's {@code HashProbe::skipProbeOnEmptyBuild()} returns true:
+ * inner, left semi filter, right, right semi filter, and right semi project. For all other join
+ * types (left outer, full outer, anti, left semi project) the flag is a no-op — the probe side
+ * must still emit rows even when the build is empty.
+ * <p>
+ * Tests run against a real external native worker (via {@link
+ * PrestoNativeQueryRunnerUtils#nativeHiveQueryRunnerBuilder()}) with {@code
+ * join_distribution_type=PARTITIONED} to force a probe-side shuffle. This puts an
+ * {@code ExchangeClient} between the upstream probe scan tasks and the hash-probe operator, which
+ * is what the flag closes early when the build side is empty.
+ * <p>
+ * For covered join types, tests assert both:
+ * <ul>
+ *   <li>Correctness — result matches the Java baseline with the flag on and with the flag off.</li>
+ *   <li>Actual cancellation — the {@code LookupJoinOperator} on the probe side processes strictly
+ *       fewer rows with the flag on than with the flag off. With the flag off, Velox drains the
+ *       full probe stream via {@code skipInput_} without a downstream abort, so upstream sends
+ *       every row. With the flag on, {@code HashProbe} calls {@code noMoreInput()} immediately,
+ *       closing the probe-side {@code ExchangeClient} and aborting the upstream producer tasks
+ *       before they emit the rest of the scan.</li>
+ * </ul>
+ * <p>
+ * For no-op join types, only correctness is asserted; the cancellation path is never taken.
+ * <p>
+ * The subquery predicate {@code orderkey > 99999999999} keeps the build side visibly non-empty at
+ * plan time so the join is not eliminated by static optimizers but produces zero rows at runtime.
+ */
+public class TestNativeHashProbeFinishEarlyOnEmptyBuild
+        extends AbstractTestQueryFramework
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return NativeTestsUtils.createNativeQueryRunner(storageFormat, sidecarEnabled);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Override
+    protected void createTables()
+    {
+        NativeTestsUtils.createTables(storageFormat);
+    }
+
+    private Session partitionedJoinWithFlag(boolean value)
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .setSystemProperty(NATIVE_HASH_PROBE_FINISH_EARLY_ON_EMPTY_BUILD, String.valueOf(value))
+                .build();
+    }
+
+    /**
+     * For join types that trigger the early-finish path. Verifies both correctness (results
+     * match the Java baseline in both flag states) and that the probe-side {@code LookupJoin}
+     * operator receives strictly fewer rows with the flag on — evidence that the upstream probe
+     * source tasks were aborted rather than drained.
+     */
+    private void assertProbeCancelledOnEmptyBuild(@Language("SQL") String sql)
+    {
+        Session off = partitionedJoinWithFlag(false);
+        Session on = partitionedJoinWithFlag(true);
+
+        assertQuery(off, sql);
+        assertQuery(on, sql);
+
+        DistributedQueryRunner runner = getDistributedQueryRunner();
+        QueryId qOff = runner.executeWithQueryId(off, sql).getQueryId();
+        QueryId qOn = runner.executeWithQueryId(on, sql).getQueryId();
+        long probeRowsOff = lookupJoinInputPositions(runner.getQueryInfo(qOff));
+        long probeRowsOn = lookupJoinInputPositions(runner.getQueryInfo(qOn));
+
+        assertTrue(
+                probeRowsOff > 0,
+                format("expected the flag-off run to drain probe rows, got %d", probeRowsOff));
+        assertTrue(
+                probeRowsOn < probeRowsOff,
+                format(
+                        "expected fewer probe rows with the flag on (upstream aborted), " +
+                                "but got on=%d, off=%d",
+                        probeRowsOn,
+                        probeRowsOff));
+    }
+
+    /**
+     * For cases where the flag must be a no-op — either a join type outside {@code
+     * skipProbeOnEmptyBuild()}, or a non-empty build side on any join type. Verifies correctness
+     * in both flag states and that the probe-side {@code LookupJoin} operator's input-row count
+     * is unchanged, so the flag never truncates probe input outside its intended path.
+     */
+    private void assertFlagIsNoOp(@Language("SQL") String sql)
+    {
+        Session off = partitionedJoinWithFlag(false);
+        Session on = partitionedJoinWithFlag(true);
+
+        assertQuery(off, sql);
+        assertQuery(on, sql);
+
+        DistributedQueryRunner runner = getDistributedQueryRunner();
+        QueryId qOff = runner.executeWithQueryId(off, sql).getQueryId();
+        QueryId qOn = runner.executeWithQueryId(on, sql).getQueryId();
+        long probeRowsOff = lookupJoinInputPositions(runner.getQueryInfo(qOff));
+        long probeRowsOn = lookupJoinInputPositions(runner.getQueryInfo(qOn));
+
+        assertEquals(
+                probeRowsOn,
+                probeRowsOff,
+                format(
+                        "flag must be a no-op for this join type but probe input differs: " +
+                                "on=%d, off=%d",
+                        probeRowsOn,
+                        probeRowsOff));
+    }
+
+    private static long lookupJoinInputPositions(QueryInfo queryInfo)
+    {
+        StageInfo output = queryInfo.getOutputStage()
+                .orElseThrow(() -> new AssertionError("query has no output stage"));
+        return output.getAllStages().stream()
+                .flatMap(stage -> stage.getLatestAttemptExecutionInfo().getTasks().stream())
+                .flatMap(task -> task.getStats().getPipelines().stream())
+                .flatMap(pipeline -> pipeline.getOperatorSummaries().stream())
+                .filter(op -> op.getOperatorType().equals("LookupJoinOperator"))
+                .mapToLong(OperatorStats::getRawInputPositions)
+                .sum();
+    }
+
+    // Join types that trigger the early-finish path (skipProbeOnEmptyBuild() == true).
+
+    @Test
+    public void testInnerJoinWithEmptyBuild()
+    {
+        assertProbeCancelledOnEmptyBuild(
+                "SELECT o.orderkey, o.custkey " +
+                        "FROM orders o " +
+                        "INNER JOIN (SELECT orderkey FROM orders WHERE orderkey > 99999999999) e " +
+                        "  ON o.orderkey = e.orderkey");
+    }
+
+    @Test
+    public void testLeftSemiFilterWithEmptyBuild()
+    {
+        assertProbeCancelledOnEmptyBuild(
+                "SELECT o.orderkey " +
+                        "FROM orders o " +
+                        "WHERE o.orderkey IN (SELECT orderkey FROM orders WHERE orderkey > 99999999999)");
+    }
+
+    @Test
+    public void testRightJoinWithEmptyBuild()
+    {
+        assertProbeCancelledOnEmptyBuild(
+                "SELECT o.orderkey, e.k " +
+                        "FROM orders o " +
+                        "RIGHT JOIN (SELECT orderkey AS k FROM orders WHERE orderkey > 99999999999) e " +
+                        "  ON o.orderkey = e.k");
+    }
+
+    // Same covered join types with a non-empty build side — the empty-build path is never taken,
+    // so the flag must not change the result or the number of probe rows processed.
+
+    @Test
+    public void testInnerJoinWithNonEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey, o.custkey " +
+                        "FROM orders o " +
+                        "INNER JOIN (SELECT orderkey FROM orders WHERE orderkey < 100) e " +
+                        "  ON o.orderkey = e.orderkey");
+    }
+
+    @Test
+    public void testLeftSemiFilterWithNonEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey " +
+                        "FROM orders o " +
+                        "WHERE o.orderkey IN (SELECT orderkey FROM orders WHERE orderkey < 100)");
+    }
+
+    @Test
+    public void testRightJoinWithNonEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey, e.k " +
+                        "FROM orders o " +
+                        "RIGHT JOIN (SELECT orderkey AS k FROM orders WHERE orderkey < 100) e " +
+                        "  ON o.orderkey = e.k");
+    }
+
+    // Join types where the flag has no effect and probe rows must still be emitted.
+
+    @Test
+    public void testLeftJoinWithEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey, e.k " +
+                        "FROM orders o " +
+                        "LEFT JOIN (SELECT orderkey AS k FROM orders WHERE orderkey > 99999999999) e " +
+                        "  ON o.orderkey = e.k");
+    }
+
+    @Test
+    public void testFullJoinWithEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey, e.k " +
+                        "FROM orders o " +
+                        "FULL OUTER JOIN (SELECT orderkey AS k FROM orders WHERE orderkey > 99999999999) e " +
+                        "  ON o.orderkey = e.k");
+    }
+
+    @Test
+    public void testAntiJoinWithEmptyBuild()
+    {
+        assertFlagIsNoOp(
+                "SELECT o.orderkey " +
+                        "FROM orders o " +
+                        "WHERE o.orderkey NOT IN (SELECT orderkey FROM orders WHERE orderkey > 99999999999)");
+    }
+}


### PR DESCRIPTION
## Description
Adds a Presto native session property to control Velox's
    kHashProbeFinishEarlyOnEmptyBuild knob per query. When enabled and an
    empty build is detected on a join type whose output requires
    build-side matches, HashProbe calls noMoreInput() instead of draining
    and dropping probe input. The standard driver cleanup then closes the
    probe-side ExchangeClient, sending abortResults DELETE to upstream
    producer tasks so they stop generating output.

Why a Presto session property is required: Velox exposes the knob via
    QueryConfig, but QueryConfig on the worker is populated exclusively
    from the SessionRepresentation.systemProperties map sent by the Java
    coordinator. Without a registered Presto system property the
    coordinator rejects the name at parse time and has nothing to
    serialize, so the worker never sees the setting. The Java side
    registers the property (name validation and SHOW SESSION) and the
    Prestissimo side maps native_hash_probe_finish_early_on_empty_build
    to Velox's hash_probe_finish_early_on_empty_build key when
    assembling QueryConfig.

The new session property is defaulted to true. Since the coordinator only 
serializes properties the user or a config file explicitly set (PropertyMetadata 
defaults never cross the wire), a worker-side injection in
    updateVeloxConfigsWithSpecialCases fills in "true" when the key is
    absent, matching the existing kDriverCpuTimeSliceLimitMs pattern.
    Velox's own QueryConfig default is left untouched.

Adds an E2E test in presto-native-tests that runs over an
    ExternalWorkerQueryRunner and asserts three things: for INNER, LEFT
    SEMI, and RIGHT joins with an empty build, the probe-side
    LookupJoinOperator processes strictly fewer rows with the flag on
    than off; for the same join types with a non-empty build, the flag
    does not change the result or the probe row count; and for LEFT,
    FULL, and anti joins with an empty build, the flag is a no-op.


<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
When examining one of the customers' workload, we found that many queries 
were very slow, even when they contains lots of inner joins with empty build side.
Although Velox already has the hash_probe_finish_early_on_empty_build QueryConfig,
it was set to false by default and there was no way for Presto to change it. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Add native_hash_probe_finish_early_on_empty_build session property with default value true.

## Test Plan
<!---Please fill in how you tested your change-->
Added Presto e2e tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add `native_hash_probe_finish_early_on_empty_build` session property, when enabled, would force cancelling probe side tasks if an empty build is detected on a join type whose output requires build-side matches. The default value is true.

```

## Summary by Sourcery

Expose a native session property to finish hash probe early when the hash join build side is empty and cancel unnecessary probe-side work.

New Features:
- Add the native_hash_probe_finish_early_on_empty_build session property for native execution hash joins.

Enhancements:
- Wire the hash_probe_finish_early_on_empty_build configuration through native query config, session properties, and the native worker session property provider.
- Extend session property validation tests to cover the new hash probe finish-early setting.