### PR TITLE
fix(plugin-lance): List tables across all schemas when no schema is given

### DIFF
--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
@@ -144,10 +144,27 @@ public class LanceMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        String schema = schemaName.orElse(LanceNamespaceHolder.DEFAULT_SCHEMA);
-        if (!namespaceHolder.schemaExists(schema)) {
-            return ImmutableList.of();
+        if (schemaName.isPresent()) {
+            String schema = schemaName.get();
+            if (!namespaceHolder.schemaExists(schema)) {
+                return ImmutableList.of();
+            }
+            return listTablesInSchema(schema);
         }
+
+        // No schema filter means every schema in the catalog. Falling back to a single
+        // default schema would return nothing in multi-level mode, where "default" is
+        // not a real namespace.
+        ImmutableList.Builder<SchemaTableName> tables = ImmutableList.builder();
+        for (String schema : namespaceHolder.listSchemaNames()) {
+            // The namespace just listed these, so an existence check would be a wasted round trip.
+            tables.addAll(listTablesInSchema(schema));
+        }
+        return tables.build();
+    }
+
+    private List<SchemaTableName> listTablesInSchema(String schema)
+    {
         return namespaceHolder.listTables(schema).stream()
                 .map(tableName -> new SchemaTableName(schema, tableName))
                 .collect(toImmutableList());

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceMetadata.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceMetadata.java
@@ -18,9 +18,17 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
+import org.apache.arrow.memory.BufferAllocator;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -153,5 +161,105 @@ public class TestLanceMetadata
         // no schema filter
         List<SchemaTableName> allTables = metadata.listTables(null, Optional.empty());
         assertEquals(ImmutableSet.copyOf(allTables), tableSet);
+    }
+
+    @Test
+    public void testListTablesWithoutSchemaSpansAllSchemas()
+    {
+        LanceNamespaceHolder holder = multiLevelHolder();
+        try {
+            // With no schema filter Presto expects every schema in the catalog. Defaulting
+            // to "default" would return nothing here, since it is not a real namespace.
+            assertEquals(
+                    ImmutableSet.copyOf(metadataFor(holder).listTables(null, Optional.empty())),
+                    ImmutableSet.of(
+                            new SchemaTableName("schema_a", "t_a1"),
+                            new SchemaTableName("schema_a", "t_a2"),
+                            new SchemaTableName("schema_b", "t_b1")));
+        }
+        finally {
+            holder.shutdown();
+        }
+    }
+
+    @Test
+    public void testListTablesWithSchemaFilterInMultiLevelMode()
+    {
+        LanceNamespaceHolder holder = multiLevelHolder();
+        try {
+            LanceMetadata multiLevel = metadataFor(holder);
+            assertEquals(
+                    ImmutableSet.copyOf(multiLevel.listTables(null, Optional.of("schema_a"))),
+                    ImmutableSet.of(
+                            new SchemaTableName("schema_a", "t_a1"),
+                            new SchemaTableName("schema_a", "t_a2")));
+            // An absent schema still yields nothing rather than throwing.
+            assertEquals(multiLevel.listTables(null, Optional.of("no_such_schema")), ImmutableList.of());
+        }
+        finally {
+            holder.shutdown();
+        }
+    }
+
+    private static LanceNamespaceHolder multiLevelHolder()
+    {
+        LanceConfig config = new LanceConfig()
+                .setImpl(MultiSchemaNamespace.class.getName())
+                .setSingleLevelNs(false);
+        return new LanceNamespaceHolder(config, ImmutableMap.of());
+    }
+
+    private static LanceMetadata metadataFor(LanceNamespaceHolder holder)
+    {
+        return new LanceMetadata(holder, jsonCodec(LanceCommitTaskData.class));
+    }
+
+    /**
+     * Serves two sibling schemas, each with its own tables.
+     */
+    public static class MultiSchemaNamespace
+            implements LanceNamespace
+    {
+        private static final Map<String, Set<String>> TABLES_BY_SCHEMA = ImmutableMap.of(
+                "schema_a", ImmutableSet.of("t_a1", "t_a2"),
+                "schema_b", ImmutableSet.of("t_b1"));
+
+        @Override
+        public void initialize(Map<String, String> properties, BufferAllocator allocator) {}
+
+        @Override
+        public String namespaceId()
+        {
+            return "multi-schema";
+        }
+
+        @Override
+        public ListNamespacesResponse listNamespaces(ListNamespacesRequest request)
+        {
+            ListNamespacesResponse response = new ListNamespacesResponse();
+            response.setNamespaces(TABLES_BY_SCHEMA.keySet());
+            return response;
+        }
+
+        @Override
+        public void namespaceExists(NamespaceExistsRequest request)
+        {
+            if (!TABLES_BY_SCHEMA.containsKey(lastElement(request.getId()))) {
+                throw new IllegalArgumentException("no such namespace");
+            }
+        }
+
+        @Override
+        public ListTablesResponse listTables(ListTablesRequest request)
+        {
+            ListTablesResponse response = new ListTablesResponse();
+            response.setTables(TABLES_BY_SCHEMA.getOrDefault(lastElement(request.getId()), ImmutableSet.of()));
+            return response;
+        }
+
+        private static String lastElement(List<String> id)
+        {
+            return id == null || id.isEmpty() ? "" : id.get(id.size() - 1);
+        }
     }
 }


### PR DESCRIPTION
## Description

List tables across all schemas when `ConnectorMetadata.listTables` is
called without a schema, instead of collapsing to the single schema
`default`.

`listTables` now fans out over `listSchemaNames` when no schema is
given, and keeps the previous single-schema path when one is supplied.
Schemas returned by the namespace skip the redundant `schemaExists`
check, since the server just reported them; only an explicitly requested
schema is still probed before listing.

## Motivation and Context

Presto calls `ConnectorMetadata.listTables` with an empty schema when it
needs every table in the catalog. That is what backs
`information_schema.tables` scans and `listTableColumns` with a
schema-less prefix.

The connector collapsed that case to the single schema `default`. In
multi-level mode (`lance.single-level-ns=false`) `default` is not a real
namespace, so the existence check failed and the call returned an empty
list. Catalog-wide table listing reported no tables and no error.

The existing coverage only exercised single-level mode, where `default`
is the one real schema, so the gap went unnoticed.

## Impact

Behavior fix for multi-level Lance catalogs: `information_schema.tables`
and schema-less `listTableColumns` now return the catalog's tables
instead of an empty result. Single-level mode returns the same results
as before, which the pre-existing `testListTables` still asserts.

A schema-less listing now issues one `listTables` call per schema rather
than one call total.

## Test Plan

- `./mvnw test -pl presto-lance` — added multi-level coverage for the
  schema-less and explicit-schema cases, using a fake `LanceNamespace`
  serving two sibling schemas.
- Reverted the fix and re-ran the new tests to confirm they fail without
  it: the schema-less case returns `[]` where three tables are expected.

## Contributor checklist

- [x] The submission follows the contributing guide and code style.
- [x] The PR description describes the change and user impact.
- [x] Adequate tests were added.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Lance Connector Changes
* Fix catalog-wide table listing returning no tables for multi-level
  Lance catalogs (``lance.single-level-ns=false``). This affected
  ``information_schema.tables`` scans.
```
