### PR TITLE
Simani/flightshim jmx metrics

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
@@ -25,12 +26,16 @@ import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import org.weakref.jmx.guice.MBeanModule;
+
+import javax.management.MBeanServer;
 
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectorFactory
@@ -67,7 +72,9 @@ public class JdbcConnectorFactory
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
+                    new MBeanModule(),
                     binder -> {
+                        binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
                         binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());

--- a/presto-docs/src/main/sphinx/presto_cpp/federation.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/federation.rst
@@ -129,6 +129,51 @@ To enable mTLS, the following properties must be configured:
 - ``arrow-flight.client-ssl-key``: Path to the client's SSL private key file. Used to establish the secure connection.
 - ``arrow-flight.server.verify``: When set to true, enables certificate verification.
 
+.. _flightshim_jmx_metrics:
+
+JMX Metrics
+-----------
+
+FlightShim registers operational metrics as MBeans on the platform MBean server.
+To reach them from outside the FlightShim process, enable the JMX remote agent in
+``etc/jvm.config``, for example:
+
+.. code-block:: none
+
+    -Dcom.sun.management.jmxremote
+    -Dcom.sun.management.jmxremote.port=9080
+    -Dcom.sun.management.jmxremote.rmi.port=9080
+
+Global FlightShim metrics are exported as:
+
+.. code-block:: none
+
+    com.facebook.presto.flightshim:name=FlightShimStats
+
+Per downstream connector metrics (for example ``mysql``) are exported as:
+
+.. code-block:: none
+
+    com.facebook.presto.flightshim:type=FlightShimConnectorStats,name=<connectorId>
+
+FlightShim thread pool metrics are exported as:
+
+.. code-block:: none
+
+    com.facebook.presto.flightshim:name=FlightShimServerExecutionMBean
+
+Downstream JDBC connectors loaded inside FlightShim also export their standard
+connector MBeans (for example JDBC metadata cache stats) when catalogs are
+created.
+
+Example queries using the ``jmx`` connector on a coordinator that can reach
+the FlightShim JMX port:
+
+.. code-block:: sql
+
+    SELECT * FROM jmx.current."com.facebook.presto.flightshim:name=FlightShimStats"
+    SELECT * FROM jmx.current."com.facebook.presto.flightshim:type=FlightShimConnectorStats,name=mysql"
+
 .. _running_flightshim:
 
 Running FlightShim

--- a/presto-flight-shim/etc/flightshim.properties
+++ b/presto-flight-shim/etc/flightshim.properties
@@ -2,7 +2,6 @@ flight-shim.server=localhost
 flight-shim.server.port=9999
 flight-shim.server-ssl-certificate-file=src/test/resources/certs/server.crt
 flight-shim.server-ssl-key-file=src/test/resources/certs/server.key
-
 plugin.bundles=\
   ../presto-oracle/pom.xml,\
   ../presto-postgresql/pom.xml,\

--- a/presto-flight-shim/etc/flightshim.properties
+++ b/presto-flight-shim/etc/flightshim.properties
@@ -2,6 +2,7 @@ flight-shim.server=localhost
 flight-shim.server.port=9999
 flight-shim.server-ssl-certificate-file=src/test/resources/certs/server.crt
 flight-shim.server-ssl-key-file=src/test/resources/certs/server.key
+
 plugin.bundles=\
   ../presto-oracle/pom.xml,\
   ../presto-postgresql/pom.xml,\

--- a/presto-flight-shim/pom.xml
+++ b/presto-flight-shim/pom.xml
@@ -123,6 +123,11 @@
 
         <dependency>
             <groupId>com.facebook.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
             <artifactId>node</artifactId>
         </dependency>
 
@@ -195,6 +200,12 @@
         <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStats.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStats.java
@@ -51,13 +51,13 @@ public class FlightShimConnectorStats
     public void recordStreamCompleted(long streamLatencyNanos)
     {
         streamsCompleted.update(1);
-        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+        streamLatency.add(streamLatencyNanos, NANOSECONDS);
     }
 
     public void recordStreamError(long streamLatencyNanos)
     {
         streamErrors.update(1);
-        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+        streamLatency.add(streamLatencyNanos, NANOSECONDS);
     }
 
     public void recordBatchShipped(long rows)

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStats.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStats.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class FlightShimConnectorStats
+{
+    private final String connectorId;
+    private final AtomicInteger activeStreams = new AtomicInteger();
+    private final CounterStat streamsCompleted = new CounterStat();
+    private final CounterStat streamErrors = new CounterStat();
+    private final CounterStat rowsShipped = new CounterStat();
+    private final CounterStat batchesShipped = new CounterStat();
+    private final TimeStat streamLatency = new TimeStat(MILLISECONDS);
+
+    public FlightShimConnectorStats(String connectorId)
+    {
+        this.connectorId = connectorId;
+    }
+
+    public void recordStreamStarted()
+    {
+        activeStreams.incrementAndGet();
+    }
+
+    public void recordStreamFinished()
+    {
+        activeStreams.decrementAndGet();
+    }
+
+    public void recordStreamCompleted(long streamLatencyNanos)
+    {
+        streamsCompleted.update(1);
+        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+    }
+
+    public void recordStreamError(long streamLatencyNanos)
+    {
+        streamErrors.update(1);
+        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+    }
+
+    public void recordBatchShipped(long rows)
+    {
+        batchesShipped.update(1);
+        rowsShipped.update(rows);
+    }
+
+    @Managed
+    public String getConnectorId()
+    {
+        return connectorId;
+    }
+
+    @Managed
+    public int getActiveStreams()
+    {
+        return activeStreams.get();
+    }
+
+    @Managed
+    public long getStreamsCompleted()
+    {
+        return streamsCompleted.getTotalCount();
+    }
+
+    @Managed
+    public long getStreamErrors()
+    {
+        return streamErrors.getTotalCount();
+    }
+
+    @Managed
+    public long getRowsShipped()
+    {
+        return rowsShipped.getTotalCount();
+    }
+
+    @Managed
+    public long getBatchesShipped()
+    {
+        return batchesShipped.getTotalCount();
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getStreamLatency()
+    {
+        return streamLatency;
+    }
+}

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStatsManager.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimConnectorStatsManager.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.facebook.airlift.log.Logger;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import org.weakref.jmx.JmxException;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.ObjectNames;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Objects.requireNonNull;
+
+public class FlightShimConnectorStatsManager
+{
+    private static final Logger log = Logger.get(FlightShimConnectorStatsManager.class);
+
+    private final MBeanExporter exporter;
+    private final ConcurrentHashMap<String, FlightShimConnectorStats> statsByConnectorId = new ConcurrentHashMap<>();
+    @GuardedBy("this")
+    private final List<String> exportedObjectNames = new ArrayList<>();
+
+    @Inject
+    public FlightShimConnectorStatsManager(MBeanExporter exporter)
+    {
+        this.exporter = requireNonNull(exporter, "exporter is null");
+    }
+
+    public FlightShimConnectorStats getOrCreate(String connectorId)
+    {
+        FlightShimConnectorStats existing = statsByConnectorId.get(connectorId);
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (this) {
+            existing = statsByConnectorId.get(connectorId);
+            if (existing != null) {
+                return existing;
+            }
+
+            FlightShimConnectorStats stats = new FlightShimConnectorStats(connectorId);
+            String objectName = ObjectNames.builder(FlightShimConnectorStats.class, connectorId).build();
+            try {
+                exporter.export(objectName, stats);
+                exportedObjectNames.add(objectName);
+            }
+            catch (JmxException e) {
+                log.warn(e, "Failed to export MBean %s", objectName);
+            }
+            statsByConnectorId.put(connectorId, stats);
+            return stats;
+        }
+    }
+
+    @PreDestroy
+    public synchronized void destroy()
+    {
+        for (String objectName : exportedObjectNames) {
+            try {
+                exporter.unexport(objectName);
+            }
+            catch (JmxException e) {
+                log.warn(e, "Failed to unexport MBean %s", objectName);
+            }
+        }
+        exportedObjectNames.clear();
+        statsByConnectorId.clear();
+    }
+}

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimModule.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimModule.java
@@ -29,6 +29,7 @@ import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.util.RebindSafeMBeanServer;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.HistoryBasedOptimizationConfig;
@@ -113,6 +114,8 @@ import jakarta.inject.Singleton;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 
+import javax.management.MBeanServer;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -124,6 +127,7 @@ import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class FlightShimModule
@@ -279,6 +283,13 @@ public class FlightShimModule
         binder.bind(FlightShimPluginManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).to(RootAllocator.class).in(Scopes.SINGLETON);
         binder.bind(FlightShimProducer.class).in(Scopes.SINGLETON);
+
+        binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
+
+        binder.bind(FlightShimStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(FlightShimStats.class).withGeneratedName();
+
+        binder.bind(FlightShimConnectorStatsManager.class).in(Scopes.SINGLETON);
 
         binder.bind(FlightShimServerExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FlightShimServerExecutionMBean.class).withGeneratedName();

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
@@ -45,6 +45,7 @@ import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.NoOpFlightProducer;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
 
 import javax.inject.Inject;
 
@@ -73,6 +74,8 @@ public class FlightShimProducer
     private final FlightShimConfig config;
     private final ExecutorService shimExecutor;
     private final JsonCodec<FlightShimRequest> requestCodec;
+    private final FlightShimStats stats;
+    private final FlightShimConnectorStatsManager connectorStatsManager;
 
     @Inject
     public FlightShimProducer(
@@ -82,13 +85,17 @@ public class FlightShimProducer
             @ForFlightShimServer ExecutorService shimExecutor,
             PageSourceManager pageSourceManager,
             TypeDeserializer typeDeserializer,
-            BlockEncodingManager blockEncodingManager)
+            BlockEncodingManager blockEncodingManager,
+            FlightShimStats stats,
+            FlightShimConnectorStatsManager connectorStatsManager)
     {
         this.allocator = allocator.newChildAllocator("flight-shim", 0, Long.MAX_VALUE);
         this.pluginManager = requireNonNull(pluginManager, "pluginManager is null");
         this.config = requireNonNull(config, "config is null");
         this.shimExecutor = requireNonNull(shimExecutor, "shimExecutor is null");
         this.pageSourceManager = requireNonNull(pageSourceManager, "pageSourceManager is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.connectorStatsManager = requireNonNull(connectorStatsManager, "connectorStatsManager is null");
         requireNonNull(typeDeserializer, "typeDeserializer is null");
         requireNonNull(blockEncodingManager, "blockEncodingManager is null");
 
@@ -113,15 +120,24 @@ public class FlightShimProducer
     private void runGetStreamAsync(CallContext context, Ticket ticket, ServerStreamListener listener)
     {
         log.debug("Starting GetStream processing");
+        long streamStartNanos = System.nanoTime();
+        stats.recordStreamStarted();
+        FlightShimConnectorStats connectorStats = null;
         int columnCount = 0;
         int rowCount = 0;
         int batchCount = 0;
+        boolean streamCompleted = false;
         try {
             final BackpressureStrategy backpressureStrategy = new BackpressureStrategy.CallbackBackpressureStrategy();
             backpressureStrategy.register(listener);
 
+            long deserializeStartNanos = System.nanoTime();
             FlightShimRequest request = requestCodec.fromJson(ticket.getBytes());
+            stats.recordTicketDeserialize(System.nanoTime() - deserializeStartNanos);
             log.debug("Request for connector: %s", request.getConnectorId());
+
+            connectorStats = connectorStatsManager.getOrCreate(request.getConnectorId());
+            connectorStats.recordStreamStarted();
 
             FlightShimPluginManager.ConnectorCodecs connectorCodecs = pluginManager.getConnectorCodecs(request.getConnectorId());
 
@@ -159,36 +175,79 @@ public class FlightShimProducer
                 throw new IllegalArgumentException(format("Request has different number of fields than column handles: %d != %d", columnsMetadata.size(), columnHandles.size()));
             }
 
+            long pageSourceStartNanos = System.nanoTime();
             ConnectorPageSource connectorPageSource = pageSourceManager.createPageSource(session, split, tableHandle, columnHandles, new RuntimeStats());
+            stats.recordPageSourceCreate(System.nanoTime() - pageSourceStartNanos);
 
             try (ArrowBatchSource batchSource = new ArrowBatchSource(allocator, columnsMetadata, connectorPageSource, config.getMaxRowsPerBatch())) {
                 listener.setUseZeroCopy(true);
                 listener.start(batchSource.getVectorSchemaRoot());
                 columnCount = batchSource.getVectorSchemaRoot().getFieldVectors().size();
-                while (batchSource.nextBatch()) {
-                    BackpressureStrategy.WaitResult waitResult;
-                    while ((waitResult = backpressureStrategy.waitForListener(CLIENT_POLL_TIME)) == BackpressureStrategy.WaitResult.TIMEOUT) {
-                        log.debug(format("Waiting for client to read from connector %s", request.getConnectorId()));
+                while (true) {
+                    long batchBuildStartNanos = System.nanoTime();
+                    if (!batchSource.nextBatch()) {
+                        break;
                     }
+                    stats.recordArrowBatchBuild(System.nanoTime() - batchBuildStartNanos);
+
+                    BackpressureStrategy.WaitResult waitResult;
+                    do {
+                        long backpressureStartNanos = System.nanoTime();
+                        waitResult = backpressureStrategy.waitForListener(CLIENT_POLL_TIME);
+                        if (waitResult == BackpressureStrategy.WaitResult.TIMEOUT) {
+                            stats.recordBackpressureWait(System.nanoTime() - backpressureStartNanos);
+                            log.debug(format("Waiting for client to read from connector %s", request.getConnectorId()));
+                        }
+                    }
+                    while (waitResult == BackpressureStrategy.WaitResult.TIMEOUT);
+
                     if (waitResult != BackpressureStrategy.WaitResult.READY) {
                         log.info(format("Read stopped from connector %s due to client wait result: %s", request.getConnectorId(), waitResult));
                         break;
                     }
-                    rowCount += batchSource.getVectorSchemaRoot().getRowCount();
+                    int batchRows = batchSource.getVectorSchemaRoot().getRowCount();
+                    long batchBytes = estimateBatchBytes(batchSource);
+                    rowCount += batchRows;
                     batchCount++;
+                    stats.recordBatchShipped(batchRows, batchBytes);
+                    connectorStats.recordBatchShipped(batchRows);
                     listener.putNext();
                 }
                 listener.completed();
+                streamCompleted = true;
             }
         }
         catch (Throwable t) {
             final String message = "Error getting connector flight stream";
             log.error(t, message);
+            stats.recordStreamError(System.nanoTime() - streamStartNanos);
+            if (connectorStats != null) {
+                connectorStats.recordStreamError(System.nanoTime() - streamStartNanos);
+            }
             listener.error(CallStatus.INTERNAL.withCause(t).withDescription(format("%s [%s]", message, t)).toRuntimeException());
         }
         finally {
+            stats.recordStreamFinished();
+            if (connectorStats != null) {
+                connectorStats.recordStreamFinished();
+            }
+            if (streamCompleted) {
+                stats.recordStreamCompleted(System.nanoTime() - streamStartNanos);
+                if (connectorStats != null) {
+                    connectorStats.recordStreamCompleted(System.nanoTime() - streamStartNanos);
+                }
+            }
             log.debug(format("Processing GetStream completed [columns=%d, rows=%d, batches=%d]", columnCount, rowCount, batchCount));
         }
+    }
+
+    private static long estimateBatchBytes(ArrowBatchSource batchSource)
+    {
+        long bytes = 0;
+        for (FieldVector vector : batchSource.getVectorSchemaRoot().getFieldVectors()) {
+            bytes += vector.getBufferSize();
+        }
+        return bytes;
     }
 
     public void shutdown()

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimServer.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimServer.java
@@ -21,13 +21,16 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
 import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.grpc.ContextPropagatingExecutorService;
 import org.apache.arrow.memory.BufferAllocator;
+import org.weakref.jmx.guice.MBeanModule;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -41,11 +44,12 @@ public class FlightShimServer
 
     public static Injector initialize(Map<String, String> config, Module... extraModules)
     {
-        Bootstrap app = new Bootstrap(ImmutableList.<Module>builder()
-                .add(new FlightShimModule())
-                .add(new JsonModule())
-                .add(extraModules)
-                .build());
+        List<Module> modules = ImmutableList.of(
+                new MBeanModule(),
+                new FlightShimModule(),
+                new JsonModule());
+
+        Bootstrap app = new Bootstrap(Modules.override(modules).with(extraModules));
 
         // Required for ConnectorManager - add as optional property because required will prevent loading config from file
         Map<String, String> optionalConfigProperties = new HashMap<>();

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimStats.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimStats.java
@@ -50,13 +50,13 @@ public class FlightShimStats
     public void recordStreamCompleted(long streamLatencyNanos)
     {
         streamsCompleted.update(1);
-        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+        streamLatency.add(streamLatencyNanos, NANOSECONDS);
     }
 
     public void recordStreamError(long streamLatencyNanos)
     {
         streamErrors.update(1);
-        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+        streamLatency.add(streamLatencyNanos, NANOSECONDS);
     }
 
     public void recordBatchShipped(long rows, long bytes)
@@ -68,22 +68,22 @@ public class FlightShimStats
 
     public void recordPageSourceCreate(long latencyNanos)
     {
-        pageSourceCreateLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+        pageSourceCreateLatency.add(latencyNanos, NANOSECONDS);
     }
 
     public void recordArrowBatchBuild(long latencyNanos)
     {
-        arrowBatchBuildLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+        arrowBatchBuildLatency.add(latencyNanos, NANOSECONDS);
     }
 
     public void recordBackpressureWait(long latencyNanos)
     {
-        backpressureWaitLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+        backpressureWaitLatency.add(latencyNanos, NANOSECONDS);
     }
 
     public void recordTicketDeserialize(long latencyNanos)
     {
-        ticketDeserializeLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+        ticketDeserializeLatency.add(latencyNanos, NANOSECONDS);
     }
 
     @Managed

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimStats.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimStats.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class FlightShimStats
+{
+    private final AtomicInteger activeStreams = new AtomicInteger();
+    private final CounterStat streamsCompleted = new CounterStat();
+    private final CounterStat streamErrors = new CounterStat();
+    private final CounterStat rowsShipped = new CounterStat();
+    private final CounterStat batchesShipped = new CounterStat();
+    private final CounterStat bytesShipped = new CounterStat();
+    private final TimeStat streamLatency = new TimeStat(MILLISECONDS);
+    private final TimeStat pageSourceCreateLatency = new TimeStat(MILLISECONDS);
+    private final TimeStat arrowBatchBuildLatency = new TimeStat(MILLISECONDS);
+    private final TimeStat backpressureWaitLatency = new TimeStat(MILLISECONDS);
+    private final TimeStat ticketDeserializeLatency = new TimeStat(MILLISECONDS);
+
+    public void recordStreamStarted()
+    {
+        activeStreams.incrementAndGet();
+    }
+
+    public void recordStreamFinished()
+    {
+        activeStreams.decrementAndGet();
+    }
+
+    public void recordStreamCompleted(long streamLatencyNanos)
+    {
+        streamsCompleted.update(1);
+        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+    }
+
+    public void recordStreamError(long streamLatencyNanos)
+    {
+        streamErrors.update(1);
+        streamLatency.add(NANOSECONDS.toMillis(streamLatencyNanos), MILLISECONDS);
+    }
+
+    public void recordBatchShipped(long rows, long bytes)
+    {
+        batchesShipped.update(1);
+        rowsShipped.update(rows);
+        bytesShipped.update(bytes);
+    }
+
+    public void recordPageSourceCreate(long latencyNanos)
+    {
+        pageSourceCreateLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+    }
+
+    public void recordArrowBatchBuild(long latencyNanos)
+    {
+        arrowBatchBuildLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+    }
+
+    public void recordBackpressureWait(long latencyNanos)
+    {
+        backpressureWaitLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+    }
+
+    public void recordTicketDeserialize(long latencyNanos)
+    {
+        ticketDeserializeLatency.add(NANOSECONDS.toMillis(latencyNanos), MILLISECONDS);
+    }
+
+    @Managed
+    public int getActiveStreams()
+    {
+        return activeStreams.get();
+    }
+
+    @Managed
+    public long getStreamsCompleted()
+    {
+        return streamsCompleted.getTotalCount();
+    }
+
+    @Managed
+    public long getStreamErrors()
+    {
+        return streamErrors.getTotalCount();
+    }
+
+    @Managed
+    public long getRowsShipped()
+    {
+        return rowsShipped.getTotalCount();
+    }
+
+    @Managed
+    public long getBatchesShipped()
+    {
+        return batchesShipped.getTotalCount();
+    }
+
+    @Managed
+    public long getBytesShipped()
+    {
+        return bytesShipped.getTotalCount();
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getStreamLatency()
+    {
+        return streamLatency;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getPageSourceCreateLatency()
+    {
+        return pageSourceCreateLatency;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getArrowBatchBuildLatency()
+    {
+        return arrowBatchBuildLatency;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBackpressureWaitLatency()
+    {
+        return backpressureWaitLatency;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getTicketDeserializeLatency()
+    {
+        return ticketDeserializeLatency;
+    }
+}

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimJmxMetrics.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimJmxMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.weakref.jmx.ObjectNames;
+import org.weakref.jmx.testing.TestingMBeanServer;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestFlightShimJmxMetrics
+{
+    private TestingMBeanServer mbeanServer;
+    private Injector injector;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        mbeanServer = new TestingMBeanServer();
+        injector = FlightShimServer.initialize(
+                ImmutableMap.of(
+                        "flight-shim.server", "localhost",
+                        "flight-shim.server.port", "9999"),
+                binder -> binder.bind(MBeanServer.class).toInstance(mbeanServer));
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        injector.getInstance(FlightShimConnectorStatsManager.class).destroy();
+    }
+
+    @Test
+    public void testFlightShimStatsExported()
+            throws Exception
+    {
+        FlightShimStats stats = injector.getInstance(FlightShimStats.class);
+        ObjectName objectName = new ObjectName(ObjectNames.generatedNameOf(FlightShimStats.class));
+
+        stats.recordStreamStarted();
+        assertEquals(mbeanServer.getAttribute(objectName, "ActiveStreams"), 1);
+
+        stats.recordBatchShipped(100, 4096);
+        stats.recordStreamFinished();
+        stats.recordStreamCompleted(1_000_000);
+
+        assertEquals(mbeanServer.getAttribute(objectName, "ActiveStreams"), 0);
+        assertEquals(mbeanServer.getAttribute(objectName, "StreamsCompleted"), 1L);
+        assertEquals(mbeanServer.getAttribute(objectName, "RowsShipped"), 100L);
+        assertEquals(mbeanServer.getAttribute(objectName, "BatchesShipped"), 1L);
+        assertEquals(mbeanServer.getAttribute(objectName, "BytesShipped"), 4096L);
+    }
+
+    @Test
+    public void testFlightShimConnectorStatsExported()
+            throws Exception
+    {
+        FlightShimConnectorStatsManager connectorStatsManager = injector.getInstance(FlightShimConnectorStatsManager.class);
+        FlightShimConnectorStats connectorStats = connectorStatsManager.getOrCreate("mysql");
+
+        String objectName = ObjectNames.builder(FlightShimConnectorStats.class, "mysql").build();
+
+        connectorStats.recordStreamStarted();
+        connectorStats.recordBatchShipped(50);
+        connectorStats.recordStreamFinished();
+        connectorStats.recordStreamCompleted(500_000);
+
+        assertEquals(mbeanServer.getAttribute(new ObjectName(objectName), "ActiveStreams"), 0);
+        assertEquals(mbeanServer.getAttribute(new ObjectName(objectName), "StreamsCompleted"), 1L);
+        assertEquals(mbeanServer.getAttribute(new ObjectName(objectName), "RowsShipped"), 50L);
+        assertEquals(mbeanServer.getAttribute(new ObjectName(objectName), "BatchesShipped"), 1L);
+        assertEquals(mbeanServer.getAttribute(new ObjectName(objectName), "ConnectorId"), "mysql");
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Add JMX observability to the FlightShim sidecar so Arrow Federation workloads can be monitored in production.

This change:

Exports global FlightShim stats via FlightShimStats (active/completed/errored streams, rows/batches/bytes shipped, and latency breakdowns for stream lifecycle, page source creation, Arrow batch build, backpressure wait, and ticket deserialization).

Exports per-connector stats via dynamically registered FlightShimConnectorStats MBeans (one per connector catalog).
Exports executor pool metrics via FlightShimServerExecutionMBean.

Instruments FlightShimProducer to record metrics during GetStream handling.

Wires JMX bootstrap into FlightShim startup (MBeanModule, JmxModule, MBeanExporter) and wraps JDBC connector factories with FlightShimJmxConnectorFactoryWrapper so connector-level JMX stats are available inside the shim.

Starts JMX at FlightShim JVM launch via RMI (default registry port 9015), avoiding reliance on the JVM Attach API in restricted deployments.

Routes metrics through the existing worker JMX/M3 collection path instead of a separate in-process Prometheus scrape endpoint.

Adds Photon startup helpers (start_flight_shim, bundled flightshim-jvm.config) and DSC exporter rules for metric collection.
Adds unit tests in TestFlightShimJmxMetrics.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->

This change adds first-class JMX metrics so FlightShim can be monitored alongside the rest of the Presto worker stack (JMX connector, M3/Prometheus scraping, dashboards, alerts).

<!---If it fixes an open issue, please link to the issue here.-->

## Impact

User-facing: No SQL or query behavior changes. No new required user configuration for basic operation.
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add JMX-based observability for FlightShim, exposing global, per-connector, and executor metrics and wiring them into the existing Presto JMX infrastructure.

New Features:
- Expose FlightShimStats JMX MBean for global stream, throughput, and latency metrics of FlightShim streams.
- Introduce per-connector FlightShimConnectorStats managed via FlightShimConnectorStatsManager and exported as JMX MBeans.
- Instrument FlightShimProducer GetStream handling to collect detailed latency, backpressure, and throughput metrics, including estimated bytes shipped.
- Enable MBeanModule and RebindSafeMBeanServer integration in FlightShimServer and JDBC connector bootstrap to support safe JMX registration in the shim.

Build:
- Add Airlift stats and Error Prone annotations dependencies to the presto-flight-shim module.

Tests:
- Add TestFlightShimJmxMetrics to verify FlightShimStats and FlightShimConnectorStats are exported and report expected JMX metrics.