### PR TITLE
feat(native): Add Arrow Flight client metrics and error propagation

### DIFF
--- a/presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowErrorCode.java
+++ b/presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowErrorCode.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.ErrorType;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 
 import static com.facebook.presto.common.ErrorType.EXTERNAL;
+import static com.facebook.presto.common.ErrorType.INSUFFICIENT_RESOURCES;
 import static com.facebook.presto.common.ErrorType.INTERNAL_ERROR;
 
 public enum ArrowErrorCode
@@ -29,13 +30,25 @@ public enum ArrowErrorCode
     ARROW_FLIGHT_METADATA_ERROR(3, EXTERNAL),
     ARROW_FLIGHT_TYPE_ERROR(4, EXTERNAL),
     ARROW_FLIGHT_INVALID_KEY_ERROR(5, INTERNAL_ERROR),
-    ARROW_FLIGHT_INVALID_CERT_ERROR(6, INTERNAL_ERROR);
+    ARROW_FLIGHT_INVALID_CERT_ERROR(6, INTERNAL_ERROR),
+    // Raised by the native Arrow Flight client; mirrored in
+    // presto-native-execution/presto_cpp/main/common/Exception.h
+    ARROW_FLIGHT_REMOTE_ERROR(7, EXTERNAL),
+    ARROW_FLIGHT_UNAVAILABLE_ERROR(8, EXTERNAL, true),
+    ARROW_FLIGHT_AUTH_ERROR(9, EXTERNAL),
+    ARROW_FLIGHT_INTERNAL_ERROR(10, INTERNAL_ERROR),
+    ARROW_FLIGHT_RESOURCE_ERROR(11, INSUFFICIENT_RESOURCES);
 
     private final ErrorCode errorCode;
 
     ArrowErrorCode(int code, ErrorType type)
     {
-        errorCode = new ErrorCode(code + 0x0510_0000, name(), type);
+        this(code, type, false);
+    }
+
+    ArrowErrorCode(int code, ErrorType type, boolean retriable)
+    {
+        errorCode = new ErrorCode(code + 0x0510_0000, name(), type, retriable);
     }
 
     @Override

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimErrors.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimErrors.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Attaches Presto error metadata to Flight call statuses so native clients can
+ * reconstruct the original error code. The Flight status itself is always
+ * INTERNAL; attribution travels in the trailers.
+ */
+public final class FlightShimErrors
+{
+    static final String ERROR_NAME_KEY = "presto-error-name";
+    static final String ERROR_CODE_KEY = "presto-error-code";
+    static final String ERROR_TYPE_KEY = "presto-error-type";
+    static final String ERROR_RETRIABLE_KEY = "presto-error-retriable";
+
+    // Trailers recognized by Arrow C++ clients; the binary details trailer is
+    // surfaced as FlightStatusDetail::extra_info only when x-arrow-status is
+    // also present (see arrow/flight/transport/grpc/util_internal.cc).
+    static final String ARROW_STATUS_KEY = "x-arrow-status";
+    static final String GRPC_STATUS_DETAILS_KEY = "grpc-status-details-bin";
+
+    // arrow::StatusCode::IOError. Carries no classification; it exists only to
+    // satisfy the gate above, since attribution travels in the details trailer.
+    private static final int ARROW_STATUS_IO_ERROR = 5;
+
+    private FlightShimErrors() {}
+
+    public static FlightRuntimeException toFlightException(String description, Throwable throwable)
+    {
+        return toCallStatus(throwable).withCause(throwable).withDescription(description).toRuntimeException();
+    }
+
+    static CallStatus toCallStatus(Throwable throwable)
+    {
+        return new CallStatus(FlightStatusCode.INTERNAL, null, null, toMetadata(findErrorCode(throwable)));
+    }
+
+    private static ErrorCode findErrorCode(Throwable throwable)
+    {
+        for (Throwable cause = throwable; cause != null; cause = (cause.getCause() == cause) ? null : cause.getCause()) {
+            if (cause instanceof PrestoException) {
+                return ((PrestoException) cause).getErrorCode();
+            }
+        }
+        return GENERIC_INTERNAL_ERROR.toErrorCode();
+    }
+
+    private static ErrorFlightMetadata toMetadata(ErrorCode errorCode)
+    {
+        ErrorFlightMetadata metadata = new ErrorFlightMetadata();
+        metadata.insert(ERROR_NAME_KEY, errorCode.getName());
+        metadata.insert(ERROR_CODE_KEY, Integer.toString(errorCode.getCode()));
+        metadata.insert(ERROR_TYPE_KEY, errorCode.getType().name());
+        metadata.insert(ERROR_RETRIABLE_KEY, Boolean.toString(errorCode.isRetriable()));
+        metadata.insert(ARROW_STATUS_KEY, Integer.toString(ARROW_STATUS_IO_ERROR));
+        metadata.insert(GRPC_STATUS_DETAILS_KEY, serializeDetails(errorCode));
+        return metadata;
+    }
+
+    private static byte[] serializeDetails(ErrorCode errorCode)
+    {
+        String payload = ERROR_NAME_KEY + "=" + errorCode.getName() + "\n" +
+                ERROR_CODE_KEY + "=" + errorCode.getCode() + "\n" +
+                ERROR_TYPE_KEY + "=" + errorCode.getType().name() + "\n" +
+                ERROR_RETRIABLE_KEY + "=" + errorCode.isRetriable();
+        return payload.getBytes(UTF_8);
+    }
+}

--- a/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
+++ b/presto-flight-shim/src/main/java/com/facebook/presto/flightshim/FlightShimProducer.java
@@ -41,7 +41,6 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.flight.BackpressureStrategy;
-import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.NoOpFlightProducer;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
@@ -184,7 +183,7 @@ public class FlightShimProducer
         catch (Throwable t) {
             final String message = "Error getting connector flight stream";
             log.error(t, message);
-            listener.error(CallStatus.INTERNAL.withCause(t).withDescription(format("%s [%s]", message, t)).toRuntimeException());
+            listener.error(FlightShimErrors.toFlightException(format("%s [%s]", message, t), t));
         }
         finally {
             log.debug(format("Processing GetStream completed [columns=%d, rows=%d, batches=%d]", columnCount, rowCount, batchCount));

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimErrors.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestFlightShimErrors.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.flightshim;
+
+import com.facebook.plugin.arrow.ArrowErrorCode;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightStatusCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.flightshim.FlightShimErrors.ARROW_STATUS_KEY;
+import static com.facebook.presto.flightshim.FlightShimErrors.ERROR_CODE_KEY;
+import static com.facebook.presto.flightshim.FlightShimErrors.ERROR_NAME_KEY;
+import static com.facebook.presto.flightshim.FlightShimErrors.ERROR_RETRIABLE_KEY;
+import static com.facebook.presto.flightshim.FlightShimErrors.ERROR_TYPE_KEY;
+import static com.facebook.presto.flightshim.FlightShimErrors.GRPC_STATUS_DETAILS_KEY;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestFlightShimErrors
+{
+    @Test
+    public void testUserError()
+    {
+        CallStatus status = FlightShimErrors.toCallStatus(new PrestoException(NOT_FOUND, "table dropped"));
+        assertEquals(status.metadata().get(ERROR_NAME_KEY), "NOT_FOUND");
+        assertEquals(status.metadata().get(ERROR_CODE_KEY), Integer.toString(NOT_FOUND.toErrorCode().getCode()));
+        assertEquals(status.metadata().get(ERROR_TYPE_KEY), "USER_ERROR");
+        assertEquals(status.metadata().get(ERROR_RETRIABLE_KEY), "false");
+    }
+
+    @Test
+    public void testRetriableExternalErrorInCauseChain()
+    {
+        CallStatus status = FlightShimErrors.toCallStatus(new RuntimeException(
+                new PrestoException(ArrowErrorCode.ARROW_FLIGHT_UNAVAILABLE_ERROR, "remote down")));
+        assertEquals(status.metadata().get(ERROR_RETRIABLE_KEY), "true");
+        String details = new String(status.metadata().getByte(GRPC_STATUS_DETAILS_KEY), UTF_8);
+        assertTrue(details.contains(ERROR_NAME_KEY + "=ARROW_FLIGHT_UNAVAILABLE_ERROR"));
+        assertTrue(details.contains(ERROR_TYPE_KEY + "=EXTERNAL"));
+        assertTrue(details.contains(ERROR_RETRIABLE_KEY + "=true"));
+    }
+
+    @Test
+    public void testInsufficientResources()
+    {
+        CallStatus status = FlightShimErrors.toCallStatus(
+                new PrestoException(GENERIC_INSUFFICIENT_RESOURCES, "out of memory"));
+        assertEquals(status.metadata().get(ERROR_TYPE_KEY), "INSUFFICIENT_RESOURCES");
+    }
+
+    @Test
+    public void testUnclassifiedErrorFallsBackToOpaqueInternalError()
+    {
+        CallStatus status = FlightShimErrors.toCallStatus(new NullPointerException("bug"));
+        assertEquals(status.code(), FlightStatusCode.INTERNAL);
+        assertEquals(status.metadata().get(ERROR_NAME_KEY), "GENERIC_INTERNAL_ERROR");
+        assertEquals(status.metadata().get(ERROR_TYPE_KEY), "INTERNAL_ERROR");
+    }
+
+    @Test
+    public void testStatusIsInternalForEveryErrorType()
+    {
+        assertStatusIsInternal(new PrestoException(NOT_FOUND, "user"));
+        assertStatusIsInternal(new PrestoException(GENERIC_INTERNAL_ERROR, "internal"));
+        assertStatusIsInternal(new PrestoException(GENERIC_INSUFFICIENT_RESOURCES, "resources"));
+        assertStatusIsInternal(new PrestoException(ArrowErrorCode.ARROW_FLIGHT_UNAVAILABLE_ERROR, "external"));
+    }
+
+    private static void assertStatusIsInternal(Throwable throwable)
+    {
+        CallStatus status = FlightShimErrors.toCallStatus(throwable);
+        assertEquals(status.code(), FlightStatusCode.INTERNAL);
+        assertEquals(status.metadata().get(ARROW_STATUS_KEY), "5");
+    }
+}

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -30,6 +30,53 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumHTTPRequest, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterNumHTTPRequestError, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterHTTPRequestLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightConnectLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightAuthenticateLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightDoGetLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightBatchWaitLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightDecodeLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightStreamLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightConnectErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightAuthenticateErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightDoGetErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightReadErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightDecodeErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightUserErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightExternalErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightInsufficientResourcesErrors,
+      facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightInternalErrors, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightStreamsStarted, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightStreamsCompleted, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightStreamsFailed, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightStreamsCancelled, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightActiveStreams, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterArrowFlightBatchesReceived, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kCounterArrowFlightRowsReceived, facebook::velox::StatType::SUM);
+  DEFINE_METRIC(
+      kCounterArrowFlightBytesReceived, facebook::velox::StatType::SUM);
   DEFINE_HISTOGRAM_METRIC(
       kCounterHTTPRequestSizeBytes,
       1 * 1024, // 1KB bucket size

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -41,6 +41,55 @@ constexpr std::string_view kCounterHTTPRequestLatencyMs{
 constexpr std::string_view kCounterHTTPRequestSizeBytes{
     "presto_cpp.http_request_size_bytes"};
 
+constexpr std::string_view kCounterArrowFlightConnectLatencyMs{
+    "presto_cpp.arrow_flight.client.connect_latency_ms"};
+constexpr std::string_view kCounterArrowFlightAuthenticateLatencyMs{
+    "presto_cpp.arrow_flight.client.authenticate_latency_ms"};
+constexpr std::string_view kCounterArrowFlightDoGetLatencyMs{
+    "presto_cpp.arrow_flight.client.do_get_latency_ms"};
+constexpr std::string_view kCounterArrowFlightBatchWaitLatencyMs{
+    "presto_cpp.arrow_flight.client.batch_wait_latency_ms"};
+constexpr std::string_view kCounterArrowFlightDecodeLatencyMs{
+    "presto_cpp.arrow_flight.client.decode_latency_ms"};
+constexpr std::string_view kCounterArrowFlightStreamLatencyMs{
+    "presto_cpp.arrow_flight.client.stream_latency_ms"};
+constexpr std::string_view kCounterArrowFlightConnectErrors{
+    "presto_cpp.arrow_flight.client.connect_errors"};
+constexpr std::string_view kCounterArrowFlightAuthenticateErrors{
+    "presto_cpp.arrow_flight.client.authenticate_errors"};
+constexpr std::string_view kCounterArrowFlightDoGetErrors{
+    "presto_cpp.arrow_flight.client.do_get_errors"};
+constexpr std::string_view kCounterArrowFlightReadErrors{
+    "presto_cpp.arrow_flight.client.read_errors"};
+constexpr std::string_view kCounterArrowFlightDecodeErrors{
+    "presto_cpp.arrow_flight.client.decode_errors"};
+// Error counters are bucketed by Presto ErrorType so they line up with the
+// error the coordinator reports for the query.
+constexpr std::string_view kCounterArrowFlightUserErrors{
+    "presto_cpp.arrow_flight.client.user_errors"};
+constexpr std::string_view kCounterArrowFlightExternalErrors{
+    "presto_cpp.arrow_flight.client.external_errors"};
+constexpr std::string_view kCounterArrowFlightInsufficientResourcesErrors{
+    "presto_cpp.arrow_flight.client.insufficient_resources_errors"};
+constexpr std::string_view kCounterArrowFlightInternalErrors{
+    "presto_cpp.arrow_flight.client.internal_errors"};
+constexpr std::string_view kCounterArrowFlightStreamsStarted{
+    "presto_cpp.arrow_flight.client.streams_started"};
+constexpr std::string_view kCounterArrowFlightStreamsCompleted{
+    "presto_cpp.arrow_flight.client.streams_completed"};
+constexpr std::string_view kCounterArrowFlightStreamsFailed{
+    "presto_cpp.arrow_flight.client.streams_failed"};
+constexpr std::string_view kCounterArrowFlightStreamsCancelled{
+    "presto_cpp.arrow_flight.client.streams_cancelled"};
+constexpr std::string_view kCounterArrowFlightActiveStreams{
+    "presto_cpp.arrow_flight.client.active_streams"};
+constexpr std::string_view kCounterArrowFlightBatchesReceived{
+    "presto_cpp.arrow_flight.client.batches_received"};
+constexpr std::string_view kCounterArrowFlightRowsReceived{
+    "presto_cpp.arrow_flight.client.rows_received"};
+constexpr std::string_view kCounterArrowFlightBytesReceived{
+    "presto_cpp.arrow_flight.client.bytes_received"};
+
 constexpr std::string_view kCounterHttpClientNumConnectionsCreated{
     "presto_cpp.http.client.num_connections_created"};
 /// Number of HTTP requests that are the first request on a connection

--- a/presto-native-execution/presto_cpp/main/common/Exception.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Exception.cpp
@@ -102,6 +102,43 @@ VeloxToPrestoExceptionTranslator::VeloxToPrestoExceptionTranslator() {
        .name = "EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT",
        .type = protocol::ErrorType::INSUFFICIENT_RESOURCES});
 
+  // Register Arrow Flight connector errors raised by the native client
+  registerError(
+      velox::error_source::kErrorSourceExternal,
+      presto_error_name::kArrowFlightRemoteErrorName,
+      {.code = presto_error_code::kArrowFlightRemoteErrorCode,
+       .name = presto_error_name::kArrowFlightRemoteErrorName,
+       .type = protocol::ErrorType::EXTERNAL});
+
+  registerError(
+      velox::error_source::kErrorSourceExternal,
+      presto_error_name::kArrowFlightUnavailableErrorName,
+      {.code = presto_error_code::kArrowFlightUnavailableErrorCode,
+       .name = presto_error_name::kArrowFlightUnavailableErrorName,
+       .type = protocol::ErrorType::EXTERNAL,
+       .retriable = true});
+
+  registerError(
+      velox::error_source::kErrorSourceExternal,
+      presto_error_name::kArrowFlightAuthErrorName,
+      {.code = presto_error_code::kArrowFlightAuthErrorCode,
+       .name = presto_error_name::kArrowFlightAuthErrorName,
+       .type = protocol::ErrorType::EXTERNAL});
+
+  registerError(
+      velox::error_source::kErrorSourceRuntime,
+      presto_error_name::kArrowFlightInternalErrorName,
+      {.code = presto_error_code::kArrowFlightInternalErrorCode,
+       .name = presto_error_name::kArrowFlightInternalErrorName,
+       .type = protocol::ErrorType::INTERNAL_ERROR});
+
+  registerError(
+      velox::error_source::kErrorSourceRuntime,
+      presto_error_name::kArrowFlightResourceErrorName,
+      {.code = presto_error_code::kArrowFlightResourceErrorCode,
+       .name = presto_error_name::kArrowFlightResourceErrorName,
+       .type = protocol::ErrorType::INSUFFICIENT_RESOURCES});
+
   // Register user errors
   registerError(
       velox::error_source::kErrorSourceUser,
@@ -177,6 +214,13 @@ protocol::ExecutionFailureInfo VeloxToPrestoExceptionTranslator::translate(
 
   const auto& errorSource = e.errorSource();
   const auto& errorCode = e.errorCode();
+
+  // Exact downstream Presto error codes travel encoded in the errorCode
+  // string; reproduce them verbatim instead of consulting the registry.
+  if (auto passthrough = passthrough_error::decode(errorCode)) {
+    error.errorCode = std::move(*passthrough);
+    return error;
+  }
 
   auto itrErrorCodesMap = errorMap_.find(errorSource);
   if (itrErrorCodesMap != errorMap_.end()) {

--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -13,7 +13,9 @@
  */
 #pragma once
 
+#include <charconv>
 #include <exception>
+#include <optional>
 #include <unordered_map>
 
 #include <folly/Singleton.h>
@@ -27,6 +29,33 @@ struct ExecutionFailureInfo;
 struct ErrorCode;
 } // namespace protocol
 
+namespace presto_error_code {
+
+// Ref: presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowErrorCode.java
+inline constexpr auto kArrowFlightErrorCodeMask = 0x5100000;
+inline constexpr auto kArrowFlightRemoteErrorCode = kArrowFlightErrorCodeMask + 7;
+inline constexpr auto kArrowFlightUnavailableErrorCode = kArrowFlightErrorCodeMask + 8;
+inline constexpr auto kArrowFlightAuthErrorCode = kArrowFlightErrorCodeMask + 9;
+inline constexpr auto kArrowFlightInternalErrorCode = kArrowFlightErrorCodeMask + 10;
+inline constexpr auto kArrowFlightResourceErrorCode = kArrowFlightErrorCodeMask + 11;
+
+}
+
+namespace presto_error_name {
+
+// Ref: presto-common-arrow/src/main/java/com/facebook/plugin/arrow/ArrowErrorCode.java
+inline constexpr auto kArrowFlightRemoteErrorName =
+    "ARROW_FLIGHT_REMOTE_ERROR"_fs;
+inline constexpr auto kArrowFlightUnavailableErrorName =
+    "ARROW_FLIGHT_UNAVAILABLE_ERROR"_fs;
+inline constexpr auto kArrowFlightAuthErrorName = "ARROW_FLIGHT_AUTH_ERROR"_fs;
+inline constexpr auto kArrowFlightInternalErrorName =
+    "ARROW_FLIGHT_INTERNAL_ERROR"_fs;
+inline constexpr auto kArrowFlightResourceErrorName =
+    "ARROW_FLIGHT_RESOURCE_ERROR"_fs;
+
+}
+
 namespace error_code {
 using namespace folly::string_literals;
 
@@ -34,6 +63,87 @@ using namespace folly::string_literals;
 inline constexpr auto kExceededLocalBroadcastJoinMemoryLimit =
     "EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT"_fs;
 } // namespace error_code
+
+// Carries an exact downstream Presto ErrorCode tuple through a VeloxException
+// errorCode string, so the translator can reproduce it verbatim without
+// per-connector registrations.
+namespace passthrough_error {
+
+inline constexpr std::string_view kPrefix = "PRESTO_PASSTHROUGH:";
+
+/// Encodes an ErrorCode tuple as "PRESTO_PASSTHROUGH:<type>:<0|1>:<code>:<name>".
+inline std::string encode(
+    std::string_view name,
+    int code,
+    std::string_view type,
+    bool retriable) {
+  std::string encoded{kPrefix};
+  encoded.append(type);
+  encoded.append(retriable ? ":1:" : ":0:");
+  encoded.append(std::to_string(code));
+  encoded.push_back(':');
+  encoded.append(name);
+  return encoded;
+}
+
+/// Decodes a string produced by encode(). Returns std::nullopt for strings
+/// without the pass-through prefix or with malformed fields.
+inline std::optional<protocol::ErrorCode> decode(std::string_view encoded) {
+  if (encoded.substr(0, kPrefix.size()) != kPrefix) {
+    return std::nullopt;
+  }
+  auto rest = encoded.substr(kPrefix.size());
+
+  const auto typeEnd = rest.find(':');
+  if (typeEnd == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const auto typeStr = rest.substr(0, typeEnd);
+  rest.remove_prefix(typeEnd + 1);
+
+  const auto retriableEnd = rest.find(':');
+  if (retriableEnd == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const auto retriableStr = rest.substr(0, retriableEnd);
+  rest.remove_prefix(retriableEnd + 1);
+
+  const auto codeEnd = rest.find(':');
+  if (codeEnd == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const auto codeStr = rest.substr(0, codeEnd);
+  const auto name = rest.substr(codeEnd + 1);
+  if (name.empty()) {
+    return std::nullopt;
+  }
+
+  protocol::ErrorCode result;
+  if (typeStr == "USER_ERROR") {
+    result.type = protocol::ErrorType::USER_ERROR;
+  } else if (typeStr == "EXTERNAL") {
+    result.type = protocol::ErrorType::EXTERNAL;
+  } else if (typeStr == "INSUFFICIENT_RESOURCES") {
+    result.type = protocol::ErrorType::INSUFFICIENT_RESOURCES;
+  } else if (typeStr == "INTERNAL_ERROR") {
+    result.type = protocol::ErrorType::INTERNAL_ERROR;
+  } else {
+    return std::nullopt;
+  }
+
+  int code = 0;
+  const auto [ptr, ec] =
+      std::from_chars(codeStr.data(), codeStr.data() + codeStr.size(), code);
+  if (ec != std::errc() || ptr != codeStr.data() + codeStr.size()) {
+    return std::nullopt;
+  }
+  result.code = code;
+  result.retriable = (retriableStr == "1");
+  result.name = std::string(name);
+  return result;
+}
+
+} // namespace passthrough_error
 
 // Exception translator singleton for converting Velox exceptions to Presto
 // errors. This follows the same pattern as velox/common/base/StatsReporter.h.

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -148,6 +148,37 @@ TEST(VeloxToPrestoExceptionTranslatorTest, exceptionTranslation) {
   EXPECT_EQ(failureInfo.errorCode.type, protocol::ErrorType::INTERNAL_ERROR);
 }
 
+TEST(VeloxToPrestoExceptionTranslatorTest, passthroughErrorCode) {
+  VeloxExternalError externalException(
+      "file_name",
+      1,
+      "function_name()",
+      "operator()",
+      "connection refused",
+      "",
+      passthrough_error::encode("JDBC_ERROR", 0x04000000, "EXTERNAL", true),
+      true);
+  try {
+    throw externalException;
+  } catch (const VeloxException& e) {
+    auto failureInfo = translateToPrestoException(e);
+    EXPECT_EQ(failureInfo.errorCode.name, "JDBC_ERROR");
+    EXPECT_EQ(failureInfo.errorCode.code, 0x04000000);
+    EXPECT_EQ(failureInfo.errorCode.type, protocol::ErrorType::EXTERNAL);
+    EXPECT_TRUE(failureInfo.errorCode.retriable);
+  }
+
+  // Malformed or foreign errorCode strings are not decodable.
+  EXPECT_FALSE(passthrough_error::decode("JDBC_ERROR").has_value());
+  EXPECT_FALSE(
+      passthrough_error::decode("PRESTO_PASSTHROUGH:BOGUS_TYPE:0:1:NAME")
+          .has_value());
+  EXPECT_FALSE(passthrough_error::decode("PRESTO_PASSTHROUGH:EXTERNAL:0:x:NAME")
+                   .has_value());
+  EXPECT_FALSE(
+      passthrough_error::decode("PRESTO_PASSTHROUGH:EXTERNAL:0:1:").has_value());
+}
+
 TEST(VeloxToPrestoExceptionTranslatorTest, allErrorCodeTranslations) {
   // Test all error codes in the translation map to ensure they translate
   // correctly
@@ -205,6 +236,28 @@ TEST(VeloxToPrestoExceptionTranslatorTest, allErrorCodeTranslations) {
         EXPECT_EQ(failureInfo.errorCode.type, expectedErrorCode.type)
             << "Error type mismatch for " << errorCode;
         EXPECT_EQ(failureInfo.type, "VeloxUserError");
+        EXPECT_EQ(failureInfo.errorLocation.lineNumber, 42);
+
+      } else if (errorSource == velox::error_source::kErrorSourceExternal) {
+        VeloxException externalException(
+            "test_file.cpp",
+            42,
+            "testFunction()",
+            "testExpression",
+            "test error message",
+            errorSource,
+            errorCode,
+            false);
+
+        auto failureInfo = translator->translate(externalException);
+
+        EXPECT_EQ(failureInfo.errorCode.code, expectedErrorCode.code)
+            << "Error code mismatch for " << errorCode;
+        EXPECT_EQ(failureInfo.errorCode.name, expectedErrorCode.name)
+            << "Error name mismatch for " << errorCode;
+        EXPECT_EQ(failureInfo.errorCode.type, expectedErrorCode.type)
+            << "Error type mismatch for " << errorCode;
+        EXPECT_EQ(failureInfo.type, "VeloxException");
         EXPECT_EQ(failureInfo.errorLocation.lineNumber, 42);
 
       } else if (errorSource == velox::error_source::kErrorSourceSystem) {

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
@@ -15,16 +15,35 @@
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
 #include <arrow/flight/api.h>
+#include <arrow/status.h>
+#include <fmt/format.h>
 #include <folly/base64.h>
+#include <atomic>
+#include <optional>
 #include <utility>
 #include "presto_cpp/main/common/ConfigReader.h"
+#include "presto_cpp/main/common/Counters.h"
+#include "presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.h"
 #include "presto_cpp/main/connectors/arrow_flight/Macros.h"
+#include "velox/common/base/StatsReporter.h"
 #include "velox/vector/arrow/Bridge.h"
 
 using namespace facebook::velox::connector;
 
 namespace facebook::presto {
 namespace {
+std::atomic<int32_t> kActiveArrowFlightStreams{0};
+
+int64_t elapsedNanos(const std::chrono::steady_clock::time_point& start) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now() - start)
+      .count();
+}
+
+int64_t toMillis(int64_t nanos) {
+  return nanos / 1'000'000;
+}
+
 std::shared_ptr<arrow::flight::Location> getDefaultLocation(
     const std::shared_ptr<ArrowFlightConfig>& config) {
   auto defaultHost = config->defaultServerHostname();
@@ -141,6 +160,114 @@ ArrowFlightDataSource::~ArrowFlightDataSource() {
   cancel();
 }
 
+void ArrowFlightDataSource::startStream() {
+  if (streamStarted_) {
+    return;
+  }
+  streamStarted_ = true;
+  streamStart_ = std::chrono::steady_clock::now();
+  streamsStarted_.addValue(1);
+  RECORD_METRIC_VALUE(kCounterArrowFlightStreamsStarted, 1);
+}
+
+void ArrowFlightDataSource::finishStream(StreamOutcome outcome) {
+  if (!streamStarted_) {
+    return;
+  }
+
+  if (streamActive_) {
+    streamActive_ = false;
+    kActiveArrowFlightStreams.fetch_sub(1);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightActiveStreams, kActiveArrowFlightStreams.load());
+  }
+
+  const auto streamNanos = elapsedNanos(streamStart_);
+  streamWallNanos_.addValue(streamNanos);
+  RECORD_METRIC_VALUE(
+      kCounterArrowFlightStreamLatencyMs, toMillis(streamNanos));
+
+  switch (outcome) {
+    case StreamOutcome::kCompleted:
+      streamsCompleted_.addValue(1);
+      RECORD_METRIC_VALUE(kCounterArrowFlightStreamsCompleted, 1);
+      break;
+    case StreamOutcome::kFailed:
+      streamsFailed_.addValue(1);
+      RECORD_METRIC_VALUE(kCounterArrowFlightStreamsFailed, 1);
+      break;
+    case StreamOutcome::kCancelled:
+      streamsCancelled_.addValue(1);
+      RECORD_METRIC_VALUE(kCounterArrowFlightStreamsCancelled, 1);
+      break;
+  }
+
+  streamStarted_ = false;
+}
+
+void ArrowFlightDataSource::closeResources(bool cancelReader) {
+  if (currentReader_ != nullptr) {
+    if (cancelReader) {
+      currentReader_->Cancel();
+    }
+    currentReader_.reset();
+  }
+
+  if (currentClient_ != nullptr) {
+    auto status = currentClient_->Close();
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to close Arrow Flight client: "
+                   << status.message();
+    }
+    currentClient_.reset();
+  }
+}
+
+void ArrowFlightDataSource::recordError(
+    ErrorPhase phase,
+    std::string_view category) {
+  errors_.addValue(1);
+  switch (phase) {
+    case ErrorPhase::kConnect:
+      RECORD_METRIC_VALUE(kCounterArrowFlightConnectErrors, 1);
+      break;
+    case ErrorPhase::kAuthenticate:
+      RECORD_METRIC_VALUE(kCounterArrowFlightAuthenticateErrors, 1);
+      break;
+    case ErrorPhase::kDoGet:
+      RECORD_METRIC_VALUE(kCounterArrowFlightDoGetErrors, 1);
+      break;
+    case ErrorPhase::kRead:
+      RECORD_METRIC_VALUE(kCounterArrowFlightReadErrors, 1);
+      break;
+    case ErrorPhase::kDecode:
+      RECORD_METRIC_VALUE(kCounterArrowFlightDecodeErrors, 1);
+      break;
+  }
+  recordCategoryCounter(category);
+
+  std::string_view phaseStr;
+  switch (phase) {
+    case ErrorPhase::kConnect:
+      phaseStr = "connect";
+      break;
+    case ErrorPhase::kAuthenticate:
+      phaseStr = "authenticate";
+      break;
+    case ErrorPhase::kDoGet:
+      phaseStr = "doGet";
+      break;
+    case ErrorPhase::kRead:
+      phaseStr = "read";
+      break;
+    case ErrorPhase::kDecode:
+      phaseStr = "decode";
+      break;
+  }
+  const auto key = fmt::format("arrowFlightError.{}.{}", phaseStr, category);
+  errorStats_[key].addValue(1);
+}
+
 void ArrowFlightDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   auto flightSplit = std::dynamic_pointer_cast<ArrowFlightSplit>(split);
   VELOX_CHECK(
@@ -151,36 +278,92 @@ void ArrowFlightDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       "Cannot add new split while previous client/reader are still active. "
       "Previous split must reach EOS or be cancelled first.");
 
-  auto flightEndpointStr =
-      folly::base64Decode(flightSplit->flightEndpointBytes_);
+  startStream();
+  auto phase = ErrorPhase::kConnect;
+  bool errorRecorded = false;
+  try {
+    auto flightEndpointStr =
+        folly::base64Decode(flightSplit->flightEndpointBytes_);
+    auto deserializeResult =
+        arrow::flight::FlightEndpoint::Deserialize(flightEndpointStr);
+    if (!deserializeResult.ok()) {
+      recordError(phase, errorCategory(deserializeResult.status()));
+      errorRecorded = true;
+      raiseFlightError(deserializeResult.status());
+    }
+    auto flightEndpoint = std::move(deserializeResult).ValueUnsafe();
 
-  arrow::flight::FlightEndpoint flightEndpoint;
-  AFC_ASSIGN_OR_RAISE(
-      flightEndpoint,
-      arrow::flight::FlightEndpoint::Deserialize(flightEndpointStr));
+    arrow::flight::Location loc;
+    if (!flightEndpoint.locations.empty()) {
+      loc = flightEndpoint.locations[0];
+    } else {
+      VELOX_CHECK_NOT_NULL(
+          defaultLocation_,
+          "No location from Flight endpoint, default host or port is missing");
+      loc = *defaultLocation_;
+    }
 
-  arrow::flight::Location loc;
-  if (!flightEndpoint.locations.empty()) {
-    loc = flightEndpoint.locations[0];
-  } else {
-    VELOX_CHECK_NOT_NULL(
-        defaultLocation_,
-        "No location from Flight endpoint, default host or port is missing");
-    loc = *defaultLocation_;
+    const auto connectStart = std::chrono::steady_clock::now();
+    auto connectResult =
+        arrow::flight::FlightClient::Connect(loc, *clientOpts_);
+    const auto connectNanos = elapsedNanos(connectStart);
+    connectWallNanos_.addValue(connectNanos);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightConnectLatencyMs, toMillis(connectNanos));
+    if (!connectResult.ok()) {
+      recordError(phase, errorCategory(connectResult.status()));
+      errorRecorded = true;
+      raiseFlightError(connectResult.status());
+    }
+    currentClient_ = std::move(connectResult).ValueUnsafe();
+
+    phase = ErrorPhase::kAuthenticate;
+    CallOptionsAddHeaders callOptsAddHeaders{};
+    const auto authenticateStart = std::chrono::steady_clock::now();
+    try {
+      authenticator_->authenticateClient(
+          currentClient_,
+          connectorQueryCtx_->sessionProperties(),
+          callOptsAddHeaders);
+    } catch (...) {
+      const auto authenticateNanos = elapsedNanos(authenticateStart);
+      authenticateWallNanos_.addValue(authenticateNanos);
+      RECORD_METRIC_VALUE(
+          kCounterArrowFlightAuthenticateLatencyMs,
+          toMillis(authenticateNanos));
+      throw;
+    }
+    const auto authenticateNanos = elapsedNanos(authenticateStart);
+    authenticateWallNanos_.addValue(authenticateNanos);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightAuthenticateLatencyMs, toMillis(authenticateNanos));
+
+    phase = ErrorPhase::kDoGet;
+    const auto doGetStart = std::chrono::steady_clock::now();
+    auto doGetResult =
+        currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket);
+    const auto doGetNanos = elapsedNanos(doGetStart);
+    doGetWallNanos_.addValue(doGetNanos);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightDoGetLatencyMs, toMillis(doGetNanos));
+    if (!doGetResult.ok()) {
+      recordError(phase, errorCategory(doGetResult.status()));
+      errorRecorded = true;
+      raiseFlightError(doGetResult.status());
+    }
+    currentReader_ = std::move(doGetResult).ValueUnsafe();
+    streamActive_ = true;
+    kActiveArrowFlightStreams.fetch_add(1);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightActiveStreams, kActiveArrowFlightStreams.load());
+  } catch (...) {
+    if (!errorRecorded) {
+      recordError(phase, currentExceptionCategory());
+    }
+    closeResources(true);
+    finishStream(StreamOutcome::kFailed);
+    throw;
   }
-
-  AFC_ASSIGN_OR_RAISE(
-      currentClient_, arrow::flight::FlightClient::Connect(loc, *clientOpts_));
-
-  CallOptionsAddHeaders callOptsAddHeaders{};
-  authenticator_->authenticateClient(
-      currentClient_,
-      connectorQueryCtx_->sessionProperties(),
-      callOptsAddHeaders);
-
-  AFC_ASSIGN_OR_RAISE(
-      currentReader_,
-      currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket));
 }
 
 std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
@@ -188,45 +371,99 @@ std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
     velox::ContinueFuture& /* unused */) {
   VELOX_CHECK_NOT_NULL(currentReader_, "Missing split, call addSplit() first");
 
-  AFC_ASSIGN_OR_RAISE(auto chunk, currentReader_->Next());
+  arrow::flight::FlightStreamChunk chunk;
+  const auto batchWaitStart = std::chrono::steady_clock::now();
+  bool errorRecorded = false;
+  try {
+    auto chunkResult = currentReader_->Next();
+    const auto batchWaitNanos = elapsedNanos(batchWaitStart);
+    batchWaitWallNanos_.addValue(batchWaitNanos);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightBatchWaitLatencyMs, toMillis(batchWaitNanos));
+    if (!chunkResult.ok()) {
+      recordError(ErrorPhase::kRead, errorCategory(chunkResult.status()));
+      errorRecorded = true;
+      raiseFlightError(chunkResult.status());
+    }
+    chunk = std::move(chunkResult).ValueUnsafe();
+  } catch (...) {
+    if (!errorRecorded) {
+      const auto batchWaitNanos = elapsedNanos(batchWaitStart);
+      batchWaitWallNanos_.addValue(batchWaitNanos);
+      RECORD_METRIC_VALUE(
+          kCounterArrowFlightBatchWaitLatencyMs, toMillis(batchWaitNanos));
+      recordError(ErrorPhase::kRead, currentExceptionCategory());
+    }
+    closeResources(true);
+    finishStream(StreamOutcome::kFailed);
+    throw;
+  }
 
   // Null values in the chunk indicates that the Flight stream is complete.
   if (!chunk.data) {
-    currentReader_ = nullptr;
-    if (currentClient_ != nullptr) {
-      auto status = currentClient_->Close();
-      if (!status.ok()) {
-        LOG(WARNING)
-            << "Failed to close Arrow Flight client after stream completion: "
-            << status.message();
-      }
-      currentClient_.reset();
-    }
+    finishStream(StreamOutcome::kCompleted);
+    closeResources(false);
     return nullptr;
   }
 
-  // Extract only required columns from the record batch as a velox RowVector.
-  auto output = projectOutputColumns(chunk.data);
+  velox::RowVectorPtr output;
+  const auto decodeStart = std::chrono::steady_clock::now();
+  try {
+    output = projectOutputColumns(chunk.data);
+  } catch (...) {
+    const auto decodeNanos = elapsedNanos(decodeStart);
+    decodeWallNanos_.addValue(decodeNanos);
+    RECORD_METRIC_VALUE(
+        kCounterArrowFlightDecodeLatencyMs, toMillis(decodeNanos));
+    recordError(ErrorPhase::kDecode, currentExceptionCategory());
+    finishStream(StreamOutcome::kFailed);
+    closeResources(true);
+    throw;
+  }
+  const auto decodeNanos = elapsedNanos(decodeStart);
+  decodeWallNanos_.addValue(decodeNanos);
+  RECORD_METRIC_VALUE(
+      kCounterArrowFlightDecodeLatencyMs, toMillis(decodeNanos));
 
-  completedRows_ += output->size();
-  completedBytes_ += output->estimateFlatSize();
+  const auto rowCount = output->size();
+  const auto byteCount = output->estimateFlatSize();
+  batches_.addValue(1);
+  rows_.addValue(rowCount);
+  bytes_.addValue(byteCount);
+  completedRows_ += rowCount;
+  completedBytes_ += byteCount;
+  RECORD_METRIC_VALUE(kCounterArrowFlightBatchesReceived, 1);
+  RECORD_METRIC_VALUE(kCounterArrowFlightRowsReceived, rowCount);
+  RECORD_METRIC_VALUE(kCounterArrowFlightBytesReceived, byteCount);
   return output;
 }
 
 void ArrowFlightDataSource::cancel() {
-  if (currentReader_ != nullptr) {
-    currentReader_->Cancel();
-    currentReader_.reset();
+  if (streamActive_ || currentReader_ != nullptr || currentClient_ != nullptr) {
+    finishStream(StreamOutcome::kCancelled);
   }
+  closeResources(true);
+}
 
-  if (currentClient_ != nullptr) {
-    auto status = currentClient_->Close();
-    if (!status.ok()) {
-      LOG(WARNING) << "Failed to close Arrow Flight client during cancel: "
-                   << status.message();
-    }
-    currentClient_.reset();
-  }
+std::unordered_map<std::string, velox::RuntimeMetric>
+ArrowFlightDataSource::getRuntimeStats() {
+  std::unordered_map<std::string, velox::RuntimeMetric> stats;
+  stats.emplace("arrowFlightConnectWallNanos", connectWallNanos_);
+  stats.emplace("arrowFlightAuthenticateWallNanos", authenticateWallNanos_);
+  stats.emplace("arrowFlightDoGetWallNanos", doGetWallNanos_);
+  stats.emplace("arrowFlightBatchWaitWallNanos", batchWaitWallNanos_);
+  stats.emplace("arrowFlightDecodeWallNanos", decodeWallNanos_);
+  stats.emplace("arrowFlightStreamWallNanos", streamWallNanos_);
+  stats.emplace("arrowFlightBatches", batches_);
+  stats.emplace("arrowFlightRows", rows_);
+  stats.emplace("arrowFlightBytes", bytes_);
+  stats.emplace("arrowFlightErrors", errors_);
+  stats.emplace("arrowFlightStreamsStarted", streamsStarted_);
+  stats.emplace("arrowFlightStreamsCompleted", streamsCompleted_);
+  stats.emplace("arrowFlightStreamsFailed", streamsFailed_);
+  stats.emplace("arrowFlightStreamsCancelled", streamsCancelled_);
+  stats.insert(errorStats_.begin(), errorStats_.end());
+  return stats;
 }
 
 velox::RowVectorPtr ArrowFlightDataSource::projectOutputColumns(

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 
+#include <chrono>
 #include "presto_cpp/main/connectors/arrow_flight/ArrowFlightConfig.h"
 #include "presto_cpp/main/connectors/arrow_flight/auth/Authenticator.h"
 #include "velox/connectors/Connector.h"
@@ -100,9 +101,7 @@ class ArrowFlightDataSource : public velox::connector::DataSource {
   }
 
   std::unordered_map<std::string, velox::RuntimeMetric> getRuntimeStats()
-      override {
-    return {};
-  }
+      override;
 
   void cancel() override;
 
@@ -110,16 +109,42 @@ class ArrowFlightDataSource : public velox::connector::DataSource {
   velox::RowTypePtr outputType_;
 
  private:
+  enum class ErrorPhase { kConnect, kAuthenticate, kDoGet, kRead, kDecode };
+  enum class StreamOutcome { kCompleted, kFailed, kCancelled };
+
   /// Convert an Arrow record batch to Velox RowVector.
   /// Process only those columns that are present in outputType_.
   velox::RowVectorPtr projectOutputColumns(
       const std::shared_ptr<arrow::RecordBatch>& input);
+  void startStream();
+  void finishStream(StreamOutcome outcome);
+  void closeResources(bool cancelReader);
+  void recordError(ErrorPhase phase, std::string_view category);
 
   std::vector<std::string> columnMapping_;
   std::unique_ptr<arrow::flight::FlightClient> currentClient_;
   std::unique_ptr<arrow::flight::FlightStreamReader> currentReader_;
   uint64_t completedRows_ = 0;
   uint64_t completedBytes_ = 0;
+  bool streamStarted_ = false;
+  bool streamActive_ = false;
+  std::chrono::steady_clock::time_point streamStart_;
+  velox::RuntimeMetric connectWallNanos_{velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric authenticateWallNanos_{
+      velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric doGetWallNanos_{velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric batchWaitWallNanos_{velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric decodeWallNanos_{velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric streamWallNanos_{velox::RuntimeCounter::Unit::kNanos};
+  velox::RuntimeMetric batches_;
+  velox::RuntimeMetric rows_;
+  velox::RuntimeMetric bytes_{velox::RuntimeCounter::Unit::kBytes};
+  velox::RuntimeMetric errors_;
+  velox::RuntimeMetric streamsStarted_;
+  velox::RuntimeMetric streamsCompleted_;
+  velox::RuntimeMetric streamsFailed_;
+  velox::RuntimeMetric streamsCancelled_;
+  std::unordered_map<std::string, velox::RuntimeMetric> errorStats_;
   std::shared_ptr<Authenticator> authenticator_;
   const velox::connector::ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<ArrowFlightConfig> flightConfig_;

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.cpp
@@ -1,0 +1,308 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.h"
+#include <arrow/flight/api.h>
+#include <arrow/status.h>
+#include <fmt/format.h>
+#include <charconv>
+#include <optional>
+#include <sstream>
+#include <string>
+#include "presto_cpp/main/common/Counters.h"
+#include "presto_cpp/main/common/Exception.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/StatsReporter.h"
+
+namespace facebook::presto {
+namespace {
+
+// Categories mirror Presto ErrorType so a metric bucket always agrees with the
+// error the query ultimately fails with.
+constexpr std::string_view kCategoryUserError = "user_error";
+constexpr std::string_view kCategoryExternal = "external";
+constexpr std::string_view kCategoryInsufficientResources =
+    "insufficient_resources";
+constexpr std::string_view kCategoryInternalError = "internal_error";
+
+// Keys in the FlightStatusDetail extra info payload that a Flight server may
+// attach to describe the Presto error behind a failed call.
+constexpr std::string_view kPrestoErrorNameKey = "presto-error-name";
+constexpr std::string_view kPrestoErrorCodeKey = "presto-error-code";
+constexpr std::string_view kPrestoErrorTypeKey = "presto-error-type";
+constexpr std::string_view kPrestoErrorRetriableKey = "presto-error-retriable";
+
+constexpr std::string_view kErrorTypeUserError = "USER_ERROR";
+constexpr std::string_view kErrorTypeExternal = "EXTERNAL";
+constexpr std::string_view kErrorTypeInsufficientResources =
+    "INSUFFICIENT_RESOURCES";
+constexpr std::string_view kErrorTypeInternalError = "INTERNAL_ERROR";
+
+struct PrestoErrorDetails {
+  std::string name;
+  std::optional<int> code;
+  std::string type;
+  bool retriable{false};
+};
+
+std::optional<PrestoErrorDetails> parsePrestoErrorDetails(
+    const arrow::Status& status) {
+  auto detail = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
+  if (detail == nullptr || detail->extra_info().empty()) {
+    return std::nullopt;
+  }
+
+  PrestoErrorDetails result;
+  std::istringstream payload{detail->extra_info()};
+  std::string line;
+  while (std::getline(payload, line)) {
+    const auto pos = line.find('=');
+    if (pos == std::string::npos) {
+      continue;
+    }
+    const std::string_view key = std::string_view(line).substr(0, pos);
+    const auto value = line.substr(pos + 1);
+    if (key == kPrestoErrorNameKey) {
+      result.name = value;
+    } else if (key == kPrestoErrorCodeKey) {
+      int code = 0;
+      const auto [ptr, ec] =
+          std::from_chars(value.data(), value.data() + value.size(), code);
+      if (ec == std::errc() && ptr == value.data() + value.size()) {
+        result.code = code;
+      }
+    } else if (key == kPrestoErrorTypeKey) {
+      result.type = value;
+    } else if (key == kPrestoErrorRetriableKey) {
+      result.retriable = (value == "true");
+    }
+  }
+
+  if (result.type.empty()) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+} // namespace
+
+std::string_view errorCategory(const arrow::Status& status) {
+  if (auto details = parsePrestoErrorDetails(status)) {
+    if (details->type == kErrorTypeUserError) {
+      return kCategoryUserError;
+    }
+    if (details->type == kErrorTypeInsufficientResources) {
+      return kCategoryInsufficientResources;
+    }
+    if (details->type == kErrorTypeExternal) {
+      return kCategoryExternal;
+    }
+    return kCategoryInternalError;
+  }
+
+  if (auto detail = arrow::flight::FlightStatusDetail::UnwrapStatus(status)) {
+    switch (detail->code()) {
+      case arrow::flight::FlightStatusCode::TimedOut:
+      case arrow::flight::FlightStatusCode::Unavailable:
+      case arrow::flight::FlightStatusCode::Unauthenticated:
+      case arrow::flight::FlightStatusCode::Unauthorized:
+        return kCategoryExternal;
+      default:
+        return kCategoryInternalError;
+    }
+  }
+
+  switch (status.code()) {
+    case arrow::StatusCode::OutOfMemory:
+    case arrow::StatusCode::CapacityError:
+      return kCategoryInsufficientResources;
+    case arrow::StatusCode::IOError:
+      return kCategoryExternal;
+    default:
+      return kCategoryInternalError;
+  }
+}
+
+std::string_view currentExceptionCategory() {
+  try {
+    throw;
+  } catch (const std::bad_alloc&) {
+    return kCategoryInsufficientResources;
+  } catch (const velox::VeloxException& e) {
+    if (e.errorCode() == "MEM_CAP_EXCEEDED" ||
+        e.errorCode() == "MEM_ARBITRATION_FAILURE" ||
+        e.errorCode() == "MEM_ARBITRATION_TIMEOUT" ||
+        e.errorCode() == "MEM_ALLOC_ERROR" || e.errorCode() == "MEM_ABORTED" ||
+        e.errorCode() == "NO_CACHE_SPACE") {
+      return kCategoryInsufficientResources;
+    }
+    if (e.errorSource() == "USER") {
+      return kCategoryUserError;
+    }
+    if (e.errorSource() == "EXTERNAL") {
+      return kCategoryExternal;
+    }
+    return kCategoryInternalError;
+  } catch (...) {
+    return kCategoryInternalError;
+  }
+}
+
+void recordCategoryCounter(std::string_view category) {
+  if (category == kCategoryUserError) {
+    RECORD_METRIC_VALUE(kCounterArrowFlightUserErrors, 1);
+  } else if (category == kCategoryExternal) {
+    RECORD_METRIC_VALUE(kCounterArrowFlightExternalErrors, 1);
+  } else if (category == kCategoryInsufficientResources) {
+    RECORD_METRIC_VALUE(kCounterArrowFlightInsufficientResourcesErrors, 1);
+  } else {
+    RECORD_METRIC_VALUE(kCounterArrowFlightInternalErrors, 1);
+  }
+}
+
+void raiseFlightError(const arrow::Status& status) {
+  const auto& message = status.message();
+
+  if (auto details = parsePrestoErrorDetails(status)) {
+    const auto detailedMessage = fmt::format("{}: {}", details->name, message);
+    // A complete tuple (name + code) is passed through verbatim so the
+    // translator reproduces the exact downstream Presto error code.
+    const bool passthrough = details->code.has_value() && !details->name.empty();
+    const auto passthroughCode = passthrough
+        ? passthrough_error::encode(
+              details->name, *details->code, details->type, details->retriable)
+        : std::string();
+    if (details->type == kErrorTypeUserError) {
+      throw velox::VeloxUserError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          detailedMessage,
+          velox::error_source::kErrorSourceUser,
+          passthrough ? passthroughCode
+                      : std::string(velox::error_code::kInvalidArgument),
+          false);
+    }
+    if (details->type == kErrorTypeInsufficientResources) {
+      throw velox::VeloxRuntimeError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          detailedMessage,
+          velox::error_source::kErrorSourceRuntime,
+          passthrough
+              ? passthroughCode
+              : std::string(presto_error_name::kArrowFlightResourceErrorName),
+          false);
+    }
+    if (details->type == kErrorTypeExternal) {
+      throw velox::VeloxExternalError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          detailedMessage,
+          velox::error_source::kErrorSourceExternal,
+          passthrough
+              ? passthroughCode
+              : std::string(presto_error_name::kArrowFlightRemoteErrorName),
+          details->retriable);
+    }
+    throw velox::VeloxRuntimeError(
+        __FILE__,
+        __LINE__,
+        __FUNCTION__,
+        "",
+        detailedMessage,
+        velox::error_source::kErrorSourceRuntime,
+        (passthrough && details->type == kErrorTypeInternalError)
+            ? passthroughCode
+            : std::string(presto_error_name::kArrowFlightInternalErrorName),
+        false);
+  }
+
+  if (auto detail = arrow::flight::FlightStatusDetail::UnwrapStatus(status)) {
+    switch (detail->code()) {
+      case arrow::flight::FlightStatusCode::TimedOut:
+      case arrow::flight::FlightStatusCode::Unavailable:
+        throw velox::VeloxExternalError(
+            __FILE__,
+            __LINE__,
+            __FUNCTION__,
+            "",
+            message,
+            velox::error_source::kErrorSourceExternal,
+            presto_error_name::kArrowFlightUnavailableErrorName,
+            true);
+      case arrow::flight::FlightStatusCode::Unauthenticated:
+      case arrow::flight::FlightStatusCode::Unauthorized:
+        throw velox::VeloxExternalError(
+            __FILE__,
+            __LINE__,
+            __FUNCTION__,
+            "",
+            message,
+            velox::error_source::kErrorSourceExternal,
+            presto_error_name::kArrowFlightAuthErrorName,
+            false);
+      default:
+        throw velox::VeloxRuntimeError(
+            __FILE__,
+            __LINE__,
+            __FUNCTION__,
+            "",
+            message,
+            velox::error_source::kErrorSourceRuntime,
+            presto_error_name::kArrowFlightInternalErrorName,
+            false);
+    }
+  }
+
+  switch (status.code()) {
+    case arrow::StatusCode::OutOfMemory:
+    case arrow::StatusCode::CapacityError:
+      throw velox::VeloxRuntimeError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          message,
+          velox::error_source::kErrorSourceRuntime,
+          presto_error_name::kArrowFlightResourceErrorName,
+          false);
+    case arrow::StatusCode::IOError:
+      throw velox::VeloxExternalError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          message,
+          velox::error_source::kErrorSourceExternal,
+          presto_error_name::kArrowFlightUnavailableErrorName,
+          true);
+    default:
+      throw velox::VeloxRuntimeError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          "",
+          message,
+          velox::error_source::kErrorSourceRuntime,
+          presto_error_name::kArrowFlightInternalErrorName,
+          false);
+  }
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+namespace arrow {
+class Status;
+}
+
+namespace facebook::presto {
+
+/// Classifies a failed Flight call into a stable metric category.
+std::string_view errorCategory(const arrow::Status& status);
+
+/// Classifies the exception currently being handled into a stable metric
+/// category. Must be called from within a catch block.
+std::string_view currentExceptionCategory();
+
+/// Records the process-level counter matching a category returned by
+/// errorCategory() or currentExceptionCategory().
+void recordCategoryCounter(std::string_view category);
+
+/// Throws a typed Velox exception for a failed Flight call, honoring Presto
+/// error metadata attached by the server when present.
+[[noreturn]] void raiseFlightError(const arrow::Status& status);
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   presto_flight_connector
   OBJECT
   ArrowFlightConnector.cpp
+  ArrowFlightErrors.cpp
   ArrowPrestoToVeloxConnector.cpp
   ArrowFlightConfig.cpp
 )
@@ -30,7 +31,7 @@ target_compile_definitions(presto_flight_connector PUBLIC PRESTO_ENABLE_ARROW_FL
 
 target_link_libraries(
   presto_flight_connector
-  velox
+  velox_connector
   ArrowFlight::arrow_flight_shared
   presto_flight_connector_utils
   presto_flight_connector_auth

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorTest.cpp
@@ -16,14 +16,17 @@
 #include <folly/init/Init.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/connectors/arrow_flight/Macros.h"
 #include "presto_cpp/main/connectors/arrow_flight/tests/utils/ArrowFlightConnectorTestBase.h"
 #include "presto_cpp/main/connectors/arrow_flight/tests/utils/ArrowFlightPlanBuilder.h"
 #include "presto_cpp/main/connectors/arrow_flight/tests/utils/Utils.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/config/Config.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PortUtil.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 
 using namespace arrow;
 using namespace facebook::velox;
@@ -129,6 +132,71 @@ TEST_F(ArrowFlightConnectorTest, dataSource) {
           .splits(makeSplits({"sample-data"}))
           .copyResults(pool()),
       "column with name 'ducks' not found");
+}
+
+TEST_F(ArrowFlightConnectorTest, runtimeStats) {
+  std::vector<int64_t> idData = {1, 2, 3};
+  std::vector<int32_t> valueData = {10, 20, 30};
+
+  updateTable(
+      "sample-data",
+      makeArrowTable(
+          {"id", "value"},
+          {makeNumericArray<arrow::Int64Type>(idData),
+           makeNumericArray<arrow::Int32Type>(valueData)}));
+
+  auto plan = ArrowFlightPlanBuilder()
+                  .flightTableScan(velox::ROW(
+                      {"id", "value"}, {velox::BIGINT(), velox::INTEGER()}))
+                  .planNode();
+
+  std::shared_ptr<velox::exec::Task> task;
+  AssertQueryBuilder(plan)
+      .splits(makeSplits({"sample-data"}))
+      .copyResults(pool(), task);
+
+  const auto opStats = toOperatorStats(task->taskStats());
+  ASSERT_EQ(opStats.count("TableScan"), 1);
+  const auto& runtimeStats = opStats.at("TableScan").runtimeStats;
+  ASSERT_EQ(runtimeStats.at("arrowFlightRows").sum, 3);
+  ASSERT_EQ(runtimeStats.at("arrowFlightBatches").sum, 1);
+  ASSERT_GT(runtimeStats.at("arrowFlightBytes").sum, 0);
+  ASSERT_GT(runtimeStats.at("arrowFlightConnectWallNanos").sum, 0);
+  ASSERT_EQ(runtimeStats.at("arrowFlightStreamsStarted").sum, 1);
+  ASSERT_EQ(runtimeStats.at("arrowFlightStreamsCompleted").sum, 1);
+  ASSERT_EQ(runtimeStats.at("arrowFlightStreamsFailed").sum, 0);
+  ASSERT_EQ(runtimeStats.at("arrowFlightErrors").sum, 0);
+}
+
+// End-to-end check that server-attached Presto error metadata survives the
+// gRPC round trip and surfaces as a typed error with the downstream name.
+TEST_F(ArrowFlightConnectorTest, prestoErrorPropagation) {
+  server_->setDoGetFailure(flight::MakeFlightError(
+      flight::FlightStatusCode::Unavailable,
+      "connection refused",
+      "presto-error-name=JDBC_ERROR\npresto-error-code=67108864\n"
+      "presto-error-type=EXTERNAL\npresto-error-retriable=false"));
+
+  auto plan = ArrowFlightPlanBuilder()
+                  .flightTableScan(velox::ROW({{"id", velox::BIGINT()}}))
+                  .planNode();
+
+  try {
+    AssertQueryBuilder(plan)
+        .splits(makeSplits({"sample-data"}))
+        .copyResults(pool());
+    FAIL() << "expected query to fail";
+  } catch (const velox::VeloxException& e) {
+    EXPECT_EQ(e.errorSource(), "EXTERNAL");
+    EXPECT_FALSE(e.isRetriable());
+    EXPECT_NE(e.message().find("JDBC_ERROR: "), std::string::npos);
+    const auto decoded = passthrough_error::decode(e.errorCode());
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->name, "JDBC_ERROR");
+    EXPECT_EQ(decoded->code, 67108864);
+    EXPECT_EQ(decoded->type, protocol::ErrorType::EXTERNAL);
+    EXPECT_FALSE(decoded->retriable);
+  }
 }
 
 TEST_F(ArrowFlightConnectorTest, multipleBatches) {

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightErrorsTest.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightErrorsTest.cpp
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/connectors/arrow_flight/ArrowFlightErrors.h"
+#include <arrow/flight/api.h>
+#include <arrow/status.h>
+#include <gtest/gtest.h>
+#include "presto_cpp/main/common/Exception.h"
+#include "velox/common/base/Exceptions.h"
+
+using namespace arrow;
+
+namespace facebook::presto::test {
+
+TEST(ArrowFlightErrorsTest, errorCategories) {
+  EXPECT_EQ(
+      errorCategory(flight::MakeFlightError(
+          flight::FlightStatusCode::Unavailable, "unavailable")),
+      "external");
+  EXPECT_EQ(
+      errorCategory(flight::MakeFlightError(
+          flight::FlightStatusCode::Unauthenticated, "unauthenticated")),
+      "external");
+  EXPECT_EQ(
+      errorCategory(arrow::Status::CapacityError("capacity")),
+      "insufficient_resources");
+  EXPECT_EQ(errorCategory(arrow::Status::IOError("io")), "external");
+  EXPECT_EQ(
+      errorCategory(arrow::Status::Invalid("invalid")), "internal_error");
+  EXPECT_EQ(
+      errorCategory(arrow::Status::UnknownError("unknown")), "internal_error");
+  // Presto error metadata takes precedence over the Flight status code.
+  EXPECT_EQ(
+      errorCategory(flight::MakeFlightError(
+          flight::FlightStatusCode::Unavailable,
+          "boom",
+          "presto-error-name=NOT_FOUND\npresto-error-type=USER_ERROR")),
+      "user_error");
+}
+
+// The metric category and the raised error must stay in agreement; they are two
+// views of the same failure and are derived independently.
+TEST(ArrowFlightErrorsTest, categoryMatchesRaisedError) {
+  const struct {
+    arrow::Status status;
+    std::string_view category;
+    std::string_view errorCode;
+  } cases[] = {
+      {flight::MakeFlightError(flight::FlightStatusCode::Unavailable, "down"),
+       "external",
+       "ARROW_FLIGHT_UNAVAILABLE_ERROR"},
+      {flight::MakeFlightError(
+           flight::FlightStatusCode::Unauthenticated, "bad token"),
+       "external",
+       "ARROW_FLIGHT_AUTH_ERROR"},
+      {flight::MakeFlightError(flight::FlightStatusCode::Cancelled, "cancel"),
+       "internal_error",
+       "ARROW_FLIGHT_INTERNAL_ERROR"},
+      {arrow::Status::CapacityError("capacity"),
+       "insufficient_resources",
+       "ARROW_FLIGHT_RESOURCE_ERROR"},
+      {arrow::Status::IOError("io"),
+       "external",
+       "ARROW_FLIGHT_UNAVAILABLE_ERROR"},
+      {arrow::Status::Invalid("invalid"),
+       "internal_error",
+       "ARROW_FLIGHT_INTERNAL_ERROR"},
+  };
+
+  for (const auto& testCase : cases) {
+    EXPECT_EQ(errorCategory(testCase.status), testCase.category)
+        << testCase.status.ToString();
+    try {
+      raiseFlightError(testCase.status);
+      FAIL() << "expected raiseFlightError to throw";
+    } catch (const velox::VeloxException& e) {
+      EXPECT_EQ(e.errorCode(), testCase.errorCode)
+          << testCase.status.ToString();
+    }
+  }
+}
+
+TEST(ArrowFlightErrorsTest, raiseFlightError) {
+  auto expectError = [](const arrow::Status& status,
+                        std::string_view errorCode,
+                        std::string_view errorSource,
+                        bool retriable) {
+    try {
+      raiseFlightError(status);
+      FAIL() << "expected raiseFlightError to throw";
+    } catch (const velox::VeloxException& e) {
+      EXPECT_EQ(e.errorCode(), errorCode);
+      EXPECT_EQ(e.errorSource(), errorSource);
+      EXPECT_EQ(e.isRetriable(), retriable);
+    }
+  };
+
+  // Metadata-driven mapping, regardless of the Flight status code.
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Internal,
+          "table dropped",
+          "presto-error-name=NOT_FOUND\npresto-error-type=USER_ERROR\n"
+          "presto-error-retriable=false"),
+      "INVALID_ARGUMENT",
+      "USER",
+      false);
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Unavailable,
+          "connection refused",
+          "presto-error-name=JDBC_ERROR\npresto-error-type=EXTERNAL\n"
+          "presto-error-retriable=true"),
+      "ARROW_FLIGHT_REMOTE_ERROR",
+      "EXTERNAL",
+      true);
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Internal,
+          "oom",
+          "presto-error-name=GENERIC_INSUFFICIENT_RESOURCES\n"
+          "presto-error-type=INSUFFICIENT_RESOURCES"),
+      "ARROW_FLIGHT_RESOURCE_ERROR",
+      "RUNTIME",
+      false);
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Internal,
+          "npe",
+          "presto-error-name=GENERIC_INTERNAL_ERROR\n"
+          "presto-error-type=INTERNAL_ERROR"),
+      "ARROW_FLIGHT_INTERNAL_ERROR",
+      "RUNTIME",
+      false);
+
+  // Fallback mapping when no metadata is present.
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Unavailable, "server down"),
+      "ARROW_FLIGHT_UNAVAILABLE_ERROR",
+      "EXTERNAL",
+      true);
+  expectError(
+      flight::MakeFlightError(
+          flight::FlightStatusCode::Unauthenticated, "bad token"),
+      "ARROW_FLIGHT_AUTH_ERROR",
+      "EXTERNAL",
+      false);
+  expectError(
+      arrow::Status::UnknownError("unknown"),
+      "ARROW_FLIGHT_INTERNAL_ERROR",
+      "RUNTIME",
+      false);
+
+  try {
+    raiseFlightError(flight::MakeFlightError(
+        flight::FlightStatusCode::Internal,
+        "table dropped",
+        "presto-error-name=NOT_FOUND\npresto-error-type=USER_ERROR"));
+    FAIL() << "expected raiseFlightError to throw";
+  } catch (const velox::VeloxException& e) {
+    EXPECT_NE(e.message().find("NOT_FOUND: table dropped"), std::string::npos);
+  }
+
+  // A complete tuple (including the numeric code) is passed through verbatim.
+  try {
+    raiseFlightError(flight::MakeFlightError(
+        flight::FlightStatusCode::Unavailable,
+        "connection refused",
+        "presto-error-name=JDBC_ERROR\npresto-error-code=67108864\n"
+        "presto-error-type=EXTERNAL\npresto-error-retriable=false"));
+    FAIL() << "expected raiseFlightError to throw";
+  } catch (const velox::VeloxException& e) {
+    EXPECT_EQ(e.errorSource(), "EXTERNAL");
+    const auto decoded = passthrough_error::decode(e.errorCode());
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded->name, "JDBC_ERROR");
+    EXPECT_EQ(decoded->code, 67108864);
+    EXPECT_EQ(decoded->type, protocol::ErrorType::EXTERNAL);
+    EXPECT_FALSE(decoded->retriable);
+  }
+}
+
+} // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
 add_executable(
   presto_flight_connector_test
   ArrowFlightConnectorTest.cpp
+  ArrowFlightErrorsTest.cpp
   ArrowFlightConnectorAuthTest.cpp
   ArrowFlightConnectorMTlsTest.cpp
   ArrowFlightConnectorTlsTest.cpp

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/TestingArrowFlightServer.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/TestingArrowFlightServer.cpp
@@ -19,6 +19,9 @@ arrow::Status TestingArrowFlightServer::DoGet(
     const arrow::flight::ServerCallContext& context,
     const arrow::flight::Ticket& request,
     std::unique_ptr<arrow::flight::FlightDataStream>* stream) {
+  if (!doGetFailure_.ok()) {
+    return doGetFailure_;
+  }
   auto it = tables_.find(request.ticket);
   if (it == tables_.end()) {
     return arrow::Status::KeyError(

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/TestingArrowFlightServer.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/TestingArrowFlightServer.h
@@ -42,6 +42,11 @@ class TestingArrowFlightServer : public arrow::flight::FlightServerBase {
     batchSize_ = std::make_optional<int64_t>(batchSize);
   }
 
+  /// Makes subsequent DoGet calls fail with the given status.
+  void setDoGetFailure(arrow::Status status) {
+    doGetFailure_ = std::move(status);
+  }
+
   arrow::Status DoGet(
       const arrow::flight::ServerCallContext& context,
       const arrow::flight::Ticket& request,
@@ -50,6 +55,7 @@ class TestingArrowFlightServer : public arrow::flight::FlightServerBase {
  private:
   std::unordered_map<std::string, std::shared_ptr<arrow::Table>> tables_;
   std::optional<int64_t> batchSize_;
+  arrow::Status doGetFailure_{arrow::Status::OK()};
 };
 
 } // namespace facebook::presto::test


### PR DESCRIPTION
Native Arrow Flight client observability:
- Per-phase runtime stats and worker counters (connect, authenticate, DoGet, batch wait, decode), stream lifecycle, and rows/bytes/batches
- Error counters bucketed by Presto ErrorType

Connector error propagation from FlightShim to the native worker:
- FlightShim maps stream errors to typed Flight statuses with Presto error metadata instead of flattening everything to INTERNAL
- Native client throws typed Velox exceptions from that metadata; a complete tuple passes through verbatim (PRESTO_PASSTHROUGH encoding) and incomplete metadata falls back to ARROW_FLIGHT_* codes

## Description
<!---Describe your changes in detail-->

Add native Arrow Flight client-side observability and end-to-end error propagation for federation workloads.

Native worker (C++):

Per-phase runtime stats and worker counters: connect, authenticate, DoGet, batch wait, decode
Stream lifecycle counters (started / completed / failed / cancelled / active)
Throughput counters (batches / rows / bytes received)
Error counters bucketed by Presto ErrorType (user, external, insufficient_resources, internal)
New ArrowFlightErrors helper for category classification, counter recording, and typed exception raising
PRESTO_PASSTHROUGH encoding in Exception.h so exact downstream Presto error codes pass through verbatim to the coordinator
FlightShim (Java):

New FlightShimErrors maps stream failures to typed Flight statuses with Presto error metadata
FlightShimProducer uses typed errors instead of flattening everything to CallStatus.INTERNAL
Error codes:

Adds ARROW_FLIGHT_*_ERROR codes to ArrowErrorCode.java, mirrored in Exception.h/cpp


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Operators need visibility into the native Arrow Flight client (latency breakdowns, throughput, failure modes) alongside existing worker metrics. Today, federation failures from downstream connectors are often surfaced as generic INTERNAL errors, making it hard to debug connector-specific issues or alert on the right failure category.

This change lets the native worker report per-phase client metrics and propagate downstream Presto error codes from FlightShim through typed Flight statuses.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

No SQL syntax, query plan, or connector configuration changes

No new required user configuration

Failed federation queries may now report typed downstream errors (e.g. EXTERNAL, USER_ERROR) instead of a generic INTERNAL error

Minimal runtime overhead from timing instrumentation on the Flight read path

## Test Plan
<!---Please fill in how you tested your change-->


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add observability and error propagation improvements for the native Arrow Flight connector and Flight shim.

New Features:
- Expose detailed runtime metrics and stream lifecycle stats for the native Arrow Flight data source, including latency, throughput, and error counters.
- Introduce end-to-end propagation of downstream Presto error codes through Arrow Flight, using typed Velox exceptions and new Arrow Flight error codes on both native and Java sides.

Enhancements:
- Register and publish Arrow Flight client metrics via the shared counters and stats reporter infrastructure.
- Extend the Velox-to-Presto exception translator to support pass-through downstream error codes using a PRESTO_PASSTHROUGH encoding.

Tests:
- Add native and Java tests covering Arrow Flight runtime stats, error categorization, and passthrough error propagation from FlightShim to the native worker.