### PR TITLE
fix(plugin-native-sidecar): Rewrite literal LIKE predicates to equality for connector pushdown

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -123,7 +123,7 @@ public final class FunctionResolution
     @Override
     public boolean isLikeFunction(FunctionHandle functionHandle)
     {
-        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "LIKE"));
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().getObjectName().equalsIgnoreCase("LIKE");
     }
 
     @Override

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -13,10 +13,15 @@
  */
 package com.facebook.presto.sidecar.expressions;
 
+import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.FunctionMetadata;
@@ -34,6 +39,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -46,6 +53,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.common.Utils.checkArgument;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
@@ -62,6 +71,7 @@ public class NativeExpressionOptimizer
     private final StandardFunctionResolution resolution;
     private final NativeSidecarExpressionInterpreter rowExpressionInterpreterService;
     private final CastInsertionVisitor castInsertionVisitor;
+    private final LikeToEqualityVisitor likeToEqualityVisitor;
 
     @Inject
     public NativeExpressionOptimizer(
@@ -74,11 +84,17 @@ public class NativeExpressionOptimizer
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.resolution = requireNonNull(resolution, "resolution is null");
         this.castInsertionVisitor = new CastInsertionVisitor(resolution, requireNonNull(typeManager, "typeManager is null"));
+        this.likeToEqualityVisitor = new LikeToEqualityVisitor(resolution);
     }
 
     @Override
     public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
+        // Rewrite literal LIKE predicates (no real wildcards) to equality before the sidecar
+        // pipeline, enabling connector predicate pushdown. On the native execution path,
+        // RowExpressionInterpreter.tryHandleLike is never invoked, so this visitor fills that gap.
+        expression = expression.accept(likeToEqualityVisitor, null);
+
         // Collect expressions to optimize
         CollectingVisitor collectingVisitor = new CollectingVisitor(functionMetadataManager, level, resolution);
         expression = expression.accept(castInsertionVisitor, null);
@@ -503,6 +519,221 @@ public class NativeExpressionOptimizer
         }
     }
 
+    /**
+     * Rewrites literal LIKE predicates to equality checks throughout the expression tree,
+     * enabling connector predicate pushdown on the native execution path.
+     * <p>
+     * Because {@code supportsLikePatternFunction()} is false in native mode, the optimizer always emits
+     * the raw VARCHAR forms:
+     * <ul>
+     *   <li>2-arg: {@code LIKE(col, patternConst)} — no ESCAPE clause</li>
+     *   <li>3-arg: {@code LIKE(col, patternConst, escapeConst)} — with ESCAPE clause</li>
+     * </ul>
+     * <p>
+     * This mirrors {@code RowExpressionInterpreter.tryHandleLike}, which is never invoked on
+     * the native execution path.
+     */
+    private static class LikeToEqualityVisitor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final StandardFunctionResolution resolution;
+
+        public LikeToEqualityVisitor(StandardFunctionResolution resolution)
+        {
+            this.resolution = requireNonNull(resolution, "resolution is null");
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            // Recurse into all arguments first — this covers NOT (a CallExpression) and any
+            // other call that may contain a LIKE node somewhere inside it.
+            List<RowExpression> processedArgs = call.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+            CallExpression visited = new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    processedArgs);
+
+            if (!resolution.isLikeFunction(visited.getFunctionHandle())) {
+                return visited;
+            }
+
+            // Returns null if the call cannot be rewritten (non-constant args, real wildcards,
+            // non-varchar column, or null escape constant).
+            Slice unescapedLiteral = extractUnescapedLiteral(visited.getArguments());
+            if (unescapedLiteral == null) {
+                return visited;
+            }
+
+            return buildEquality(visited, visited.getArguments().get(0), unescapedLiteral);
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> processedArgs = specialForm.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+            return new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), processedArgs);
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            RowExpression processedBody = lambda.getBody().accept(this, context);
+            return new LambdaDefinitionExpression(lambda.getSourceLocation(), lambda.getArgumentTypes(), lambda.getArguments(), processedBody);
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression variable, Void context)
+        {
+            return variable;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression constant, Void context)
+        {
+            return constant;
+        }
+
+        @Override
+        public RowExpression visitExpression(RowExpression expression, Void context)
+        {
+            return expression;
+        }
+
+        /**
+         * Validates the LIKE call arguments and returns the unescaped literal to compare against,
+         * or null if the call cannot be rewritten to equality (non-constant args, non-varchar
+         * column, null escape constant, or the pattern contains real wildcards).
+         */
+        private Slice extractUnescapedLiteral(List<RowExpression> args)
+        {
+            if (args.size() < 2 || args.size() > 3) {
+                return null;
+            }
+            if (!(args.get(0).getType() instanceof VarcharType)) {
+                return null;
+            }
+            if (!(args.get(1) instanceof ConstantExpression)
+                    || !(((ConstantExpression) args.get(1)).getValue() instanceof Slice)) {
+                return null; // non-constant or null pattern — leave null-propagation to runtime
+            }
+            if (args.size() == 3
+                    && (!(args.get(2) instanceof ConstantExpression)
+                    || !(((ConstantExpression) args.get(2)).getValue() instanceof Slice))) {
+                return null; // non-constant or null escape — leave null-propagation to runtime
+            }
+
+            Slice pattern = (Slice) ((ConstantExpression) args.get(1)).getValue();
+            Slice escape = args.size() == 3 ? (Slice) ((ConstantExpression) args.get(2)).getValue() : null;
+
+            if (hasLikeWildcards(pattern, escape)) {
+                return null;
+            }
+
+            return stripEscapes(pattern, escape);
+        }
+
+        /**
+         * Returns true if the pattern contains any unescaped '%' or '_' wildcard.
+         * Mirrors {@code LikeFunctions.isLikePattern} but returns true for malformed escape
+         * instead of throwing, leaving error handling to the runtime.
+         */
+        private boolean hasLikeWildcards(Slice pattern, Slice escape)
+        {
+            String stringPattern = pattern.toStringUtf8();
+            if (escape == null) {
+                return stringPattern.contains("%") || stringPattern.contains("_");
+            }
+
+            String stringEscape = escape.toStringUtf8();
+            checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+
+            char escapeChar = stringEscape.charAt(0);
+            boolean escaped = false;
+            boolean hasWildcards = false;
+            for (int currentChar : stringPattern.codePoints().toArray()) {
+                if (!escaped && currentChar == escapeChar) {
+                    escaped = true;
+                }
+                else if (escaped) {
+                    checkEscape(currentChar == '%' || currentChar == '_' || currentChar == escapeChar);
+                    escaped = false;
+                }
+                else if (currentChar == '%' || currentChar == '_') {
+                    hasWildcards = true;
+                }
+            }
+            checkEscape(!escaped);
+            return hasWildcards;
+        }
+
+        /**
+         * Strips escape prefixes from a pattern that has no wildcards, returning the literal string.
+         * Mirrors {@code LikeFunctions.unescapeLiteralLikePattern}.
+         */
+        private Slice stripEscapes(Slice pattern, Slice escape)
+        {
+            if (escape == null) {
+                return pattern;
+            }
+
+            String stringEscape = escape.toStringUtf8();
+            checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+            char escapeChar = stringEscape.charAt(0);
+            String stringPattern = pattern.toStringUtf8();
+            StringBuilder unescapedPattern = new StringBuilder(stringPattern.length());
+            boolean escaped = false;
+            for (int currentChar : stringPattern.codePoints().toArray()) {
+                if (!escaped && currentChar == escapeChar) {
+                    escaped = true;
+                }
+                else {
+                    unescapedPattern.append(Character.toChars(currentChar));
+                    escaped = false;
+                }
+            }
+            return Slices.utf8Slice(unescapedPattern.toString());
+        }
+
+        /**
+         * Builds EQUAL(col, literal), widening both sides to a common varchar type if needed.
+         */
+        private RowExpression buildEquality(CallExpression originalCall, RowExpression col, Slice literal)
+        {
+            VarcharType colType = (VarcharType) col.getType();
+            VarcharType literalType = createVarcharType(literal.length());
+            Type commonType = (colType.isUnbounded() || literalType.isUnbounded())
+                    ? VarcharType.createUnboundedVarcharType()
+                    : createVarcharType(Math.max(colType.getLengthSafe(), literalType.getLengthSafe()));
+
+            RowExpression lhs = widen(col, colType, commonType);
+            RowExpression rhs = widen(
+                    new ConstantExpression(originalCall.getArguments().get(1).getSourceLocation(), literal, literalType),
+                    literalType, commonType);
+
+            return new CallExpression(
+                    originalCall.getSourceLocation(), "EQUAL",
+                    resolution.comparisonFunction(OperatorType.EQUAL, commonType, commonType),
+                    BooleanType.BOOLEAN,
+                    ImmutableList.of(lhs, rhs));
+        }
+
+        private RowExpression widen(RowExpression expr, Type from, Type to)
+        {
+            if (from.equals(to)) {
+                return expr;
+            }
+            return new CallExpression(expr.getSourceLocation(), "CAST",
+                    resolution.lookupCast("CAST", from, to), to, ImmutableList.of(expr));
+        }
+    }
+
     private static RowExpression toRowExpression(Optional<SourceLocation> sourceLocation, Object object, Type type)
     {
         requireNonNull(type, "type is null");
@@ -558,5 +789,17 @@ public class NativeExpressionOptimizer
         }
 
         return false;
+    }
+
+    private static void checkCondition(boolean condition, ErrorCodeSupplier errorCode, String formatString, Object... args)
+    {
+        if (!condition) {
+            throw new PrestoException(errorCode, format(formatString, args));
+        }
+    }
+
+    private static void checkEscape(boolean condition)
+    {
+        checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -870,6 +870,37 @@ public class TestNativeSidecarPlugin
 
         // Verify UNKNOWN type expressions produce a structured error instead of crashing the sidecar.
         assertQueryFails(session, "SELECT array_except(ARRAY[], ARRAY[])", ".*Errors encountered while optimizing expressions\\..*", true);
+
+        // LikeToEqualityVisitor must rewrite LIKE with no real wildcards into a constant equality, enabling
+        // connector predicate pushdown (ScanFilterProject). We assert structural properties of the native
+        // EXPLAIN directly — PlanNodeIds and cost estimates differ between runners, so cross-runner string
+        // comparison is not viable.
+
+        // Escaped '_': LIKE 'curre\_nt' ESCAPE '\' → equality on 'curre_nt'
+        @Language("SQL") String likeEscapeQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'curre\\_nt' ESCAPE '\\'";
+        String likeEscapePlan = (String) computeActual(session, likeEscapeQuery).getOnlyValue();
+        assertTrue(likeEscapePlan.contains("ScanFilterProject"),
+                "Expected ScanFilterProject (predicate pushed into scan), but got:\n" + likeEscapePlan);
+        assertFalse(likeEscapePlan.contains("- Filter[") && likeEscapePlan.contains("LIKE"),
+                "Expected no Filter+LIKE node above the scan, but got:\n" + likeEscapePlan);
+        assertTrue(likeEscapePlan.contains("VARCHAR'curre_nt'"),
+                "Expected constant VARCHAR'curre_nt' in the scan projection, but got:\n" + likeEscapePlan);
+
+        // Escaped '%': LIKE '100\%' ESCAPE '\' → equality on '100%'
+        @Language("SQL") String likeEscapePercentQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_name LIKE '100\\%' ESCAPE '\\'";
+        String likeEscapePercentPlan = (String) computeActual(session, likeEscapePercentQuery).getOnlyValue();
+        assertTrue(likeEscapePercentPlan.contains("ScanFilterProject"),
+                "Expected ScanFilterProject (predicate pushed into scan), but got:\n" + likeEscapePercentPlan);
+        assertFalse(likeEscapePercentPlan.contains("- Filter[") && likeEscapePercentPlan.contains("LIKE"),
+                "Expected no Filter+LIKE node above the scan, but got:\n" + likeEscapePercentPlan);
+        assertTrue(likeEscapePercentPlan.contains("VARCHAR'100%'"),
+                "Expected constant VARCHAR'100%' in the scan projection, but got:\n" + likeEscapePercentPlan);
+
+        // Real wildcard: LIKE '%' must NOT be rewritten — LIKE must remain in the plan.
+        @Language("SQL") String likeWildcardQuery = "EXPLAIN SELECT * FROM system.jdbc.columns WHERE table_schem LIKE '%'";
+        String likeWildcardPlan = (String) computeActual(session, likeWildcardQuery).getOnlyValue();
+        assertTrue(likeWildcardPlan.contains("LIKE"),
+                "Expected LIKE to be preserved in the plan for a real wildcard, but got:\n" + likeWildcardPlan);
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionOptimizer.java
@@ -144,6 +144,55 @@ public class TestNativeExpressionOptimizer
                 session);
     }
 
+    @Test
+    public void testLikeToEqualityRewrite()
+    {
+        // escaped '_' is a literal, not a wildcard — must rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE 'curre\\_nt' ESCAPE '\\'",
+                "unbound_string = CAST('curre_nt' AS VARCHAR)");
+
+        // Escaped '%' is a literal — rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE '100\\%' ESCAPE '\\'",
+                "unbound_string = CAST('100%' AS VARCHAR)");
+
+        // Escaped '_' and escaped escapeChar in same pattern
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a#_##b' ESCAPE '#'",
+                "unbound_string = CAST('a_#b' AS VARCHAR)");
+
+        // No escape clause, no wildcards — rewrite to equality
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc'",
+                "unbound_string = CAST('abc' AS VARCHAR)");
+
+        // Real '%' wildcard — must NOT rewrite, leave as LIKE
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc%' ESCAPE '\\'",
+                "unbound_string LIKE 'abc%' ESCAPE '\\'");
+
+        // Real unescaped '_' wildcard — must NOT rewrite
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a_b' ESCAPE '\\'",
+                "unbound_string LIKE 'a_b' ESCAPE '\\'");
+
+        // Escaped '_' but also an unescaped '_' — has real wildcard, must NOT rewrite
+        assertOptimizedEquals(
+                "unbound_string LIKE 'a#__b' ESCAPE '#'",
+                "unbound_string LIKE 'a#__b' ESCAPE '#'");
+
+        // LIKE inside AND — nested rewrite must fire
+        assertOptimizedEquals(
+                "unbound_string LIKE 'abc' AND unbound_string LIKE 'x\\_y' ESCAPE '\\'",
+                "unbound_string = CAST('abc' AS VARCHAR) AND unbound_string = CAST('x_y' AS VARCHAR)");
+
+        // LIKE inside NOT — nested rewrite via CallExpression recursion must fire
+        assertOptimizedEquals(
+                "NOT (unbound_string LIKE 'abc')",
+                "NOT (unbound_string = CAST('abc' AS VARCHAR))");
+    }
+
     private void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
     {
         assertOptimizedEquals(actual, expected, TEST_SESSION);


### PR DESCRIPTION
## Description

Rewrite literal `LIKE` predicates without real wildcards to equality comparisons in the native sidecar expression optimizer, so connector predicate pushdown can apply while preserving wildcard semantics when a pattern actually contains wildcards.

This is a cherry-pick of #28237 (commit b2ef468, authored by @pdabre12) onto the current `master`. No functional changes were made to the original patch.

## Motivation and Context

A `LIKE 'foo'` predicate with no wildcard characters is semantically an equality check, but is not pushed down to connectors because it stays a `LIKE` call expression. Rewriting such literals to equality enables ScanFilterProject pushdown while leaving genuine wildcard patterns (`%`, `_`, escaped literals) as `LIKE`.

## Impact

Native sidecar only. `LIKE` predicates whose patterns contain no real wildcards are rewritten to equality and can be pushed into `ScanFilterProject`; wildcard patterns are unaffected.

## Test Plan

- `TestNativeExpressionOptimizer` unit tests for `LikeToEqualityVisitor` covering patterns with and without escapes.
- `TestNativeSidecarPlugin` integration tests asserting wildcard-free `LIKE` predicates are pushed into `ScanFilterProject` and real wildcard patterns remain `LIKE`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Rewrite native sidecar expression optimization to convert literal LIKE predicates without real wildcards into equality comparisons to enable connector predicate pushdown while preserving true wildcard LIKE behavior.

Bug Fixes:
- Ensure native sidecar recognizes LIKE functions by name case-insensitively so LIKE predicates are properly identified for optimization.

Enhancements:
- Introduce a LikeToEqualityVisitor in the native expression optimizer to rewrite constant, wildcard-free LIKE predicates into varchar equality predicates suitable for pushdown.
- Extend native sidecar optimizer tests to cover LIKE-to-equality rewrites with escaped characters, nested logical expressions, and wildcard patterns that must remain LIKE.
- Add native sidecar plugin integration tests asserting that rewritten LIKE predicates are pushed into ScanFilterProject while real wildcard LIKE predicates remain in the plan.