### PR TITLE
fix(native): Remove wrong Host header from announcement and heartbeat requests

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -63,8 +63,6 @@ proxygen::HTTPMessage announcementRequest(
   request.setMethod(proxygen::HTTPMethod::PUT);
   request.setURL(fmt::format("/v1/announcement/{}", nodeId));
   request.getHeaders().set(
-      proxygen::HTTP_HEADER_HOST, fmt::format("{}:{}", address, port));
-  request.getHeaders().set(
       proxygen::HTTP_HEADER_CONTENT_TYPE, "application/json");
   request.getHeaders().set(
       proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));

--- a/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
@@ -40,8 +40,6 @@ PeriodicHeartbeatManager::httpRequest() {
   request.setMethod(proxygen::HTTPMethod::PATCH);
   request.setURL("/v1/resource-manager/node/" + status.nodeId);
   request.getHeaders().set(
-      proxygen::HTTP_HEADER_HOST, fmt::format("{}:{}", address_, port_));
-  request.getHeaders().set(
       proxygen::HTTP_HEADER_CONTENT_TYPE, "application/json");
   request.getHeaders().set(
       proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));


### PR DESCRIPTION
## Description
Remove the explicit `Host` header from Prestissimo worker announcement and heartbeat requests.

Both code paths were setting `Host` to the worker's own address and port even though the request is sent to the coordinator/resource-manager endpoint. This change lets the HTTP client populate `Host` from the actual destination at send time.

## Motivation and Context
This fixes the incorrect `Host` header behavior.

The previous behavior was semantically wrong and could cause misrouting or rejection if a Host-routed intermediary is introduced between the worker and coordinator. Although the issue is currently latent in existing deployments, removing the explicit header is the correct and robust fix.

## Impact
No public API or user-facing feature changes.

Functional impact is limited to request construction for worker announcement and heartbeat calls:
- worker announcement requests no longer send the worker's own address as `Host`
- heartbeat requests no longer send the worker's own address as `Host`
- `Host` is now derived from the actual request destination by the HTTP client

No expected performance impact.

## Test Plan
- Verified the change in:
  - [`Announcer.cpp`](presto-native-execution/presto_cpp/main/Announcer.cpp)
  - [`PeriodicHeartbeatManager.cpp`](presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp)
- Confirmed the explicit `HTTP_HEADER_HOST` assignment was removed from both request paths
- Reviewed the resulting diff to ensure the change is minimal and limited to Host header handling

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Stop setting the Host header to the worker address for announcement and heartbeat requests to avoid misrouting when intermediaries rely on Host-based routing.