### PR TITLE
[OSS] feat(optimizer): Let a query state an objective instead of a mode (#28264)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -57,7 +57,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice
 import com.facebook.presto.sql.analyzer.FunctionsConfig;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewriteStrategy;
-import com.facebook.presto.sql.planner.plan.RPCNode;
+import com.facebook.presto.sql.planner.optimizations.RpcExecutionMode;
 import com.facebook.presto.tracing.TracingConfig;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -1447,18 +1447,20 @@ public final class SystemSessionProperties
                         false),
                 new PropertyMetadata<>(
                         RPC_STREAMING_MODE,
-                        format("Streaming mode for RPC function execution. Options are %s. "
-                                        + "PER_ROW dispatches each row individually, BATCH accumulates rows and dispatches in batches, "
-                                        + "AUTOMATIC picks PER_ROW or BATCH from the estimated input row count (see rpc_batch_min_rows).",
-                                Stream.of(RPCNode.StreamingMode.values())
-                                        .map(RPCNode.StreamingMode::name)
+                        format("Dispatch mode for RPC function execution. Options are %s. Explicit PER_ROW "
+                                        + "dispatches each row individually and BATCH accumulates rows and dispatches in batches; "
+                                        + "the objectives LATENCY (per-row), THROUGHPUT/COST (batch), and AUTOMATIC "
+                                        + "(cardinality-based where supported, see rpc_batch_min_rows) are resolved to PER_ROW/BATCH "
+                                        + "at plan time.",
+                                Stream.of(RpcExecutionMode.values())
+                                        .map(RpcExecutionMode::name)
                                         .collect(joining(","))),
                         VARCHAR,
-                        RPCNode.StreamingMode.class,
-                        RPCNode.StreamingMode.PER_ROW,
+                        RpcExecutionMode.class,
+                        RpcExecutionMode.PER_ROW,
                         false,
-                        value -> RPCNode.StreamingMode.valueOf(((String) value).toUpperCase()),
-                        RPCNode.StreamingMode::name),
+                        value -> RpcExecutionMode.valueOf(((String) value).toUpperCase()),
+                        RpcExecutionMode::name),
                 integerProperty(
                         RPC_DISPATCH_BATCH_SIZE,
                         "Batch size for RPC function dispatch in BATCH streaming mode. "
@@ -3430,9 +3432,9 @@ public final class SystemSessionProperties
         return session.getSystemProperty(RPC_FUNCTION_OPTIMIZER_ENABLED, Boolean.class);
     }
 
-    public static RPCNode.StreamingMode getRpcStreamingMode(Session session)
+    public static RpcExecutionMode getRpcStreamingMode(Session session)
     {
-        return session.getSystemProperty(RPC_STREAMING_MODE, RPCNode.StreamingMode.class);
+        return session.getSystemProperty(RPC_STREAMING_MODE, RpcExecutionMode.class);
     }
 
     public static int getRpcDispatchBatchSize(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/DefaultRpcExecutionPolicy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/DefaultRpcExecutionPolicy.java
@@ -16,10 +16,10 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.sql.planner.plan.RPCNode;
 
 /**
- * Default {@link RpcExecutionPolicy}: carries no batching heuristic, so it ignores the input
- * stats. Explicit PER_ROW/BATCH pass through unchanged; AUTOMATIC degrades to PER_ROW (a safe
- * fallback). A deployment that wants stats-driven AUTOMATIC resolution binds an override of
- * {@link RpcExecutionPolicy} via a Guice module.
+ * Default {@link RpcExecutionPolicy}: carries no cardinality heuristic. Explicit PER_ROW/BATCH
+ * resolve to themselves; THROUGHPUT/COST resolve to BATCH; LATENCY and AUTOMATIC resolve to
+ * PER_ROW (no stats heuristic here). A deployment that wants stats-driven AUTOMATIC resolution
+ * binds an override of {@link RpcExecutionPolicy} via a Guice module.
  */
 public class DefaultRpcExecutionPolicy
         implements RpcExecutionPolicy
@@ -27,10 +27,23 @@ public class DefaultRpcExecutionPolicy
     @Override
     public RpcExecutionProperties translateIntent(RpcExecutionIntent intent)
     {
-        RPCNode.StreamingMode requested = intent.getRequestedMode();
-        RPCNode.StreamingMode resolved = requested == RPCNode.StreamingMode.AUTOMATIC
-                ? RPCNode.StreamingMode.PER_ROW
-                : requested;
+        RPCNode.StreamingMode resolved;
+        switch (intent.getRequestedMode()) {
+            case BATCH:
+            case THROUGHPUT:
+            case COST:
+                resolved = RPCNode.StreamingMode.BATCH;
+                break;
+            case PER_ROW:
+            case LATENCY:
+            case AUTOMATIC:
+                resolved = RPCNode.StreamingMode.PER_ROW;
+                break;
+            default:
+                // A new objective must state its own mapping. Falling through to
+                // PER_ROW here would silently discard the objective's meaning.
+                throw new IllegalArgumentException("Unhandled RpcExecutionMode: " + intent.getRequestedMode());
+        }
         return RpcExecutionProperties.of(resolved);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionIntent.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionIntent.java
@@ -20,8 +20,8 @@ import com.facebook.presto.sql.planner.plan.RPCNode;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The planning intent for a single RPC function call: the requested streaming mode plus the
- * context a policy may use to resolve it.
+ * The planning intent for a single RPC function call: the requested execution mode (a mechanism
+ * or an objective) plus the context a policy may use to resolve it.
  *
  * This is the input to {@link RpcExecutionPolicy#translateIntent}. It is built via {@link
  * #builder} and is intentionally growable — new context fields can be added here (a new builder
@@ -34,13 +34,13 @@ import static java.util.Objects.requireNonNull;
  */
 public class RpcExecutionIntent
 {
-    private final RPCNode.StreamingMode requestedMode;
+    private final RpcExecutionMode requestedMode;
     private final PlanNodeStatsEstimate inputStats;
     private final Session session;
     private final String functionName;
 
     private RpcExecutionIntent(
-            RPCNode.StreamingMode requestedMode,
+            RpcExecutionMode requestedMode,
             PlanNodeStatsEstimate inputStats,
             Session session,
             String functionName)
@@ -52,9 +52,10 @@ public class RpcExecutionIntent
     }
 
     /**
-     * The streaming mode requested for the call (PER_ROW, BATCH, or AUTOMATIC).
+     * The requested dispatch mode — an explicit mechanism (PER_ROW/BATCH) or an objective
+     * (LATENCY/THROUGHPUT/COST/AUTOMATIC) the policy resolves to a concrete streaming mode.
      */
-    public RPCNode.StreamingMode getRequestedMode()
+    public RpcExecutionMode getRequestedMode()
     {
         return requestedMode;
     }
@@ -89,12 +90,12 @@ public class RpcExecutionIntent
 
     public static class Builder
     {
-        private RPCNode.StreamingMode requestedMode;
+        private RpcExecutionMode requestedMode;
         private PlanNodeStatsEstimate inputStats = PlanNodeStatsEstimate.unknown();
         private Session session;
         private String functionName;
 
-        public Builder setRequestedMode(RPCNode.StreamingMode requestedMode)
+        public Builder setRequestedMode(RpcExecutionMode requestedMode)
         {
             this.requestedMode = requestedMode;
             return this;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionMode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcExecutionMode.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+/**
+ * The user-facing RPC dispatch mode — the value space of the {@code rpc_streaming_mode} session
+ * property. A value is either an explicit mechanism (PER_ROW / BATCH) or an optimization objective
+ * (LATENCY / THROUGHPUT / COST / AUTOMATIC) that {@link RpcExecutionPolicy} resolves to a concrete
+ * {@link com.facebook.presto.sql.planner.plan.RPCNode.StreamingMode} (PER_ROW/BATCH) at plan time.
+ * Objectives let the caller state WHAT to optimize for rather than the mechanism. Growable — a new
+ * objective maps to a mechanism in the policy, no other code changes.
+ */
+public enum RpcExecutionMode
+{
+    /** Explicit mechanism: one RPC per row. */
+    PER_ROW,
+    /** Explicit mechanism: accumulate rows and dispatch as a batch. */
+    BATCH,
+    /** Objective: minimize tail / time-to-first-row latency — resolves to per-row. */
+    LATENCY,
+    /** Objective: maximize rows/sec — resolves to batch. */
+    THROUGHPUT,
+    /** Objective: minimize $/GPU — resolves to batch (aliases THROUGHPUT until real cost signals). */
+    COST,
+    /** Objective: let the system decide (cardinality-based where the policy supports it). */
+    AUTOMATIC
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -22,6 +22,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.Assignments;
@@ -48,6 +49,7 @@ import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -59,7 +61,9 @@ import java.util.function.Supplier;
 import static com.facebook.presto.SystemSessionProperties.getRpcDispatchBatchSize;
 import static com.facebook.presto.SystemSessionProperties.getRpcStreamingMode;
 import static com.facebook.presto.SystemSessionProperties.isRpcFunctionOptimizerEnabled;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class RpcFunctionOptimizer
@@ -671,12 +675,13 @@ public class RpcFunctionOptimizer
         // Resolves the plan-time execution properties for one RPC call. The requested mode (from
         // options JSON or the session property), the requested dispatch size, and the estimated
         // input stats are handed to the injected RpcExecutionPolicy as an RpcExecutionIntent; the
-        // policy returns the resolved RpcExecutionProperties. AUTOMATIC is resolved here so the
-        // RPCNode never carries it. The default policy carries no batching heuristic
-        // (AUTOMATIC -> PER_ROW, no overrides); a deployment may bind a stats-driven policy.
+        // policy returns the resolved RpcExecutionProperties. Every objective (LATENCY/THROUGHPUT/
+        // COST/AUTOMATIC) is resolved to a concrete PER_ROW/BATCH mode here, so the RPCNode only
+        // ever carries a mechanism. The default policy applies no cardinality heuristic (objectives
+        // map to fixed mechanisms, AUTOMATIC -> PER_ROW); a deployment may bind a stats-driven policy.
         private RpcExecutionProperties resolveExecutionProperties(CallExpression rpcCall, PlanNode source)
         {
-            RPCNode.StreamingMode requested = parseStreamingMode(rpcCall);
+            RpcExecutionMode requested = parseStreamingMode(rpcCall);
             PlanNodeStatsEstimate sourceStats = statsProvider == null
                     ? PlanNodeStatsEstimate.unknown()
                     : statsProvider.getStats(source);
@@ -698,17 +703,27 @@ public class RpcFunctionOptimizer
             return properties;
         }
 
-        private RPCNode.StreamingMode parseStreamingMode(CallExpression rpcCall)
+        private RpcExecutionMode parseStreamingMode(CallExpression rpcCall)
         {
-            // Per-function override from constant options JSON takes precedence.
-            Optional<RPCNode.StreamingMode> fromJson = parseOptionsJson(rpcCall)
+            // Per-function override from constant options JSON takes precedence over
+            // the session property; an unrecognized value is a user error (fail fast
+            // with a clear message rather than silently falling back).
+            Optional<String> fromJson = parseOptionsJson(rpcCall)
                     .map(json -> json.path("streaming_mode").asText(""))
-                    .filter(mode -> mode.equalsIgnoreCase("batch"))
-                    .map(mode -> RPCNode.StreamingMode.BATCH);
+                    .filter(mode -> !mode.isEmpty());
             if (fromJson.isPresent()) {
-                return fromJson.get();
+                for (RpcExecutionMode mode : RpcExecutionMode.values()) {
+                    if (mode.name().equalsIgnoreCase(fromJson.get())) {
+                        return mode;
+                    }
+                }
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        format(
+                                "Invalid rpc streaming_mode '%s' in RPC options JSON; valid values: %s",
+                                fromJson.get(),
+                                Arrays.toString(RpcExecutionMode.values())));
             }
-            // Fall back to session property.
             return getRpcStreamingMode(session);
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -114,17 +114,17 @@ public class TestRpcFunctionOptimizer
         };
     }
 
-    private RPCNode.StreamingMode invokeParseStreamingMode(CallExpression rpcCall) throws Exception
+    private RpcExecutionMode invokeParseStreamingMode(CallExpression rpcCall) throws Exception
     {
         return invokeParseStreamingMode(rpcCall, TestingSession.testSessionBuilder().build());
     }
 
-    private RPCNode.StreamingMode invokeParseStreamingMode(CallExpression rpcCall, Session session) throws Exception
+    private RpcExecutionMode invokeParseStreamingMode(CallExpression rpcCall, Session session) throws Exception
     {
         Object rewriter = createRewriter(session);
         Method method = rewriter.getClass().getDeclaredMethod("parseStreamingMode", CallExpression.class);
         method.setAccessible(true);
-        return (RPCNode.StreamingMode) method.invoke(rewriter, rpcCall);
+        return (RpcExecutionMode) method.invoke(rewriter, rpcCall);
     }
 
     private int invokeParseDispatchBatchSize(CallExpression rpcCall) throws Exception
@@ -167,7 +167,7 @@ public class TestRpcFunctionOptimizer
     {
         CallExpression rpcCall = createRpcCall(
                 varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"batch\"}"));
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.BATCH);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.BATCH);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TestRpcFunctionOptimizer
     {
         CallExpression rpcCall = createRpcCall(
                 varchar("{\"api_key\":\"test-key\"}"));
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.PER_ROW);
     }
 
     @Test
@@ -183,7 +183,38 @@ public class TestRpcFunctionOptimizer
     {
         CallExpression rpcCall = createRpcCall(
                 varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"per_row\"}"));
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.PER_ROW);
+    }
+
+    @Test
+    public void testParseStreamingModeConstantObjectives() throws Exception
+    {
+        // The full RpcExecutionMode enum parses from the JSON streaming_mode, including objectives.
+        assertEquals(invokeParseStreamingMode(createRpcCall(
+                varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"automatic\"}"))), RpcExecutionMode.AUTOMATIC);
+        assertEquals(invokeParseStreamingMode(createRpcCall(
+                varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"latency\"}"))), RpcExecutionMode.LATENCY);
+        assertEquals(invokeParseStreamingMode(createRpcCall(
+                varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"throughput\"}"))), RpcExecutionMode.THROUGHPUT);
+        assertEquals(invokeParseStreamingMode(createRpcCall(
+                varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"cost\"}"))), RpcExecutionMode.COST);
+    }
+
+    @Test
+    public void testParseStreamingModeUnknownValueThrows() throws Exception
+    {
+        // An unrecognized streaming_mode in JSON is a user error: fail fast rather
+        // than silently falling back to the session property.
+        CallExpression rpcCall = createRpcCall(
+                varchar("{\"api_key\":\"test-key\",\"streaming_mode\":\"bogus\"}"));
+        try {
+            invokeParseStreamingMode(rpcCall);
+            fail("Expected PrestoException for unknown streaming_mode");
+        }
+        catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof PrestoException);
+            assertTrue(e.getCause().getMessage().contains("Invalid rpc streaming_mode 'bogus'"));
+        }
     }
 
     @Test
@@ -196,7 +227,7 @@ public class TestRpcFunctionOptimizer
                 new VariableReferenceExpression(Optional.empty(), "key_col", VARCHAR),
                 varchar("\"}"));
         CallExpression rpcCall = createRpcCall(concatOptions);
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.PER_ROW);
     }
 
     @Test
@@ -211,7 +242,7 @@ public class TestRpcFunctionOptimizer
         Session batchSession = TestingSession.testSessionBuilder()
                 .setSystemProperty("rpc_streaming_mode", "BATCH")
                 .build();
-        assertEquals(invokeParseStreamingMode(rpcCall, batchSession), RPCNode.StreamingMode.BATCH);
+        assertEquals(invokeParseStreamingMode(rpcCall, batchSession), RpcExecutionMode.BATCH);
     }
 
     @Test
@@ -219,7 +250,7 @@ public class TestRpcFunctionOptimizer
     {
         CallExpression rpcCall = createRpcCall(
                 new VariableReferenceExpression(Optional.empty(), "options_col", VARCHAR));
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.PER_ROW);
     }
 
     @Test
@@ -231,7 +262,7 @@ public class TestRpcFunctionOptimizer
                 handle,
                 VARCHAR,
                 ImmutableList.of(varchar("prompt"), varchar("model")));
-        assertEquals(invokeParseStreamingMode(rpcCall), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(invokeParseStreamingMode(rpcCall), RpcExecutionMode.PER_ROW);
     }
 
     @Test
@@ -243,7 +274,7 @@ public class TestRpcFunctionOptimizer
         Session batchSession = TestingSession.testSessionBuilder()
                 .setSystemProperty("rpc_streaming_mode", "BATCH")
                 .build();
-        assertEquals(invokeParseStreamingMode(rpcCall, batchSession), RPCNode.StreamingMode.BATCH);
+        assertEquals(invokeParseStreamingMode(rpcCall, batchSession), RpcExecutionMode.BATCH);
     }
 
     @Test
@@ -906,7 +937,7 @@ public class TestRpcFunctionOptimizer
 
     // Runs a policy's translateIntent for the given requested mode + input stats and returns the
     // resolved streaming mode.
-    private static RPCNode.StreamingMode resolvedMode(RpcExecutionPolicy policy, RPCNode.StreamingMode requested, PlanNodeStatsEstimate stats, Session session)
+    private static RPCNode.StreamingMode resolvedMode(RpcExecutionPolicy policy, RpcExecutionMode requested, PlanNodeStatsEstimate stats, Session session)
     {
         RpcExecutionIntent intent = RpcExecutionIntent.builder()
                 .setRequestedMode(requested)
@@ -918,16 +949,20 @@ public class TestRpcFunctionOptimizer
     }
 
     @Test
-    public void testDefaultPolicyResolvesAutomaticToPerRow()
+    public void testDefaultPolicyResolvesModes()
     {
-        // OSS default carries no batching heuristic: AUTOMATIC -> PER_ROW; explicit modes pass through.
+        // OSS default (no cardinality heuristic): explicit PER_ROW/BATCH pass through; THROUGHPUT /
+        // COST -> BATCH; LATENCY and AUTOMATIC -> PER_ROW.
         DefaultRpcExecutionPolicy policy = new DefaultRpcExecutionPolicy();
         Session session = TestingSession.testSessionBuilder().build();
         PlanNodeStatsEstimate largeStats = PlanNodeStatsEstimate.builder().setOutputRowCount(1_000_000).build();
-        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.AUTOMATIC, largeStats, session), RPCNode.StreamingMode.PER_ROW);
-        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.AUTOMATIC, PlanNodeStatsEstimate.unknown(), session), RPCNode.StreamingMode.PER_ROW);
-        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.BATCH, PlanNodeStatsEstimate.builder().setOutputRowCount(1).build(), session), RPCNode.StreamingMode.BATCH);
-        assertEquals(resolvedMode(policy, RPCNode.StreamingMode.PER_ROW, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.PER_ROW, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.BATCH, PlanNodeStatsEstimate.unknown(), session), RPCNode.StreamingMode.BATCH);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.THROUGHPUT, largeStats, session), RPCNode.StreamingMode.BATCH);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.COST, largeStats, session), RPCNode.StreamingMode.BATCH);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.LATENCY, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.AUTOMATIC, largeStats, session), RPCNode.StreamingMode.PER_ROW);
+        assertEquals(resolvedMode(policy, RpcExecutionMode.AUTOMATIC, PlanNodeStatsEstimate.unknown(), session), RPCNode.StreamingMode.PER_ROW);
     }
 
     @Test
@@ -946,9 +981,9 @@ public class TestRpcFunctionOptimizer
         // The optimizer enforces the policy contract at plan time: a policy that returns
         // AUTOMATIC (e.g. by passing the requested mode through unchanged) must fail loudly
         // here rather than leak AUTOMATIC into the serialized RPCNode and fail at the worker.
-        RpcExecutionPolicy passthrough = intent -> RpcExecutionProperties.of(intent.getRequestedMode());
+        RpcExecutionPolicy returnsAutomatic = intent -> RpcExecutionProperties.of(RPCNode.StreamingMode.AUTOMATIC);
         try {
-            optimizeWithPolicy(streamingModeSession("AUTOMATIC"), passthrough);
+            optimizeWithPolicy(streamingModeSession("AUTOMATIC"), returnsAutomatic);
             fail("expected rejection when policy returns AUTOMATIC");
         }
         catch (IllegalArgumentException expected) {


### PR DESCRIPTION
Summary:

Part 7 of 11 — mode selection. See D113094973 for the stack guide.

Choosing a dispatch mode required the author to know which one was faster for
their data, so rpc_streaming_mode was set by hand and went stale as the
workload changed.

Let a query state an objective instead. rpc_streaming_mode gains intent
objectives, and DefaultRpcExecutionPolicy maps an objective to a concrete mode.

Lands alone: explicit PER_ROW and BATCH pass through unchanged, and without
the Meta override AUTOMATIC degrades to PER_ROW -- defined and conservative
rather than unhandled. D114682924 binds the override that resolves it from
cardinality, and depends on this diff for the policy it overrides.

Differential Revision: D114682925


