### PR TITLE
fix(optimizer): Disable dereference pushdown optimizations for native engine

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaConnectorFactory.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaConnectorFactory.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.gcs.HiveGcsModule;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
 import com.facebook.presto.hive.s3.HiveS3Module;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
@@ -67,6 +68,7 @@ public class DeltaConnectorFactory
                     new HiveCommonModule(),
                     binder -> {
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                        binder.bind(ConnectorSystemConfig.class).toInstance(context.getConnectorSystemConfig());
                     });
 
             Injector injector = app

--- a/presto-delta/src/main/java/com/facebook/presto/delta/rule/DeltaPlanOptimizerProvider.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/rule/DeltaPlanOptimizerProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.delta.rule;
 
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.common.collect.ImmutableSet;
@@ -21,15 +22,26 @@ import jakarta.inject.Inject;
 
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 public class DeltaPlanOptimizerProvider
         implements ConnectorPlanOptimizerProvider
 {
     private final Set<ConnectorPlanOptimizer> planOptimizers;
 
     @Inject
-    public DeltaPlanOptimizerProvider(RowExpressionService rowExpressionService)
+    public DeltaPlanOptimizerProvider(RowExpressionService rowExpressionService, ConnectorSystemConfig connectorSystemConfig)
     {
-        planOptimizers = ImmutableSet.of(new DeltaParquetDereferencePushDown(rowExpressionService));
+        requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
+
+        // DeltaParquetDereferencePushDown hoists a nested field into a top level column whose name is the
+        // flattened subfield path ("msg$_$_$x") while its required subfield keeps the original root ("msg.x").
+        // The Java Parquet reader resolves such columns through the subfield path and ignores the column name,
+        // but Velox requires the required subfield root to match the column handle name and fails the scan with
+        // "Required subfield does not match column name".
+        planOptimizers = connectorSystemConfig.isNativeExecution()
+                ? ImmutableSet.of()
+                : ImmutableSet.of(new DeltaParquetDereferencePushDown(rowExpressionService));
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
@@ -55,9 +55,15 @@ public class HivePlanOptimizerProvider
         requireNonNull(typeManager, "typeManager is null");
         ImmutableSet.Builder<ConnectorPlanOptimizer> planOptimizerBuilder = ImmutableSet.<ConnectorPlanOptimizer>builder()
                 .add(new HiveFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, partitionManager))
-                .add(new HiveAddRequestedColumnsToLayout())
-                .add(new HiveParquetDereferencePushDown(transactionManager, rowExpressionService));
+                .add(new HiveAddRequestedColumnsToLayout());
         if (!connectorSystemConfig.isNativeExecution()) {
+            // HiveParquetDereferencePushDown hoists a nested field into a top level column whose name is the
+            // flattened subfield path ("msg$_$_$x") while its required subfield keeps the original root ("msg.x").
+            // The Java Parquet reader resolves such columns through the subfield path and ignores the column name,
+            // but Velox requires the required subfield root to match the column handle name and fails the scan with
+            // "Required subfield does not match column name". Native workers get equivalent pruning from
+            // PushdownSubfields, which preserves the base column name.
+            planOptimizerBuilder.add(new HiveParquetDereferencePushDown(transactionManager, rowExpressionService));
             planOptimizerBuilder.add(new HivePartialAggregationPushdown(functionResolution, metadataFactory));
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.iceberg.IcebergTableProperties;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionManager;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -41,24 +42,40 @@ public class IcebergPlanOptimizerProvider
             StandardFunctionResolution functionResolution,
             FunctionMetadataManager functionMetadataManager,
             IcebergTableProperties tableProperties,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         requireNonNull(transactionManager, "transactionManager is null");
         requireNonNull(rowExpressionService, "rowExpressionService is null");
         requireNonNull(functionResolution, "functionResolution is null");
         requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         requireNonNull(typeManager, "typeManager is null");
-        this.planOptimizers = ImmutableSet.of(
-                new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
-                new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
-                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties));
-        this.logicalPlanOptimizers = ImmutableSet.of(
-                new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
-                new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
-                new IcebergAggregationOptimizer(transactionManager, functionResolution),
-                new IcebergMetadataOptimizer(functionMetadataManager, typeManager, transactionManager, rowExpressionService, functionResolution),
-                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties),
-                new IcebergEqualityDeleteAsJoin(functionResolution, transactionManager, typeManager));
+        requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
+
+        ImmutableSet.Builder<ConnectorPlanOptimizer> planOptimizerBuilder = ImmutableSet.<ConnectorPlanOptimizer>builder()
+                .add(new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager))
+                .add(new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager));
+        ImmutableSet.Builder<ConnectorPlanOptimizer> logicalPlanOptimizerBuilder = ImmutableSet.<ConnectorPlanOptimizer>builder()
+                .add(new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager))
+                .add(new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager))
+                .add(new IcebergAggregationOptimizer(transactionManager, functionResolution))
+                .add(new IcebergMetadataOptimizer(functionMetadataManager, typeManager, transactionManager, rowExpressionService, functionResolution));
+
+        // IcebergParquetDereferencePushDown hoists a nested field into a top level column whose name is the
+        // flattened subfield path ("msg$_$_$x") while its required subfield keeps the original root ("msg.x").
+        // The Java Parquet reader resolves such columns through the subfield path and ignores the column name,
+        // but Velox requires the required subfield root to match the column handle name and fails the scan with
+        // "Required subfield does not match column name". Native workers get equivalent pruning from
+        // PushdownSubfields, which preserves the base column name.
+        if (!connectorSystemConfig.isNativeExecution()) {
+            planOptimizerBuilder.add(new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties));
+            logicalPlanOptimizerBuilder.add(new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties));
+        }
+
+        logicalPlanOptimizerBuilder.add(new IcebergEqualityDeleteAsJoin(functionResolution, transactionManager, typeManager));
+
+        this.planOptimizers = planOptimizerBuilder.build();
+        this.logicalPlanOptimizers = logicalPlanOptimizerBuilder.build();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
@@ -13,14 +13,38 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.iceberg.IcebergTableLayoutHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Map;
+
+import static com.facebook.presto.common.predicate.Domain.singleValue;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.isPushedDownSubfield;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestPrestoNativeIcebergGeneralQueries
         extends AbstractTestQueryFramework
@@ -70,6 +94,68 @@ public class TestPrestoNativeIcebergGeneralQueries
         javaQueryRunner.execute("DROP TABLE IF EXISTS test_analyze");
         javaQueryRunner.execute("CREATE TABLE test_analyze(i int)");
         javaQueryRunner.execute("INSERT INTO test_analyze VALUES 1, 2, 3, 4, 5");
+
+        javaQueryRunner.execute("DROP TABLE IF EXISTS test_nested_column_pushdown");
+        javaQueryRunner.execute("CREATE TABLE test_nested_column_pushdown(event_id VARCHAR, statisticsinformation ROW(processingdate VARCHAR, region VARCHAR))");
+        javaQueryRunner.execute("INSERT INTO test_nested_column_pushdown VALUES" +
+                " ('evt-1', ROW('2024-06-16', 'AMERICA'))," +
+                " ('evt-2', ROW('2024-06-17', 'ASIA'))," +
+                " ('evt-3', ROW('2024-06-18', 'EUROPE'))");
+    }
+
+    @Test
+    public void testNestedColumnPushdown()
+    {
+        // A projection or filter on a single field of a ROW column is rewritten by the dereference pushdown rules.
+        // The connector level rule (IcebergParquetDereferencePushDown, enabled by default) renames the pushed down
+        // column to the flattened subfield path while leaving the required subfield rooted at the base column, which
+        // Velox rejects with "Required subfield does not match column name". These queries verify native workers
+        // read nested fields correctly.
+        assertQuery("SELECT statisticsinformation.processingdate FROM test_nested_column_pushdown");
+        assertQuery("SELECT event_id FROM test_nested_column_pushdown WHERE statisticsinformation.processingdate = '2024-06-17'");
+        assertQuery("SELECT statisticsinformation.processingdate, statisticsinformation.region FROM test_nested_column_pushdown");
+        assertQuery("SELECT count(*) FROM test_nested_column_pushdown WHERE statisticsinformation.region = 'ASIA'");
+    }
+
+    @Test
+    public void testNestedColumnFilterPushedToTableScan()
+    {
+        // Under native execution the connector level IcebergParquetDereferencePushDown rule is not registered because it
+        // renames the pushed down column to the flattened subfield path ("statisticsinformation$_$_$processingdate")
+        // while leaving the required subfield rooted at the base column, which Velox rejects with
+        // "Required subfield does not match column name". Verify the subfield filter still reaches the table scan and
+        // that every scan column keeps its base column name, the only shape Velox accepts.
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
+        String query = "SELECT event_id FROM test_nested_column_pushdown WHERE statisticsinformation.processingdate = '2024-06-17'";
+
+        assertPlan(session, query, anyTree(tableScan("test_nested_column_pushdown")), plan -> {
+            // The subfield predicate is fully enforced by the scan, no residual FilterNode remains.
+            assertTrue(searchFrom(plan.getRoot()).where(FilterNode.class::isInstance).findAll().isEmpty());
+
+            TableScanNode tableScan = searchFrom(plan.getRoot())
+                    .where(TableScanNode.class::isInstance)
+                    .findOnlyElement();
+
+            // No column was hoisted into a flattened "$_$_$" column by the dereference pushdown rule.
+            for (ColumnHandle column : tableScan.getAssignments().values()) {
+                assertFalse(isPushedDownSubfield((IcebergColumnHandle) column));
+            }
+
+            assertTrue(tableScan.getTable().getLayout().isPresent());
+            IcebergTableLayoutHandle layoutHandle = (IcebergTableLayoutHandle) tableScan.getTable().getLayout().get();
+
+            Map<Subfield, Domain> domains = layoutHandle.getDomainPredicate().getDomains().orElseThrow(AssertionError::new);
+            assertEquals(domains, ImmutableMap.of(
+                    new Subfield("statisticsinformation.processingdate"),
+                    singleValue(VARCHAR, utf8Slice("2024-06-17"))));
+            assertEquals(layoutHandle.getRemainingPredicate(), TRUE_CONSTANT);
+            // The predicate column is the base ROW column, not a synthesized flattened column.
+            assertEquals(layoutHandle.getPredicateColumns().keySet(), ImmutableSet.of("statisticsinformation"));
+        });
+
+        assertQuery(session, query, "VALUES ('evt-2')");
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
The Dereference Pushdown rules renames the pushed down column to the flattened subfield path 
 ("statisticsinformation$_$_$processingdate") while leaving the required subfield rooted at the base column, which Velox rejects with "Required subfield does not match column name". 
 
Native gets its pruning from PushdownSubfields instead, which keeps base name and is what Velox expects. Hence adding the guard in the three *PlanOptimizerProvider classes.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Disable Parquet dereference pushdown optimizations when running under native execution and ensure nested column filters are still pushed correctly to table scans.

Bug Fixes:
- Avoid scan failures in native execution caused by dereference pushdown renaming nested Parquet columns in a way Velox rejects.

Enhancements:
- Guard Hive, Iceberg, and Delta Parquet dereference pushdown rules behind the native-execution flag and wire connector system configuration into the respective optimizer providers.

Tests:
- Add Iceberg native execution tests that create nested-row tables, validate nested field projections and filters, and assert that subfield predicates are pushed to table scans without generating flattened column handles.