### PR TITLE
fix(plugin-mongodb): Enforce replica-set discovery mode for MongoDB connections

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientModule.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientModule.java
@@ -96,10 +96,13 @@ public class MongoClientModule
                 connectionString.append("/")
                         .append(credential.getSource()));
 
-        // Enable replica set discovery when replica set name is configured or multiple seeds are provided
-        if (config.getRequiredReplicaSetName() != null || config.getSeeds().size() > 1) {
-            connectionString.append("?directConnection=false");
-        }
+        // Always use replica-set discovery mode. MongoDB driver 5.x defaults to direct
+        // (SINGLE topology) for a single-host URI, unlike 3.x which defaulted to
+        // replica-set discovery. Without directConnection=false a single-seed catalog
+        // sends writes directly to the named host which may be a secondary, causing
+        // NotWritablePrimary (error 10107) on CREATE TABLE. directConnection=false is
+        // safe for standalone nodes too — the driver simply discovers a STANDALONE topology.
+        connectionString.append("?directConnection=false");
         return connectionString.toString();
     }
     private static ReadPreference configureReadPreference(MongoClientConfig config)


### PR DESCRIPTION
## Description

Remove the conditional guard in buildConnectionString() that only appended ?directConnection=false when mongodb.required-replica-set was set or more than one seed was listed. The parameter is now appended unconditionally, so every MongoDB connection string produced by the connector explicitly uses replica-set topology discovery mode.

## Motivation and Context
Setting ?directConnection=false unconditionally instructs driver 5.x to perform replica-set discovery regardless of seed count and always route writes to the current primary, which is the correct and expected behaviour for any managed MongoDB deployment.

## Impact
Single-seed MongoDB catalogs with no mongodb.required-replica-set configured: CREATE TABLE now works correctly. No catalog property changes are required.

## Test Plan

Before : 

```
presto> create table mongodb.tm_lakehouse_engine_db_2.tt1 (id int);

Query 20260730_233450_00000_z56wv, FAILED, 0 nodes
http://localhost:8080/ui/query.html?20260730_233450_00000_z56wv
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:04, server-side: 0:03] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260730_233450_00000_z56wv failed: Command execution failed on MongoDB server with error 10107 (NotWritablePrimary): 'not primary' on server cc742329-497e-4c14-a69f-d22dcb9d53a6-1.c9v3nfod0e3fgcbd1oug.databases.appdomain.cloud:32467. The full response is {"topologyVersion": {"processId": {"$oid": "6a615ed68207ae5854f15a25"}, "counter": 3}, "ok": 0.0, "errmsg": "not primary", "code": 10107, "codeName": "NotWritablePrimary", "$clusterTime": {"clusterTime": {"$timestamp": {"t": 1785454488, "i": 1}}, "signature": {"hash": {"$binary": {"base64": "fN5UxrIVatLswT1M1Jh3MoBKL5o=", "subType": "00"}}, "keyId": 7632122813016440833}}, "operationTime": {"$timestamp": {"t": 1785454488, "i": 1}}}
com.mongodb.MongoNotPrimaryException: Command execution failed on MongoDB server with error 10107 (NotWritablePrimary): 'not primary' on server cc742329-497e-4c14-a69f-d22dcb9d53a6-1.c9v3nfod0e3fgcbd1oug.databases.appdomain.cloud:32467. The full response is {"topologyVersion": {"processId": {"$oid": "6a615ed68207ae5854f15a25"}, "counter": 3}, "ok": 0.0, "errmsg": "not primary", "code": 10107, "codeName": "NotWritablePrimary", "$clusterTime": {"clusterTime": {"$timestamp": {"t": 1785454488, "i": 1}}, "signature": {"hash": {"$binary": {"base64": "fN5UxrIVatLswT1M1Jh3MoBKL5o=", "subType": "00"}}, "keyId": 7632122813016440833}}, "operationTime": {"$timestamp": {"t": 1785454488, "i": 1}}}
        at com.mongodb.internal.connection.ProtocolHelper.createSpecialException(ProtocolHelper.java:266)
        at com.mongodb.internal.connection.ProtocolHelper.getCommandFailureException(ProtocolHelper.java:206)
        at com.mongodb.internal.connection.InternalStreamConnection.receiveCommandMessageResponse(InternalStreamConnection.java:520)
        at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceiveInternal(InternalStreamConnection.java:448)
        at com.mongodb.internal.connection.InternalStreamConnection.lambda$sendAndReceive$0(InternalStreamConnection.java:375)
        at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceive(InternalStreamConnection.java:378)
        at com.mongodb.internal.connection.UsageTrackingInternalConnection.sendAndReceive(UsageTrackingInternalConnection.java:111)
        at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.sendAndReceive(DefaultConnectionPool.java:757)
        at com.mongodb.internal.connection.CommandProtocolImpl.execute(CommandProtocolImpl.java:60)
        at com.mongodb.internal.connection.DefaultServer$DefaultServerProtocolExecutor.execute(DefaultServer.java:207)
        at com.mongodb.internal.connection.DefaultServerConnection.executeProtocol(DefaultServerConnection.java:112)
        at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:82)
        at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:74)
        at com.mongodb.internal.connection.DefaultServer$OperationCountTrackingConnection.command(DefaultServer.java:297)
        at com.mongodb.internal.operation.SyncOperationHelper.lambda$executeCommand$5(SyncOperationHelper.java:209)
        at com.mongodb.internal.operation.SyncOperationHelper.lambda$withSourceAndConnection$0(SyncOperationHelper.java:131)
        at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:156)
        at com.mongodb.internal.operation.SyncOperationHelper.lambda$withSourceAndConnection$1(SyncOperationHelper.java:130)
        at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:156)
        at com.mongodb.internal.operation.SyncOperationHelper.withSourceAndConnection(SyncOperationHelper.java:129)
        at com.mongodb.internal.operation.SyncOperationHelper.executeCommand(SyncOperationHelper.java:207)
        at com.mongodb.internal.operation.CreateIndexesOperation.execute(CreateIndexesOperation.java:111)
        at com.mongodb.internal.operation.CreateIndexesOperation.execute(CreateIndexesOperation.java:60)
        at com.mongodb.client.internal.MongoClusterImpl$OperationExecutorImpl.execute(MongoClusterImpl.java:448)
        at com.mongodb.client.internal.MongoCollectionImpl.executeCreateIndexes(MongoCollectionImpl.java:942)
        at com.mongodb.client.internal.MongoCollectionImpl.createIndexes(MongoCollectionImpl.java:924)
        at com.mongodb.client.internal.MongoCollectionImpl.createIndexes(MongoCollectionImpl.java:919)
        at com.mongodb.client.internal.MongoCollectionImpl.createIndex(MongoCollectionImpl.java:904)
        at com.facebook.presto.mongodb.MongoSession.createTableMetadata(MongoSession.java:462)
        at com.facebook.presto.mongodb.MongoSession.createTable(MongoSession.java:174)
        at com.facebook.presto.mongodb.MongoMetadata.createTable(MongoMetadata.java:206)
        at com.facebook.presto.metadata.MetadataManager.createTable(MetadataManager.java:749)
        at com.facebook.presto.execution.CreateTableTask.internalExecute(CreateTableTask.java:232)
        at com.facebook.presto.execution.CreateTableTask.execute(CreateTableTask.java:99)
        at com.facebook.presto.execution.CreateTableTask.execute(CreateTableTask.java:78)
        at com.facebook.presto.execution.DDLDefinitionExecution.executeTask(DDLDefinitionExecution.java:66)
        at com.facebook.presto.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:217)
        at com.facebook.presto.$gen.Presto_null__testversion____20260730_233325_1.run(Unknown Source)
        at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:331)
        at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:217)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)

presto>
```

After : 

```
presto> create table mongodb.tm_lakehouse_engine_db_2.tt1 (id int);
CREATE TABLE

Query 20260730_234535_00000_ts7kd, FINISHED, 0 nodes
http://localhost:8080/ui/query.html?20260730_234535_00000_ts7kd
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:04, server-side: 0:04] [0 rows, 0B] [0 rows/s, 0B/s]

presto> select * from mongodb.tm_lakehouse_engine_db_2.tt1;

Query 20260730_234600_00001_ts7kd, RUNNING, 1 node, 17 splits
http://localhost:8080/ui/query.html?20260730_234600_00001_ts7kd
Splits:   0 queued, 17 running, 0 done
CPU Time: 0.0s total,     0 rows/s,     0B/s, 10% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
Peak Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B
S0-createTime: sum=1.79T count=1 min=1.79T max=1.79T
S0-driverCountPerTask: sum=16 count=1 min=16 max=16
S0-eventLoopMethodExecutionCpuNanos: sum=124ms count=8 min=0ms max=116ms
S0-schedulerCpuTimeNanos: sum=8ms count=1 min=8ms max=8ms
S0-schedulerWallTimeNanos: sum=14ms count=1 min=14ms max=14ms
S0-taskBlockedTimeNanos: sum=0:03 count=1 min=0:03 max=0:03
S0-taskElapsedTimeNanos: sum=0ms count=1 min=0ms max=0ms
S0-taskPlanSerializedCpuNanos: sum=72ms count=1 min=72ms max=72ms
S0-taskQueuedTimeNanos: sum=194ms count=1 min=194ms max=194ms
S0-taskScheduledTimeNanos: sum=105ms count=1 min=105ms max=105ms
S0-taskStartWaitForEventLoop: sum=0ms count=1 min=0ms max=0ms
S0-taskUpdateDeliveredUpdates: sum=2 count=2 min=1 max=1
S0-taskUpdateDeliveredWallTimeNanos: sum=0:01 count=2 min=0:01 max=0:01
S0-taskUpdateRoundTripTime: sum=0:01 count=2 min=91ms max=0:01
S0-taskUpdateSerializedCpuNanos: sum=45ms count=2 min=4ms max=41ms
S1-createTime: sum=1.79T count=1 min=1.79T max=1.79T
S1-driverCountPerTask: sum=1 count=1 min=1 max=1
S1-eventLoopMethodExecutionCpuNanos: sum=120ms count=7 min=0ms max=108ms
S1-getSplitsTimeNanos: sum=0ms count=1 min=0ms max=0ms
S1-scanStageSchedulerCpuTimeNanos: sum=37ms count=2 min=1ms max=36ms
S1-scanStageSchedulerWallTimeNanos: sum=42ms count=2 min=1ms max=41ms
S1-schedulerCpuTimeNanos: sum=37ms count=2 min=1ms max=36ms
S1-schedulerWallTimeNanos: sum=42ms count=2 min=1ms max=41ms
S1-taskElapsedTimeNanos: sum=0ms count=1 min=0ms max=0ms
S1-taskPlanSerializedCpuNanos: sum=68ms count=1 min=68ms max=68ms
S1-taskQueuedTimeNanos: sum=190ms count=1 min=190ms max=190ms
S1-taskScheduledTimeNanos: sum=0ms count=1 min=0ms max=0ms
S1-taskStartWaitForEventLoop: sum=0ms count=1 min=0ms max=0ms
S1-taskUpdateDeliveredUpdates: sum=2 count=2 min=1 max=1
S1-taskUpdateDeliveredWallTimeNanos: sum=0:01 count=2 min=0:01 max=0:01
S1-taskUpdateRoundTripTime: sum=0:01 count=2 min=89ms max=0:01
S1-taskUpdateSerializedCpuNanos: sum=44ms count=2 min=5ms max=39ms
analyzeTimeNanos: sum=0:01 count=1 min=0:01 max=0:01
analyzeTimeNanosOnCpu: sum=71ms count=1 min=71ms max=71ms
checkAccessPermissionsTimeNanos: sum=1ms count=1 min=1ms max=1ms
checkAccessPermissionsTimeNanosOnCpu: sum=1ms count=1 min=1ms max=1ms
createSchedulerTimeNanos: sum=21ms count=1 min=21ms max=21ms
createSchedulerTimeNanosOnCpu: sum=16ms count=1 min=16ms max=16ms
fragmentPlanTimeNanos: sum=69ms count=1 min=69ms max=69ms
fragmentPlanTimeNanosOnCpu: sum=60ms count=1 min=60ms max=60ms
getCanonicalInfoTimeNanos: sum=1ms count=1 min=1ms max=1ms
getCanonicalInfoTimeNanosOnCpu: sum=1ms count=1 min=1ms max=1ms
getColumnHandleTimeNanos: sum=2ms count=1 min=2ms max=2ms
getColumnMetadataTimeNanos: sum=3ms count=1 min=3ms max=3ms
getIdentifierNormalizationTimeNanos: sum=0ms count=5 min=0ms max=0ms
getLayoutTimeNanos: sum=0ms count=2 min=0ms max=0ms
getMaterializedViewTimeNanos: sum=0ms count=1 min=0ms max=0ms
getTableHandleTimeNanos: sum=0:01 count=1 min=0:01 max=0:01
getViewTimeNanos: sum=0ms count=1 min=0ms max=0ms
logicalPlannerTimeNanos: sum=30ms count=1 min=30ms max=30ms
logicalPlannerTimeNanosOnCpu: sum=24ms count=1 min=24ms max=24ms
optimizerTimeNanos: sum=228ms count=1 min=228ms max=228ms
optimizerTimeNanosOnCpu: sum=198ms count=1 min=198ms max=198ms
 id
----
(0 rows)

Query 20260730_234600_00001_ts7kd, FINISHED, 1 node
http://localhost:8080/ui/query.html?20260730_234600_00001_ts7kd
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [0 rows, 5B] [0 rows/s, 1B/s]

presto>
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Ensure writes from single-seed MongoDB catalogs are routed to the primary instead of a potential secondary, fixing NotWritablePrimary errors on CREATE TABLE.