### PR TITLE
feat(native): Enable plan consistency check by default

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -308,7 +308,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kTextReaderEnabled, true),
           BOOL_PROP(kCharNToVarcharImplicitCast, false),
           BOOL_PROP(kEnumTypesEnabled, true),
-          BOOL_PROP(kPlanConsistencyCheckEnabled, false),
+          BOOL_PROP(kPlanConsistencyCheckEnabled, true),
       };
 }
 


### PR DESCRIPTION
All tests run with `plan-consistency-check-enabled=true`, making it true by default to catch plan inconsistencies early.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

New Features:
- Run plan consistency checks by default in native execution via the system configuration flag.