### PR TITLE
fix(plugin-lance): Follow page tokens when listing tables and namespaces

### DIFF
--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -398,8 +398,8 @@ public class LanceNamespaceHolder
             }
         }
         catch (Exception e) {
-            log.debug("Failed to get storage options from describeTable for %s: %s", tableId, e.getMessage());
-        }
++            log.debug(e, "Failed to get storage options from describeTable for %s", tableId);
++        }
 
         if (!namespaceStorageOptions.isEmpty()) {
             return namespaceStorageOptions;

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -52,12 +52,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -283,16 +285,17 @@ public class LanceNamespaceHolder
             return Collections.singletonList(DEFAULT_SCHEMA);
         }
 
-        ListNamespacesRequest request = new ListNamespacesRequest();
-        if (parentPrefix.isPresent()) {
-            request.setId(parentPrefix.get());
-        }
-        ListNamespacesResponse response = namespace.listNamespaces(request);
-        Set<String> namespaces = response.getNamespaces();
-        if (namespaces == null || namespaces.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return namespaces.stream().collect(toImmutableList());
+        return drainPages(
+                pageToken -> {
+                    ListNamespacesRequest request = new ListNamespacesRequest();
+                    parentPrefix.ifPresent(request::setId);
+                    if (pageToken != null) {
+                        request.setPageToken(pageToken);
+                    }
+                    return namespace.listNamespaces(request);
+                },
+                ListNamespacesResponse::getNamespaces,
+                ListNamespacesResponse::getPageToken);
     }
 
     /**
@@ -419,15 +422,48 @@ public class LanceNamespaceHolder
     public List<String> listTables(String schemaName)
     {
         List<String> namespaceId = prestoSchemaToLanceNamespace(schemaName);
-        ListTablesRequest request = new ListTablesRequest();
-        request.setId(namespaceId);
+        return drainPages(
+                pageToken -> {
+                    ListTablesRequest request = new ListTablesRequest();
+                    request.setId(namespaceId);
+                    if (pageToken != null) {
+                        request.setPageToken(pageToken);
+                    }
+                    return namespace.listTables(request);
+                },
+                ListTablesResponse::getTables,
+                ListTablesResponse::getPageToken);
+    }
 
-        ListTablesResponse response = namespace.listTables(request);
-        Set<String> tables = response.getTables();
-        if (tables == null || tables.isEmpty()) {
-            return Collections.emptyList();
+    /**
+     * Drains a paginated listing, following page tokens until the server stops
+     * returning one. Results accumulate in encounter order, and entries repeated
+     * across pages collapse.
+     * <p>
+     * Paging also stops if the server echoes back the token that was just
+     * requested, so a misbehaving server cannot spin the coordinator in a hot loop.
+     *
+     * @param fetchPage fetches one page; receives null for the first request
+     */
+    private static <T> List<String> drainPages(
+            Function<String, T> fetchPage,
+            Function<T, Set<String>> getItems,
+            Function<T, String> getPageToken)
+    {
+        Set<String> items = new LinkedHashSet<>();
+        String requestedToken = null;
+        while (true) {
+            T page = fetchPage.apply(requestedToken);
+            Set<String> pageItems = getItems.apply(page);
+            if (pageItems != null) {
+                items.addAll(pageItems);
+            }
+            String responseToken = getPageToken.apply(page);
+            if (responseToken == null || responseToken.isEmpty() || responseToken.equals(requestedToken)) {
+                return items.stream().collect(toImmutableList());
+            }
+            requestedToken = responseToken;
         }
-        return tables.stream().collect(toImmutableList());
     }
 
     /**

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -398,8 +398,8 @@ public class LanceNamespaceHolder
             }
         }
         catch (Exception e) {
-+            log.debug(e, "Failed to get storage options from describeTable for %s", tableId);
-+        }
+            log.debug(e, "Failed to get storage options from describeTable for %s", tableId);
+        }
 
         if (!namespaceStorageOptions.isEmpty()) {
             return namespaceStorageOptions;

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
@@ -13,7 +13,15 @@
  */
 package com.facebook.presto.lance;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.arrow.memory.BufferAllocator;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
 import org.testng.annotations.Test;
 
 import java.nio.file.Files;
@@ -270,6 +278,123 @@ public class TestLanceNamespaceHolder
         }
         finally {
             deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testListTablesFollowsPageTokens()
+    {
+        LanceConfig config = new LanceConfig()
+                .setImpl(PagingNamespace.class.getName())
+                .setSingleLevelNs(false);
+        LanceNamespaceHolder holder = new LanceNamespaceHolder(config, ImmutableMap.of());
+        try {
+            // The namespace serves three tables across two pages; a single unpaged call
+            // would silently return only the first page.
+            assertEquals(holder.listTables("my_schema"), ImmutableList.of("t1", "t2", "t3"));
+        }
+        finally {
+            holder.shutdown();
+        }
+    }
+
+    @Test
+    public void testListSchemaNamesFollowsPageTokens()
+    {
+        LanceConfig config = new LanceConfig()
+                .setImpl(PagingNamespace.class.getName())
+                .setSingleLevelNs(false);
+        LanceNamespaceHolder holder = new LanceNamespaceHolder(config, ImmutableMap.of());
+        try {
+            assertEquals(holder.listSchemaNames(), ImmutableList.of("ns1", "ns2", "ns3"));
+        }
+        finally {
+            holder.shutdown();
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testRepeatedPageTokenTerminates()
+    {
+        LanceConfig config = new LanceConfig()
+                .setImpl(StuckTokenNamespace.class.getName())
+                .setSingleLevelNs(false);
+        LanceNamespaceHolder holder = new LanceNamespaceHolder(config, ImmutableMap.of());
+        try {
+            // A server that keeps echoing the same token must not spin forever.
+            assertEquals(holder.listTables("my_schema"), ImmutableList.of("t1"));
+        }
+        finally {
+            holder.shutdown();
+        }
+    }
+
+    /**
+     * Serves tables and namespaces across two pages, keyed off the incoming page token.
+     */
+    public static class PagingNamespace
+            implements LanceNamespace
+    {
+        @Override
+        public void initialize(Map<String, String> properties, BufferAllocator allocator) {}
+
+        @Override
+        public String namespaceId()
+        {
+            return "paging";
+        }
+
+        @Override
+        public ListTablesResponse listTables(ListTablesRequest request)
+        {
+            ListTablesResponse response = new ListTablesResponse();
+            if (request.getPageToken() == null) {
+                response.setTables(ImmutableSet.of("t1", "t2"));
+                response.setPageToken("page2");
+            }
+            else {
+                response.setTables(ImmutableSet.of("t3"));
+            }
+            return response;
+        }
+
+        @Override
+        public ListNamespacesResponse listNamespaces(ListNamespacesRequest request)
+        {
+            ListNamespacesResponse response = new ListNamespacesResponse();
+            if (request.getPageToken() == null) {
+                response.setNamespaces(ImmutableSet.of("ns1", "ns2"));
+                response.setPageToken("page2");
+            }
+            else {
+                response.setNamespaces(ImmutableSet.of("ns3"));
+            }
+            return response;
+        }
+    }
+
+    /**
+     * Always returns the same page token, as a misbehaving server would.
+     */
+    public static class StuckTokenNamespace
+            implements LanceNamespace
+    {
+        @Override
+        public void initialize(Map<String, String> properties, BufferAllocator allocator) {}
+
+        @Override
+        public String namespaceId()
+        {
+            return "stuck";
+        }
+
+        @Override
+        public ListTablesResponse listTables(ListTablesRequest request)
+        {
+            ListTablesResponse response = new ListTablesResponse();
+            response.setTables(ImmutableSet.of("t1"));
+            response.setPageToken("always-the-same");
+            return response;
         }
     }
 


### PR DESCRIPTION
## Description

Follow page tokens when listing tables and namespaces in the Lance
connector, instead of issuing a single request and discarding the token.

`listTables` and `listSchemaNames` now loop, feeding each response page
token into the next request until the server stops returning one.
Results accumulate into a `LinkedHashSet`, so page order is preserved
and entries repeated across pages collapse. Paging also stops if the
server returns the token that was just requested, so a misbehaving
server cannot spin the coordinator in a hot loop.

## Motivation and Context

The Lance namespace API paginates `ListTables` and `ListNamespaces`. The
connector issued a single request and dropped the returned page token,
so `SHOW TABLES` returned only the first page and reported success. A
catalog with more tables than the server page size silently appeared to
have fewer tables than it does — no error, no warning, just a short
list.

Against a REST namespace that caps a page at 1000 entries, every schema
past that threshold is affected.

## Impact

`SHOW TABLES`, `information_schema.tables`, and `SHOW SCHEMAS` now
return complete results for Lance catalogs larger than one server page.
Catalogs that fit in a single page are unaffected: the server returns no
page token and the loop exits after one request, exactly as before.

Listing a large catalog now issues one request per page rather than one
request total.

## Test Plan

- `./mvnw test -pl presto-lance` — new tests cover multi-page listing
  for both `listTables` and `listSchemaNames`, plus the repeated-token
  guard, using a fake `LanceNamespace` wired in through `lance.impl`.
- Reverted the fix and re-ran the new tests to confirm they fail without
  it — both report 2 entries instead of 3.
- Verified the truncation against a live REST namespace rather than only
  in a fake: the table list endpoint returns `"page_token":"1000"`
  alongside the first 1000 tables, which the old code dropped.

## Contributor checklist

- [x] The submission follows the contributing guide and code style.
- [x] The PR description describes the change and user impact.
- [x] Adequate tests were added.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Lance Connector Changes
* Fix ``SHOW TABLES`` and ``SHOW SCHEMAS`` silently returning only the
  first page of results for catalogs larger than the namespace server's
  page size.
```
