### PR TITLE
fix: Improve task cleanup in TaskManagerTest to prevent flaky tests

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1114,6 +1114,7 @@ TEST_P(TaskManagerTest, tableScanMultipleTasks) {
   TaskIdGenerator taskIdGenerator("scan");
 
   std::vector<std::string> tasks;
+  std::vector<protocol::TaskId> taskIds;
   long splitSequenceId{0};
   for (int i = 0; i < filePaths.size(); i++) {
     const auto taskId = taskIdGenerator.makeTaskId(0, i);
@@ -1121,6 +1122,7 @@ TEST_P(TaskManagerTest, tableScanMultipleTasks) {
     protocol::TaskUpdateRequest updateRequest;
     updateRequest.sources.push_back(source);
     auto taskInfo = createOrUpdateTask(taskId, updateRequest, planFragment);
+    taskIds.emplace_back(taskId);
     tasks.emplace_back(taskInfo->taskStatus.self);
   }
 
@@ -1128,6 +1130,12 @@ TEST_P(TaskManagerTest, tableScanMultipleTasks) {
       tasks, planFragment.planNode->outputType(), splitSequenceId);
   assertResults(
       outputTaskInfo->taskId, rowType_, "SELECT * FROM tmp WHERE c0 % 5 = 1");
+
+  taskManager_->deleteTask(outputTaskInfo->taskId, true, true);
+  for (const auto& taskId : taskIds) {
+    taskManager_->deleteTask(taskId, true, true);
+  }
+  waitForAllOldTasksToBeCleaned(taskManager_.get(), 3'000'000);
 }
 
 TEST_P(TaskManagerTest, countAggregation) {


### PR DESCRIPTION
## Description
Fixes a flaky crash in `TaskManagerTest.tableScanMultipleTasks`. The test asserts on the output task's results but never explicitly tears down the 5 upstream scan tasks, leaving their cleanup to an async, fire-and-forget signal from the exchange client. `OperatorTestBase::TearDown()` hard-fails if any Velox `Task` is still alive after 3s — under CI load that async cleanup can occasionally miss the window, so the process aborts (`SIGABRT`) instead of failing one test.

Fix: explicitly `deleteTask()` the output task and all scan tasks after `assertResults()`, then wait via the existing `waitForAllOldTasksToBeCleaned()` helper (same pattern used elsewhere in this file) so cleanup is deterministic before teardown runs.

## Motivation and Context
CI intermittently reported `presto_server_test` as "Subprocess aborted" rather than a normal test failure, which aborts the whole 313-test binary instead of failing a single case:

```
2026-08-03T13:01:20.4634010Z 20: [ RUN      ] TaskManagerTest/TaskManagerTest.tableScanMultipleTasks/0
2026-08-03T13:01:23.5102301Z 20: E20260803 13:01:23.509348  7658 Exceptions.h:87] Line: /__w/presto/presto/presto-native-execution/velox/velox/exec/tests/utils/QueryAssertions.cpp:1515, Function:waitForAllTasksToBeDeleted, Expression:  1 pending tasks
2026-08-03T13:01:23.5106184Z 20: {Task tk:41569 (scan.0.0.1.0) Running
2026-08-03T13:01:23.5106823Z 20: Plan:
2026-08-03T13:01:23.5107299Z 20: -- PartitionedOutput[2][SINGLE Presto in-memory] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5108085Z 20:   -- Filter[1][expression: eq(mod(cast(ROW["c0"] as BIGINT),5),1)] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5108784Z 20:     -- TableScan[0][table: hive_table] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5109231Z 20: 
2026-08-03T13:01:23.5109515Z 20: }, Source: RUNTIME, ErrorCode: INVALID_STATE
2026-08-03T13:01:23.5719286Z 20: unknown file: Failure
2026-08-03T13:01:23.5720162Z 20: C++ exception with description "Exception: VeloxRuntimeError
2026-08-03T13:01:23.5721001Z 20: Error Source: RUNTIME
2026-08-03T13:01:23.5721506Z 20: Error Code: INVALID_STATE
2026-08-03T13:01:23.5722280Z 20: Reason: 1 pending tasks
2026-08-03T13:01:23.5723418Z 20: {Task tk:41569 (scan.0.0.1.0) Running
2026-08-03T13:01:23.5723854Z 20: Plan:
2026-08-03T13:01:23.5724650Z 20: -- PartitionedOutput[2][SINGLE Presto in-memory] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5725758Z 20:   -- Filter[1][expression: eq(mod(cast(ROW["c0"] as BIGINT),5),1)] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5726967Z 20:     -- TableScan[0][table: hive_table] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:23.5727660Z 20: 
2026-08-03T13:01:23.5727992Z 20: }
2026-08-03T13:01:23.5728349Z 20: Retriable: False
2026-08-03T13:01:23.5728830Z 20: Function: waitForAllTasksToBeDeleted
2026-08-03T13:01:23.5729797Z 20: File: /__w/presto/presto/presto-native-execution/velox/velox/exec/tests/utils/QueryAssertions.cpp
2026-08-03T13:01:23.5730695Z 20: Line: 1515
2026-08-03T13:01:23.5731065Z 20: Stack trace:
2026-08-03T13:01:23.5731587Z 20: # 0  _ZN8facebook5velox7process10StackTraceC1Ei
2026-08-03T13:01:23.5732903Z 20: # 1  _ZN8facebook5velox14VeloxExceptionC1EPKcmS3_St17basic_string_viewIcSt11char_traitsIcEES7_S7_S7_bNS0_24CompileTimeStringLiteralENS1_4TypeES7_
2026-08-03T13:01:23.5734538Z 20: # 2  _ZN8facebook5velox6detail14veloxCheckFailINS0_17VeloxRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKNS1_18VeloxCheckFailArgsET0_NS0_24CompileTimeStringLiteralE
2026-08-03T13:01:23.5736228Z 20: # 3  _ZN8facebook5velox4exec4test26waitForAllTasksToBeDeletedEm
2026-08-03T13:01:23.5736818Z 20: # 4  _ZN8facebook5velox4exec4test16OperatorTestBase8TearDownEv
2026-08-03T13:01:23.5737263Z 20: # 5  0x000000000004fe0c
2026-08-03T13:01:23.5737551Z 20: # 6  _ZN7testing8TestInfo3RunEv
2026-08-03T13:01:23.5737865Z 20: # 7  _ZN7testing9TestSuite3RunEv
2026-08-03T13:01:23.5738174Z 20: # 8  _ZN7testing8internal12UnitTestImpl11RunAllTestsEv
2026-08-03T13:01:23.5738495Z 20: # 9  _ZN7testing8UnitTest3RunEv
2026-08-03T13:01:23.5738736Z 20: # 10 main
2026-08-03T13:01:23.5738927Z 20: # 11 __libc_start_call_main
2026-08-03T13:01:23.5739146Z 20: # 12 __libc_start_main
2026-08-03T13:01:23.5739340Z 20: # 13 _start
2026-08-03T13:01:23.5739524Z 20: " thrown in TearDown().
2026-08-03T13:01:26.5836957Z 20: E20260803 13:01:26.582891  7658 Exceptions.h:87] Line: /__w/presto/presto/presto-native-execution/velox/velox/exec/tests/utils/QueryAssertions.cpp:1515, Function:waitForAllTasksToBeDeleted, Expression:  1 pending tasks
2026-08-03T13:01:26.5838688Z 20: {Task tk:41569 (scan.0.0.1.0) Running
2026-08-03T13:01:26.5839223Z 20: Plan:
2026-08-03T13:01:26.5839771Z 20: -- PartitionedOutput[2][SINGLE Presto in-memory] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.5840790Z 20:   -- Filter[1][expression: eq(mod(cast(ROW["c0"] as BIGINT),5),1)] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.5842525Z 20:     -- TableScan[0][table: hive_table] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.5843417Z 20: 
2026-08-03T13:01:26.5843950Z 20: }, Source: RUNTIME, ErrorCode: INVALID_STATE
2026-08-03T13:01:26.5845444Z 20: E20260803 13:01:26.583822  7658 ExceptionTracer.cpp:223] terminate() called, exception stack follows
2026-08-03T13:01:26.6493419Z 20: E20260803 13:01:26.583894  7658 ExceptionTracer.cpp:225] Exception type: facebook::velox::VeloxRuntimeError (16 frames)
2026-08-03T13:01:26.6494745Z 20:     @ 0000000000d947b7 _ZZN5folly12_GLOBAL__N_111InitializerC4EvENKUlPvPSt9type_infoPPFvS2_EE_clES2_S4_S7_
2026-08-03T13:01:26.6495797Z 20:                        /build/deps-download/folly/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp:118
2026-08-03T13:01:26.6496861Z 20:     @ 0000000000d947e7 _ZZN5folly12_GLOBAL__N_111InitializerC4EvENUlPvPSt9type_infoPPFvS2_EE_4_FUNES2_S4_S7_
2026-08-03T13:01:26.6497892Z 20:                        /build/deps-download/folly/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp:118
2026-08-03T13:01:26.6498588Z 20:     @ 0000000000d98061 __cxa_throw
2026-08-03T13:01:26.6499218Z 20:                        /build/deps-download/folly/folly/debugging/exception_tracer/ExceptionTracerLib.cpp:85
2026-08-03T13:01:26.6501133Z 20:     @ 0000000000f57097 _ZN8facebook5velox6detail14veloxCheckFailINS0_17VeloxRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKNS1_18VeloxCheckFailArgsET0_NS0_24CompileTimeStringLiteralE
2026-08-03T13:01:26.6502924Z 20:     @ 0000000005d77b22 _ZN8facebook5velox4exec4test26waitForAllTasksToBeDeletedEm
2026-08-03T13:01:26.6503708Z 20:     @ 0000000005d42f80 _ZN8facebook5velox4exec4test16OperatorTestBaseD2Ev
2026-08-03T13:01:26.6504625Z 20:     @ 0000000000c60502 _ZTv0_n24_N8facebook6presto12_GLOBAL__N_143TaskManagerTest_tableScanMultipleTasks_TestD0Ev
2026-08-03T13:01:26.6505369Z 20:     @ 000000000004fe0c (unknown)
2026-08-03T13:01:26.6505658Z 20:     @ 000000000003097b _ZN7testing8TestInfo3RunEv
2026-08-03T13:01:26.6505978Z 20:     @ 0000000000030af9 _ZN7testing9TestSuite3RunEv
2026-08-03T13:01:26.6506379Z 20:     @ 000000000003ffc5 _ZN7testing8internal12UnitTestImpl11RunAllTestsEv
2026-08-03T13:01:26.6506796Z 20:     @ 000000000003d7c8 _ZN7testing8UnitTest3RunEv
2026-08-03T13:01:26.6507082Z 20:     @ 0000000000b86d52 main
2026-08-03T13:01:26.6507325Z 20:     @ 000000000002a610 __libc_start_call_main
2026-08-03T13:01:26.6507599Z 20:     @ 000000000002a6c0 __libc_start_main
2026-08-03T13:01:26.6507848Z 20:     @ 0000000000bc4725 _start
2026-08-03T13:01:26.6508061Z 20: 
2026-08-03T13:01:26.6508356Z 20: E20260803 13:01:26.648844  7658 ExceptionTracer.cpp:227] exception stack complete
2026-08-03T13:01:26.6508913Z 20: terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
2026-08-03T13:01:26.7112955Z 20:   what():  Exception: VeloxRuntimeError
2026-08-03T13:01:26.7113854Z 20: Error Source: RUNTIME
2026-08-03T13:01:26.7114504Z 20: Error Code: INVALID_STATE
2026-08-03T13:01:26.7115185Z 20: Reason: 1 pending tasks
2026-08-03T13:01:26.7115845Z 20: {Task tk:41569 (scan.0.0.1.0) Running
2026-08-03T13:01:26.7116655Z 20: Plan:
2026-08-03T13:01:26.7117381Z 20: -- PartitionedOutput[2][SINGLE Presto in-memory] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.7118306Z 20:   -- Filter[1][expression: eq(mod(cast(ROW["c0"] as BIGINT),5),1)] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.7119014Z 20:     -- TableScan[0][table: hive_table] -> c0:INTEGER, c1:VARCHAR
2026-08-03T13:01:26.7119467Z 20: 
2026-08-03T13:01:26.7119696Z 20: }
2026-08-03T13:01:26.7119937Z 20: Retriable: False
2026-08-03T13:01:26.7120260Z 20: Function: waitForAllTasksToBeDeleted
2026-08-03T13:01:26.7120949Z 20: File: /__w/presto/presto/presto-native-execution/velox/velox/exec/tests/utils/QueryAssertions.cpp
2026-08-03T13:01:26.7121622Z 20: Line: 1515
2026-08-03T13:01:26.7122193Z 20: Stack trace:
2026-08-03T13:01:26.7122531Z 20: # 0  _ZN8facebook5velox7process10StackTraceC1Ei
2026-08-03T13:01:26.7123541Z 20: # 1  _ZN8facebook5velox14VeloxExceptionC1EPKcmS3_St17basic_string_viewIcSt11char_traitsIcEES7_S7_S7_bNS0_24CompileTimeStringLiteralENS1_4TypeES7_
2026-08-03T13:01:26.7125344Z 20: # 2  _ZN8facebook5velox6detail14veloxCheckFailINS0_17VeloxRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKNS1_18VeloxCheckFailArgsET0_NS0_24CompileTimeStringLiteralE
2026-08-03T13:01:26.7126924Z 20: # 3  _ZN8facebook5velox4exec4test26waitForAllTasksToBeDeletedEm
2026-08-03T13:01:26.7127349Z 20: # 4  _ZN8facebook5velox4exec4test16OperatorTestBaseD2Ev
2026-08-03T13:01:26.7127869Z 20: # 5  _ZTv0_n24_N8facebook6presto12_GLOBAL__N_143TaskManagerTest_tableScanMultipleTasks_TestD0Ev
2026-08-03T13:01:26.7128333Z 20: # 6  0x000000000004fe0c
2026-08-03T13:01:26.7128560Z 20: # 7  _ZN7testing8TestInfo3RunEv
2026-08-03T13:01:26.7128816Z 20: # 8  _ZN7testing9TestSuite3RunEv
2026-08-03T13:01:26.7129140Z 20: # 9  _ZN7testing8internal12UnitTestImpl11RunAllTestsEv
2026-08-03T13:01:26.7129473Z 20: # 10 _ZN7testing8UnitTest3RunEv
2026-08-03T13:01:26.7129712Z 20: # 11 main
2026-08-03T13:01:26.7129897Z 20: # 12 __libc_start_call_main
2026-08-03T13:01:26.7130115Z 20: # 13 __libc_start_main
2026-08-03T13:01:26.7130315Z 20: # 14 _start
2026-08-03T13:01:26.7130490Z 20: 
2026-08-03T13:01:26.7130776Z 20: *** Aborted at 1785762086 (Unix time, try 'date -d @1785762086') ***
2026-08-03T13:01:26.7131648Z 20: *** Signal 6 (SIGABRT) (0x1dea) received by PID 7658 (pthread TID 0x7f3dac1c0940) (linux TID 7658) (maybe from PID 7658, UID 0) (code: -6), stack trace: ***
2026-08-03T13:01:26.7132440Z 20: (error retrieving stack trace)
2026-08-03T13:01:27.7436303Z 23/23 Test #20: presto_server_test ..........................Subprocess aborted***Exception: 284.54 sec
```

Root-caused via reproduction under artificial CPU contention rather than by inspection alone — confirmed this is a pre-existing timing race in the test's task cleanup, not a regression from application logic.

## Impact
Test-only change. No production code, public API, or user-facing behavior is affected. No performance impact.

## Test Plan
- Rebuilt `presto_server_test` and ran `TaskManagerTest/*.tableScanMultipleTasks/*` 20x in a loop — all passed.
- Ran the same filter under artificial CPU contention (3 concurrent `yes` processes) with `--gtest_repeat=25 --gtest_shuffle` — all passed, no zombie/pending-task warnings for this test.
- Ran the full `TaskManagerTest/*` suite (75 cases) — all passed, no regressions.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Stabilize TaskManagerTest.tableScanMultipleTasks by making task cleanup deterministic to avoid pending-task crashes during teardown.

Bug Fixes:
- Ensure tableScanMultipleTasks explicitly deletes the output and upstream scan tasks to prevent pending tasks from triggering teardown failures under contention.

Tests:
- Add deterministic cleanup in tableScanMultipleTasks using explicit task deletions and waitForAllOldTasksToBeCleaned to eliminate flaky behavior in presto_server_test.