### PR TITLE
feat(spi): Add opt-in write-side compression verification to the ORC writer (#28266)

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATIS
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MIN_OUTPUT_BUFFER_CHUNK_SIZE;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_RESET_OUTPUT_BUFFER;
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_VERIFY_COMPRESSION;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -54,6 +55,7 @@ public class ColumnWriterOptions
     private final int maxFlattenedMapKeyCount;
     private final boolean resetOutputBuffer;
     private final boolean lazyOutputBuffer;
+    private final boolean verifyCompression;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
@@ -72,7 +74,8 @@ public class ColumnWriterOptions
             boolean mapStatisticsEnabled,
             int maxFlattenedMapKeyCount,
             boolean resetOutputBuffer,
-            boolean lazyOutputBuffer)
+            boolean lazyOutputBuffer,
+            boolean verifyCompression)
     {
         checkArgument(maxFlattenedMapKeyCount > 0, "maxFlattenedMapKeyCount must be positive: %s", maxFlattenedMapKeyCount);
         requireNonNull(compressionMaxBufferSize, "compressionMaxBufferSize is null");
@@ -94,6 +97,7 @@ public class ColumnWriterOptions
         this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
         this.resetOutputBuffer = resetOutputBuffer;
         this.lazyOutputBuffer = lazyOutputBuffer;
+        this.verifyCompression = verifyCompression;
     }
 
     public CompressionKind getCompressionKind()
@@ -180,6 +184,12 @@ public class ColumnWriterOptions
     {
         return lazyOutputBuffer;
     }
+
+    public boolean isVerifyCompression()
+    {
+        return verifyCompression;
+    }
+
     /**
      * Create a copy of this ColumnWriterOptions, but disable string and integer dictionary encodings.
      */
@@ -210,7 +220,8 @@ public class ColumnWriterOptions
                 .setMapStatisticsEnabled(isMapStatisticsEnabled())
                 .setMaxFlattenedMapKeyCount(getMaxFlattenedMapKeyCount())
                 .setResetOutputBuffer(resetOutputBuffer)
-                .setLazyOutputBuffer(lazyOutputBuffer);
+                .setLazyOutputBuffer(lazyOutputBuffer)
+                .setVerifyCompression(verifyCompression);
     }
 
     public static Builder builder()
@@ -237,6 +248,7 @@ public class ColumnWriterOptions
         private int maxFlattenedMapKeyCount = DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT;
         private boolean resetOutputBuffer = DEFAULT_RESET_OUTPUT_BUFFER;
         private boolean lazyOutputBuffer = DEFAULT_LAZY_OUTPUT_BUFFER;
+        private boolean verifyCompression = DEFAULT_VERIFY_COMPRESSION;
 
         private Builder() {}
 
@@ -342,6 +354,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setVerifyCompression(boolean verifyCompression)
+        {
+            this.verifyCompression = verifyCompression;
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
             return new ColumnWriterOptions(
@@ -361,7 +379,8 @@ public class ColumnWriterOptions
                     mapStatisticsEnabled,
                     maxFlattenedMapKeyCount,
                     resetOutputBuffer,
-                    lazyOutputBuffer);
+                    lazyOutputBuffer,
+                    verifyCompression);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcCompressionVerificationException.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcCompressionVerificationException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import static java.lang.String.format;
+
+/**
+ * Thrown by the writer when the optional write-side compression verification
+ * detects that a freshly compressed chunk does not decode back to its original
+ * bytes. Aborting the write prevents persisting a corrupt file.
+ */
+public class OrcCompressionVerificationException
+        extends RuntimeException
+{
+    public OrcCompressionVerificationException(String messageFormat, Object... args)
+    {
+        super(format(messageFormat, args));
+    }
+
+    public OrcCompressionVerificationException(Throwable cause, String messageFormat, Object... args)
+    {
+        super(format(messageFormat, args), cause);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -17,11 +17,16 @@ import com.facebook.presto.orc.checkpoint.InputStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.writer.CompressionBufferPool;
 import com.facebook.presto.orc.zlib.DeflateCompressor;
+import com.facebook.presto.orc.zlib.InflateDecompressor;
 import com.facebook.presto.orc.zstd.ZstdJniCompressor;
+import com.facebook.presto.orc.zstd.ZstdJniDecompressor;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.compress.Compressor;
+import io.airlift.compress.Decompressor;
 import io.airlift.compress.lz4.Lz4Compressor;
+import io.airlift.compress.lz4.Lz4Decompressor;
 import io.airlift.compress.snappy.SnappyCompressor;
+import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import jakarta.annotation.Nullable;
@@ -62,6 +67,16 @@ public class OrcOutputBuffer
     private final Optional<DwrfDataEncryptor> dwrfEncryptor;
     @Nullable
     private final Compressor compressor;
+    // When non-null, each freshly compressed chunk is decompressed and compared
+    // against its source bytes before being written, so a corrupt frame aborts
+    // the write instead of being persisted. Null when verification is disabled.
+    @Nullable
+    private final Decompressor verifyDecompressor;
+    // Dedicated scratch-buffer pool holding the decompressed bytes produced during
+    // verification, kept separate from 'compressionBufferPool' so the compressed chunk
+    // being verified and its decoded copy never alias. Null when verification is disabled.
+    @Nullable
+    private final CompressionBufferPool verifyDecompressionBufferPool;
 
     private OrcChunkedOutputBuffer compressedOutputStream;
     private Slice slice;
@@ -115,6 +130,13 @@ public class OrcOutputBuffer
         else {
             throw new IllegalArgumentException("Unsupported compression " + compressionKind);
         }
+
+        this.verifyDecompressor = (columnWriterOptions.isVerifyCompression() && compressor != null)
+                ? createVerifyDecompressor(compressionKind)
+                : null;
+        this.verifyDecompressionBufferPool = verifyDecompressor != null
+                ? new CompressionBufferPool.LastUsedCompressionBufferPool()
+                : null;
     }
 
     public long getOutputDataSize()
@@ -527,6 +549,9 @@ public class OrcOutputBuffer
                 compressionBuffer = compressionBufferPool.checkOut(minCompressionBufferSize);
                 int compressedSize = compressor.compress(chunk, offset, length, compressionBuffer, 0, compressionBuffer.length);
                 if (compressedSize < length) {
+                    if (verifyDecompressor != null) {
+                        verifyCompressedChunk(verifyDecompressor, verifyDecompressionBufferPool, chunk, offset, length, compressionBuffer, compressedSize);
+                    }
                     isCompressed = true;
                     chunk = compressionBuffer;
                     length = compressedSize;
@@ -558,6 +583,69 @@ public class OrcOutputBuffer
         compressedOutputStream.ensureAvailable(3, length + 3);
         compressedOutputStream.writeHeader(header);
         compressedOutputStream.writeBytes(chunk, offset, length);
+    }
+
+    private static Decompressor createVerifyDecompressor(CompressionKind compressionKind)
+    {
+        switch (compressionKind) {
+            case SNAPPY:
+                return new SnappyDecompressor();
+            case ZLIB:
+                return new InflateDecompressor();
+            case LZ4:
+                return new Lz4Decompressor();
+            case ZSTD:
+                return new ZstdJniDecompressor();
+            default:
+                throw new IllegalArgumentException("Unsupported compression for verification: " + compressionKind);
+        }
+    }
+
+    /**
+     * Decompresses a freshly compressed chunk and checks it round-trips to the original bytes.
+     * Throws {@link OrcCompressionVerificationException} on decode failure or content mismatch so
+     * the write is aborted before a corrupt chunk is persisted. The scratch buffer is borrowed
+     * from a dedicated 'decompressionBufferPool', kept separate from the compression buffer pool
+     * so the compressed chunk being verified and its decoded copy never alias.
+     */
+    @VisibleForTesting
+    static void verifyCompressedChunk(
+            Decompressor verifyDecompressor,
+            CompressionBufferPool decompressionBufferPool,
+            byte[] original,
+            int offset,
+            int length,
+            byte[] compressed,
+            int compressedLength)
+    {
+        byte[] decompressed = decompressionBufferPool.checkOut(length);
+        try {
+            int decompressedLength;
+            try {
+                decompressedLength = verifyDecompressor.decompress(compressed, 0, compressedLength, decompressed, 0, length);
+            }
+            catch (RuntimeException e) {
+                // Any decode failure (ZstdException, MalformedInputException, ...) means the
+                // freshly compressed chunk is not decodable. Chain the cause so the original
+                // decoder stack trace is preserved.
+                throw new OrcCompressionVerificationException(
+                        e,
+                        "Write-side compression verification failed: %s (uncompressedSize=%s compressedSize=%s)",
+                        e.getMessage(),
+                        length,
+                        compressedLength);
+            }
+            if (decompressedLength != length || !Arrays.equals(decompressed, 0, length, original, offset, offset + length)) {
+                throw new OrcCompressionVerificationException(
+                        "Write-side compression verification failed: chunk does not decode back to the original bytes (uncompressedSize=%s compressedSize=%s decompressedSize=%s)",
+                        length,
+                        compressedLength,
+                        decompressedLength);
+            }
+        }
+        finally {
+            decompressionBufferPool.checkIn(decompressed);
+        }
     }
 
     @VisibleForTesting

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -238,6 +238,7 @@ public class OrcWriter
                 .setMaxFlattenedMapKeyCount(options.getMaxFlattenedMapKeyCount())
                 .setResetOutputBuffer(options.isResetOutputBuffer())
                 .setLazyOutputBuffer(options.isLazyOutputBuffer())
+                .setVerifyCompression(options.isVerifyCompression())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
         recordValidation(validation -> validation.setFlattenedNodes(flattenedNodes));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -51,6 +51,7 @@ public class OrcWriterOptions
     public static final boolean DEFAULT_STRING_DICTIONARY_SORTING_ENABLED = true;
     public static final boolean DEFAULT_RESET_OUTPUT_BUFFER = false;
     public static final boolean DEFAULT_LAZY_OUTPUT_BUFFER = false;
+    public static final boolean DEFAULT_VERIFY_COMPRESSION = false;
     private final OrcWriterFlushPolicy flushPolicy;
     private final int rowGroupMaxRowCount;
     private final DataSize dictionaryMaxMemory;
@@ -77,6 +78,7 @@ public class OrcWriterOptions
     private final int maxFlattenedMapKeyCount;
     private final boolean resetOutputBuffer;
     private final boolean lazyOutputBuffer;
+    private final boolean verifyCompression;
 
     /**
      * Contains indexes of columns (not nodes!) for which writer should use flattened encoding, e.g. flat maps.
@@ -106,7 +108,8 @@ public class OrcWriterOptions
             boolean mapStatisticsEnabled,
             int maxFlattenedMapKeyCount,
             boolean resetOutputBuffer,
-            boolean lazyOutputBuffer)
+            boolean lazyOutputBuffer,
+            boolean verifyCompression)
     {
         requireNonNull(flushPolicy, "flushPolicy is null");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
@@ -146,6 +149,7 @@ public class OrcWriterOptions
         this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
         this.resetOutputBuffer = resetOutputBuffer;
         this.lazyOutputBuffer = lazyOutputBuffer;
+        this.verifyCompression = verifyCompression;
     }
 
     public OrcWriterFlushPolicy getFlushPolicy()
@@ -263,6 +267,11 @@ public class OrcWriterOptions
         return lazyOutputBuffer;
     }
 
+    public boolean isVerifyCompression()
+    {
+        return verifyCompression;
+    }
+
     @Override
     public String toString()
     {
@@ -288,6 +297,7 @@ public class OrcWriterOptions
                 .add("maxFlattenedMapKeyCount", maxFlattenedMapKeyCount)
                 .add("resetOutputBuffer", resetOutputBuffer)
                 .add("lazyOutputBuffer", lazyOutputBuffer)
+                .add("verifyCompression", verifyCompression)
                 .toString();
     }
 
@@ -328,6 +338,7 @@ public class OrcWriterOptions
         private int maxFlattenedMapKeyCount = DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT;
         private boolean resetOutputBuffer = DEFAULT_RESET_OUTPUT_BUFFER;
         private boolean lazyOutputBuffer = DEFAULT_LAZY_OUTPUT_BUFFER;
+        private boolean verifyCompression = DEFAULT_VERIFY_COMPRESSION;
 
         public Builder withFlushPolicy(OrcWriterFlushPolicy flushPolicy)
         {
@@ -481,6 +492,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withVerifyCompression(boolean verifyCompression)
+        {
+            this.verifyCompression = verifyCompression;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -514,7 +531,8 @@ public class OrcWriterOptions
                     mapStatisticsEnabled,
                     maxFlattenedMapKeyCount,
                     resetOutputBuffer,
-                    lazyOutputBuffer);
+                    lazyOutputBuffer,
+                    verifyCompression);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.units.DataSize;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.stream.SharedBuffer;
 import com.facebook.presto.orc.writer.CompressionBufferPool;
+import com.facebook.presto.orc.zstd.ZstdJniCompressor;
+import com.facebook.presto.orc.zstd.ZstdJniDecompressor;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.BasicSliceInput;
 import io.airlift.slice.DynamicSliceOutput;
@@ -43,6 +45,7 @@ import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.util.Collections.reverse;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 public class TestOrcOutputBuffer
@@ -186,6 +189,78 @@ public class TestOrcOutputBuffer
         orcOutputBuffer.writeBytes(byteArray, 0, ZSTD.getMinCompressibleSize() + 10);
         orcOutputBuffer.flush();
         assertTrue(pool.getLastUsedSize() > ZSTD.getMinCompressibleSize() + 10);
+    }
+
+    @Test
+    public void testVerifyCompressionRoundTrips()
+    {
+        int size = 1024 * 1024;
+        byte[] data = new byte[size];
+        Arrays.fill(data, (byte) 0xA);
+
+        ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder()
+                .setCompressionKind(ZSTD)
+                .setCompressionLevel(OptionalInt.of(7))
+                .setCompressionMaxBufferSize(new DataSize(256, KILOBYTE))
+                .setVerifyCompression(true)
+                .build();
+        OrcOutputBuffer orcOutputBuffer = new OrcOutputBuffer(columnWriterOptions, Optional.empty());
+
+        // A well-formed ZSTD chunk must pass verification (no throw) and still round-trip on read.
+        orcOutputBuffer.writeBytes(data, 0, size);
+        orcOutputBuffer.flush();
+
+        DynamicSliceOutput output = new DynamicSliceOutput(orcOutputBuffer.size());
+        orcOutputBuffer.writeDataTo(output);
+        assertEquals(wrappedBuffer(decompress(output.slice()).bytes), wrappedBuffer(data));
+    }
+
+    @Test
+    public void testVerifyCompressionDetectsCorruptFrame()
+    {
+        int length = 4096;
+        byte[] original = new byte[length];
+        Arrays.fill(original, (byte) 0xA);
+        // Not a valid ZSTD frame; decompression fails and must surface as a verification error.
+        byte[] garbage = new byte[64];
+        Arrays.fill(garbage, (byte) 0xFF);
+
+        assertThrows(
+                OrcCompressionVerificationException.class,
+                () -> OrcOutputBuffer.verifyCompressedChunk(
+                        new ZstdJniDecompressor(),
+                        new CompressionBufferPool.LastUsedCompressionBufferPool(),
+                        original,
+                        0,
+                        length,
+                        garbage,
+                        garbage.length));
+    }
+
+    @Test
+    public void testVerifyCompressionDetectsContentMismatch()
+    {
+        int length = 4096;
+        byte[] original = new byte[length];
+        Arrays.fill(original, (byte) 0xA);
+
+        // Validly compress DIFFERENT bytes: the frame decodes fine but not back to 'original'.
+        byte[] other = new byte[length];
+        Arrays.fill(other, (byte) 0xB);
+        ZstdJniCompressor compressor = new ZstdJniCompressor(OptionalInt.of(7));
+        byte[] compressed = new byte[compressor.maxCompressedLength(length)];
+        int compressedLength = compressor.compress(other, 0, length, compressed, 0, compressed.length);
+
+        assertThrows(
+                OrcCompressionVerificationException.class,
+                () -> OrcOutputBuffer.verifyCompressedChunk(
+                        new ZstdJniDecompressor(),
+                        new CompressionBufferPool.LastUsedCompressionBufferPool(),
+                        original,
+                        0,
+                        length,
+                        compressed,
+                        compressedLength));
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -199,7 +199,7 @@ public class TestOrcWriterOptions
                 "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
                 "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
                 "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4], mapStatisticsEnabled=true, " +
-                "maxFlattenedMapKeyCount=27, resetOutputBuffer=false, lazyOutputBuffer=false}";
+                "maxFlattenedMapKeyCount=27, resetOutputBuffer=false, lazyOutputBuffer=false, verifyCompression=false}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
Summary:

The ORC/DWRF writer can emit a compressed chunk that later fails to decode, surfacing far downstream as a read-time ZSTD error long after the file is committed. This adds an opt-in write-side check: when enabled, each freshly compressed chunk is immediately decompressed and compared against its source bytes before it is written, so a corrupt frame aborts the write instead of being persisted.

The check is controlled by a new `OrcWriterOptions.verifyCompression` option (off by default), threaded through `ColumnWriterOptions` to `OrcOutputBuffer`. Verification reuses the reader's codec (for example `ZstdJniDecompressor`) and borrows a dedicated scratch buffer from a separate `CompressionBufferPool` instance (created only when verification is enabled), since the compression buffer still holds the chunk being verified. Any decode failure or byte mismatch throws `OrcCompressionVerificationException` (chaining the underlying decoder exception), aborting the write.

```
== NO RELEASE NOTE ==
```

Differential Revision: D114293190


