### PR TITLE
fix(server): Make plugin ArtifactResolver initialization lazy

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -97,7 +97,7 @@ public class PluginManager
     private final QueryPrerequisitesManager queryPrerequisitesManager;
     private final NodeTtlFetcherManager nodeTtlFetcherManager;
     private final ClusterTtlProviderManager clusterTtlProviderManager;
-    private final ArtifactResolver resolver;
+    private final Supplier<ArtifactResolver> resolver;
     private final File installedPluginsDir;
     private final List<String> plugins;
     private final AtomicBoolean pluginsLoading = new AtomicBoolean();
@@ -150,7 +150,7 @@ public class PluginManager
         else {
             this.plugins = ImmutableList.copyOf(config.getPlugins());
         }
-        this.resolver = new ArtifactResolver(config.getMavenLocalRepository(), config.getMavenRemoteRepository());
+        this.resolver = Suppliers.memoize(() -> new ArtifactResolver(config.getMavenLocalRepository(), config.getMavenRemoteRepository()));
 
         this.connectorManager = requireNonNull(connectorManager, "connectorManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.RouterPlugin;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import org.eclipse.aether.artifact.Artifact;
@@ -138,6 +139,26 @@ public class PluginManagerUtil
             ClassLoader parent)
             throws Exception
     {
+        return buildClassLoaders(
+                installedPluginsDir,
+                plugins,
+                () -> resolver,
+                spiPackages,
+                coordinatorPluginServicesFile,
+                pluginServicesFile,
+                parent);
+    }
+
+    public static List<PluginClassLoaderHandle> buildClassLoaders(
+            File installedPluginsDir,
+            List<String> plugins,
+            Supplier<ArtifactResolver> resolver,
+            List<String> spiPackages,
+            String coordinatorPluginServicesFile,
+            String pluginServicesFile,
+            ClassLoader parent)
+            throws Exception
+    {
         List<String> pluginsToLoad = new ArrayList<>();
         for (File file : listFiles(installedPluginsDir)) {
             if (file.isDirectory()) {
@@ -214,7 +235,7 @@ public class PluginManagerUtil
 
     private static URLClassLoader buildClassLoader(
             String plugin,
-            ArtifactResolver resolver,
+            Supplier<ArtifactResolver> resolver,
             List<String> spiPackages,
             String coordinatorPluginServicesFile,
             String pluginServicesFile,
@@ -223,12 +244,12 @@ public class PluginManagerUtil
     {
         File file = Paths.get(plugin).toFile();
         if (file.isFile() && (file.getName().equals("pom.xml") || file.getName().endsWith(".pom"))) {
-            return buildClassLoaderFromPom(file, resolver, spiPackages, coordinatorPluginServicesFile, pluginServicesFile, parent);
+            return buildClassLoaderFromPom(file, resolver.get(), spiPackages, coordinatorPluginServicesFile, pluginServicesFile, parent);
         }
         if (file.isDirectory()) {
             return buildClassLoaderFromDirectory(file, spiPackages, parent);
         }
-        return buildClassLoaderFromCoordinates(plugin, resolver, spiPackages, parent);
+        return buildClassLoaderFromCoordinates(plugin, resolver.get(), spiPackages, parent);
     }
 
     private static URLClassLoader buildClassLoaderFromPom(


### PR DESCRIPTION
Summary: Defer Resolver construction until a POM or Maven-coordinate plugin actually needs it while preserving thread-safe memoization.

Differential Revision: D114823869

## Summary by Sourcery

Make plugin artifact resolution lazily initialized and memoized while updating plugin classloader construction APIs to accept a resolver supplier.

Enhancements:
- Introduce an overloaded PluginManagerUtil.buildClassLoaders method that accepts a lazily evaluated ArtifactResolver supplier.
- Update plugin classloader creation to retrieve an ArtifactResolver on demand via a Supplier rather than constructing it eagerly.
- Wrap ArtifactResolver construction in a memoized supplier in PluginManager to preserve single-instance reuse while deferring initialization.

```
== NO RELEASE NOTE ==
```