### PR TITLE
perf(plugin-iceberg): Read total-records from snapshot summary to skip redundant manifest scan

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -107,6 +107,7 @@ import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.statistics.KllHistogram.isKllHistogramSupportedType;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateAndSetTableSize;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.formatIdentifier;
+import static com.facebook.presto.iceberg.util.StatisticsUtil.getTotalRecords;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.HISTOGRAM;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_DISTINCT_VALUES;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.TOTAL_SIZE_IN_BYTES;
@@ -122,7 +123,6 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.iceberg.SnapshotSummary.TOTAL_RECORDS_PROP;
 
 public class TableStatisticsMaker
 {
@@ -225,10 +225,12 @@ public class TableStatisticsMaker
                     .setRowCount(Estimate.of(0))
                     .build();
         }
-        // the total record count for the whole table
+        // the total record count for the whole table: prefer the O(1) snapshot summary,
+        // and fall back to a full manifest scan only when the summary lacks total-records
         Optional<Long> totalRecordCount = Optional.of(intersection)
                 .filter(domain -> !domain.isAll())
-                .map(domain -> getDataTableSummary(tableHandle, ImmutableList.of(), TupleDomain.all(), idToTypeMapping, nonPartitionPrimitiveColumns, partitionFields).getRecordCount());
+                .map(domain -> getTotalRecords(icebergTable.snapshot(tableHandle.getIcebergTableName().getSnapshotId().get()))
+                        .orElseGet(() -> getDataTableSummary(tableHandle, ImmutableList.of(), TupleDomain.all(), idToTypeMapping, nonPartitionPrimitiveColumns, partitionFields).getRecordCount()));
 
         double recordCount = summary.getRecordCount();
         TableStatistics.Builder result = TableStatistics.builder();
@@ -576,12 +578,9 @@ public class TableStatisticsMaker
                     long firstDiff = abs(target.timestampMillis() - firstSnap.timestampMillis());
                     long secondDiff = abs(target.timestampMillis() - secondSnap.timestampMillis());
 
-                    // check if total-record exists
-                    Optional<Long> targetTotalRecords = Optional.ofNullable(target.summary().get(TOTAL_RECORDS_PROP)).map(Long::parseLong);
-                    Optional<Long> firstTotalRecords = Optional.ofNullable(firstSnap.summary().get(TOTAL_RECORDS_PROP))
-                            .map(Long::parseLong);
-                    Optional<Long> secondTotalRecords = Optional.ofNullable(secondSnap.summary().get(TOTAL_RECORDS_PROP))
-                            .map(Long::parseLong);
+                    Optional<Long> targetTotalRecords = getTotalRecords(target);
+                    Optional<Long> firstTotalRecords = getTotalRecords(firstSnap);
+                    Optional<Long> secondTotalRecords = getTotalRecords(secondSnap);
 
                     if (targetTotalRecords.isPresent() && firstTotalRecords.isPresent() && secondTotalRecords.isPresent()) {
                         long targetTotal = targetTotalRecords.get();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
@@ -41,6 +41,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 
 import java.util.Arrays;
@@ -198,6 +200,19 @@ public final class StatisticsUtil
     public static String formatIdentifier(String s)
     {
         return '"' + s.replace("\"", "\"\"") + '"';
+    }
+
+    /**
+     * Returns the total record count stored in the snapshot summary, or empty if unavailable.
+     * Iceberg writes {@code total-records} into every snapshot summary on commit; it may be absent
+     * for snapshots produced by very old writers or external tools that do not populate summary stats.
+     */
+    public static Optional<Long> getTotalRecords(Snapshot snapshot)
+    {
+        if (snapshot == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(snapshot.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)).map(Long::parseLong);
     }
 
     /**


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

When a predicate is present, `makeTableStatistics` was re-running a full manifest scan (`getDataTableSummary` with `TupleDomain.all()`) to obtain the unfiltered row count for NDV scaling. The Iceberg snapshot summary already carries this value as `total-records`. Reading it is `O(1)` vs `O(files)`. Also consolidates three inline `TOTAL_RECORDS_PROP` lookups in `getClosestStatisticsFileForSnapshot` into the new `StatisticsUtil.getTotalRecords` helper.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Optimize the table stats aggregation for iceberg

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
N.A.

## Test Plan
<!---Please fill in how you tested your change-->
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Improve Iceberg table statistics computation by using snapshot-level total record counts instead of re-scanning manifests.
```

## Summary by Sourcery

Optimize Iceberg table statistics computation by using snapshot-level total record counts instead of re-scanning manifests.

Enhancements:
- Add a StatisticsUtil helper to read total-records from Iceberg snapshot summaries.
- Use snapshot total-records to derive unfiltered row counts when predicates are present, avoiding redundant manifest scans.
- Refactor snapshot statistics selection logic to reuse the new total-records helper for consistency.