### PR TITLE
perf(function): Lazily resolve window functions in FunctionResolution (#28265)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -868,7 +868,6 @@ public class RowExpressionInterpreter
 
         private SpecialCallResult tryHandleLike(CallExpression callExpression, List<Object> argumentValues, List<Type> argumentTypes, Object context)
         {
-            FunctionResolution resolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
             checkArgument(resolution.isLikeFunction(callExpression.getFunctionHandle()));
             checkArgument(callExpression.getArguments().size() == 2);
             RowExpression likePatternExpression = callExpression.getArguments().get(1);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -59,17 +59,31 @@ public final class FunctionResolution
         implements StandardFunctionResolution
 {
     private final FunctionAndTypeResolver functionAndTypeResolver;
-    private final List<QualifiedObjectName> windowValueFunctions;
+    private volatile ImmutableList<QualifiedObjectName> windowValueFunctions;
 
     public FunctionResolution(FunctionAndTypeResolver functionAndTypeResolver)
     {
         this.functionAndTypeResolver = requireNonNull(functionAndTypeResolver, "functionManager is null");
-        this.windowValueFunctions = ImmutableList.of(
-                functionAndTypeResolver.qualifyObjectName(QualifiedName.of("lead")),
-                functionAndTypeResolver.qualifyObjectName(QualifiedName.of("lag")),
-                functionAndTypeResolver.qualifyObjectName(QualifiedName.of("first_value")),
-                functionAndTypeResolver.qualifyObjectName(QualifiedName.of("last_value")),
-                functionAndTypeResolver.qualifyObjectName(QualifiedName.of("nth_value")));
+    }
+
+    private List<QualifiedObjectName> getWindowValueFunctions()
+    {
+        ImmutableList<QualifiedObjectName> result = windowValueFunctions;
+        if (result == null) {
+            synchronized (this) {
+                result = windowValueFunctions;
+                if (result == null) {
+                    result = ImmutableList.of(
+                            functionAndTypeResolver.qualifyObjectName(QualifiedName.of("lead")),
+                            functionAndTypeResolver.qualifyObjectName(QualifiedName.of("lag")),
+                            functionAndTypeResolver.qualifyObjectName(QualifiedName.of("first_value")),
+                            functionAndTypeResolver.qualifyObjectName(QualifiedName.of("last_value")),
+                            functionAndTypeResolver.qualifyObjectName(QualifiedName.of("nth_value")));
+                    windowValueFunctions = result;
+                }
+            }
+        }
+        return result;
     }
 
     @Override
@@ -434,7 +448,7 @@ public final class FunctionResolution
 
     public boolean isWindowValueFunction(FunctionHandle functionHandle)
     {
-        return windowValueFunctions.contains(functionAndTypeResolver.getFunctionMetadata(functionHandle).getName());
+        return getWindowValueFunctions().contains(functionAndTypeResolver.getFunctionMetadata(functionHandle).getName());
     }
 
     public boolean isMapSubSetFunction(FunctionHandle functionHandle)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
@@ -103,6 +103,19 @@ public class TestFunctionResolution
     }
 
     @Test
+    public void testIsWindowValueFunction()
+    {
+        assertTrue(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("lead", ImmutableList.of(BIGINT))));
+        assertTrue(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("lag", ImmutableList.of(BIGINT))));
+        assertTrue(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("first_value", ImmutableList.of(BIGINT))));
+        assertTrue(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("last_value", ImmutableList.of(BIGINT))));
+        assertTrue(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("nth_value", ImmutableList.of(BIGINT, BIGINT))));
+
+        assertFalse(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("rank", ImmutableList.of())));
+        assertFalse(functionResolution.isWindowValueFunction(functionResolution.lookupBuiltInFunction("sum", ImmutableList.of(BIGINT))));
+    }
+
+    @Test
     public void testLookupFunctionWithNonDefaultSchemaAndCatalog()
     {
         StandardFunctionResolution standardFunctionResolution = functionResolution;


### PR DESCRIPTION
Summary:

`FunctionResolution`'s constructor eagerly resolved five window-value
function names (`lead`, `lag`, `first_value`, `last_value`, `nth_value`)
via `qualifyObjectName`. Since `RowExpressionInterpreter` constructs a new
`FunctionResolution` per instance and `RowExpressionOptimizer` builds a new
interpreter on every `optimize` call, constraint evaluation over partitions
and per-prefix `information_schema` LIKE evaluation repeated this resolution
on every iteration, even though those paths never call
`isWindowValueFunction`.

Resolve the window-value function names lazily on first use, and reuse the
interpreter's existing `FunctionResolution` in `tryHandleLike` instead of
allocating a new one per LIKE evaluation.

Differential Revision: D114714184

```
== RELEASE NOTES ==

General Changes
* Improve query planning performance by resolving window-value functions
  lazily during expression optimization.
```