### PR TITLE
fix: Fix ANALYZE failing with "Multiple entries with same key" and "Unexpected N statistics for M columns" when the Hive metastore contains duplicated column statistics for a column

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -11,8 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.facebook.presto.hive.metastore.thrift;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.MapType;
@@ -56,6 +58,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Striped;
 import com.google.errorprone.annotations.ThreadSafe;
 import jakarta.inject.Inject;
 import org.apache.hadoop.fs.Path;
@@ -100,6 +103,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -110,7 +114,9 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -173,7 +179,11 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_
 public class ThriftHiveMetastore
         implements HiveMetastore
 {
+    private static final Logger log = Logger.get(ThriftHiveMetastore.class);
     private static final HdfsContext hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()));
+    private static final Pattern DUPLICATE_COLUMN_STATISTICS_PATTERN = Pattern.compile(
+            "(?i)unexpected\\s+\\d+\\s+statistics?\\s+for\\s+\\d+\\s+columns?",
+            Pattern.CASE_INSENSITIVE);
 
     private final ThriftHiveMetastoreStats stats;
     private final HiveCluster clientProvider;
@@ -182,6 +192,7 @@ public class ThriftHiveMetastore
     private final boolean impersonationEnabled;
     private final boolean isMetastoreAuthenticationEnabled;
     private final boolean deleteFilesOnTableDrop;
+    private final Striped<Lock> columnStatisticsRepairLocks = Striped.lock(32);
 
     private volatile boolean metastoreKnownToSupportTableParamEqualsPredicate;
     private volatile boolean metastoreKnownToSupportTableParamLikePredicate;
@@ -488,7 +499,10 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("getTableColumnStatistics", stats.getGetTableColumnStatistics().wrap(() ->
                             getMetastoreClientThenCall(metastoreContext, client ->
-                                    groupStatisticsByColumn(client.getTableColumnStatistics(databaseName, tableName, columns), rowCount))));
+                                    groupStatisticsByColumn(
+                                            new SchemaTableName(databaseName, tableName),
+                                            client.getTableColumnStatistics(databaseName, tableName, columns),
+                                            rowCount))));
         }
         catch (NoSuchObjectException e) {
             throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
@@ -570,7 +584,11 @@ public class ThriftHiveMetastore
                 .filter(entry -> !entry.getValue().isEmpty())
                 .collect(toImmutableMap(
                         Map.Entry::getKey,
-                        entry -> groupStatisticsByColumn(entry.getValue(), partitionRowCounts.getOrDefault(entry.getKey(), OptionalLong.empty()))));
+                        entry ->
+                                groupStatisticsByColumn(
+                                        new SchemaTableName(databaseName, tableName),
+                                        entry.getValue(),
+                                        partitionRowCounts.getOrDefault(entry.getKey(), OptionalLong.empty()))));
     }
 
     private Map<String, List<ColumnStatisticsObj>> getMetastorePartitionColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, Set<String> partitionNames, List<String> columnNames)
@@ -594,10 +612,22 @@ public class ThriftHiveMetastore
         }
     }
 
-    private Map<String, HiveColumnStatistics> groupStatisticsByColumn(List<ColumnStatisticsObj> statistics, OptionalLong rowCount)
+    private static Map<String, HiveColumnStatistics> groupStatisticsByColumn(SchemaTableName schemaTableName, List<ColumnStatisticsObj> statistics, OptionalLong rowCount)
     {
-        return statistics.stream()
-                .collect(toImmutableMap(ColumnStatisticsObj::getColName, statisticsObj -> ThriftMetastoreUtil.fromMetastoreApiColumnStatistics(statisticsObj, rowCount)));
+        Map<String, HiveColumnStatistics> statisticsByColumn = new HashMap<>();
+        for (ColumnStatisticsObj stats : statistics) {
+            HiveColumnStatistics newColumnStatistics = ThriftMetastoreUtil.fromMetastoreApiColumnStatistics(stats, rowCount);
+            if (statisticsByColumn.containsKey(stats.getColName())) {
+                HiveColumnStatistics existingColumnStatistics = statisticsByColumn.get(stats.getColName());
+                if (!newColumnStatistics.equals(existingColumnStatistics)) {
+                    log.warn("Ignore inconsistent statistics in %s column of table %s: %s and %s", stats.getColName(), schemaTableName, newColumnStatistics, existingColumnStatistics);
+                }
+            }
+            else {
+                statisticsByColumn.put(stats.getColName(), newColumnStatistics);
+            }
+        }
+        return ImmutableMap.copyOf(statisticsByColumn);
     }
 
     @Override
@@ -628,6 +658,62 @@ public class ThriftHiveMetastore
     private void setTableColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
     {
         try {
+            storeTableColumnStatistics(metastoreContext, databaseName, tableName, statistics);
+        }
+        catch (PrestoException e) {
+            if (!isDuplicateColumnStatisticsError(e)) {
+                throw e;
+            }
+            repairAndStoreTableColumnStatistics(metastoreContext, databaseName, tableName, statistics, e);
+        }
+    }
+
+    private void repairAndStoreTableColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, List<ColumnStatisticsObj> statistics, PrestoException cause)
+    {
+        Lock lock = columnStatisticsRepairLocks.get(new SchemaTableName(databaseName, tableName));
+        lock.lock();
+        try {
+            try {
+                storeTableColumnStatistics(metastoreContext, databaseName, tableName, statistics);
+                return;
+            }
+            catch (PrestoException e) {
+                if (!isDuplicateColumnStatisticsError(e)) {
+                    throw e;
+                }
+            }
+
+            List<String> columnNames = statistics.stream()
+                    .map(ColumnStatisticsObj::getColName)
+                    .collect(toImmutableList());
+            log.warn(cause, "Duplicated column statistics in %s.%s, purging statistics for %s columns and retrying", databaseName, tableName, columnNames.size());
+            deleteAllTableColumnStatistics(metastoreContext, databaseName, tableName);
+            storeTableColumnStatistics(metastoreContext, databaseName, tableName, statistics);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    private static boolean isDuplicateColumnStatisticsError(Throwable throwable)
+    {
+        for (Throwable cause = throwable; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
+            if (cause instanceof MetaException && cause.getMessage() != null) {
+                String message = cause.getMessage();
+                if (DUPLICATE_COLUMN_STATISTICS_PATTERN.matcher(message).find()) {
+                    return true;
+                }
+                if (message.toLowerCase().contains("column statistics") || message.toLowerCase().contains("statistics for")) {
+                    log.debug("Found MetaException containing column statistics text, but pattern did not match: %s", message);
+                }
+            }
+        }
+        return false;
+    }
+
+    private void storeTableColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    {
+        try {
             retry()
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
@@ -646,6 +732,11 @@ public class ThriftHiveMetastore
         catch (Exception e) {
             throw propagate(e);
         }
+    }
+
+    private void deleteAllTableColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        deleteTableColumnStatistics(metastoreContext, databaseName, tableName, null);
     }
 
     private void deleteTableColumnStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveAnalyzeCorruptStatistics.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveAnalyzeCorruptStatistics.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.hive.HiveSessionProperties.COLLECT_COLUMN_STATISTICS_ON_WRITE;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveAnalyzeCorruptStatistics
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "hive";
+    private static final String SCHEMA = "test_analyze_corrupt_statistics_schema";
+    private static final int COLUMN_COUNT = 1000;
+    private static final int THREADS = 10;
+    private static final int COLUMN_NAME_FIELD = 0;
+    private static final int NULLS_FRACTION_FIELD = 3;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+
+        queryRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .build();
+
+        queryRunner.createCatalog(CATALOG, CATALOG, properties);
+        queryRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+
+        return queryRunner;
+    }
+
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @Test(invocationCount = 3)
+    public void testAnalyzeCorruptColumnStatisticsOnEmptyTable()
+            throws Exception
+    {
+        String tableName = "test_analyze_corrupt_column_statistics_" + randomTableSuffix();
+
+        try {
+            // Concurrent ANALYZE statements on a table whose column statistics are still empty are what leaves duplicated rows behind in the metastore column statistics.
+            prepareTableWithoutColumnStatistics(tableName);
+            assertEquals(columnsWithStatistics(tableName), 0, "expected the table to start without column statistics");
+
+            analyzeConcurrently(tableName);
+            assertEquals(columnsWithStatistics(tableName), COLUMN_COUNT, "expected every column to end up with statistics");
+
+            // Reading and rewriting the statistics has to keep working afterwards.
+            assertQuerySucceeds("SHOW STATS FOR " + tableName);
+            assertQuerySucceeds("ANALYZE " + tableName);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    private void prepareTableWithoutColumnStatistics(String tableName)
+    {
+        List<String> columnNames = IntStream.rangeClosed(1, COLUMN_COUNT)
+                .mapToObj(column -> "col_" + column + " integer")
+                .collect(toImmutableList());
+        List<String> columnValues = IntStream.rangeClosed(1, COLUMN_COUNT)
+                .mapToObj(String::valueOf)
+                .collect(toImmutableList());
+
+        // Writing without column statistics is what CALL system.drop_stats(...) is used for on engines that have the procedure: it leaves the table with data but with no column statistics at all.
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(CATALOG, COLLECT_COLUMN_STATISTICS_ON_WRITE, "false")
+                .build();
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (" + join(",", columnNames) + ")");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (" + join(",", columnValues) + ")", 1);
+    }
+
+    private int columnsWithStatistics(String tableName)
+    {
+        MaterializedResult statistics = getQueryRunner().execute(getSession(), "SHOW STATS FOR " + tableName);
+        return (int) statistics.getMaterializedRows().stream()
+                .filter(row -> row.getField(COLUMN_NAME_FIELD) != null && row.getField(NULLS_FRACTION_FIELD) != null)
+                .count();
+    }
+
+    private void analyzeConcurrently(String tableName)
+            throws Exception
+    {
+        CyclicBarrier barrier = new CyclicBarrier(THREADS);
+        ExecutorService executor = newFixedThreadPool(THREADS);
+        try {
+            List<Future<Optional<String>>> futures = IntStream.range(0, THREADS)
+                    .mapToObj(threadNumber -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        try {
+                            getQueryRunner().execute(getSession(), "ANALYZE " + tableName);
+                            return Optional.<String>empty();
+                        }
+                        catch (Exception e) {
+                            return Optional.of(e.getMessage());
+                        }
+                    }))
+                    .collect(toImmutableList());
+
+            List<String> failures = futures.stream()
+                    .map(future -> getFutureValue(future))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(toImmutableList());
+
+            assertTrue(failures.isEmpty(), format("%s of %s concurrent ANALYZE invocations failed: %s", failures.size(), THREADS, failures));
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Two changes in `ThriftHiveMetastore`, both dealing with duplicated column statistics rows in the Hive metastore:

- `groupStatisticsByColumn` now handles duplicate column statistics without failing, logging a warning if the duplicates conflict.
- `setTableColumnStatistics` recovers from the metastore rejecting the write. If a duplicate-statistics error occurs, it deletes the table's existing column statistics and writes them again.

## Motivation and Context

In the Hive Metastore database, column statistics tables do not enforce unique constraints per column. When multiple statistics updates run at the same time, the Metastore can accidentally create duplicate entries for the same column.

This is a known upstream Apache Hive concurrency bug tracked in:
- **[HIVE-28578](https://github.com/apache/hive/pull/6159):** Concurrency issue in `updateTableColumnStatistics`
- **[HIVE-29316](https://github.com/apache/hive/pull/6188):** Concurrency issue in `updatePartitionColumnStatistics`

Once that happens, every `ANALYZE` on the table fails, because the metastore reads the old statistics before writing.

## Impact

Without these changes, a table whose metastore holds duplicated column statistics rows fails on every statistics update, leaving `ANALYZE` completely broken for that table.

It fails first on the read side, when the existing statistics are grouped by column name:

```
java.lang.IllegalArgumentException: Multiple entries with same key: col999=HiveColumnStatistics{...} and col999=HiveColumnStatistics{...}
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:378)
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:587)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.groupStatisticsByColumn(ThriftHiveMetastore.java:600)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.getTableColumnStatistics(ThriftHiveMetastore.java:489)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.getTableStatistics(ThriftHiveMetastore.java:479)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.updateTableStatistics(ThriftHiveMetastore.java:606)
```

and then on the write side, once the read no longer fails, because the metastore reads the old statistics before writing:

```
com.facebook.presto.spi.PrestoException: Unexpected 4000 statistics for 1000 columns
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.setTableColumnStatistics(ThriftHiveMetastore.java:660)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.updateTableStatistics(ThriftHiveMetastore.java:638)
Caused by: org.apache.hadoop.hive.metastore.api.MetaException: Unexpected 4000 statistics for 1000 columns
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.update_table_column_statistics(ThriftHiveMetastore.java:3826)
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastoreClient.setTableColumnStatistics(ThriftHiveMetastoreClient.java:244)
```

### How to reproduce duplicated statistics

1. Set `hive.metastore-timeout=30s` (or a lower timeout on high-latency/large metastores).
2. Run multiple concurrent `ANALYZE` queries against the same wide Hive table.
3. Under this scenario, statistics can be duplicated, leaving duplicate `TAB_COL_STATS` entries for identical columns in the underlying Metastore database and corrupting subsequent statistics operations on that table.

## Test Plan

- Added `TestHiveAnalyzeCorruptStatistics`, which runs concurrent `ANALYZE` statements against a 1000-column table with no column statistics and asserts they all succeed and that every column ends up with statistics.

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix ANALYZE failing with Multiple entries with same key and Unexpected N statistics for M columns when the Hive metastore contains duplicated column statistics for a column.
```

## Summary by Sourcery

Make Hive table statistics operations resilient to duplicate column-statistics entries created by concurrent metastore updates.

Bug Fixes:
- Prevent ANALYZE and related table statistics operations from failing when the Hive metastore contains duplicate column-statistics entries.
- Recover from duplicate-statistics write errors by purging the affected table statistics and retrying the update.

Enhancements:
- Handle duplicate column statistics during reads by retaining a single value and warning when conflicting entries are found.
- Serialize statistics repairs per table to avoid concurrent cleanup and rewrite conflicts.

Tests:
- Add coverage for concurrent ANALYZE operations on wide tables with initially empty column statistics, including subsequent statistics reads and updates.