### PR TITLE
fix(connector): Look up serialization codecs by connector name, not catalog name

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorCodecManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorCodecManager.java
@@ -16,7 +16,6 @@ package com.facebook.presto.connector;
 import com.facebook.drift.codec.ThriftCodecManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorMergeTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
@@ -49,58 +48,65 @@ public class ConnectorCodecManager
         connectorCodecProviders.put(REMOTE_CONNECTOR_ID.toString(), new RemoteCodecProvider(thriftCodecManagerProvider));
     }
 
-    public void addConnectorCodecProvider(ConnectorId connectorId, ConnectorCodecProvider connectorCodecProvider)
+    public void addConnectorCodecProvider(String connectorName, ConnectorCodecProvider connectorCodecProvider)
     {
-        requireNonNull(connectorId, "connectorId is null");
+        requireNonNull(connectorName, "connectorName is null");
         requireNonNull(connectorCodecProvider, "connectorThriftCodecProvider is null");
-        connectorCodecProviders.put(connectorId.getCatalogName(), connectorCodecProvider);
+        // Catalogs sharing a connector register equivalent providers; the first wins.
+        connectorCodecProviders.putIfAbsent(connectorName, connectorCodecProvider);
     }
 
-    public Optional<ConnectorCodec<ConnectorSplit>> getConnectorSplitCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorSplit>> getConnectorSplitCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorSplitCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorSplitCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorTransactionHandle>> getTransactionHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorTransactionHandle>> getTransactionHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorTransactionHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorTransactionHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorOutputTableHandle>> getOutputTableHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorOutputTableHandle>> getOutputTableHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorOutputTableHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorOutputTableHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorInsertTableHandle>> getInsertTableHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorInsertTableHandle>> getInsertTableHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorInsertTableHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorInsertTableHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorDeleteTableHandle>> getDeleteTableHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorDeleteTableHandle>> getDeleteTableHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorDeleteTableHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorDeleteTableHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorMergeTableHandle>> getMergeTableHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorMergeTableHandle>> getMergeTableHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorMergeTableHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorMergeTableHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorTableLayoutHandle>> getTableLayoutHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorTableLayoutHandle>> getTableLayoutHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorTableLayoutHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorTableLayoutHandleCodec);
     }
 
-    public Optional<ConnectorCodec<ConnectorTableHandle>> getTableHandleCodec(String connectorId)
+    public Optional<ConnectorCodec<ConnectorTableHandle>> getTableHandleCodec(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        return Optional.ofNullable(connectorCodecProviders.get(connectorId)).flatMap(ConnectorCodecProvider::getConnectorTableHandleCodec);
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName)).flatMap(ConnectorCodecProvider::getConnectorTableHandleCodec);
+    }
+
+    public Optional<ConnectorCodecProvider> getConnectorCodecProvider(String connectorName)
+    {
+        requireNonNull(connectorName, "connectorName is null");
+        return Optional.ofNullable(connectorCodecProviders.get(connectorName));
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -290,6 +290,9 @@ public class ConnectorManager
 
         try {
             addConnectorInternal(connector);
+            // Keyed by connector name, which is what a handle carries as its type id.
+            connector.getConnectorCodecProvider()
+                    .ifPresent(codecProvider -> connectorCodecManager.addConnectorCodecProvider(connectorName, codecProvider));
             addConnectorInternal(informationSchemaConnector);
             addConnectorInternal(systemConnector);
             catalogManager.registerCatalog(catalog);
@@ -326,7 +329,6 @@ public class ConnectorManager
             connector.getPlanOptimizerProvider()
                     .ifPresent(planOptimizerProvider -> connectorPlanOptimizerManager.addPlanOptimizerProvider(connectorId, planOptimizerProvider));
         }
-        connector.getConnectorCodecProvider().ifPresent(connectorCodecProvider -> connectorCodecManager.addConnectorCodecProvider(connectorId, connectorCodecProvider));
         metadataManager.getProcedureRegistry().addProcedures(connectorId,
                 connector.getProcedures());
         Set<Class<?>> systemFunctions = connector.getSystemFunctions();
@@ -415,14 +417,9 @@ public class ConnectorManager
         }
     }
 
-    public Optional<ConnectorCodecProvider> getConnectorCodecProvider(ConnectorId connectorId)
+    public Optional<ConnectorCodecProvider> getConnectorCodecProvider(String connectorName)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        MaterializedConnector materializedConnector = connectors.get(connectorId);
-        if (materializedConnector == null) {
-            return Optional.empty();
-        }
-        return materializedConnector.getConnectorCodecProvider();
+        return connectorCodecManager.getConnectorCodecProvider(connectorName);
     }
 
     private static class MaterializedConnector

--- a/presto-main-base/src/main/java/com/facebook/presto/index/IndexHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/index/IndexHandleJacksonModule.java
@@ -17,7 +17,6 @@ import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.metadata.AbstractTypedJacksonModule;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorIndexHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -40,15 +39,15 @@ public class IndexHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getIndexHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorIndexHandleCodec));
     }
 
     public IndexHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorIndexHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorIndexHandle>>> codecExtractor)
     {
         super(ConnectorIndexHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -59,7 +58,7 @@ public abstract class AbstractTypedJacksonModule<T>
             Function<T, String> nameResolver,
             Function<String, Class<? extends T>> classResolver,
             boolean binarySerializationEnabled,
-            Function<ConnectorId, Optional<ConnectorCodec<T>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<T>>> codecExtractor)
     {
         super(baseClass.getSimpleName() + "Module", Version.unknownVersion());
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/CodecDeserializer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/CodecDeserializer.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.TreeNode;
@@ -34,14 +33,14 @@ class CodecDeserializer<T>
         extends JsonDeserializer<T>
 {
     private final Function<String, Class<? extends T>> classResolver;
-    private final Function<ConnectorId, Optional<ConnectorCodec<T>>> codecExtractor;
+    private final Function<String, Optional<ConnectorCodec<T>>> codecExtractor;
     private final String typePropertyName;
     private final String dataPropertyName;
 
     public CodecDeserializer(
             String typePropertyName,
             String dataPropertyName,
-            Function<ConnectorId, Optional<ConnectorCodec<T>>> codecExtractor,
+            Function<String, Optional<ConnectorCodec<T>>> codecExtractor,
             Function<String, Class<? extends T>> classResolver)
     {
         this.classResolver = requireNonNull(classResolver, "classResolver is null");
@@ -72,14 +71,13 @@ class CodecDeserializer<T>
             if (!node.has(typePropertyName)) {
                 throw new IOException("Missing " + typePropertyName + " field");
             }
-            String connectorIdString = node.get(typePropertyName).asText();
+            String connectorName = node.get(typePropertyName).asText();
             // Check if @data field is present (binary serialization)
             if (node.has(dataPropertyName)) {
                 // Binary data is present, we need a codec to deserialize it
                 // Special handling for internal handles like "$remote"
-                if (!connectorIdString.startsWith("$")) {
-                    ConnectorId connectorId = new ConnectorId(connectorIdString);
-                    Optional<ConnectorCodec<T>> codec = codecExtractor.apply(connectorId);
+                if (!connectorName.startsWith("$")) {
+                    Optional<ConnectorCodec<T>> codec = codecExtractor.apply(connectorName);
                     if (codec.isPresent()) {
                         String base64Data = node.get(dataPropertyName).asText();
                         byte[] data = Base64.getDecoder().decode(base64Data);
@@ -87,11 +85,11 @@ class CodecDeserializer<T>
                     }
                 }
                 // @data field present but no codec available or internal handle
-                throw new IOException("Type " + connectorIdString + " has binary data (" + dataPropertyName + " field) but no codec available to deserialize it");
+                throw new IOException("Type " + connectorName + " has binary data (" + dataPropertyName + " field) but no codec available to deserialize it");
             }
 
             // No @data field - use standard JSON deserialization
-            Class<? extends T> handleClass = classResolver.apply(connectorIdString);
+            Class<? extends T> handleClass = classResolver.apply(connectorName);
 
             // Remove the @type field and deserialize the remaining content
             node.remove(typePropertyName);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/CodecSerializer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/CodecSerializer.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -40,7 +39,7 @@ class CodecSerializer<T>
         extends JsonSerializer<T>
 {
     private final Function<T, String> nameResolver;
-    private final Function<ConnectorId, Optional<ConnectorCodec<T>>> codecExtractor;
+    private final Function<String, Optional<ConnectorCodec<T>>> codecExtractor;
     private final TypeIdResolver typeResolver;
     private final TypeSerializer typeSerializer;
     private final Cache<Class<?>, JsonSerializer<Object>> serializerCache = CacheBuilder.newBuilder().build();
@@ -50,7 +49,7 @@ class CodecSerializer<T>
     public CodecSerializer(
             String typePropertyName,
             String dataPropertyName,
-            Function<ConnectorId, Optional<ConnectorCodec<T>>> codecExtractor,
+            Function<String, Optional<ConnectorCodec<T>>> codecExtractor,
             Function<T, String> nameResolver,
             TypeIdResolver typeIdResolver)
     {
@@ -71,18 +70,17 @@ class CodecSerializer<T>
             return;
         }
 
-        String connectorIdString = nameResolver.apply(value);
+        // A handle's type id is the name of its connector, not of any catalog using that connector
+        String connectorName = nameResolver.apply(value);
 
         // Only try binary serialization for actual connectors (not internal handles like "$remote")
-        if (!connectorIdString.startsWith("$")) {
-            ConnectorId connectorId = new ConnectorId(connectorIdString);
-
+        if (!connectorName.startsWith("$")) {
             // Check if connector has a binary codec
-            Optional<ConnectorCodec<T>> codec = codecExtractor.apply(connectorId);
+            Optional<ConnectorCodec<T>> codec = codecExtractor.apply(connectorName);
             if (codec.isPresent()) {
                 // Use binary serialization with flat structure
                 jsonGenerator.writeStartObject();
-                jsonGenerator.writeStringField(typePropertyName, connectorIdString);
+                jsonGenerator.writeStringField(typePropertyName, connectorName);
                 byte[] data = codec.get().serialize(value);
                 jsonGenerator.writeStringField(dataPropertyName, Base64.getEncoder().encodeToString(data));
                 jsonGenerator.writeEndObject();

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/ColumnHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/ColumnHandleJacksonModule.java
@@ -16,7 +16,6 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import jakarta.inject.Inject;
@@ -38,15 +37,15 @@ public class ColumnHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getColumnHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getColumnHandleCodec));
     }
 
     public ColumnHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ColumnHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ColumnHandle>>> codecExtractor)
     {
         super(ColumnHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DeleteTableHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DeleteTableHandleJacksonModule.java
@@ -16,7 +16,6 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import jakarta.inject.Inject;
@@ -38,15 +37,15 @@ public class DeleteTableHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getDeleteTableHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorDeleteTableHandleCodec));
     }
 
     public DeleteTableHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorDeleteTableHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorDeleteTableHandle>>> codecExtractor)
     {
         super(ConnectorDeleteTableHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DistributedProcedureHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DistributedProcedureHandleJacksonModule.java
@@ -16,7 +16,6 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDistributedProcedureHandle;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import jakarta.inject.Provider;
@@ -39,15 +38,15 @@ public class DistributedProcedureHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getDistributedProcedureHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorDistributedProcedureHandleCodec));
     }
 
     public DistributedProcedureHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorDistributedProcedureHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorDistributedProcedureHandle>>> codecExtractor)
     {
         super(ConnectorDistributedProcedureHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/InsertTableHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/InsertTableHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class InsertTableHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getInsertTableHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorInsertTableHandleCodec));
     }
 
     public InsertTableHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorInsertTableHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorInsertTableHandle>>> codecExtractor)
     {
         super(ConnectorInsertTableHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MergeTableHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MergeTableHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorMergeTableHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -39,15 +38,15 @@ public class MergeTableHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getMergeTableHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorMergeTableHandleCodec));
     }
 
     public MergeTableHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorMergeTableHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorMergeTableHandle>>> codecExtractor)
     {
         super(ConnectorMergeTableHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/OutputTableHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/OutputTableHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class OutputTableHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getOutputTableHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorOutputTableHandleCodec));
     }
 
     public OutputTableHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorOutputTableHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorOutputTableHandle>>> codecExtractor)
     {
         super(ConnectorOutputTableHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/PartitioningHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/PartitioningHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class PartitioningHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getPartitioningHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorPartitioningHandleCodec));
     }
 
     public PartitioningHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorPartitioningHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorPartitioningHandle>>> codecExtractor)
     {
         super(ConnectorPartitioningHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SplitJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SplitJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,8 +37,8 @@ public class SplitJacksonModule
                 handleResolver::getId,
                 handleResolver::getSplitClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorSplitCodec));
     }
 
@@ -50,7 +49,7 @@ public class SplitJacksonModule
     public SplitJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorSplit>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorSplit>>> codecExtractor)
     {
         super(ConnectorSplit.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionJacksonHandleModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionJacksonHandleModule.java
@@ -33,8 +33,8 @@ public class TableFunctionJacksonHandleModule
                 handleResolver::getId,
                 handleResolver::getTableFunctionHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorTableFunctionHandleCodec));
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class TableHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getTableHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorTableHandleCodec));
     }
 
     public TableHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorTableHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorTableHandle>>> codecExtractor)
     {
         super(ConnectorTableHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableLayoutHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableLayoutHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class TableLayoutHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getTableLayoutHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorTableLayoutHandleCodec));
     }
 
     public TableLayoutHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorTableLayoutHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorTableLayoutHandle>>> codecExtractor)
     {
         super(ConnectorTableLayoutHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TransactionHandleJacksonModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TransactionHandleJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -38,15 +37,15 @@ public class TransactionHandleJacksonModule
                 handleResolver::getId,
                 handleResolver::getTransactionHandleClass,
                 featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                connectorId -> connectorManagerProvider.get()
-                        .getConnectorCodecProvider(connectorId)
+                connectorName -> connectorManagerProvider.get()
+                        .getConnectorCodecProvider(connectorName)
                         .flatMap(ConnectorCodecProvider::getConnectorTransactionHandleCodec));
     }
 
     public TransactionHandleJacksonModule(
             HandleResolver handleResolver,
             FeaturesConfig featuresConfig,
-            Function<ConnectorId, Optional<ConnectorCodec<ConnectorTransactionHandle>>> codecExtractor)
+            Function<String, Optional<ConnectorCodec<ConnectorTransactionHandle>>> codecExtractor)
     {
         super(ConnectorTransactionHandle.class,
                 handleResolver::getId,

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/TestConnectorCodecManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/TestConnectorCodecManager.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector;
+
+import com.facebook.presto.spi.connector.ConnectorCodecProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestConnectorCodecManager
+{
+    private static final String CONNECTOR_NAME = "mock_connector";
+
+    private static ConnectorCodecManager createCodecManager()
+    {
+        return new ConnectorCodecManager(() -> null);
+    }
+
+    @Test
+    public void testRegistersUnderConnectorNameNotCatalogName()
+    {
+        ConnectorCodecManager codecManager = createCodecManager();
+        codecManager.addConnectorCodecProvider(CONNECTOR_NAME, new ConnectorCodecProvider() {});
+
+        assertTrue(codecManager.getConnectorCodecProvider(CONNECTOR_NAME).isPresent());
+        assertFalse(codecManager.getConnectorCodecProvider("catalog_named_after_nothing").isPresent());
+    }
+
+    @Test
+    public void testCatalogsSharingAConnectorShareOneProvider()
+    {
+        ConnectorCodecManager codecManager = createCodecManager();
+        ConnectorCodecProvider first = new ConnectorCodecProvider() {};
+        ConnectorCodecProvider second = new ConnectorCodecProvider() {};
+
+        codecManager.addConnectorCodecProvider(CONNECTOR_NAME, first);
+        codecManager.addConnectorCodecProvider(CONNECTOR_NAME, second);
+
+        Optional<ConnectorCodecProvider> provider = codecManager.getConnectorCodecProvider(CONNECTOR_NAME);
+        assertTrue(provider.isPresent());
+        assertSame(provider.get(), first);
+    }
+
+    @Test
+    public void testUnregisteredConnectorHasNoProvider()
+    {
+        assertFalse(createCodecManager().getConnectorCodecProvider(CONNECTOR_NAME).isPresent());
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestAbstractTypedJacksonModule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestAbstractTypedJacksonModule.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.airlift.json.JsonModule;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
@@ -566,12 +565,12 @@ public class TestAbstractTypedJacksonModule
             this.codecProvider = codecProvider;
         }
 
-        public Optional<ConnectorCodecProvider> getConnectorCodecProvider(ConnectorId connectorId)
+        public Optional<ConnectorCodecProvider> getConnectorCodecProvider(String connectorName)
         {
             // Only return codec provider for specific connectors if it's a SelectiveCodecProvider
             if (codecProvider instanceof SelectiveCodecProvider) {
                 SelectiveCodecProvider selective = (SelectiveCodecProvider) codecProvider;
-                if (connectorId.getCatalogName().equals(selective.connectorIdWithCodec)) {
+                if (connectorName.equals(selective.connectorIdWithCodec)) {
                     return Optional.of(codecProvider);
                 }
                 return Optional.empty();
@@ -594,8 +593,8 @@ public class TestAbstractTypedJacksonModule
                     TestHandle::getConnectorId,
                     id -> TestHandle.class,
                     featuresConfig.isUseConnectorProvidedSerializationCodecs(),
-                    connectorId -> testConnectorManager
-                            .getConnectorCodecProvider(connectorId)
+                    connectorName -> testConnectorManager
+                            .getConnectorCodecProvider(connectorName)
                             .flatMap(provider -> {
                                 Optional<ConnectorCodec<com.facebook.presto.spi.ConnectorTableHandle>> codec =
                                         provider.getConnectorTableHandleCodec();

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
@@ -655,30 +655,30 @@ public class TestHttpRemoteTaskConnectorCodec
                         handleResolver.addConnectorName(connectorWithoutCodec, new TestConnectorWithoutCodecHandleResolver());
                         binder.bind(HandleResolver.class).toInstance(handleResolver);
 
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorTableHandle>>> tableHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(tableHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorTableLayoutHandle>>> tableLayoutHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(tableLayoutHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ColumnHandle>>> columnHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(columnHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorOutputTableHandle>>> outputTableHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(outputTableHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorInsertTableHandle>>> insertTableHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(insertTableHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorDeleteTableHandle>>> deleteTableHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(deleteTableHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorMergeTableHandle>>> mergeTableHandleCodecExtractor =
-                                connectorId -> Optional.ofNullable(mergeTableHandleCodecMap.get(connectorId.getCatalogName()));
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorIndexHandle>>> noOpIndexCodec =
-                                connectorId -> Optional.empty();
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorTransactionHandle>>> noOpTransactionCodec =
-                                connectorId -> Optional.empty();
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorPartitioningHandle>>> noOpPartitioningCodec =
-                                connectorId -> Optional.empty();
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorDistributedProcedureHandle>>> noOpDistributedProcedureCodec =
-                                connectorId -> Optional.empty();
-                        Function<ConnectorId, Optional<ConnectorCodec<ConnectorSplit>>> splitCodecExtractor =
-                                connectorId -> Optional.ofNullable(splitCodecMap.get(connectorId.getCatalogName()));
+                        Function<String, Optional<ConnectorCodec<ConnectorTableHandle>>> tableHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(tableHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorTableLayoutHandle>>> tableLayoutHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(tableLayoutHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ColumnHandle>>> columnHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(columnHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorOutputTableHandle>>> outputTableHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(outputTableHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorInsertTableHandle>>> insertTableHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(insertTableHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorDeleteTableHandle>>> deleteTableHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(deleteTableHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorMergeTableHandle>>> mergeTableHandleCodecExtractor =
+                                connectorName -> Optional.ofNullable(mergeTableHandleCodecMap.get(connectorName));
+                        Function<String, Optional<ConnectorCodec<ConnectorIndexHandle>>> noOpIndexCodec =
+                                connectorName -> Optional.empty();
+                        Function<String, Optional<ConnectorCodec<ConnectorTransactionHandle>>> noOpTransactionCodec =
+                                connectorName -> Optional.empty();
+                        Function<String, Optional<ConnectorCodec<ConnectorPartitioningHandle>>> noOpPartitioningCodec =
+                                connectorName -> Optional.empty();
+                        Function<String, Optional<ConnectorCodec<ConnectorDistributedProcedureHandle>>> noOpDistributedProcedureCodec =
+                                connectorName -> Optional.empty();
+                        Function<String, Optional<ConnectorCodec<ConnectorSplit>>> splitCodecExtractor =
+                                connectorName -> Optional.ofNullable(splitCodecMap.get(connectorName));
 
                         jsonBinder(binder).addModuleBinding().toInstance(new TableHandleJacksonModule(handleResolver, featuresConfig, tableHandleCodecExtractor));
                         jsonBinder(binder).addModuleBinding().toInstance(new TableLayoutHandleJacksonModule(handleResolver, featuresConfig, tableLayoutHandleCodecExtractor));
@@ -788,7 +788,7 @@ public class TestHttpRemoteTaskConnectorCodec
         handleResolver.addConnectorName("test", new com.facebook.presto.testing.TestingHandleResolver());
 
         ConnectorCodecManager codecManager = injector.getInstance(ConnectorCodecManager.class);
-        codecManager.addConnectorCodecProvider(new ConnectorId(connectorWithCodec), new TestConnectorWithCodecProvider());
+        codecManager.addConnectorCodecProvider(connectorWithCodec, new TestConnectorWithCodecProvider());
 
         return injector;
     }


### PR DESCRIPTION
## Description

A connector's codec is registered under the catalog name but looked up by the connector name, so it is found only when a catalog happens to be named after its connector.

`CodecSerializer` and `CodecDeserializer` wrap a handle's type id in `new ConnectorId(...)` and index `ConnectorManager.connectors`, which is keyed by catalog name. That type id is the *connector* name: `HandleResolver.addConnectorName` is called with `ConnectorFactory.getName()`. `ConnectorCodecManager` has the same mismatch on the Thrift path.

This keys both registries by connector name and drops the `ConnectorId` conversions. Registration is first-wins, since catalogs sharing a connector register equivalent providers.

Most of the diff is a rename. These lookups already took a `String connectorId` that in fact held a connector name, and the misnomer is what made the mismatch easy to introduce and hard to see — it reads as correct right up until someone converts it to a `ConnectorId`. Renaming the parameters to `connectorName` keeps the two concepts distinct at every call site; the same rename in the extractor's type (`Function<ConnectorId, ...>` to `Function<String, ...>`) is what forces the bad conversions to be deleted rather than left in place.

## Motivation and Context

Any catalog not named after its connector silently falls back to legacy typed JSON, so `use-connector-provided-serialization-codecs` has no effect there. That is invisible for a connector whose native counterpart also implements JSON handle deserialization, and fatal for one implementing only the binary path, where the C++ worker fails the query with `from_json not implemented`.

#28111 fixed the same confusion in the Flight shim server by resolving a connector name from a catalog name via `CatalogManager`. That approach does not apply here: one connector has many catalogs, so the registry key itself has to be the connector name.

## Impact

`use-connector-provided-serialization-codecs=true` now applies to every catalog of a codec-providing connector rather than only one named after it. Connectors without codecs are unaffected.

`ConnectorManager.getConnectorCodecProvider` and `ConnectorCodecManager.addConnectorCodecProvider` take a connector name instead of a `ConnectorId`. No documentation change: `admin/properties.rst` already describes the behaviour this restores.

## Test Plan

New `TestConnectorCodecManager` (3 tests):

- `testRegistersUnderConnectorNameNotCatalogName` — a provider registered under a connector name resolves by that name; a catalog-shaped name does not resolve.
- `testCatalogsSharingAConnectorShareOneProvider` — two registrations under one connector name keep the first.
- `testUnregisteredConnectorHasNoProvider`

Existing suites, run unchanged: `TestAbstractTypedJacksonModule` (9) and `TestHttpRemoteTaskConnectorCodec` (7), the latter covering JSON and Thrift `TaskUpdateRequest` round-trips for connectors both with and without a codec.

Manually on a native cluster, two catalogs of one codec-providing connector, neither named after the connector. `COUNT(*)`, an aggregate over a projected column, a pushed-down `WHERE` filter, and `information_schema.tables` all return correct results on both catalogs. Without this change every one of those queries fails on the worker with `from_json not implemented`, on both catalogs; renaming either catalog to match the connector name makes both work again.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix connector-provided serialization codecs being ignored when a catalog is named differently from its connector.
```

## Summary by Sourcery

Ensure connector-provided serialization codecs are registered and looked up by connector name rather than catalog name so binary handle serialization works consistently across all catalogs using a connector.

Bug Fixes:
- Fix mismatch between codec registration under catalog name and lookup by connector name that caused connector-provided codecs to be ignored for catalogs not named after their connector.

Enhancements:
- Simplify codec extraction APIs by passing connector names as strings instead of ConnectorId objects and adding a direct accessor for connector codec providers.
- Clarify naming across Jackson handle modules and related tests to distinguish connector names from catalog identifiers and avoid future misconfiguration.

Tests:
- Add unit tests for ConnectorCodecManager to verify registration under connector name, first-wins behavior for shared connectors, and absence of providers for unregistered connectors.
- Update existing Jackson and remote task codec tests to exercise the new connector-name-based codec extraction behavior without changing coverage.