### PR TITLE
fix(ci): Skip product-tests specific steps on docs-only PRs

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -76,7 +76,7 @@ jobs:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro,mixed_case
       - name: Product Tests Specific 1.2
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
@@ -84,17 +84,17 @@ jobs:
       # - name: Product Tests Specific 1.3
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.4
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.6
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
@@ -143,22 +143,22 @@ jobs:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-ldap -g ldap -x simba_jdbc
       - name: Product Tests Specific 2.2
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls -g smoke,cli,group-by,join,tls
       - name: Product Tests Specific 2.3
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
       - name: Product Tests Specific 2.4
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
@@ -166,12 +166,12 @@ jobs:
       # - name: Product Tests Specific 2.6
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kafka -g kafka
       - name: Product Tests Specific 2.8
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: needs.changes.outputs.codechange == 'true' && always()
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-sqlserver -g sqlserver


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
`if: ... && ${{ always() }}` caused GitHub Actions to always evaluate the step, ignoring the `codechange` guard and running the full matrix on docs-only PRs. Drop the `${{ }}` wrapper so `always()` is part of the `if:` expression itself.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Sample run where this is currently failing and not skipped: https://github.com/prestodb/presto/actions/runs/30702003715/job/91374545053?pr=28255

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
N.A

## Test Plan
<!---Please fill in how you tested your change-->
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Correct conditional guards in the product-tests-specific-environment GitHub Actions workflow so product test matrix jobs only run when code changes are present.