### PR TITLE
docs: Document native aggregation/hash join spill file create configs

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -278,6 +278,30 @@ These parameters are provided to the underlying file system, allowing for custom
 The format and options of these parameters are determined by the capabilities of the underlying file system
 and may include settings such as file location, size limits, and file system-specific optimizations.
 
+``native_aggregation_spill_file_create_config``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+Native Execution only. Specifies the configuration parameters used to create spill files for the
+aggregation operators, overriding ``native_spill_file_create_config`` for those operators.
+These parameters are provided to the underlying file system and are free form, with the format and
+options determined by the capabilities of the underlying file system.
+If left empty, aggregation spill files are created with ``native_spill_file_create_config``.
+
+``native_hash_join_spill_file_create_config``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+Native Execution only. Specifies the configuration parameters used to create spill files for the
+hash join build and probe operators, overriding ``native_spill_file_create_config`` for those operators.
+These parameters are provided to the underlying file system and are free form, with the format and
+options determined by the capabilities of the underlying file system.
+If left empty, hash join spill files are created with ``native_spill_file_create_config``.
+
 ``native_spill_write_buffer_size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
The native_aggregation_spill_file_create_config and
    native_hash_join_spill_file_create_config session properties were added
    without corresponding entries in the native session properties doc. Add
    both next to native_spill_file_create_config, noting that each overrides
    the generic config for its operators and falls back to it when empty.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
User will see the explanation of two native session properties in Presto documentation.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Add documentation for native_aggregation_spill_file_create_config and native_hash_join_spill_file_create_config session properties, including their relationship to native_spill_file_create_config.