### PR TITLE
fix: Route planning-time constant folding through the pluggable expression optimizer

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -165,7 +165,7 @@ public final class HiveTestUtils
     };
 
     public static final FilterStatsCalculatorService FILTER_STATS_CALCULATOR_SERVICE = new ConnectorFilterStatsCalculatorService(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, ROW_EXPRESSION_SERVICE), new StatsNormalizer()));
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, ROW_EXPRESSION_SERVICE), new StatsNormalizer(), ROW_EXPRESSION_SERVICE));
 
     public static final HiveClientConfig HIVE_CLIENT_CONFIG = new HiveClientConfig();
     public static final MetastoreClientConfig METASTORE_CLIENT_CONFIG = new MetastoreClientConfig();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -151,7 +151,7 @@ public class TestRenameTableOnFragileFileSystem
 
     private static final ExpressionOptimizerProvider EXPRESSION_OPTIMIZER_PROVIDER = new InMemoryExpressionOptimizerProvider(METADATA);
     private static final FilterStatsCalculatorService FILTER_STATS_CALCULATOR_SERVICE = new ConnectorFilterStatsCalculatorService(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), new StatsNormalizer()));
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), new StatsNormalizer(), EXPRESSION_OPTIMIZER_PROVIDER));
     private static final JsonCodec<DatabaseMetadata> DATABASE_CODEC = jsonCodec(DatabaseMetadata.class);
     private static final JsonCodec<TableMetadata> TABLE_CODEC = jsonCodec(TableMetadata.class);
 

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.InputReferenceExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -32,11 +33,11 @@ import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
 import com.facebook.presto.sql.analyzer.Scope;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.LiteralInterpreter;
 import com.facebook.presto.sql.planner.NoOpVariableResolver;
-import com.facebook.presto.sql.planner.RowExpressionInterpreter;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.AstVisitor;
@@ -113,15 +114,22 @@ public class FilterStatsCalculator
     private final StatsNormalizer normalizer;
     private final LiteralEncoder literalEncoder;
     private final FunctionResolution functionResolution;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
     @Inject
-    public FilterStatsCalculator(Metadata metadata, ScalarStatsCalculator scalarStatsCalculator, StatsNormalizer normalizer)
+    public FilterStatsCalculator(Metadata metadata, ScalarStatsCalculator scalarStatsCalculator, StatsNormalizer normalizer, ExpressionOptimizerManager expressionOptimizerManager)
+    {
+        this(metadata, scalarStatsCalculator, normalizer, (ExpressionOptimizerProvider) expressionOptimizerManager);
+    }
+
+    public FilterStatsCalculator(Metadata metadata, ScalarStatsCalculator scalarStatsCalculator, StatsNormalizer normalizer, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.scalarStatsCalculator = requireNonNull(scalarStatsCalculator, "scalarStatsCalculator is null");
         this.normalizer = requireNonNull(normalizer, "normalizer is null");
         this.literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
         this.functionResolution = new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver());
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
     }
 
     @Deprecated
@@ -176,8 +184,11 @@ public class FilterStatsCalculator
 
     private RowExpression simplifyExpression(ConnectorSession session, RowExpression predicate)
     {
-        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(predicate, metadata.getFunctionAndTypeManager(), session, OPTIMIZED);
-        Object value = interpreter.optimize();
+        // Route through the session's pluggable optimizer so the native/sidecar optimizer evaluates the
+        // predicate (matching how the plan's expressions were optimized) instead of the hardcoded Java
+        // interpreter, which mis-folds native-produced expressions.
+        RowExpression optimized = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(predicate, OPTIMIZED, session);
+        Object value = optimized instanceof ConstantExpression ? ((ConstantExpression) optimized).getValue() : optimized;
 
         if (value == null) {
             // Expression evaluates to SQL null, which in Filter is equivalent to false. This assumes the expression is a top-level expression (eg. not in NOT).

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -796,7 +796,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        new PickTableLayout(metadata).rules()),
+                        new PickTableLayout(metadata, expressionOptimizerManager).rules()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         metadata,
@@ -836,7 +836,7 @@ public class PlanOptimizers
                 // Run inlineProjections and PruneUnreferencedOutputs to simplify the plan after ReplaceConstantVariableReferencesWithConstants optimization
                 inlineProjections,
                 new PruneUnreferencedOutputs(), // Make sure to run this before index join. Filtered projections may not have all the columns.
-                new IndexJoinOptimizer(metadata), // Run this after projections and filters have been fully simplified and pushed down
+                new IndexJoinOptimizer(metadata, expressionOptimizerManager), // Run this after projections and filters have been fully simplified and pushed down
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,
@@ -858,7 +858,7 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new MinMaxByToWindowFunction(metadata.getFunctionAndTypeManager()))),
                 new LimitPushDown(), // Run LimitPushDown before WindowFilterPushDown
-                new WindowFilterPushDown(metadata), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
+                new WindowFilterPushDown(metadata, expressionOptimizerManager), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
                 prefilterForLimitingAggregation,
                 new IterativeOptimizer(
                         metadata,
@@ -925,7 +925,7 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 estimatedExchangesCostCalculator,
-                new PickTableLayout(metadata).rules()));
+                new PickTableLayout(metadata, expressionOptimizerManager).rules()));
 
         // PlanRemoteProjections only handles RowExpression so this need to run after TranslateExpressions
         // Rules applied after this need to handle locality of ProjectNode properly.
@@ -1097,7 +1097,7 @@ public class PlanOptimizers
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
             builder.add(new CteProjectionAndPredicatePushDown(metadata, expressionOptimizerManager)); // must run before PhysicalCteOptimizer
             builder.add(new PhysicalCteOptimizer(metadata)); // Must run before AddExchanges
-            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled())));
+            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled(), expressionOptimizerManager)));
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchangesForSingleNodeExecution(metadata)));
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -24,6 +24,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.operator.scalar.TryFunction;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -33,6 +34,8 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DomainTranslator;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.RowExpressionInterpreter;
@@ -46,6 +49,7 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import jakarta.annotation.Nullable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -77,10 +81,21 @@ import static java.util.Objects.requireNonNull;
 public class PickTableLayout
 {
     private final Metadata metadata;
+    // When present, constant-folding during partition pruning goes through the session's pluggable
+    // optimizer so the native/sidecar optimizer evaluates predicates instead of the hardcoded Java
+    // interpreter. Null on callers that don't run on native-optimized plans (e.g. tests).
+    @Nullable
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
     public PickTableLayout(Metadata metadata)
     {
+        this(metadata, null);
+    }
+
+    public PickTableLayout(Metadata metadata, @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
+    {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerProvider = expressionOptimizerProvider;
     }
 
     public Set<Rule<?>> rules()
@@ -93,7 +108,7 @@ public class PickTableLayout
 
     public PickTableLayoutForPredicate pickTableLayoutForPredicate()
     {
-        return new PickTableLayoutForPredicate(metadata);
+        return new PickTableLayoutForPredicate(metadata, expressionOptimizerProvider);
     }
 
     public PickTableLayoutWithoutPredicate pickTableLayoutWithoutPredicate()
@@ -105,10 +120,13 @@ public class PickTableLayout
             implements Rule<FilterNode>
     {
         private final Metadata metadata;
+        @Nullable
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-        private PickTableLayoutForPredicate(Metadata metadata)
+        private PickTableLayoutForPredicate(Metadata metadata, @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.expressionOptimizerProvider = expressionOptimizerProvider;
         }
 
         private static final Capture<TableScanNode> TABLE_SCAN = newCapture();
@@ -142,7 +160,8 @@ public class PickTableLayout
                     false,
                     context.getSession(),
                     context.getIdAllocator(),
-                    metadata);
+                    metadata,
+                    expressionOptimizerProvider);
 
             if (arePlansSame(filterNode, tableScan, rewritten)) {
                 return Result.empty();
@@ -247,12 +266,24 @@ public class PickTableLayout
             PlanNodeIdAllocator idAllocator,
             Metadata metadata)
     {
+        return pushPredicateIntoTableScan(node, predicate, pruneWithPredicateExpression, session, idAllocator, metadata, null);
+    }
+
+    public static PlanNode pushPredicateIntoTableScan(
+            TableScanNode node,
+            RowExpression predicate,
+            boolean pruneWithPredicateExpression,
+            Session session,
+            PlanNodeIdAllocator idAllocator,
+            Metadata metadata,
+            @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
+    {
         if (!metadata.isLegacyGetLayoutSupported(session, node.getTable())) {
             return node;
         }
 
-        DomainTranslator translator = new RowExpressionDomainTranslator(metadata);
-        return pushPredicateIntoTableScan(node, predicate, pruneWithPredicateExpression, session, idAllocator, metadata, translator);
+        DomainTranslator translator = new RowExpressionDomainTranslator(metadata, expressionOptimizerProvider);
+        return pushPredicateIntoTableScan(node, predicate, pruneWithPredicateExpression, session, idAllocator, metadata, translator, expressionOptimizerProvider);
     }
 
     /**
@@ -265,7 +296,8 @@ public class PickTableLayout
             Session session,
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
-            DomainTranslator domainTranslator)
+            DomainTranslator domainTranslator,
+            @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         // don't include non-deterministic predicates
         LogicalRowExpressions logicalRowExpressions = new LogicalRowExpressions(
@@ -304,7 +336,8 @@ public class PickTableLayout
                             deterministicPredicate,
                             // Simplify the tuple domain to avoid creating an expression with too many nodes,
                             // which would be expensive to evaluate in the call to isCandidate below.
-                            domainTranslator.toPredicate(newDomain.simplify().transform(column -> assignments.getOrDefault(column, null)))));
+                            domainTranslator.toPredicate(newDomain.simplify().transform(column -> assignments.getOrDefault(column, null)))),
+                    expressionOptimizerProvider);
             constraint = new Constraint<>(newDomain, evaluator::isCandidate);
         }
         else {
@@ -363,14 +396,30 @@ public class PickTableLayout
     private static class LayoutConstraintEvaluatorForRowExpression
     {
         private final Map<VariableReferenceExpression, ColumnHandle> assignments;
+        private final RowExpression expression;
+        private final ConnectorSession session;
         private final RowExpressionInterpreter evaluator;
+        // When present, per-partition constant-folding goes through the session's pluggable optimizer so
+        // the native/sidecar optimizer evaluates the predicate; the resolved optimizer is captured once
+        // to avoid a lookup per partition. Null keeps the hardcoded Java interpreter.
+        @Nullable
+        private final ExpressionOptimizer expressionOptimizer;
         private final Set<ColumnHandle> arguments;
 
-        public LayoutConstraintEvaluatorForRowExpression(Metadata metadata, Session session, Map<VariableReferenceExpression, ColumnHandle> assignments, RowExpression expression)
+        public LayoutConstraintEvaluatorForRowExpression(Metadata metadata, Session session, Map<VariableReferenceExpression, ColumnHandle> assignments, RowExpression expression, @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.assignments = assignments;
+            this.expression = expression;
+            this.session = session.toConnectorSession();
 
-            evaluator = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), session.toConnectorSession(), OPTIMIZED);
+            if (expressionOptimizerProvider != null) {
+                this.expressionOptimizer = expressionOptimizerProvider.getExpressionOptimizer(this.session);
+                this.evaluator = null;
+            }
+            else {
+                this.expressionOptimizer = null;
+                this.evaluator = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), this.session, OPTIMIZED);
+            }
             arguments = VariablesExtractor.extractUnique(expression).stream()
                     .map(assignments::get)
                     .collect(toImmutableSet());
@@ -385,10 +434,21 @@ public class PickTableLayout
 
             // Skip pruning if evaluation fails in a recoverable way. Failing here can cause
             // spurious query failures for partitions that would otherwise be filtered out.
-            Object optimized = TryFunction.evaluate(() -> evaluator.optimize(inputs), true);
+            Object optimized = TryFunction.evaluate(() -> optimize(inputs), true);
 
             // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned
             return !Boolean.FALSE.equals(optimized) && optimized != null && (!(optimized instanceof ConstantExpression) || !((ConstantExpression) optimized).isNull());
+        }
+
+        private Object optimize(LookupVariableResolver inputs)
+        {
+            if (expressionOptimizer != null) {
+                RowExpression result = expressionOptimizer.optimize(expression, OPTIMIZED, session, inputs::getValue);
+                // Match the interpreter's contract: a fully-folded expression returns a raw constant
+                // value (so the FALSE/null checks in isCandidate apply), otherwise a RowExpression.
+                return result instanceof ConstantExpression ? ((ConstantExpression) result).getValue() : result;
+            }
+            return evaluator.optimize(inputs);
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -63,6 +63,7 @@ import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.statistics.TableStatistics;
@@ -186,12 +187,14 @@ public class AddExchanges
     private final Metadata metadata;
     private final PartitioningProviderManager partitioningProviderManager;
     private final boolean nativeExecution;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-    public AddExchanges(Metadata metadata, PartitioningProviderManager partitioningProviderManager, boolean nativeExecution)
+    public AddExchanges(Metadata metadata, PartitioningProviderManager partitioningProviderManager, boolean nativeExecution, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.nativeExecution = nativeExecution;
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
     }
 
     @Override
@@ -204,7 +207,7 @@ public class AddExchanges
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager, nativeExecution).accept(plan, PreferredProperties.any());
+            PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager, nativeExecution, expressionOptimizerProvider).accept(plan, PreferredProperties.any());
             boolean optimizerTriggered = PlanNodeSearcher.searchFrom(result.getNode()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isRemote()).findFirst().isPresent();
             return PlanOptimizerResult.optimizerResult(result.getNode(), optimizerTriggered);
         }
@@ -229,6 +232,7 @@ public class AddExchanges
         private final ExchangeMaterializationStrategy exchangeMaterializationStrategy;
         private final PartitioningProviderManager partitioningProviderManager;
         private final boolean nativeExecution;
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
         private boolean isDeleteOrUpdateQuery;
 
         public Rewriter(
@@ -236,7 +240,8 @@ public class AddExchanges
                 VariableAllocator variableAllocator,
                 Session session,
                 PartitioningProviderManager partitioningProviderManager,
-                boolean nativeExecution)
+                boolean nativeExecution,
+                ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.idAllocator = idAllocator;
             this.variableAllocator = variableAllocator;
@@ -253,6 +258,7 @@ public class AddExchanges
             this.exchangeMaterializationStrategy = getExchangeMaterializationStrategy(session);
             this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
             this.nativeExecution = nativeExecution;
+            this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         }
 
         @Override
@@ -1716,7 +1722,7 @@ public class AddExchanges
         private ActualProperties deriveProperties(PlanNode result, List<ActualProperties> inputProperties)
         {
             // TODO: move this logic to PlanChecker once PropertyDerivations.deriveProperties fully supports local exchanges
-            ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, metadata, session);
+            ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, metadata, session, expressionOptimizerProvider);
             verify(result instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated) || outputProperties.isNullsAndAnyReplicated(),
                     "SemiJoinNode is the only node that can strip null replication");
             return outputProperties;
@@ -1724,7 +1730,7 @@ public class AddExchanges
 
         private ActualProperties derivePropertiesRecursively(PlanNode result)
         {
-            return PropertyDerivations.derivePropertiesRecursively(result, metadata, session);
+            return PropertyDerivations.derivePropertiesRecursively(result, metadata, session, expressionOptimizerProvider);
         }
 
         private PlanWithProperties accept(PlanNode plan, PreferredProperties context)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
@@ -81,10 +82,12 @@ public class IndexJoinOptimizer
         implements PlanOptimizer
 {
     private final Metadata metadata;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-    public IndexJoinOptimizer(Metadata metadata)
+    public IndexJoinOptimizer(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
     }
 
     @Override
@@ -103,10 +106,10 @@ public class IndexJoinOptimizer
 
         IndexJoinRewriter rewriter;
         if (isNativeExecutionEnabled(session)) {
-            rewriter = new NativeIndexJoinRewriter(idAllocator, metadata, session);
+            rewriter = new NativeIndexJoinRewriter(idAllocator, metadata, session, expressionOptimizerProvider);
         }
         else {
-            rewriter = new DefaultIndexJoinRewriter(idAllocator, metadata, session);
+            rewriter = new DefaultIndexJoinRewriter(idAllocator, metadata, session, expressionOptimizerProvider);
         }
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
@@ -118,13 +121,15 @@ public class IndexJoinOptimizer
         protected final PlanNodeIdAllocator idAllocator;
         protected final Metadata metadata;
         protected final Session session;
+        protected final ExpressionOptimizerProvider expressionOptimizerProvider;
         protected boolean planChanged;
 
-        protected IndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
+        protected IndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.session = requireNonNull(session, "session is null");
+            this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         }
 
         public boolean isPlanChanged()
@@ -177,9 +182,9 @@ public class IndexJoinOptimizer
     private static class DefaultIndexJoinRewriter
             extends IndexJoinRewriter
     {
-        private DefaultIndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
+        private DefaultIndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
-            super(idAllocator, metadata, session);
+            super(idAllocator, metadata, session, expressionOptimizerProvider);
         }
 
         @Override
@@ -197,7 +202,8 @@ public class IndexJoinOptimizer
                         ImmutableSet.copyOf(leftJoinVariables),
                         idAllocator,
                         metadata,
-                        session);
+                        session,
+                        expressionOptimizerProvider);
                 if (leftIndexCandidate.isPresent()) {
                     // Sanity check that we can trace the path for the index lookup key
                     Map<VariableReferenceExpression, VariableReferenceExpression> trace
@@ -210,7 +216,8 @@ public class IndexJoinOptimizer
                         ImmutableSet.copyOf(rightJoinVariables),
                         idAllocator,
                         metadata,
-                        session);
+                        session,
+                        expressionOptimizerProvider);
                 if (rightIndexCandidate.isPresent()) {
                     // Sanity check that we can trace the path for the index lookup key
                     Map<VariableReferenceExpression, VariableReferenceExpression> trace
@@ -327,9 +334,9 @@ public class IndexJoinOptimizer
     private static class NativeIndexJoinRewriter
             extends IndexJoinRewriter
     {
-        private NativeIndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
+        private NativeIndexJoinRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
-            super(idAllocator, metadata, session);
+            super(idAllocator, metadata, session, expressionOptimizerProvider);
         }
 
         @Override
@@ -389,7 +396,8 @@ public class IndexJoinOptimizer
                         leftLookupVariables,
                         idAllocator,
                         metadata,
-                        session);
+                        session,
+                        expressionOptimizerProvider);
             }
             else {
                 leftIndexCandidate = Optional.empty();
@@ -408,7 +416,8 @@ public class IndexJoinOptimizer
                         rightLookupVariables,
                         idAllocator,
                         metadata,
-                        session);
+                        session,
+                        expressionOptimizerProvider);
             }
             else {
                 rightIndexCandidate = Optional.empty();
@@ -532,10 +541,10 @@ public class IndexJoinOptimizer
         private final LogicalRowExpressions logicalRowExpressions;
         private final Session session;
 
-        private IndexSourceRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
+        private IndexSourceRewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
-            this.domainTranslator = new RowExpressionDomainTranslator(metadata);
+            this.domainTranslator = new RowExpressionDomainTranslator(metadata, requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null"));
             this.logicalRowExpressions = new LogicalRowExpressions(
                     new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),
                     new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver()),
@@ -549,10 +558,11 @@ public class IndexJoinOptimizer
                 Set<VariableReferenceExpression> lookupVariables,
                 PlanNodeIdAllocator idAllocator,
                 Metadata metadata,
-                Session session)
+                Session session,
+                ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             AtomicBoolean success = new AtomicBoolean();
-            IndexSourceRewriter indexSourceRewriter = new IndexSourceRewriter(idAllocator, metadata, session);
+            IndexSourceRewriter indexSourceRewriter = new IndexSourceRewriter(idAllocator, metadata, session, expressionOptimizerProvider);
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(indexSourceRewriter, planNode, new Context(lookupVariables, success));
             if (success.get()) {
                 return Optional.of(rewritten);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -136,10 +136,10 @@ public class PredicatePushDown
     public PredicatePushDown(Metadata metadata, SqlParser sqlParser, ExpressionOptimizerProvider expressionOptimizerProvider, boolean nativeExecution)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        rowExpressionDomainTranslator = new RowExpressionDomainTranslator(metadata);
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
+        rowExpressionDomainTranslator = new RowExpressionDomainTranslator(metadata, expressionOptimizerProvider);
         this.effectivePredicateExtractor = new EffectivePredicateExtractor(rowExpressionDomainTranslator, metadata.getFunctionAndTypeManager());
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.nativeExecution = nativeExecution;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -56,6 +56,7 @@ import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.RowExpressionInterpreter;
@@ -124,15 +125,25 @@ public class PropertyDerivations
 
     public static ActualProperties derivePropertiesRecursively(PlanNode node, Metadata metadata, Session session)
     {
+        return derivePropertiesRecursively(node, metadata, session, null);
+    }
+
+    public static ActualProperties derivePropertiesRecursively(PlanNode node, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
+    {
         List<ActualProperties> inputProperties = node.getSources().stream()
-                .map(source -> derivePropertiesRecursively(source, metadata, session))
+                .map(source -> derivePropertiesRecursively(source, metadata, session, expressionOptimizerProvider))
                 .collect(toImmutableList());
-        return deriveProperties(node, inputProperties, metadata, session);
+        return deriveProperties(node, inputProperties, metadata, session, expressionOptimizerProvider);
     }
 
     public static ActualProperties deriveProperties(PlanNode node, List<ActualProperties> inputProperties, Metadata metadata, Session session)
     {
-        ActualProperties output = node.accept(new Visitor(metadata, session), inputProperties);
+        return deriveProperties(node, inputProperties, metadata, session, null);
+    }
+
+    public static ActualProperties deriveProperties(PlanNode node, List<ActualProperties> inputProperties, Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
+    {
+        ActualProperties output = node.accept(new Visitor(metadata, session, expressionOptimizerProvider), inputProperties);
 
         output.getNodePartitioning().ifPresent(partitioning ->
                 verify(node.getOutputVariables().containsAll(partitioning.getVariableReferences()), "Node-level partitioning properties contain columns not present in node's output"));
@@ -149,7 +160,7 @@ public class PropertyDerivations
 
     public static ActualProperties streamBackdoorDeriveProperties(PlanNode node, List<ActualProperties> inputProperties, Metadata metadata, Session session)
     {
-        return node.accept(new Visitor(metadata, session), inputProperties);
+        return node.accept(new Visitor(metadata, session, null), inputProperties);
     }
 
     public static Optional<ActualProperties> uniqueToGroupProperties(ActualProperties properties)
@@ -173,11 +184,17 @@ public class PropertyDerivations
     {
         private final Metadata metadata;
         private final Session session;
+        // When present (i.e. the caller is on the physical-planning path with a configured optimizer),
+        // constant-folding for property derivation goes through the session's pluggable optimizer so the
+        // native/sidecar optimizer evaluates expressions instead of the hardcoded Java interpreter. Null
+        // on paths that don't have an optimizer wired (sanity checks), which keep the Java interpreter.
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-        public Visitor(Metadata metadata, Session session)
+        public Visitor(Metadata metadata, Session session, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.metadata = metadata;
             this.session = session;
+            this.expressionOptimizerProvider = expressionOptimizerProvider;
         }
 
         @Override
@@ -799,7 +816,7 @@ public class PropertyDerivations
             ActualProperties properties = inputProperties.stream().collect(onlyElement());
 
             Map<VariableReferenceExpression, ConstantExpression> constants = new HashMap<>(properties.getConstants());
-            TupleDomain<VariableReferenceExpression> tupleDomain = new RowExpressionDomainTranslator(metadata).fromPredicate(session.toConnectorSession(), node.getPredicate(), BASIC_COLUMN_EXTRACTOR).getTupleDomain();
+            TupleDomain<VariableReferenceExpression> tupleDomain = new RowExpressionDomainTranslator(metadata, expressionOptimizerProvider).fromPredicate(session.toConnectorSession(), node.getPredicate(), BASIC_COLUMN_EXTRACTOR).getTupleDomain();
             constants.putAll(extractFixedValuesToConstantExpressions(tupleDomain)
                     .orElse(ImmutableMap.of()));
 
@@ -843,7 +860,23 @@ public class PropertyDerivations
                 // to take advantage of constant-folding for complex expressions
                 // However, that currently causes errors when those expressions operate on arrays or row types
                 // ("ROW comparison not supported for fields with null elements", etc)
-                Object value = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), session.toConnectorSession(), OPTIMIZED).optimize();
+                //
+                // Use the session's pluggable optimizer when available so the native/sidecar optimizer
+                // evaluates the expression (matching how the plan's expressions were optimized). Falling
+                // back to the hardcoded Java interpreter would evaluate a native-produced expression with
+                // different semantics and mis-derive constants. When no optimizer is wired (e.g.
+                // sanity-check callers), keep the Java interpreter.
+                Object value;
+                if (expressionOptimizerProvider != null) {
+                    RowExpression optimized = expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession())
+                            .optimize(expression, OPTIMIZED, session.toConnectorSession());
+                    // Downstream logic expects a raw constant value for a fully-folded expression and a
+                    // RowExpression otherwise; unwrap a ConstantExpression to match the interpreter's contract.
+                    value = optimized instanceof ConstantExpression ? ((ConstantExpression) optimized).getValue() : optimized;
+                }
+                else {
+                    value = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), session.toConnectorSession(), OPTIMIZED).optimize();
+                }
 
                 if (value instanceof VariableReferenceExpression) {
                     ConstantExpression existingConstantValue = constants.get(value);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TopNRowNumberNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -67,10 +68,10 @@ public class WindowFilterPushDown
     private final RowExpressionDomainTranslator domainTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
 
-    public WindowFilterPushDown(Metadata metadata)
+    public WindowFilterPushDown(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.domainTranslator = new RowExpressionDomainTranslator(metadata);
+        this.domainTranslator = new RowExpressionDomainTranslator(metadata, requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null"));
         this.logicalRowExpressions = new LogicalRowExpressions(
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),
                 new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver()),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.InputReferenceExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -97,14 +98,26 @@ public final class RowExpressionDomainTranslator
     private final LogicalRowExpressions logicalRowExpressions;
     private final StandardFunctionResolution functionResolution;
     private final Metadata metadata;
+    // When present, constant-folding during predicate-to-domain extraction goes through the session's
+    // pluggable optimizer so the native/sidecar optimizer evaluates expressions instead of the hardcoded
+    // Java interpreter. Null on callers that don't run on native-optimized plans (e.g. materialized-view
+    // rewriting, tests), which keep the Java interpreter.
+    @Nullable
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
     @Inject
     public RowExpressionDomainTranslator(Metadata metadata)
+    {
+        this(metadata, null);
+    }
+
+    public RowExpressionDomainTranslator(Metadata metadata, @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.functionAndTypeManager = metadata.getFunctionAndTypeManager();
         this.logicalRowExpressions = new LogicalRowExpressions(new RowExpressionDeterminismEvaluator(functionAndTypeManager), new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver()), functionAndTypeManager);
         this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        this.expressionOptimizerProvider = expressionOptimizerProvider;
     }
 
     @Override
@@ -128,7 +141,7 @@ public final class RowExpressionDomainTranslator
     @Override
     public <T> ExtractionResult<T> fromPredicate(ConnectorSession session, RowExpression predicate, ColumnExtractor<T> columnExtractor)
     {
-        return predicate.accept(new Visitor<>(metadata, session, columnExtractor), false);
+        return predicate.accept(new Visitor<>(metadata, session, columnExtractor, expressionOptimizerProvider), false);
     }
 
     public RowExpression toPredicate(Domain domain, RowExpression reference)
@@ -294,8 +307,10 @@ public final class RowExpressionDomainTranslator
         private final DeterminismEvaluator determinismEvaluator;
         private final StandardFunctionResolution resolution;
         private final ColumnExtractor<T> columnExtractor;
+        @Nullable
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-        private Visitor(Metadata metadata, ConnectorSession session, ColumnExtractor<T> columnExtractor)
+        private Visitor(Metadata metadata, ConnectorSession session, ColumnExtractor<T> columnExtractor, @Nullable ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionAndTypeManager());
             this.metadata = metadata;
@@ -305,6 +320,18 @@ public final class RowExpressionDomainTranslator
             this.determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
             this.resolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
             this.columnExtractor = requireNonNull(columnExtractor, "columnExtractor is null");
+            this.expressionOptimizerProvider = expressionOptimizerProvider;
+        }
+
+        private Object optimize(RowExpression expression)
+        {
+            if (expressionOptimizerProvider != null) {
+                RowExpression optimized = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(expression, OPTIMIZED, session);
+                // Downstream logic expects a raw constant value for a fully-folded expression and a
+                // RowExpression otherwise; unwrap a ConstantExpression to match the interpreter's contract.
+                return optimized instanceof ConstantExpression ? ((ConstantExpression) optimized).getValue() : optimized;
+            }
+            return new RowExpressionInterpreter(expression, functionAndTypeManager, session, OPTIMIZED).optimize();
         }
 
         @Override
@@ -636,13 +663,13 @@ public final class RowExpressionDomainTranslator
                 left = leftExpression;
             }
             else {
-                left = new RowExpressionInterpreter(leftExpression, metadata.getFunctionAndTypeManager(), session, OPTIMIZED).optimize();
+                left = optimize(leftExpression);
             }
             if (rightExpression instanceof VariableReferenceExpression) {
                 right = rightExpression;
             }
             else {
-                right = new RowExpressionInterpreter(rightExpression, metadata.getFunctionAndTypeManager(), session, OPTIMIZED).optimize();
+                right = optimize(rightExpression);
             }
 
             if (left instanceof RowExpression == right instanceof RowExpression) {

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -489,7 +489,7 @@ public class LocalQueryRunner
         this.accessControl = new TestingAccessControlManager(transactionManager);
         this.statsNormalizer = new StatsNormalizer();
         this.scalarStatsCalculator = new ScalarStatsCalculator(metadata, expressionOptimizerManager);
-        this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
+        this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, expressionOptimizerManager);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, createTestingSessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig(), featuresConfig, new NodeVersion("1"));
         this.fragmentStatsProvider = new FragmentStatsProvider();
         this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider, expressionOptimizerManager);
@@ -526,7 +526,7 @@ public class LocalQueryRunner
                 new RowExpressionDomainTranslator(metadata),
                 new RowExpressionPredicateCompiler(metadata),
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),
-                new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer),
+                new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, expressionOptimizerManager),
                 blockEncodingManager,
                 featuresConfig,
                 new ConnectorCodecManager(ThriftCodecManager::new));

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -68,7 +68,7 @@ public class TestingConnectorContext
     private final PredicateCompiler predicateCompiler = new RowExpressionPredicateCompiler(metadata);
     private final DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
     private final ExpressionOptimizerProvider expressionOptimizerProvider = (ConnectorSession session) -> new RowExpressionOptimizer(metadata);
-    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, expressionOptimizerProvider), new StatsNormalizer()));
+    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, expressionOptimizerProvider), new StatsNormalizer(), expressionOptimizerProvider));
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
@@ -83,7 +83,7 @@ public abstract class AbstractTestComparisonStatsCalculator
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
+        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer(), new InMemoryExpressionOptimizerProvider(metadata));
 
         uStats = VariableStatsEstimate.builder()
                 .setAverageRowSize(8.0)

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
@@ -179,7 +179,7 @@ public abstract class AbstractTestFilterStatsCalculator
                 .build());
 
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
+        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer(), new InMemoryExpressionOptimizerProvider(metadata));
         translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -62,7 +62,8 @@ public class TestConnectorFilterStatsCalculatorService
                 new ScalarStatsCalculator(
                         metadata,
                         new InMemoryExpressionOptimizerProvider(metadata)),
-                new StatsNormalizer());
+                new StatsNormalizer(),
+                new InMemoryExpressionOptimizerProvider(metadata));
         statsCalculatorService = new ConnectorFilterStatsCalculatorService(statsCalculator);
         xStats = ColumnStatistics.builder()
                 .setDistinctValuesCount(Estimate.of(40))

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorExpressionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculatorExpressionOptimizer.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that FilterStatsCalculator simplifies predicates through the session's pluggable
+ * ExpressionOptimizer. Under the native expression optimizer this routes predicate simplification to the
+ * sidecar instead of the hardcoded Java interpreter, which would mis-fold native-produced expression
+ * shapes when computing filter selectivity.
+ */
+public class TestFilterStatsCalculatorExpressionOptimizer
+{
+    private static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
+    private static final Session SESSION = testSessionBuilder().build();
+    private static final VariableReferenceExpression X = new VariableReferenceExpression(Optional.empty(), "x", BIGINT);
+
+    private static class CountingExpressionOptimizerProvider
+            implements ExpressionOptimizerProvider
+    {
+        private final AtomicInteger optimizeCalls = new AtomicInteger();
+
+        @Override
+        public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
+        {
+            ExpressionOptimizer delegate = new RowExpressionOptimizer(METADATA);
+            return new ExpressionOptimizer()
+            {
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session)
+                {
+                    optimizeCalls.incrementAndGet();
+                    return delegate.optimize(expression, level, session);
+                }
+
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+                {
+                    optimizeCalls.incrementAndGet();
+                    return delegate.optimize(expression, level, session, variableResolver);
+                }
+            };
+        }
+    }
+
+    // x > (1 + 1): a predicate whose constant sub-expression must be folded during simplification.
+    private RowExpression predicateWithFoldableConstant()
+    {
+        RowExpression rhs = call(
+                ADD.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+                BIGINT,
+                constant(1L, BIGINT),
+                constant(1L, BIGINT));
+        return call(
+                GREATER_THAN.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(GREATER_THAN, fromTypes(BIGINT, BIGINT)),
+                BOOLEAN,
+                X,
+                rhs);
+    }
+
+    @Test
+    public void testFilterStatsUsesSuppliedExpressionOptimizer()
+    {
+        CountingExpressionOptimizerProvider provider = new CountingExpressionOptimizerProvider();
+        FilterStatsCalculator filterStatsCalculator = new FilterStatsCalculator(
+                METADATA,
+                new ScalarStatsCalculator(METADATA, provider),
+                new StatsNormalizer(),
+                provider);
+
+        VariableStatsEstimate xStats = VariableStatsEstimate.builder()
+                .setLowValue(0)
+                .setHighValue(10)
+                .setDistinctValuesCount(10)
+                .setNullsFraction(0)
+                .build();
+        PlanNodeStatsEstimate input = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(1000)
+                .addVariableStatistics(X, xStats)
+                .build();
+
+        filterStatsCalculator.filterStats(input, predicateWithFoldableConstant(), SESSION);
+
+        assertTrue(provider.optimizeCalls.get() > 0, "expected FilterStatsCalculator to simplify the predicate via the supplied optimizer");
+    }
+
+    @Test
+    public void testConstantExpressionUnwrappedToValue()
+    {
+        // A predicate that folds fully to a constant TRUE must be simplified to a constant, matching the
+        // interpreter's contract (the unwrap of ConstantExpression to its raw value). We assert the routed
+        // optimizer is consulted; the ConstantExpression it returns is unwrapped without error.
+        CountingExpressionOptimizerProvider provider = new CountingExpressionOptimizerProvider();
+        FilterStatsCalculator filterStatsCalculator = new FilterStatsCalculator(
+                METADATA,
+                new ScalarStatsCalculator(METADATA, provider),
+                new StatsNormalizer(),
+                provider);
+
+        RowExpression alwaysTrue = call(
+                GREATER_THAN.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(GREATER_THAN, fromTypes(BIGINT, BIGINT)),
+                BOOLEAN,
+                constant(2L, BIGINT),
+                constant(1L, BIGINT));
+
+        PlanNodeStatsEstimate input = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(1000)
+                .addVariableStatistics(X, VariableStatsEstimate.builder().setLowValue(0).setHighValue(10).setDistinctValuesCount(10).setNullsFraction(0).build())
+                .build();
+
+        PlanNodeStatsEstimate result = filterStatsCalculator.filterStats(input, alwaysTrue, SESSION);
+
+        assertTrue(provider.optimizeCalls.get() > 0, "expected the always-true predicate to be folded via the supplied optimizer");
+        // An always-true filter keeps all input rows.
+        assertTrue(result.getOutputRowCount() > 0);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -95,7 +95,7 @@ public class TestJoinStatsRule
 
     private static final ExpressionOptimizerProvider EXPRESSION_OPTIMIZER_PROVIDER = new InMemoryExpressionOptimizerProvider(METADATA);
     private static final JoinStatsRule JOIN_STATS_RULE = new JoinStatsRule(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), NORMALIZER),
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), NORMALIZER, EXPRESSION_OPTIMIZER_PROVIDER),
             NORMALIZER,
             1.0);
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -46,6 +46,7 @@ public class TestPickTableLayout
         extends BaseRuleTest
 {
     private PickTableLayout pickTableLayout;
+    private PickTableLayout pickTableLayoutWithOptimizer;
     private TableHandle nationTableHandle;
     private TableHandle ordersTableHandle;
     private ConnectorId connectorId;
@@ -54,6 +55,9 @@ public class TestPickTableLayout
     public void setUpBeforeClass()
     {
         pickTableLayout = new PickTableLayout(tester().getMetadata());
+        // Wired with the session's pluggable optimizer, so partition-pruning constant folding routes
+        // through it (native -> sidecar) instead of the hardcoded Java interpreter.
+        pickTableLayoutWithOptimizer = new PickTableLayout(tester().getMetadata(), tester().getExpressionManager());
 
         connectorId = tester().getCurrentConnectorId();
 
@@ -115,6 +119,25 @@ public class TestPickTableLayout
                                     ordersTableHandle,
                                     ImmutableList.of(variable("orderstatus", createVarcharType(1))),
                                     ImmutableMap.of(variable("orderstatus", createVarcharType(1)), new TpchColumnHandle("orderstatus", createVarcharType(1)))));
+                })
+                .matches(values("A"));
+    }
+
+    @Test
+    public void routesConstantFoldingThroughExpressionOptimizer()
+    {
+        // The rule wired with the pluggable optimizer must produce the same pruning result as the default
+        // (hardcoded-interpreter) path: routing is a no-op for the default optimizer, and correct for
+        // native. This guards against regressing partition pruning while closing the interpreter over the
+        // pluggable optimizer.
+        tester().assertThat(pickTableLayoutWithOptimizer.pickTableLayoutForPredicate())
+                .on(p -> {
+                    p.variable("orderstatus", createVarcharType(1));
+                    return p.filter(p.rowExpression("orderstatus = 'G'"),
+                            p.tableScan(
+                                    ordersTableHandle,
+                                    ImmutableList.of(p.variable("orderstatus", createVarcharType(1))),
+                                    ImmutableMap.of(p.variable("orderstatus", createVarcharType(1)), new TpchColumnHandle("orderstatus", createVarcharType(1)))));
                 })
                 .matches(values("A"));
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchanges.java
@@ -17,6 +17,9 @@ import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.ConstantProperty;
 import com.facebook.presto.spi.GroupingProperty;
 import com.facebook.presto.spi.SortingProperty;
+import com.facebook.presto.spi.plan.Partitioning;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.optimizations.ActualProperties.Global;
 import com.google.common.collect.ImmutableList;
@@ -41,6 +44,8 @@ import static com.facebook.presto.sql.planner.optimizations.ActualProperties.bui
 import static com.facebook.presto.sql.planner.optimizations.AddExchanges.streamingExecutionPreference;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * These are unit test for the internal logic in AddExchanges.
@@ -743,6 +748,57 @@ public class TestAddExchanges
                         .build())
                 .build();
         assertEquals(stableSort(input, preference), expected);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Regression coverage for the native-optimizer partitioning divergence. AddExchanges decides whether
+    // to insert a repartitioning exchange under a partitioned join by asking whether a child is already
+    // node-partitioned on the join keys (AddExchanges.planPartitionedJoin ->
+    // ActualProperties.isNodePartitionedOn). When the native expression optimizer folds the
+    // rolled-up grouping columns of a ROLLUP rewrite to NULL literals, the probe side is
+    // node-partitioned on HASH[joinKey, null, null, ...]. Because isNodePartitionedOn ignores
+    // constant partition arguments, the probe is reported as partitioned on just [joinKey] and
+    // the exchange is skipped -- even though the build side is really hash-partitioned on
+    // HASH[joinKey, g1, g2] and therefore uses a different hash. These tests operate on the real
+    // ActualProperties the rule consults.
+    // ----------------------------------------------------------------------------------------
+
+    private static ActualProperties nodePartitionedOn(RowExpression... arguments)
+    {
+        Partitioning partitioning = Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.copyOf(arguments));
+        return builder().global(partitionedOn(partitioning, Optional.of(partitioning))).build();
+    }
+
+    @Test
+    public void testProbeWithNullConstantPartitionColumnsReportedPartitionedOnJoinKey()
+    {
+        VariableReferenceExpression joinKey = variable("field_337");
+        ConstantExpression nullConstant = new ConstantExpression(null, BIGINT);
+
+        // Native probe side: hash-partitioned on the join key plus folded NULL rollup columns.
+        ActualProperties probe = nodePartitionedOn(joinKey, nullConstant, nullConstant);
+
+        // AddExchanges asks exactly this (see AddExchanges.planPartitionedJoin, isNodePartitionedOn
+        // on the right/probe child). It answers true, so no repartition exchange is added under the
+        // join -- this is the root cause of the dropped exchange.
+        assertTrue(probe.isNodePartitionedOn(ImmutableList.of(joinKey), false));
+    }
+
+    @Test
+    public void testBuildWithVariablePartitionColumnsNotReportedPartitionedOnJoinKey()
+    {
+        VariableReferenceExpression joinKey = variable("field");
+        VariableReferenceExpression g1 = variable("expr_147");
+        VariableReferenceExpression g2 = variable("expr_148");
+
+        // Build side (and the probe side under the DEFAULT optimizer): the trailing columns are
+        // real grouping variables, not constants.
+        ActualProperties build = nodePartitionedOn(joinKey, g1, g2);
+
+        // Correctly reported as NOT partitioned on the join key alone, so a repartition exchange is
+        // required. The only difference from the probe above is variables vs. NULL constants in the
+        // trailing partition positions -- yet the exchange decision flips.
+        assertFalse(build.isNodePartitionedOn(ImmutableList.of(joinKey), false));
     }
 
     private static <T> List<T> stableSort(List<T> list, Comparator<T> comparator)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -140,7 +140,7 @@ public class TestEliminateSorts
                         getQueryRunner().getStatsCalculator(),
                         getQueryRunner().getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
-                new AddExchanges(getQueryRunner().getMetadata(), new PartitioningProviderManager(), false),
+                new AddExchanges(getQueryRunner().getMetadata(), new PartitioningProviderManager(), false, getQueryRunner().getExpressionManager()),
                 new AddLocalExchanges(getMetadata(), getQueryRunner().getStatsCalculator(), false),
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
                 new PruneUnreferencedOutputs(),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPropertyDerivationsExpressionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPropertyDerivationsExpressionOptimizer.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that PropertyDerivations routes ProjectNode constant-folding through the session's pluggable
+ * ExpressionOptimizer when one is supplied. Under the native expression optimizer this sends the
+ * expression to the sidecar instead of evaluating it with the hardcoded Java interpreter, which would
+ * mis-derive constants for native-produced expression shapes.
+ */
+public class TestPropertyDerivationsExpressionOptimizer
+{
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final Session SESSION = testSessionBuilder().build();
+
+    // A stub optimizer standing in for the native/sidecar optimizer: it folds ANY non-trivial expression
+    // to a constant NULL (mimicking the shape divergence that produced the poisoned constant property).
+    private static final ExpressionOptimizerProvider FOLDS_TO_NULL = new ExpressionOptimizerProvider()
+    {
+        @Override
+        public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
+        {
+            return new ExpressionOptimizer()
+            {
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session)
+                {
+                    return new ConstantExpression(null, expression.getType());
+                }
+
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+                {
+                    return new ConstantExpression(null, expression.getType());
+                }
+            };
+        }
+    };
+
+    private final VariableReferenceExpression out = new VariableReferenceExpression(Optional.empty(), "out", BIGINT);
+
+    private ProjectNode nonTrivialProjection()
+    {
+        PlanBuilder p = new PlanBuilder(SESSION, new PlanNodeIdAllocator(), METADATA);
+        VariableReferenceExpression a = p.variable("a", BIGINT);
+        // out := a + a  (a non-constant, non-variable expression, so visitProject invokes the optimizer)
+        RowExpression expression = call(
+                ADD.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+                BIGINT, a, a);
+        return p.project(assignment(out, expression), p.values(a));
+    }
+
+    @Test
+    public void testProjectUsesSuppliedExpressionOptimizer()
+    {
+        ProjectNode project = nonTrivialProjection();
+
+        // With the stub optimizer wired in, the projection is folded to a constant and recorded as a
+        // constant property -- proving PropertyDerivations consulted the pluggable optimizer.
+        ActualProperties withOptimizer = PropertyDerivations.deriveProperties(
+                project,
+                ImmutableList.of(ActualProperties.builder().build()),
+                METADATA,
+                SESSION,
+                FOLDS_TO_NULL);
+        assertTrue(withOptimizer.getConstants().containsKey(out),
+                "expected the projection to be folded to a constant via the supplied optimizer");
+    }
+
+    @Test
+    public void testProjectFallsBackToJavaInterpreterWithoutProvider()
+    {
+        ProjectNode project = nonTrivialProjection();
+
+        // Without a provider (legacy path, e.g. sanity checks), the hardcoded Java interpreter runs and
+        // does NOT fold `a + a` to a constant. This confirms the routing genuinely changes behavior.
+        ActualProperties withoutOptimizer = PropertyDerivations.deriveProperties(
+                project,
+                ImmutableList.of(ActualProperties.builder().build()),
+                METADATA,
+                SESSION);
+        assertFalse(withoutOptimizer.getConstants().containsKey(out),
+                "the Java interpreter must not fold a + a to a constant");
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionDomainTranslatorExpressionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionDomainTranslatorExpressionOptimizer.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.relation.DomainTranslator.BASIC_COLUMN_EXTRACTOR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that RowExpressionDomainTranslator routes constant-folding of comparison operands through the
+ * session's pluggable ExpressionOptimizer when one is supplied. Under the native expression optimizer this
+ * sends operands to the sidecar instead of the hardcoded Java interpreter, which would mis-fold
+ * native-produced expression shapes and poison the extracted TupleDomain (issue behind the RightJoin
+ * wrong-results bug).
+ */
+public class TestRowExpressionDomainTranslatorExpressionOptimizer
+{
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final Session SESSION = testSessionBuilder().build();
+    private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression(Optional.empty(), "c_bigint", BIGINT);
+
+    // A provider that records whether it was consulted and delegates to the real Java optimizer, so the
+    // extracted domain is unchanged. This proves the translator routes operand folding through the
+    // pluggable optimizer without altering results on the default path.
+    private static class CountingExpressionOptimizerProvider
+            implements ExpressionOptimizerProvider
+    {
+        private final AtomicInteger optimizeCalls = new AtomicInteger();
+
+        @Override
+        public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
+        {
+            ExpressionOptimizer delegate = new RowExpressionOptimizer(METADATA);
+            return new ExpressionOptimizer()
+            {
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session)
+                {
+                    optimizeCalls.incrementAndGet();
+                    return delegate.optimize(expression, level, session);
+                }
+
+                @Override
+                public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+                {
+                    optimizeCalls.incrementAndGet();
+                    return delegate.optimize(expression, level, session, variableResolver);
+                }
+            };
+        }
+    }
+
+    // c_bigint = (1 + 1): the right side is a non-trivial constant expression, so extraction folds it via
+    // the optimizer to recover the singleton domain {2}.
+    private RowExpression comparisonWithFoldableConstant()
+    {
+        RowExpression rhs = call(
+                ADD.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+                BIGINT,
+                constant(1L, BIGINT),
+                constant(1L, BIGINT));
+        return call(
+                EQUAL.name(),
+                METADATA.getFunctionAndTypeManager().resolveOperator(EQUAL, fromTypes(BIGINT, BIGINT)),
+                BOOLEAN,
+                C_BIGINT,
+                rhs);
+    }
+
+    @Test
+    public void testUsesSuppliedExpressionOptimizer()
+    {
+        CountingExpressionOptimizerProvider provider = new CountingExpressionOptimizerProvider();
+        RowExpressionDomainTranslator translator = new RowExpressionDomainTranslator(METADATA, provider);
+
+        ExtractionResult<VariableReferenceExpression> result = translator.fromPredicate(
+                SESSION.toConnectorSession(),
+                comparisonWithFoldableConstant(),
+                BASIC_COLUMN_EXTRACTOR);
+
+        assertTrue(provider.optimizeCalls.get() > 0, "expected the translator to consult the supplied optimizer for operand folding");
+        // The folded operand 1 + 1 = 2 yields the singleton domain {2} on c_bigint.
+        assertTrue(result.getTupleDomain().getDomains().isPresent());
+        assertTrue(result.getTupleDomain().getDomains().get().containsKey(C_BIGINT));
+    }
+
+    @Test
+    public void testDefaultProviderMatchesJavaInterpreter()
+    {
+        // The default provider (RowExpressionOptimizer, which wraps the Java interpreter) and the legacy
+        // hardcoded-interpreter path must extract identical domains, so the routing is a no-op for default.
+        RowExpressionDomainTranslator routed = new RowExpressionDomainTranslator(METADATA, new CountingExpressionOptimizerProvider());
+        RowExpressionDomainTranslator legacy = new RowExpressionDomainTranslator(METADATA);
+
+        ExtractionResult<VariableReferenceExpression> routedResult = routed.fromPredicate(
+                SESSION.toConnectorSession(), comparisonWithFoldableConstant(), BASIC_COLUMN_EXTRACTOR);
+        ExtractionResult<VariableReferenceExpression> legacyResult = legacy.fromPredicate(
+                SESSION.toConnectorSession(), comparisonWithFoldableConstant(), BASIC_COLUMN_EXTRACTOR);
+
+        assertEquals(routedResult.getTupleDomain(), legacyResult.getTupleDomain());
+    }
+}


### PR DESCRIPTION
## Description

Route planning-time constant folding through the session's pluggable expression optimizer (`ExpressionOptimizerProvider` / `ExpressionOptimizerManager`) instead of the hardcoded Java `RowExpressionInterpreter`.

Several planner components fold constants during optimization — `FilterStatsCalculator`, `PickTableLayout` (partition pruning), `PropertyDerivations`, `RowExpressionDomainTranslator`, `AddExchanges`, `IndexJoinOptimizer`, and `WindowFilterPushDown`. Today they all hardcode the Java interpreter. This change threads an optional `ExpressionOptimizerProvider` through those paths so the configured optimizer evaluates the expression, matching how the plan's expressions were optimized. When no provider is wired (e.g. sanity-check paths and existing tests), the original Java-interpreter behavior is preserved via overloads / nullable arguments, so this is backward compatible.

## Motivation and Context

When a pluggable expression optimizer is configured, the plan's expressions are optimized by that optimizer, but planning-time constant folding still used the hardcoded Java `RowExpressionInterpreter`. That mismatch can mis-fold expressions the pluggable optimizer produced. Routing folding through the session's optimizer keeps the two consistent.

## Impact

Planner only. Behavior is unchanged unless an `ExpressionOptimizerProvider` is supplied; when it is, planning-time constant folding is delegated to it. All old constructors/method overloads are retained (or add a nullable parameter that defaults to the prior behavior).

## Test Plan

New unit tests added:
- `TestFilterStatsCalculatorExpressionOptimizer`
- `TestPropertyDerivationsExpressionOptimizer`
- `TestRowExpressionDomainTranslatorExpressionOptimizer`
- New cases in `TestPickTableLayout` (`routesConstantFoldingThroughExpressionOptimizer`) and `TestAddExchanges`.

Verified locally: `presto-main-base` test-compiles and the affected test classes pass (`Tests run: 30, Failures: 0`).

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Route planner-time constant folding through the session’s pluggable expression optimizer instead of the hardcoded Java interpreter, keeping predicate/domain extraction, partition pruning, property derivation, and stats estimation consistent with optimizer-produced expressions.

New Features:
- Allow PickTableLayout, AddExchanges, IndexJoinOptimizer, WindowFilterPushDown, and property derivation to use an optional ExpressionOptimizerProvider for planning-time constant folding.
- Wire the planner’s FilterStatsCalculator and domain translation to the session’s ExpressionOptimizerProvider so filter and comparison simplifications honor the configured optimizer.

Enhancements:
- Extend RowExpressionDomainTranslator, PropertyDerivations, and PickTableLayout APIs to accept an optional ExpressionOptimizerProvider while preserving existing constructors and behavior when none is supplied.
- Update PlanOptimizers and test harnesses to construct optimizers with the session’s ExpressionOptimizerManager, ensuring native and default execution paths share the same expression optimization configuration.

Tests:
- Add dedicated tests to verify FilterStatsCalculator, RowExpressionDomainTranslator, PropertyDerivations, and PickTableLayout route constant folding through a supplied ExpressionOptimizer.
- Add regression tests around AddExchanges’ partitioning behavior when partitioning arguments include folded NULL constants versus variables, guarding against native optimizer partitioning divergences.