### PR TITLE
Allow ST_LineString consecutive duplicate points; update RPCNode for Velox

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -155,7 +155,7 @@ public final class GeoFunctions
     @SqlType(GEOMETRY_TYPE_NAME)
     public static Slice stLineString(@SqlType("array(" + GEOMETRY_TYPE_NAME + ")") Block input)
     {
-        CoordinateSequence coordinates = readPointCoordinates(input, "ST_LineString", true);
+        CoordinateSequence coordinates = readPointCoordinates(input, "ST_LineString", false);
         if (coordinates.size() < 2) {
             return serialize(createJtsEmptyLineString());
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoFunctions.java
@@ -1064,7 +1064,9 @@ public class TestGeoFunctions
         assertFunction("ST_LineString(array[ST_GeometryFromText('POINT (1 2)'), ST_GeometryFromText('POINT (3 4)')])", GEOMETRY, "LINESTRING (1 2, 3 4)");
 
         // Duplicate consecutive points throws exception
-        assertInvalidFunction("ST_LineString(array[ST_Point(1, 2), ST_Point(1, 2)])", INVALID_FUNCTION_ARGUMENT, "Invalid input to ST_LineString: consecutive duplicate points at index 2");
+        // Consecutive duplicate points are allowed (Sedona ST_MakeLine / SpatialBench Q7 parity).
+        assertFunction("ST_LineString(array[ST_Point(1, 2), ST_Point(1, 2)])", GEOMETRY, "LINESTRING (1 2, 1 2)");
+        assertFunction("ST_Length(ST_LineString(array[ST_Point(1, 2), ST_Point(1, 2)]))", DOUBLE, 0.0);
         assertFunction("ST_LineString(array[ST_Point(1, 2), ST_Point(3, 4), ST_Point(1, 2)])", GEOMETRY, "LINESTRING (1 2, 3 4, 1 2)");
 
         // Single point

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2498,16 +2498,36 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   outputTypes.push_back(resultType);
   auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
 
+  // Velox RPCNode now takes a CallTypedExpr (folded from the legacy flattened
+  // argumentColumns/argumentTypes/constantInputs fields).
+  VELOX_CHECK_EQ(
+      argumentColumns.size(),
+      argumentTypes.size(),
+      "RPCNode argumentColumns and argumentTypes must have the same size");
+  VELOX_CHECK_EQ(
+      argumentColumns.size(),
+      constantInputs.size(),
+      "RPCNode argumentColumns and constantInputs must have the same size");
+  std::vector<core::TypedExprPtr> callInputs;
+  callInputs.reserve(argumentColumns.size());
+  for (size_t i = 0; i < argumentColumns.size(); ++i) {
+    if (constantInputs[i] != nullptr) {
+      callInputs.push_back(
+          std::make_shared<core::ConstantTypedExpr>(constantInputs[i]));
+    } else {
+      callInputs.push_back(std::make_shared<core::FieldAccessTypedExpr>(
+          argumentTypes[i], argumentColumns[i]));
+    }
+  }
+  auto call = std::make_shared<core::CallTypedExpr>(
+      resultType, std::move(callInputs), node->functionName);
+
   return std::make_shared<core::RPCNode>(
       node->id,
       sourceNode,
-      node->functionName,
-      resultType,
+      std::move(call),
       node->outputVariable.name,
       std::move(outputType),
-      std::move(argumentColumns),
-      std::move(argumentTypes),
-      std::move(constantInputs),
       veloxStreamingMode,
       dispatchBatchSize);
 }


### PR DESCRIPTION
## Summary
- Allow consecutive duplicate vertices in Java `ST_LineString` (Sedona `ST_MakeLine` / SpatialBench Q7 parity; zero-length segments are valid and contribute 0 to `ST_Length`).
- Update `PrestoToVeloxQueryPlan` to construct Velox `RPCNode` via `CallTypedExpr`, matching the current Velox plan-node API after the RPC argument fold.

## Test plan
- [ ] `TestGeoFunctions` — duplicate `ST_LineString` / `ST_Length` cases pass
- [ ] Native worker builds against current Velox (no `RPCNode` ctor mismatch)
- [ ] SpatialBench Q7 on Presto Native CPU completes (equal pickup/dropoff rows no longer fail)

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix ``ST_LineString`` to allow consecutive duplicate points. Zero-length segments are valid and contribute ``0`` to ``ST_Length``.
```
 