### PR TITLE
fix(security): Upgrade libthrift to 0.24.0 to address CVE-2026-48144

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1675,7 +1675,7 @@
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.23.0</version>
+                <version>0.24.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TSocket;
@@ -93,7 +94,8 @@ public final class Transport
         return new TTransportException(e.getType(), String.format("%s: %s", address, e.getMessage()), e);
     }
 
-    private static class TTransportWrapper
+    @VisibleForTesting
+    static class TTransportWrapper
             extends TTransport
     {
         private final TTransport transport;
@@ -222,7 +224,16 @@ public final class Transport
         @Override
         public TConfiguration getConfiguration()
         {
-            return transport.getConfiguration();
+            TConfiguration config = transport.getConfiguration();
+            // Hive's TFilterTransport (parent of TUGIAssumingTransport used in Kerberos auth) was compiled
+            // against pre-0.21 libthrift and its getConfiguration() unconditionally returns null.
+            // libthrift 0.21 introduced TTransport.getConfiguration() as an abstract method and
+            // TProtocol.incrementRecursionDepth() as a guard against deep recursion.
+            // libthrift 0.24 wired incrementRecursionDepth() into TProtocol.writeStruct(), which
+            // unconditionally calls getConfiguration().getRecursionLimit() — causing a NullPointerException
+            // at runtime when writing nested Thrift objects (e.g. update_table_column_statistics) over a
+            // Kerberos SASL connection. Fall back to TConfiguration.DEFAULT to restore safe behaviour.
+            return config != null ? config : TConfiguration.DEFAULT;
         }
 
         @Override

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/TestTransport.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/TestTransport.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.thrift;
+
+import com.google.common.net.HostAndPort;
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.transport.TTransport;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class TestTransport
+{
+    private static final HostAndPort ADDRESS = HostAndPort.fromParts("localhost", 9083);
+
+    // Simulates Hive's TUGIAssumingTransport returning null from getConfiguration()
+    @Test
+    public void testGetConfigurationFallsBackToDefaultWhenWrappedTransportReturnsNull()
+    {
+        TTransport wrapper = new Transport.TTransportWrapper(new NullConfigTransport(), ADDRESS);
+
+        TConfiguration config = wrapper.getConfiguration();
+
+        assertNotNull(config, "TTransportWrapper.getConfiguration() must never return null");
+        assertSame(config, TConfiguration.DEFAULT,
+                "TTransportWrapper must return TConfiguration.DEFAULT when wrapped transport returns null");
+    }
+
+    /**
+     * Verify that TTransportWrapper delegates getConfiguration() to the wrapped transport
+     * when the wrapped transport returns a non-null value (normal TSocket path).
+     */
+    @Test
+    public void testGetConfigurationDelegatesWhenWrappedTransportReturnsNonNull()
+    {
+        TConfiguration expected = new TConfiguration();
+        TTransport wrapper = new Transport.TTransportWrapper(new FixedConfigTransport(expected), ADDRESS);
+
+        assertSame(wrapper.getConfiguration(), expected,
+                "TTransportWrapper must delegate getConfiguration() to the wrapped transport when non-null");
+    }
+
+    /**
+     * Simulates Hive's TFilterTransport compiled against pre-0.21 libthrift.
+     * getConfiguration() returns null because that abstract method did not exist
+     * in the old libthrift API when the class was compiled.
+     */
+    private static class NullConfigTransport
+            extends TTransport
+    {
+        @Override
+        public boolean isOpen()
+        {
+            return true;
+        }
+
+        @Override
+        public void open() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public int read(byte[] buf, int off, int len)
+        {
+            return 0;
+        }
+
+        @Override
+        public void write(byte[] buf, int off, int len) {}
+
+        @Override
+        public TConfiguration getConfiguration()
+        {
+            return null;
+        }
+
+        @Override
+        public void updateKnownMessageSize(long size) {}
+
+        @Override
+        public void checkReadBytesAvailable(long numBytes) {}
+    }
+
+    /**
+     * Simulates a well-behaved transport (e.g. TSocket) that returns a real TConfiguration.
+     */
+    private static class FixedConfigTransport
+            extends TTransport
+    {
+        private final TConfiguration configuration;
+
+        FixedConfigTransport(TConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return true;
+        }
+
+        @Override
+        public void open() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public int read(byte[] buf, int off, int len)
+        {
+            return 0;
+        }
+
+        @Override
+        public void write(byte[] buf, int off, int len) {}
+
+        @Override
+        public TConfiguration getConfiguration()
+        {
+            return configuration;
+        }
+
+        @Override
+        public void updateKnownMessageSize(long size) {}
+
+        @Override
+        public void checkReadBytesAvailable(long numBytes) {}
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Upgrade libthrift to 0.24.0 to address below CVEs

CVE-2026-41608
CVE-2026-43871
CVE-2026-45112
CVE-2026-48144
CVE-2026-48145
CVE-2026-48586
CVE-2026-49158
CVE-2026-55968
CVE-2026-55969
CVE-2026-55970
CVE-2026-55971
CVE-2026-58023
CVE-2026-58389
CVE-2026-58662
CVE-2026-66053

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

**Problem while upgrading libthrift from version 0.23.0 to 0.24.0**

The singlenode-kerberos-hdfs-impersonation product test ImpersonationTests.testHdfsImpersonationEnabled fails with:

```
NullPointerException: Cannot invoke "org.apache.thrift.TConfiguration.getRecursionLimit()"
  because the return value of "org.apache.thrift.transport.TTransport.getConfiguration()" is null
    at org.apache.thrift.protocol.TProtocol.incrementRecursionDepth(TProtocol.java:59)

```
This crash occurs when Presto commits a CREATE TABLE AS SELECT query over a Kerberos-authenticated Hive Metastore connection, specifically during the update_table_column_statistics Thrift RPC. The Thrift serialisation of the nested ColumnStatistics → ColumnStatisticsObj → TUnion object graph calls TProtocol.incrementRecursionDepth(), which requires TTransport.getConfiguration() to return a non-null TConfiguration.

Root Cause
The Kerberos metastore authentication path in KerberosHiveMetastoreAuthentication wraps the transport as follows:

```
TSocket (rawTransport)
  └─ TSaslClientTransport          (libthrift — has valid TConfiguration)
       └─ TUGIAssumingTransport     (hive-exec — extends TFilterTransport)
            └─ TTransportWrapper   (Presto wrapper)
```

TUGIAssumingTransport extends TFilterTransport from hive-exec-4.0.1-1.jar. The bytecode of TFilterTransport.getConfiguration() unconditionally returns null — it was compiled against a pre-0.21 libthrift where getConfiguration() did not exist as a mandatory method. As a result, TTransportWrapper.getConfiguration() delegated to this null return, which propagated to TProtocol.incrementRecursionDepth() and caused the NPE.

This is a binary compatibility break between hive-exec (built against old libthrift) and the new libthrift (0.21+) where TProtocol.incrementRecursionDepth() unconditionally dereferences the result of getConfiguration().

Note: This bug was latent since c45405dfc8 (libthrift 0.18.1 → 0.23.0) which introduced incrementRecursionDepth() for the first time. libthrift 0.18.1 did not have this method at all, so the null return was harmless. The failure was surfaced when the singlenode-kerberos-hdfs-impersonation CI profile ran against the updated stack.

Fix
Override getConfiguration() in TTransportWrapper to return TConfiguration.DEFAULT when the wrapped transport returns null, instead of blindly propagating the null:

```
// Transport.java — TTransportWrapper
@Override
public TConfiguration getConfiguration()
{
    TConfiguration config = transport.getConfiguration();
    // TFilterTransport (used by Hive's TUGIAssumingTransport) returns null for getConfiguration()
    // when compiled against pre-0.21 libthrift. libthrift 0.21+ requires a non-null TConfiguration
    // from TProtocol.incrementRecursionDepth(), so fall back to the default configuration.
    return config != null ? config : TConfiguration.DEFAULT;
}
```

TConfiguration.DEFAULT carries exactly the same values (maxMessageSize=100MB, maxFrameSize=16MB, recursionLimit=64) that TSocket and TSaslTransport construct themselves — so this is a purely restorative fix with no observable behaviour change on any other transport path.

**The tests passed on libthrift 0.23.0, why ?**

The tests passed on libthrift 0.23.0 for a completely different reason than TFilterTransport.getConfiguration() returning null. The root cause is that writeStruct() did not call incrementRecursionDepth() in 0.23.0 — that call was only added in 0.24.0.

```
Here is the bytecode proof side-by-side:

TProtocol.writeStruct() — libthrift 0.23.0
0: aload_0
1: aload_1
2: invokevirtual  writeStructBegin()    ← goes straight to write, NO incrementRecursionDepth
5: aload_2
7: invokeinterface WriteCallback.call()
12: invokevirtual  writeStructEnd()
16: return

TProtocol.writeStruct() — libthrift 0.24.0
0: aload_0
1: invokevirtual  incrementRecursionDepth()  ← NEW in 0.24.0 — calls getConfiguration().getRecursionLimit() → NPE
4: aload_0
5: aload_1
6: invokevirtual  writeStructBegin()
9: invokeinterface WriteCallback.call()
17: invokevirtual  writeStructEnd()
20: invokevirtual  decrementRecursionDepth()
```


`Note : `The method incrementRecursionDepth() was added in 0.23.0 but was not yet wired into writeStruct(). In 0.24.0, it was wired in — every struct serialisation now calls it. That is precisely why 0.23.0 passed and 0.24.0 crashes. The null return from TFilterTransport.getConfiguration() was always there in both Hive versions, but it was only ever reached starting with libthrift 0.24.0.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade libthrift to 0.24.0 to address `CVE-2026-41608 <https://github.com/advisories/GHSA-6pjx-3pjc-mrj8>`_ , `CVE-2026-43871 <https://github.com/advisories/GHSA-8wv5-x4w7-5gww>`_ , `CVE-2026-45112 <https://github.com/advisories/GHSA-g9fj-fh28-776p>`_ , `CVE-2026-48144 <https://github.com/advisories/GHSA-367h-9jj5-w29f>`_ , `CVE-2026-48145 <https://github.com/advisories/GHSA-p2c7-c4gw-678h>`_ , `CVE-2026-48586 <https://github.com/advisories/GHSA-6h9h-5c4r-fqgf>`_ , `CVE-2026-49158 <https://github.com/advisories/GHSA-jcj7-w43p-gjh8>`_ , `CVE-2026-55968 <https://github.com/advisories/GHSA-8cj2-994r-9fpq>`_ , `CVE-2026-55969 <https://github.com/advisories/GHSA-x8jh-qfcv-fp29>`_ , `CVE-2026-55970 <https://github.com/advisories/GHSA-g7xp-pggm-c7w2>`_ , `CVE-2026-55971 <https://github.com/advisories/GHSA-gwj4-q93m-wwqc>`_ , `CVE-2026-58023 <https://github.com/advisories/GHSA-7rjc-4234-rgwm>`_ , `CVE-2026-58389 <https://github.com/advisories/GHSA-jx7g-767m-86hp>`_ , `CVE-2026-58662 <https://github.com/advisories/GHSA-x4w6-p6f8-24qw>`_ , `CVE-2026-66053 <https://github.com/advisories/GHSA-hwrj-9rr4-24xh>`_.
```

