### PR TITLE
docs: Fix formatting in connector/bigquery.rst

### DIFF
--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -29,21 +29,19 @@ that should generally lead to better read performance:
 
 **Direct Streaming**
 
-    It does not leave any temporary files in Google Cloud Storage. Rows are read
-    directly from BigQuery servers using an Avro wire format.
+It does not leave any temporary files in Google Cloud Storage. Rows are read 
+directly from BigQuery servers using an Avro wire format.
 
 **Column Filtering**
 
-    The new API allows column filtering to only read the data you are interested in.
-    `Backed by a columnar datastore <https://cloud.google.com/blog/products/bigquery/inside-capacitor-bigquerys-next-generation-columnar-storage-format>`_,
-    it can efficiently stream data without reading all columns.
+The new API allows column filtering to only read the data you are interested in. 
+`Backed by a columnar datastore <https://cloud.google.com/blog/products/bigquery/inside-capacitor-bigquerys-next-generation-columnar-storage-format>`_, 
+it can efficiently stream data without reading all columns.
 
 **Dynamic Sharding**
 
-    The API rebalances records between readers until they all complete. This means
-    that all Map phases will finish nearly concurrently. See this blog article on
-    `how dynamic sharding is similarly used in Google Cloud Dataflow
-    <https://cloud.google.com/blog/products/gcp/no-shard-left-behind-dynamic-work-rebalancing-in-google-cloud-dataflow>`_.
+The API rebalances records between readers until they all complete. This means 
+that all Map phases will finish nearly concurrently. See this blog article on `how dynamic sharding is similarly used in Google Cloud Dataflow <https://cloud.google.com/blog/products/gcp/no-shard-left-behind-dynamic-work-rebalancing-in-google-cloud-dataflow>`_.
 
 Requirements
 ------------


### PR DESCRIPTION
## Description
Fix formatting of paragraphs in https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/bigquery.rst. 

## Motivation and Context
The broken formatting adds vertical gray bars as unneeded emphasis, and a reader could be confused by wondering what these gray bars mean. 

## Impact
Documentation. 

## Test Plan
Local doc builds. 

Before:
<img width="638" height="591" alt="Screenshot 2026-07-30 at 10 54 44 AM" src="https://github.com/user-attachments/assets/41d8c99c-8e1f-43f4-9567-1bdfaa7473b4" />


After: 
<img width="627" height="604" alt="Screenshot 2026-07-30 at 10 57 02 AM" src="https://github.com/user-attachments/assets/38a88ce4-414d-4832-a8e0-627ff983a0b9" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Fix paragraph formatting in the BigQuery connector documentation to eliminate unwanted gray bar styling.