### PR TITLE
fix(docs): Change brackets for array type hints

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -447,7 +447,7 @@ General Aggregate Functions
         SELECT set_agg(x) FROM (VALUES(ROW(ROW(1, null))), ROW((ROW(2, 'a'))), ROW((ROW(1, null))), (null)) t(x) -- ARRAY[ROW(1, null), ROW(2, 'a'), null]
 
 
-.. function:: set_union(array(T)) -> array(T)
+.. function:: set_union(array[T]) -> array[T]
 
     Returns an array of all the distinct values contained in each array of the input.
 
@@ -581,7 +581,7 @@ Map Aggregate Functions
             ) AS t(maps);
             --{'a'->6,'b'->5,'c'->4,'d'->6}
 
-.. function:: multimap_agg(key, value) -> map(K,array(V))
+.. function:: multimap_agg(key, value) -> map(K,array[V])
 
     Returns a multimap created from the input ``key`` / ``value`` pairs.
     Each key can be associated with multiple values.
@@ -1626,7 +1626,7 @@ Reservoir sample functions use a fixed sample size, as opposed to
 fixed total size while still guaranteeing that each record in dataset has an
 equal probability of being chosen. See [Vitter1985]_.
 
-.. function:: reservoir_sample(initial_sample: array(T), initial_processed_count: bigint, values_to_sample: T, desired_sample_size: int) -> row(processed_count: bigint, sample: array(T))
+.. function:: reservoir_sample(initial_sample: array[T], initial_processed_count: bigint, values_to_sample: T, desired_sample_size: int) -> row(processed_count: bigint, sample: array[T])
 
     Computes a new reservoir sample given:
     

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -23,21 +23,21 @@ Array Functions
 
 For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:array functions`.
 
-.. function:: all_match(array(T), function(T,boolean)) -> boolean
+.. function:: all_match(array[T], function(T,boolean)) -> boolean
 
     Returns whether all elements of an array match the given predicate. Returns ``true`` if all the elements
     match the predicate (a special case is when the array is empty); ``false`` if one or more elements don't
     match; ``NULL`` if the predicate function returns ``NULL`` for one or more elements and ``true`` for all
     other elements.
 
-.. function:: any_match(array(T), function(T,boolean)) -> boolean
+.. function:: any_match(array[T], function(T,boolean)) -> boolean
 
     Returns whether any elements of an array match the given predicate. Returns ``true`` if one or more
     elements match the predicate; ``false`` if none of the elements matches (a special case is when the
     array is empty); ``NULL`` if the predicate function returns ``NULL`` for one or more elements and ``false``
     for all other elements.
 
-.. function:: array_cum_sum(array(T)) -> array(T)
+.. function:: array_cum_sum(array[T]) -> array[T]
 
     Returns the array whose elements are the cumulative sum of the input array: result[i] = input[1]+input[2]+...+input[i].
     If there are null elements in the array, the cumulative sum at and after the element is null. ::
@@ -49,8 +49,8 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
     Remove duplicate values from the array ``x``.
     This function uses ``IS DISTINCT FROM`` to determine the distinct elements. ::
 
-        SELECT array_distinct(ARRAY [1, 2, null, null, 2]) -- ARRAY[1, 2, null]
-        SELECT array_distinct(ARRAY [ROW(1, null), ROW (1, null)] -- ARRAY[ROW(1, null)
+        SELECT array_distinct(ARRAY[1, 2, null, null, 2]) -- ARRAY[1, 2, null]
+        SELECT array_distinct(ARRAY[ROW(1, null), ROW (1, null)]) -- ARRAY[ROW(1, null)
 
 .. function:: array_except(x, y) -> array
 
@@ -104,7 +104,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
     Sorts and returns the array ``x``. The elements of ``x`` must be orderable.
     Null elements are placed at the end of the returned array.
 
-.. function:: array_sort(array(T), function(T,T,int)) -> array(T)
+.. function:: array_sort(array[T], function(T,T,int)) -> array[T]
 
     Sorts and returns the ``array`` based on the given comparator ``function``. The comparator will take
     two nullable arguments representing two nullable elements of the ``array``. It returns -1, 0, or 1
@@ -134,7 +134,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
                                        -1,
                                        IF(cardinality(x) = cardinality(y), 0, 1))); -- [[1, 2], [2, 3, 1], [4, 2, 1, 4]]
 
-.. function:: array_sort(array(T), function(T,U)) -> array(T)
+.. function:: array_sort(array[T], function(T,U)) -> array[T]
 
     Sorts and returns the ``array`` using a lambda function to extract sorting keys. The function is applied
     to each element of the array to produce a key, and the array is sorted based on these keys in ascending order.
@@ -146,7 +146,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT array_sort(ARRAY[CAST(0.0 AS DOUBLE), CAST('NaN' AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE)], x -> x); -- [-Infinity, 0.0, Infinity, NaN]
         SELECT array_sort(ARRAY[ROW('a', 3), ROW('b', 1), ROW('c', 2)], x -> x[2]); -- [ROW('b', 1), ROW('c', 2), ROW('a', 3)]
 
-.. function:: array_sort_desc(array(T), function(T,U)) -> array(T)
+.. function:: array_sort_desc(array[T], function(T,U)) -> array[T]
 
     Sorts and returns the ``array`` in descending order using a lambda function to extract sorting keys.
     The function is applied to each element of the array to produce a key, and the array is sorted based
@@ -158,7 +158,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT array_sort_desc(ARRAY[CAST(0.0 AS DOUBLE), CAST('NaN' AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE)], x -> x); -- [NaN, Infinity, 0.0, -Infinity]
         SELECT array_sort_desc(ARRAY[ROW('a', 3), ROW('b', 1), ROW('c', 2)], x -> x[2]); -- [ROW('a', 3), ROW('c', 2), ROW('b', 1)]
 
-.. function:: array_sum(array(T)) -> bigint/double
+.. function:: array_sum(array[T]) -> bigint/double
 
     Returns the sum of all non-null elements of the ``array``. If there is no non-null elements, returns ``0``.
     The behavior is similar to aggregation function :func:`!sum`.
@@ -194,7 +194,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
     Concatenates the arrays ``array1``, ``array2``, ``...``, ``arrayN``.
     This function provides the same functionality as the SQL-standard concatenation operator (``||``).
 
-.. function:: combinations(array(T), n) -> array(array(T))
+.. function:: combinations(array[T], n) -> array[array[T]]
 
     Returns n-element combinations of the input array.
     If the input array has no duplicates, ``combinations`` returns n-element subsets.
@@ -210,13 +210,13 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 
     Returns true if the array ``x`` contains the ``element``.
 
-.. function:: element_at(array(E), index) -> E
+.. function:: element_at(array[E], index) -> E
 
     Returns element of ``array`` at given ``index``.
     If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``), except that it returns ``NULL`` when ``index`` is out of bounds.
     If ``index`` < 0, ``element_at`` accesses elements from the last to the first.
 
-.. function:: filter(array(T), function(T,boolean)) -> array(T)
+.. function:: filter(array[T], function(T,boolean)) -> array[T]
 
     Constructs an array from those elements of ``array`` for which ``function`` returns true::
 
@@ -226,14 +226,14 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 
 .. function:: flatten(x) -> array
 
-    Flattens an ``array(array(T))`` to an ``array(T)`` by concatenating the contained arrays.
+    Flattens an ``array[array[T]]`` to an ``array[T]`` by concatenating the contained arrays.
 
-.. function:: find_first(array(E), function(T,boolean)) -> E
+.. function:: find_first(array[E], function(T,boolean)) -> E
 
     Returns the first element of ``array`` which returns true for ``function(T,boolean)``, throws exception if the returned element is NULL.
     Returns ``NULL`` if no such element exists.
 
-.. function:: find_first(array(E), index, function(T,boolean)) -> E
+.. function:: find_first(array[E], index, function(T,boolean)) -> E
 
     Returns the first element of ``array`` which returns true for ``function(T,boolean)``, throws exception if the returned element is NULL.
     Returns ``NULL`` if no such element exists.
@@ -245,12 +245,12 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT find_first(ARRAY[3, 4, 5, 6], 2, x -> x < 4); -- NULL
         SELECT find_first(ARRAY[3, 4, 5, 6], -2, x -> x > 5); -- NULL
 
-.. function:: find_first_index(array(E), function(T,boolean)) -> BIGINT
+.. function:: find_first_index(array[E], function(T,boolean)) -> BIGINT
 
     Returns the index of the first element of ``array`` which returns true for ``function(T,boolean)``.
     Returns ``NULL`` if no such element exists.
 
-.. function:: find_first_index(array(E), index, function(T,boolean)) -> BIGINT
+.. function:: find_first_index(array[E], index, function(T,boolean)) -> BIGINT
 
     Returns the index of the first element of ``array`` which returns true for ``function(T,boolean)``.
     Returns ``NULL`` if no such element exists.
@@ -262,7 +262,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT find_first(ARRAY[3, 4, 5, 6], 2, x -> x < 4); -- NULL
         SELECT find_first(ARRAY[3, 4, 5, 6], -2, x -> x > 5); -- NULL
 
-.. function:: ngrams(array(T), n) -> array(array(T))
+.. function:: ngrams(array[T], n) -> array[array[T]]
 
     Returns ``n``-grams for the ``array``::
 
@@ -272,13 +272,13 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 5); -- [['foo', 'bar', 'baz', 'foo']]
         SELECT ngrams(ARRAY[1, 2, 3, 4], 2); -- [[1, 2], [2, 3], [3, 4]]
 
-.. function:: none_match(array(T), function(T,boolean)) -> boolean
+.. function:: none_match(array[T], function(T,boolean)) -> boolean
 
     Returns whether no elements of an array match the given predicate. Returns ``true`` if none of the elements
     matches the predicate (a special case is when the array is empty); ``false`` if one or more elements match;
     ``NULL`` if the predicate function returns ``NULL`` for one or more elements and ``false`` for all other elements.
 
-.. function:: reduce(array(T), initialState S, inputFunction(S,T,S), outputFunction(S,R)) -> R
+.. function:: reduce(array[T], initialState S, inputFunction(S,T,S), outputFunction(S,R)) -> R
 
     Returns a single value reduced from ``array``. ``inputFunction`` will
     be invoked for each element in ``array`` in order. In addition to taking
@@ -307,26 +307,26 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 
     Returns an array which has the reversed order of array ``x``.
 
-.. function:: sequence(start, stop) -> array(bigint)
+.. function:: sequence(start, stop) -> array[bigint]
 
     Generate a sequence of integers from ``start`` to ``stop``, incrementing
     by ``1`` if ``start`` is less than or equal to ``stop``, otherwise ``-1``.
 
-.. function:: sequence(start, stop, step) -> array(bigint)
+.. function:: sequence(start, stop, step) -> array[bigint]
 
     Generate a sequence of integers from ``start`` to ``stop``, incrementing by ``step``.
 
-.. function:: sequence(start, stop) -> array(date)
+.. function:: sequence(start, stop) -> array[date]
 
     Generate a sequence of dates from ``start`` date to ``stop`` date, incrementing
     by ``1`` day if ``start`` date is less than or equal to ``stop`` date, otherwise ``-1`` day.
 
-.. function:: sequence(start, stop, step) -> array(date)
+.. function:: sequence(start, stop, step) -> array[date]
 
     Generate a sequence of dates from ``start`` to ``stop``, incrementing by ``step``.
     The type of ``step`` can be either ``INTERVAL DAY TO SECOND`` or ``INTERVAL YEAR TO MONTH``.
 
-.. function:: sequence(start, stop, step) -> array(timestamp)
+.. function:: sequence(start, stop, step) -> array[timestamp]
 
     Generate a sequence of timestamps from ``start`` to ``stop``, incrementing by ``step``.
     The type of ``step`` can be either ``INTERVAL DAY TO SECOND`` or ``INTERVAL YEAR TO MONTH``.
@@ -350,7 +350,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT trim_array(ARRAY[1, 2, 3, 4], 2);
         -- [1, 2]
 
-.. function:: transform(array(T), function(T,U)) -> array(U)
+.. function:: transform(array[T], function(T,U)) -> array[U]
 
     Returns an array that is the result of applying ``function`` to each element of ``array``::
 
@@ -360,7 +360,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
         SELECT transform(ARRAY ['x', 'abc', 'z'], x -> x || '0'); -- ['x0', 'abc0', 'z0']
         SELECT transform(ARRAY [ARRAY [1, NULL, 2], ARRAY[3, NULL]], a -> filter(a, x -> x IS NOT NULL)); -- [[1, 2], [3]]
 
-.. function:: zip(array1, array2[, ...]) -> array(row)
+.. function:: zip(array1, array2[, ...]) -> array[row]
 
     Merges the given arrays, element-wise, into a single array of rows. The M-th element of
     the N-th argument will be the N-th field of the M-th output element.
@@ -368,7 +368,7 @@ For plugin-loaded array functions, see :ref:`functions/plugin-loaded-functions:a
 
         SELECT zip(ARRAY[1, 2], ARRAY['1b', null, '3b']); -- [ROW(1, '1b'), ROW(2, null), ROW(null, '3b')]
 
-.. function:: zip_with(array(T), array(U), function(T,U,R)) -> array(R)
+.. function:: zip_with(array[T], array[U], function(T,U,R)) -> array[R]
 
     Merges the two given arrays, element-wise, into a single array using ``function``.
     If one array is shorter, nulls are appended at the end to match the length of the longer array, before applying ``function``::

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -82,7 +82,7 @@ Constructors
 
     Returns a geometry type linestring object from WKT representation.
 
-.. function:: ST_LineString(array(Point)) -> LineString
+.. function:: ST_LineString(array[Point]) -> LineString
 
     Returns a LineString formed from an array of points. If there are fewer
     than two non-empty points in the input array, an empty LineString will be
@@ -91,7 +91,7 @@ Constructors
     simple: for instance, it may self-intersect or may contain duplicate vertices depending
     on the input.
 
-.. function:: ST_MultiPoint(array(Point)) -> MultiPoint
+.. function:: ST_MultiPoint(array[Point]) -> MultiPoint
 
     Returns a MultiPoint geometry object formed from the specified points.
     Return ``null`` if input array is empty.  Throws an exception if any element
@@ -176,7 +176,7 @@ Relationship Tests
 Operations
 ----------
 
-.. function:: geometry_union(array(Geometry)) -> Geometry
+.. function:: geometry_union(array[Geometry]) -> Geometry
 
     Returns a geometry that represents the point set union of the input
     geometries. Performance of this function, in conjunction with
@@ -204,7 +204,7 @@ Operations
 
     Returns the bounding rectangular polygon of a geometry.
 
-.. function:: ST_EnvelopeAsPts(Geometry) -> array(Geometry)
+.. function:: ST_EnvelopeAsPts(Geometry) -> array[Geometry]
 
     Returns an array of two points: the lower left and upper right corners of
     the bounding rectangular polygon of a geometry. Returns ``null`` if input
@@ -294,7 +294,7 @@ Accessors
 
     Returns the great-circle distance in meters between two SphericalGeography points.
 
-.. function:: geometry_nearest_points(Geometry, Geometry) -> array(Point)
+.. function:: geometry_nearest_points(Geometry, Geometry) -> array[Point]
 
     Returns the points on each geometry nearest the other.  If either geometry
     is empty, return ``NULL``.  Otherwise, return an array of two Points that have
@@ -365,7 +365,7 @@ Accessors
     returns ``NULL``.
     Use :func:``ST_NumPoints`` to find out the total number of elements.
 
-.. function:: ST_Points(Geometry) -> array(Point)
+.. function:: ST_Points(Geometry) -> array[Point]
 
     Returns an array of points in a linestring.
 
@@ -403,7 +403,7 @@ Accessors
 
     Return the Y coordinate of the point.
 
-.. function:: ST_InteriorRings(Geometry) -> array(Geometry)
+.. function:: ST_InteriorRings(Geometry) -> array[Geometry]
 
    Returns an array of all interior rings found in the input geometry, or an empty
    array if the polygon has no interior rings. Returns ``null`` if the input geometry
@@ -419,7 +419,7 @@ Accessors
     ``ST_NumGeometries(ST_GeometryFromText('GEOMETRYCOLLECTION(MULTIPOINT EMPTY)'))``
     will evaluate to 1.
 
-.. function:: ST_Geometries(Geometry) -> array(Geometry)
+.. function:: ST_Geometries(Geometry) -> array[Geometry]
 
    Returns an array of geometries in the specified collection. Returns a one-element array
    if the input geometry is not a multi-geometry. Returns ``null`` if input geometry is empty.
@@ -429,7 +429,7 @@ Accessors
    ``GEOMETRYCOLLECTION(MULTIPOINT(0 0, 1 1), GEOMETRYCOLLECTION(MULTILINESTRING((2 2, 3 3))))``
    would produce ``array[MULTIPOINT(0 0, 1 1), GEOMETRYCOLLECTION(MULTILINESTRING((2 2, 3 3)))]``.
 
-.. function:: flatten_geometry_collections(Geometry) -> array(Geometry)
+.. function:: flatten_geometry_collections(Geometry) -> array[Geometry]
 
     Recursively flattens any GeometryCollections in Geometry, returning an array
     of constituent non-GeometryCollection geometries.  The order of the array is
@@ -535,12 +535,12 @@ represent a valid tile will raise an exception.
     Throws an exception if newZoom is less than 0, or newZoom is greater than
     the tile's zoom.
 
-.. function:: bing_tile_children(tile) -> array(BingTile)
+.. function:: bing_tile_children(tile) -> array[BingTile]
 
     Returns the children of the Bing tile at one higher zoom level.
     Throws an exception if tile is at max zoom level.
 
-.. function:: bing_tile_children(tile, newZoom) -> array(BingTile)
+.. function:: bing_tile_children(tile, newZoom) -> array[BingTile]
 
     Returns the children of the Bing tile at the specified higher zoom level.
     Throws an exception if newZoom is greater than the max zoom level, or
@@ -552,12 +552,12 @@ represent a valid tile will raise an exception.
     and longitude. Latitude must be within ``[-85.05112878, 85.05112878]`` range.
     Longitude must be within ``[-180, 180]`` range. Zoom levels from 1 to 23 are supported.
 
-.. function:: bing_tiles_around(latitude, longitude, zoom_level) -> array(BingTile)
+.. function:: bing_tiles_around(latitude, longitude, zoom_level) -> array[BingTile]
 
     Returns a collection of Bing tiles that surround the point specified
     by the latitude and longitude arguments at a given zoom level.
 
-.. function:: bing_tiles_around(latitude, longitude, zoom_level, radius_in_km) -> array(BingTile)
+.. function:: bing_tiles_around(latitude, longitude, zoom_level, radius_in_km) -> array[BingTile]
 
     Returns a minimum set of Bing tiles at specified zoom level that cover a circle of specified
     radius in km around a specified (latitude, longitude) point.
@@ -578,12 +578,12 @@ represent a valid tile will raise an exception.
 
     Returns the zoom level of a given Bing tile.
 
-.. function:: geometry_to_bing_tiles(geometry, zoom_level) -> array(BingTile)
+.. function:: geometry_to_bing_tiles(geometry, zoom_level) -> array[BingTile]
 
     Returns the minimum set of Bing tiles that fully covers a given geometry at
     a given zoom level. Zoom levels from 1 to 23 are supported.
 
-.. function:: geometry_to_dissolved_bing_tiles(geometry, max_zoom_level) -> array(BingTile)
+.. function:: geometry_to_dissolved_bing_tiles(geometry, max_zoom_level) -> array[BingTile]
 
     Returns the minimum set of Bing tiles that fully covers a given geometry at
     a given zoom level, recursively dissolving full sets of children into parents.

--- a/presto-docs/src/main/sphinx/functions/hyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/hyperloglog.rst
@@ -89,7 +89,7 @@ Functions
     Returns the ``HyperLogLog`` of the aggregate union of the individual ``hll``
     HyperLogLog structures.
 
-.. function:: merge_hll(array(HyperLogLog)) -> HyperLogLog
+.. function:: merge_hll(array[HyperLogLog]) -> HyperLogLog
 
     Returns the ``HyperLogLog`` of the union of an array ``hll`` HyperLogLog
     structures.

--- a/presto-docs/src/main/sphinx/functions/ip.rst
+++ b/presto-docs/src/main/sphinx/functions/ip.rst
@@ -26,7 +26,7 @@ IP Functions
         SELECT ip_subnet_max(IPPREFIX '192.64.0.0/9'); -- {192.127.255.255}
         SELECT ip_subnet_max(IPPREFIX '2001:0db8:85a3:0001:0001:8a2e:0370:7334/48'); -- {2001:db8:85a3:ffff:ffff:ffff:ffff:ffff}
 
-.. function:: ip_subnet_range(ip_prefix) -> array(ip_address)
+.. function:: ip_subnet_range(ip_prefix) -> array[ip_address]
 
     Return an array of 2 IP addresses.
     The array contains the smallest and the largest IP address
@@ -50,7 +50,7 @@ IP Functions
         SELECT is_subnet_of(IPPREFIX '64:ff9b::17/64', IPPREFIX '64:ffff::17/64'); -- false
         SELECT is_subnet_of(IPPREFIX '192.168.3.131/26', IPPREFIX '192.168.3.131/26'); -- true
 
-.. function:: ip_prefix_collapse(array(ip_prefix)) -> array(ip_prefix)
+.. function:: ip_prefix_collapse(array[ip_prefix]) -> array[ip_prefix]
 
     Returns the minimal CIDR representation of the input ``IPPREFIX`` array.
     Every ``IPPREFIX`` in the input array must be the same IP version (that is, only IPv4 or only IPv6)
@@ -70,7 +70,7 @@ IP Functions
         SELECT is_private_ip(IPADDRESS '157.240.200.99'); -- false
         SELECT is_private_ip(IPADDRESS '2a03:2880:f031:12:face:b00c:0:2'); -- false
 
-.. function:: ip_prefix_subnets(ip_prefix, prefix_length) -> array(ip_prefix)
+.. function:: ip_prefix_subnets(ip_prefix, prefix_length) -> array[ip_prefix]
 
     Returns the subnets of ``ip_prefix`` of size ``prefix_length``. ``prefix_length`` must be valid ([0, 32] for IPv4
     and [0, 128] for IPv6) or the query will fail and raise an error. An empty array is returned if ``prefix_length``

--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -71,6 +71,6 @@ Functions
     Returns the ``KHyperLogLog`` of the aggregate union of the individual ``KHyperLogLog``
     structures.
 
-.. function:: merge_khll(array(khll)) -> KHyperLogLog
+.. function:: merge_khll(array[khll]) -> KHyperLogLog
 
     Returns the ``KHyperLogLog`` of the union of an array of KHyperLogLog structures.

--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -30,7 +30,7 @@ For plugin-loaded map functions, see :ref:`functions/plugin-loaded-functions:map
 
         SELECT map(); -- {}
 
-.. function:: map(array(K), array(V)) -> map(K,V)
+.. function:: map(array[K], array[V]) -> map(K,V)
 
     Returns a map created using the given key/value arrays. ::
 
@@ -38,19 +38,19 @@ For plugin-loaded map functions, see :ref:`functions/plugin-loaded-functions:map
 
     See also :func:`map_agg` and :func:`multimap_agg` for creating a map as an aggregation.
 
-.. function:: map_from_entries(array(row(K,V))) -> map(K,V)
+.. function:: map_from_entries(array[row(K,V)]) -> map(K,V)
 
     Returns a map created from the given array of entries. ::
 
         SELECT map_from_entries(ARRAY[(1, 'x'), (2, 'y')]); -- {1 -> 'x', 2 -> 'y'}
 
-.. function:: multimap_from_entries(array(row(K,V))) -> map(K,array(V))
+.. function:: multimap_from_entries(array[row(K,V)]) -> map(K,array[V])
 
     Returns a multimap created from the given array of entries. Each key can be associated with multiple values. ::
 
         SELECT multimap_from_entries(ARRAY[(1, 'x'), (2, 'y'), (1, 'z')]); -- {1 -> ['x', 'z'], 2 -> ['y']}
 
-.. function:: map_entries(map(K,V)) -> array(row(K,V))
+.. function:: map_entries(map(K,V)) -> array[row(K,V)]
 
     Returns an array of all entries in the given map. ::
 
@@ -69,7 +69,7 @@ For plugin-loaded map functions, see :ref:`functions/plugin-loaded-functions:map
         SELECT map_filter(MAP(ARRAY[10, 20, 30], ARRAY['a', NULL, 'c']), (k, v) -> v IS NOT NULL); -- {10 -> a, 30 -> c}
         SELECT map_filter(MAP(ARRAY['k1', 'k2', 'k3'], ARRAY[20, 3, 15]), (k, v) -> v > 10); -- {k1 -> 20, k3 -> 15}
 
-.. function:: map_subset(map(K,V), array(k)) -> map(K,V)
+.. function:: map_subset(map(K,V), array[k]) -> map(K,V)
 
     Constructs a map from those entries of ``map`` for which the key is in the array given::
 
@@ -79,11 +79,11 @@ For plugin-loaded map functions, see :ref:`functions/plugin-loaded-functions:map
         SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[]); -- {}
         SELECT map_subset(MAP(ARRAY[], ARRAY[]), ARRAY[1,2]); -- {}
 
-.. function:: map_keys(x(K,V)) -> array(K)
+.. function:: map_keys(x(K,V)) -> array[K]
 
     Returns all the keys in the map ``x``.
 
-.. function:: map_values(x(K,V)) -> array(V)
+.. function:: map_values(x(K,V)) -> array[V]
 
     Returns all the values in the map ``x``.
 

--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -47,30 +47,30 @@ Mathematical Functions
 
         SELECT cosine_similarity(ARRAY[1.2], ARRAY[2.0]); -- 1.0
 
-.. function:: l2_squared(array(real), array(real)) -> real
+.. function:: l2_squared(array[real], array[real]) -> real
 
-    Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(real).
+    Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array[real].
     If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT l2_squared(ARRAY[1.0], ARRAY[2.0]); -- 1.0
 
-.. function:: l2_squared(array(double), array(double)) -> double
+.. function:: l2_squared(array[double], array[double]) -> double
 
-    Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(double).
+    Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array[double].
     If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT l2_squared(ARRAY[1.0], ARRAY[2.0]); -- 1.0
 
-.. function:: dot_product(array(real), array(real)) -> real
+.. function:: dot_product(array[real], array[real]) -> real
 
-    Returns the dot product of two vectors represented as array(real).
+    Returns the dot product of two vectors represented as array[real].
     If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]); -- 11.0
 
-.. function:: dot_product(array(double), array(double)) -> double
+.. function:: dot_product(array[double], array[double]) -> double
 
-    Returns the dot product of two vectors represented as array(double).
+    Returns the dot product of two vectors represented as array[double].
     If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]); -- 11.0

--- a/presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst
+++ b/presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst
@@ -9,19 +9,19 @@ For more details on loading these functions, refer to the
 Array Functions
 ---------------
 
-.. function:: array_intersect(array(array(E))) -> array(E)
+.. function:: array_intersect(array[array[E]]) -> array[E]
 
     Returns an array of the elements in the intersection of all arrays in the given array, without duplicates.
     This function uses ``IS NOT DISTINCT FROM`` to determine which elements are the same. ::
 
         SELECT array_intersect(ARRAY[ARRAY[1, 2, 3, 2, null], ARRAY[1, 2, 2, 4, null], ARRAY [1, 2, 3, 4, null]])  -- ARRAY[1, 2, null]
 
-.. function:: array_average(array(double)) -> double
+.. function:: array_average(array[double]) -> double
 
     Returns the average of all non-null elements of the ``array``. If there are no non-null elements, returns
     ``null``.
 
-.. function:: array_split_into_chunks(array(T), int) -> array(array(T))
+.. function:: array_split_into_chunks(array[T], int) -> array[array[T]]
 
     Returns an ``array`` of arrays splitting the input ``array`` into chunks of given length.
     The last chunk will be shorter than the chunk length if the array's length is not an integer multiple of
@@ -31,12 +31,12 @@ Array Functions
         SELECT array_split_into_chunks(null, null); -- null
         SELECT array_split_into_chunks(array[1, 2, 3, cast(null as int)], 2); -- [[1, 2], [3, null]]
 
-.. function:: array_frequency(array(E)) -> map(E, int)
+.. function:: array_frequency(array[E]) -> map(E, int)
 
     Returns a map: keys are the unique elements in the ``array``, values are how many times the key appears.
     Ignores null elements. Empty array returns empty map.
 
-.. function:: array_duplicates(array(T)) -> array(bigint/varchar)
+.. function:: array_duplicates(array[T]) -> array[bigint/varchar]
 
     Returns a set of elements that occur more than once in ``array``.
     Throws an exception if any of the elements are rows or arrays that contain nulls. ::
@@ -44,7 +44,7 @@ Array Functions
         SELECT array_duplicates(ARRAY[1, 2, null, 1, null, 3]) -- ARRAY[1, null]
         SELECT array_duplicates(ARRAY[ROW(1, null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
 
-.. function:: array_has_duplicates(array(T)) -> boolean
+.. function:: array_has_duplicates(array[T]) -> boolean
 
     Returns a boolean: whether ``array`` has any elements that occur more than once.
     Throws an exception if any of the elements are rows or arrays that contain nulls. ::
@@ -52,7 +52,7 @@ Array Functions
         SELECT array_has_duplicates(ARRAY[1, 2, null, 1, null, 3]) -- true
         SELECT array_has_duplicates(ARRAY[ROW(1, null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
 
-.. function:: array_least_frequent(array(T)) -> array(T)
+.. function:: array_least_frequent(array[T]) -> array[T]
 
     Returns the least frequent non-null element of an array. If there are multiple elements with the same frequency, the function returns the smallest element.
     If the array has more than one element and any elements are ``ROWS`` with null fields or ``ARRAYS`` with null elements, an exception is returned. ::
@@ -61,7 +61,7 @@ Array Functions
         select array_least_frequent(ARRAY[1, null, 1]) -- ARRAY[1]
         select array_least_frequent(ARRAY[ROW(1,null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
 
-.. function:: array_least_frequent(array(T), n) -> array(T)
+.. function:: array_least_frequent(array[T], n) -> array[T]
 
     Returns ``n`` least frequent non-null elements of an array. The elements are ordered in increasing order of their frequencies.
     If two elements have the same frequency, smaller elements will appear first.
@@ -71,14 +71,14 @@ Array Functions
         select array_least_frequent(ARRAY[1, null, 1], 2) -- ARRAY[1]
         select array_least_frequent(ARRAY[ROW(1,null), ROW(1, null)], 2) -- "map key cannot be null or contain nulls"
 
-.. function:: array_max_by(array(T), function(T, U)) -> T
+.. function:: array_max_by(array[T], function(T, U)) -> T
 
     Applies the provided function to each element, and returns the element that gives the maximum value.
     ``U`` can be any orderable type. ::
 
         SELECT array_max_by(ARRAY ['a', 'bbb', 'cc'], x -> LENGTH(x)) -- 'bbb'
 
-.. function:: array_min_by(array(T), function(T, U)) -> T
+.. function:: array_min_by(array[T], function(T, U)) -> T
 
     Applies the provided function to each element, and returns the element that gives the minimum value.
     ``U`` can be any orderable type. ::
@@ -94,11 +94,11 @@ Array Functions
         SELECT array_sort_desc(ARRAY [null, 100, null, 1, 10, 50]); -- [100, 50, 10, 1, null, null]
         SELECT array_sort_desc(ARRAY [ARRAY ["a", null], null, ARRAY ["a"]]); -- [["a", null], ["a"], null]
 
-.. function:: remove_nulls(array(T)) -> array
+.. function:: remove_nulls(array[T]) -> array
 
     Remove all null elements in the array.
 
-.. function:: array_top_n(array(T), int) -> array(T)
+.. function:: array_top_n(array[T], int) -> array[T]
 
     Returns an array of the top ``n`` elements from a given ``array``, sorted according to its natural descending order.
     If ``n`` is larger than the size of the given ``array``, the returned list will be the same size as the input instead of ``n``. ::
@@ -107,7 +107,7 @@ Array Functions
         SELECT array_top_n(ARRAY [1, 100], 5); -- [100, 1]
         SELECT array_top_n(ARRAY ['a', 'zzz', 'zz', 'b', 'g', 'f'], 3); -- ['zzz', 'zz', 'g']
 
-.. function:: array_top_n(array(T), int, function(T,T,int)) -> array(T)
+.. function:: array_top_n(array[T], int, function(T,T,int)) -> array[T]
 
     Returns an array of the top ``n`` elements from a given ``array`` using the specified comparator ``function``.
     The comparator will take two nullable arguments representing two nullable elements of the ``array``. It returns -1, 0, or 1
@@ -118,7 +118,7 @@ Array Functions
         SELECT array_top_n(ARRAY [100, 1, 3, -10, 6, -5], 3, (x, y) -> IF(abs(x) < abs(y), -1, IF(abs(x) = abs(y), 0, 1))); -- [100, -10, 6]
         SELECT array_top_n(ARRAY [CAST(ROW(1, 2) AS ROW(x INT, y INT)), CAST(ROW(0, 11) AS ROW(x INT, y INT)), CAST(ROW(5, 10) AS ROW(x INT, y INT))], 2, (a, b) -> IF(a.x*a.y < b.x*b.y, -1, IF(a.x*a.y = b.x*b.y, 0, 1))); -- [ROW(5, 10), ROW(1, 2)]
 
-.. function:: array_transpose(array(array(T))) -> array(array(T))
+.. function:: array_transpose(array[array[T]]) -> array[array[T]]
 
     Returns a transpose of a 2D array (matrix), where rows become columns and columns become rows.
     Converts ``a[x][y]`` to ``transpose(a)[y][x]``. All rows in the input array must have the same length, otherwise the function will fail with an error.
@@ -137,7 +137,7 @@ Map Functions
     Returns the map with the same keys but all non-null values are scaled proportionally so that the sum of values becomes 1.
     Map entries with null values remain unchanged.
 
-.. function:: map_keys_by_top_n_values(x(K,V), n) -> array(K)
+.. function:: map_keys_by_top_n_values(x(K,V), n) -> array[K]
 
     Returns top ``n`` keys in the map ``x`` by sorting its values in descending order. If two or more keys have equal values, the higher key takes precedence.
     ``n`` must be a non-negative integer.::
@@ -157,7 +157,7 @@ Map Functions
 
         SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[2, 3, 1]), 2) --- {'b' -> 3, 'a' -> 2}
 
-.. function:: map_top_n_keys(x(K,V), n) -> array(K)
+.. function:: map_top_n_keys(x(K,V), n) -> array[K]
 
     Returns top ``n`` keys in the map ``x`` by sorting its keys in descending order.
     ``n`` must be a non-negative integer.
@@ -166,7 +166,7 @@ Map Functions
 
         SELECT map_top_n_keys(map(ARRAY['a', 'b', 'c'], ARRAY[3, 2, 1]), 2) --- ['c', 'b']
 
-.. function:: map_top_n_keys(x(K,V), n, function(K,K,int)) -> array(K)
+.. function:: map_top_n_keys(x(K,V), n, function(K,K,int)) -> array[K]
 
     Returns top ``n`` keys in the map ``x`` by sorting its keys using the given comparator ``function``. The comparator takes
     two non-nullable arguments representing two keys of the ``map``. It returns -1, 0, or 1
@@ -175,14 +175,14 @@ Map Functions
 
         SELECT map_top_n_keys(map(ARRAY['a', 'b', 'c'], ARRAY[3, 2, 1]), 2, (x, y) -> IF(x < y, -1, IF(x = y, 0, 1))) --- ['c', 'b']
 
-.. function:: map_top_n_values(x(K,V), n) -> array(V)
+.. function:: map_top_n_values(x(K,V), n) -> array[V]
 
     Returns top ``n`` values in the map ``x`` by sorting its values in descending order.
     ``n`` must be a non-negative integer. ::
 
         SELECT map_top_n_values(map(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]), 2) --- [3, 2]
 
-.. function:: map_top_n_values(x(K,V), n, function(V,V,int)) -> array(V)
+.. function:: map_top_n_values(x(K,V), n, function(V,V,int)) -> array[V]
 
     Returns top n values in the map ``x`` based on the given comparator ``function``. The comparator will take
     two nullable arguments representing two values of the ``map``. It returns -1, 0, or 1
@@ -225,7 +225,7 @@ Map Functions
 
         SELECT no_values_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x = 'd'); -- true
 
-.. function:: map_int_keys_to_array(map(int,V)) -> array(V)
+.. function:: map_int_keys_to_array(map(int,V)) -> array[V]
 
     Returns an ``array`` of values from the ``map`` with value at indexed by the original keys from ``map``. ::
 
@@ -233,9 +233,9 @@ Map Functions
         SELECT MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[3, 5, 6, 9], ARRAY['a', null, 'c', 'd'])) -> ARRAY[null, null, 'a', null, null, 'c', 'd']
 
 
-.. function:: array_to_map_int_keys(array(v)) -> map(int, v)
+.. function:: array_to_map_int_keys(array[v]) -> map(int, v)
 
-    Returns an ``map`` with indices of all non-null values from the ``array`` as keys and element at the specified index as the value. ::
+    Returns a ``map`` with indices of all non-null values from the ``array`` as keys and element at the specified index as the value. ::
 
         SELECT ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, 6, 9] AS ARRAY<INT>)) -> MAP(ARRAY[1, 2, 3,4], ARRAY[3, 5, 6, 9])
         SELECT ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, null, 6, 9] AS ARRAY<INT>)) -> MAP(ARRAY[1, 2, 4, 5], ARRAY[3, 5, 6, 9])

--- a/presto-docs/src/main/sphinx/functions/regexp.rst
+++ b/presto-docs/src/main/sphinx/functions/regexp.rst
@@ -41,14 +41,14 @@ with a few notable exceptions:
 
     .. _Capturing groups: http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg
 
-.. function:: regexp_extract_all(string, pattern) -> array(varchar)
+.. function:: regexp_extract_all(string, pattern) -> array[varchar]
 
     Returns the substring(s) matched by the regular expression ``pattern``
     in ``string``::
 
         SELECT regexp_extract_all('1a 2b 14m', '\d+'); -- [1, 2, 14]
 
-.. function:: regexp_extract_all(string, pattern, group) -> array(varchar)
+.. function:: regexp_extract_all(string, pattern, group) -> array[varchar]
 
     Finds all occurrences of the regular expression ``pattern`` in ``string``
     and returns the `capturing group number`_ ``group``::
@@ -109,7 +109,7 @@ with a few notable exceptions:
 
         SELECT regexp_replace('new york', '(\w)(\w*)', x -> upper(x[1]) || lower(x[2])); --'New York'
 
-.. function:: regexp_split(string, pattern) -> array(varchar)
+.. function:: regexp_split(string, pattern) -> array[varchar]
 
     Splits ``string`` using the regular expression ``pattern`` and returns an
     array. Trailing empty strings are preserved::

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -135,11 +135,11 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
         SELECT rtrim('test', 't'); -- tes
         SELECT rtrim('test...', '.'); -- test
 
-.. function:: split(string, delimiter) -> array(varchar)
+.. function:: split(string, delimiter) -> array[varchar]
 
     Splits ``string`` on ``delimiter`` and returns an array.
 
-.. function:: split(string, delimiter, limit) -> array(varchar)
+.. function:: split(string, delimiter, limit) -> array[varchar]
 
     Splits ``string`` on ``delimiter`` and returns an array of size at most
     ``limit``. The last element in the array always contain everything
@@ -169,7 +169,7 @@ For plugin-loaded string functions, see :ref:`functions/plugin-loaded-functions:
         SELECT(split_to_map('a:1;b:2;a:3', ';', ':', (k, v1, v2) -> v1)); -- {"a": "1", "b": "2"}
         SELECT(split_to_map('a:1;b:2;a:3', ';', ':', (k, v1, v2) -> CONCAT(v1, v2))); -- {"a": "13", "b": "2"}
 
-.. function:: split_to_multimap(string, entryDelimiter, keyValueDelimiter) -> map(varchar, array(varchar))
+.. function:: split_to_multimap(string, entryDelimiter, keyValueDelimiter) -> map(varchar, array[varchar])
 
     Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map
     containing an array of values for each unique key. ``entryDelimiter`` splits ``string``

--- a/presto-docs/src/main/sphinx/release/release-0.289.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.289.rst
@@ -24,8 +24,8 @@ _______________
 * Fix stddev and variance functions to always return correct results when input is constant. :pr:`23447`
 * Add an optimization to remove cross join when one side of inputs is a single row of constant values. The optimization is controlled by the session property ``remove_cross_join_with_constant_single_row_input`` (default is ``true```). :pr:`23081`
 * Add configuration property ``warn-on-possible-nans`` and session property ``warn_on_possible_nans`` to produce a warning on division operations or comparison operations involving double or real types. Division operations are common causes of accidental creation of NaNs, and the semantics of comparison operations involving NaNs changed considerably in the most recent Presto release. :pr:`23059`
-* Add function :func:`ip_prefix_collapse`. :pr:`23445`
-* Add function :func:`array_split_into_chunks`. :pr:`23264`
+* Add function :func:`!ip_prefix_collapse`. :pr:`23445`
+* Add function :func:`!array_split_into_chunks`. :pr:`23264`
 * Add a warning when an ``IGNORE NULL``` clause is used on any non lag, lead, first, last, or nth value function.  In future releases these queries will fail. :pr:`23325`
 * Add treatment of low confidence, zero estimations as ``UNKNOWN`` during joins, with the ``treat-low-confidence-zero-estimation-as-unknown`` session property :pr:`23047`
 * Add confidence based broadcasting, side of join with highest confidence will be on build side.  This can be enabled with the ``confidence_based_broadcast`` session property :pr:`23016`

--- a/presto-docs/src/main/sphinx/release/release-0.290.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.290.rst
@@ -19,7 +19,7 @@ Release 0.290
 
 General Changes
 _______________
-* Fix :func:`array_intersect` for single parameter array<array<T>> to be deterministic regardless of the order of null input. :pr:`23890`
+* Fix :func:`!array_intersect` for single parameter array<array<T>> to be deterministic regardless of the order of null input. :pr:`23890`
 * Fix bug in local property calculation when spill is enabled. :pr:`23922`
 * Fix bug to unescape like pattern and validate escape string with no unresolved value. :pr:`23456`
 * Fix to query and filter using Iceberg metadata columns ``$path`` and ``$data_sequence_number``. :pr:`23472`
@@ -36,7 +36,7 @@ _______________
 * Add a session property ``native_max_partial_aggregation_memory`` which specifies Presto native max partial aggregation memory when data reduction is not optimal. :pr:`23527`
 * Add a session property ``native_max_spill_bytes`` which specifies Presto native max allowed spill bytes. :pr:`23527`
 * Add function :func:`!is_private_ip` that returns true when the input IP address is private or a reserved IP address. :pr:`23520`
-* Add function :func:`ip_prefix_subnets` that splits the input prefix into subnets the size of the new prefix length. :pr:`23656`
+* Add function :func:`!ip_prefix_subnets` that splits the input prefix into subnets the size of the new prefix length. :pr:`23656`
 * Add new configuration property ``eager-plan-validation-enabled`` for eager building of validation of a logical plan before queuing. :pr:`23649`
 * Add session property ``inline_projections_on_values`` and configuration property ``optimizer.inline-projections-on-values`` to evaluate project node on values node. :pr:`23245`
 * Add support in QueuedStatement protocol to accept pre-minted query id and slug. :pr:`23407`

--- a/presto-docs/src/main/sphinx/release/release-0.294.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.294.rst
@@ -32,14 +32,14 @@ _______________
 * Improve semi join performance for large filtering tables. `#25236 <https://github.com/prestodb/presto/pull/25236>`_
 * Improve efficiency of queries with distinct aggregation and semi joins. `#25238 <https://github.com/prestodb/presto/pull/25238>`_
 * Improve performance of min_by/max_by aggregations. `#25190 <https://github.com/prestodb/presto/pull/25190>`_
-* Add :func:`dot_product(array(real), array(real)) -> real()` to calculate the sum of element wise product between two identically sized vectors represented as arrays. This function supports both array(real) and array(double) input types. For more information, refer to the `Dot Product definition <https://en.wikipedia.org/wiki/Dot_product>`_. `#25508 <https://github.com/prestodb/presto/pull/25508>`_
+* Add :func:`!dot_product` to calculate the sum of element wise product between two identically sized vectors represented as arrays. This function supports both array(real) and array(double) input types. For more information, refer to the `Dot Product definition <https://en.wikipedia.org/wiki/Dot_product>`_. `#25508 <https://github.com/prestodb/presto/pull/25508>`_
 * Add ``broadcast_semi_join_for_delete`` session property to disable the ReplicateSemiJoinInDelete optimizer. `#25256 <https://github.com/prestodb/presto/pull/25256>`_
 * Add ``history_based_optimizer_estimate_size_using_variables`` session property to have HBO estimate plan node output size using individual variables. `#25400 <https://github.com/prestodb/presto/pull/25400>`_
 * Add changes to populate data source metadata to support combined lineage tracking. `#25127 <https://github.com/prestodb/presto/pull/25127>`_
 * Add mixed case support for schema and table names. `#24551 <https://github.com/prestodb/presto/pull/24551>`_
 * Add session property ``native_query_memory_reclaimer_priority`` which controls which queries are killed first when a worker is running low on memory. Higher value means lower priority to be consistent with Velox memory reclaimer's convention. See :doc:`/presto_cpp/properties-session`. `#25325 <https://github.com/prestodb/presto/pull/25325>`_
 * Add xxhash64 override with seed argument. `#25521 <https://github.com/prestodb/presto/pull/25521>`_
-* Add the :func:`l2_squared(array(real), array(real)) -> real()` function to Java workers. `#25409 <https://github.com/prestodb/presto/pull/25409>`_
+* Add the :func:`!l2_squared` function to Java workers. `#25409 <https://github.com/prestodb/presto/pull/25409>`_
 * Update QueryPlanner to only include the optional ``$row_id`` column in :ref:`sql/delete:DELETE` query output variables when it is actually used by the connector. `#25284 <https://github.com/prestodb/presto/pull/25284>`_
 * Update the default value of ``check_access_control_on_utilized_columns_only`` session property to ``true``. The ``false`` value makes the access check apply to all columns. See :ref:`admin/properties-session:\`\`check_access_control_on_utilized_columns_only\`\``. `#25469 <https://github.com/prestodb/presto/pull/25469>`_
 

--- a/presto-docs/src/main/sphinx/release/release-0.296.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.296.rst
@@ -23,7 +23,7 @@ _______________
 * Improve sort-merge join performance when one side of the join input is already sorted. `#26361 <https://github.com/prestodb/presto/pull/26361>`_
 * Improve query performance for semi joins (used in ``IN`` and ``EXISTS`` subqueries) when join keys contain many null values. `#26251 <https://github.com/prestodb/presto/pull/26251>`_
 * Improve connector optimizer to support queries involving multiple connectors. `#26246 <https://github.com/prestodb/presto/pull/26246>`_
-* Add :func:`array_transpose` to return a transpose of an array. `#26470 <https://github.com/prestodb/presto/pull/26470>`_
+* Add :func:`!array_transpose` to return a transpose of an array. `#26470 <https://github.com/prestodb/presto/pull/26470>`_
 * Add :ref:`admin/properties:\`\`cluster-tag\`\`` configuration property to assign a custom identifier to the cluster, which is displayed in the Web UI. `#26485 <https://github.com/prestodb/presto/pull/26485>`_
 * Add a session property ``query_types_enabled_for_history_based_optimization`` to specify query types which will use HBO. See :doc:`/optimizer/history-based-optimization`. `#26183 <https://github.com/prestodb/presto/pull/26183>`_
 * Add data compression support for HTTP/2 protocol. `#26381 <https://github.com/prestodb/presto/pull/26381>`_ `#26382 <https://github.com/prestodb/presto/pull/26382>`_
@@ -35,7 +35,7 @@ _______________
 * Add support for the :doc:`/sql/merge` command in the Presto engine. `#26278 <https://github.com/prestodb/presto/pull/26278>`_
 * Add ``enable-java-cluster-query-retry`` configuration property in ``router-scheduler.properties`` to retry queries on ``router-java-url`` when they fail on ``router-native-url``. `#25720 <https://github.com/prestodb/presto/pull/25720>`_
 * Add :func:`array_to_map_int_keys` function. `#26681 <https://github.com/prestodb/presto/pull/26681>`_
-* Add :func:`map_int_keys_to_array` function. `#26681 <https://github.com/prestodb/presto/pull/26681>`_
+* Add :func:`!map_int_keys_to_array` function. `#26681 <https://github.com/prestodb/presto/pull/26681>`_
 * Add :func:`!t_cdf` and :func:`!inverse_t_cdf` functions for Student's t-distribution calculations. `#26363 <https://github.com/prestodb/presto/pull/26363>`_
 * Add support for distributed execution of procedures. `#26373 <https://github.com/prestodb/presto/pull/26373>`_
 * Add support for :doc:`Materialized Views </admin/materialized-views>`. `#26492 <https://github.com/prestodb/presto/pull/26492>`_


### PR DESCRIPTION
## Description
The PR changes array type notation in function documentation from the parenthetical syntax `array(T)` to the bracket syntax `array[T]`, and fixes the following warnings:
```
./presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst:64: WARNING: duplicate function description of array_least_frequent, other function in functions/plugin-loaded-functions                                                                                                                                                                                                       
./presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst:110: WARNING: duplicate function description of array_top_n, other function in functions/plugin-loaded-functions                                                                                                                                                                                                               
./presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst:169: WARNING: duplicate function description of map_top_n_keys, other function in functions/plugin-loaded-functions                                                                                                                                                                                                            
./presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst:185: WARNING: duplicate function description of map_top_n_values, other function in functions/plugin-loaded-functions        
                                                                                                                                                                                                  
./presto-docs/src/main/sphinx/functions/regexp.rst:51: WARNING: duplicate function description of regexp_extract_all, other function in functions/regexp

./presto-docs/src/main/sphinx/functions/string.rst:142: WARNING: duplicate function description of split, other function in functions/string

./presto-docs/src/main/sphinx/functions/array.rst:137: WARNING: duplicate function description of array_sort, other function in functions/array
./presto-docs/src/main/sphinx/functions/array.rst:315: WARNING: duplicate function description of sequence, other function in functions/array
./presto-docs/src/main/sphinx/functions/array.rst:319: WARNING: duplicate function description of sequence, other function in functions/array
./presto-docs/src/main/sphinx/functions/array.rst:324: WARNING: duplicate function description of sequence, other function in functions/array
./presto-docs/src/main/sphinx/functions/array.rst:329: WARNING: duplicate function description of sequence, other function in functions/array

./presto-docs/src/main/sphinx/functions/geospatial.rst:543: WARNING: duplicate function description of bing_tile_children, other function in functions/geospatial
./presto-docs/src/main/sphinx/functions/geospatial.rst:560: WARNING: duplicate function description of bing_tiles_around, other function in functions/geospatial
```

Also the PR adds [exclamation mark !](https://www.sphinx-doc.org/en/master/usage/domains/python.html#target-specification) to related release pages to avoid reference creation similar to other release pages and [PR#28254](https://github.com/prestodb/presto/pull/28254).

## Motivation and Context
Reduce the number of warnings during the documentation build process.
The end goal to have zero warnings and enable zero warnings policy for documentation to prevent introducing new issues.

## Impact
None

## Test Plan
Build the documentation and check there are no mentioned warnings and the number of warnings reduced.
```shell
presto-docs/build
```
Before changes: `build succeeded, 26 warnings.`
After changes: `build succeeded, 12 warnings.`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Standardize documentation type notation for arrays and reduce Sphinx build warnings in function and release docs.

Documentation:
- Update array type hints in function documentation from parenthetical to bracket syntax for consistency.
- Adjust function reference entries and release notes markup to eliminate duplicate description and reference warnings in Sphinx builds.