### PR TITLE
fix: Refactor PlanOptimizer to be immutable

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDistributedCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDistributedCteExecution.java
@@ -16,7 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.testing.QueryRunner;
 import org.testng.annotations.Test;
 
-@Test(singleThreaded = true)
+@Test
 public class TestDistributedCteExecution
         extends AbstractTestCteExecution
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSingleNodeCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSingleNodeCteExecution.java
@@ -16,7 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.testing.QueryRunner;
 import org.testng.annotations.Test;
 
-@Test(singleThreaded = true)
+@Test
 public class TestSingleNodeCteExecution
         extends AbstractTestCteExecution
 {

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -255,7 +255,7 @@ public class SqlQueryScheduler
                 splitSourceFactory,
                 session);
 
-        this.rootStageId = stageExecutions.stream().reduce((first, second) -> second).get().getStageExecution().getStageExecutionId().getStageId();
+        this.rootStageId = stageExecutions.get(stageExecutions.size() - 1).getStageExecution().getStageExecutionId().getStageId();
 
         stageExecutions.stream()
                 .forEach(execution -> this.stageExecutions.put(execution.getStageExecution().getStageExecutionId().getStageId(), execution));
@@ -655,7 +655,7 @@ public class SqlQueryScheduler
         PlanFragment fragment = subPlan.getFragment();
         PlanNode newRoot = fragment.getRoot();
         for (PlanOptimizer optimizer : runtimePlanOptimizers) {
-            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector).getPlanNode();
+            newRoot = optimizer.optimize(newRoot, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, false).getPlanNode();
         }
         if (newRoot != fragment.getRoot()) {
             Optional<StatsAndCosts> estimatedStatsAndCosts = fragment.getStatsAndCosts();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/Optimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/Optimizer.java
@@ -164,10 +164,13 @@ public class Optimizer
 
         String optimizerName = getOptimizerNameForLog(optimizer);
         boolean isTriggered = planOptimizerResult.isOptimizerTriggered();
+
+        // The `isApplicable` flag indicates that either the optimizer has been effectively invoked, or it has been skipped
+        // because of session properties configuration but possesses the ability to influence the optimization of the plan.
         boolean isApplicable =
                 isTriggered ||
                         !optimizer.isEnabled(session, false) && isVerboseOptimizerInfoEnabled(session) &&
-                                optimizer.isApplicable(oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator);
+                                isApplicable(optimizer, oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator);
         boolean isCostBased = isTriggered && optimizer.isCostBased(session);
         String statsSource = optimizer.getStatsSource();
 
@@ -180,6 +183,25 @@ public class Optimizer
             String oldNodeStr = PlannerUtils.getPlanString(oldNode, session, types, metadata, false);
             String newNodeStr = PlannerUtils.getPlanString(planOptimizerResult.getPlanNode(), session, types, metadata, false);
             session.getOptimizerResultCollector().addOptimizerResult(optimizerName, oldNodeStr, newNodeStr);
+        }
+    }
+
+    static boolean isApplicable(
+            PlanOptimizer optimizer,
+            PlanNode plan,
+            Session session,
+            TypeProvider types,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        boolean isApplicable = false;
+        try {
+            // wrap in try/catch block in case optimization throws an error
+            PlanOptimizerResult optimizerResult = optimizer.optimize(plan, session, types, variableAllocator, idAllocator, WarningCollector.NOOP, true);
+            isApplicable = optimizerResult.isOptimizerTriggered();
+        }
+        finally {
+            return isApplicable;
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/Optimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/Optimizer.java
@@ -111,7 +111,7 @@ public class Optimizer
                     throw new PrestoException(QUERY_PLANNING_TIMEOUT, String.format("The query optimizer exceeded the timeout of %s.", getQueryAnalyzerTimeout(session).toString()));
                 }
                 long start = System.nanoTime();
-                PlanOptimizerResult optimizerResult = optimizer.optimize(root, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+                PlanOptimizerResult optimizerResult = optimizer.optimize(root, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, false);
                 requireNonNull(optimizerResult, format("%s returned a null plan", optimizer.getClass().getName()));
                 if (enableVerboseRuntimeStats || trackOptimizerRuntime(session, optimizer)) {
                     session.getRuntimeStats().addMetricValue(String.format("optimizer%sTimeNanos", getOptimizerNameForLog(optimizer)), NANO, System.nanoTime() - start);
@@ -166,8 +166,8 @@ public class Optimizer
         boolean isTriggered = planOptimizerResult.isOptimizerTriggered();
         boolean isApplicable =
                 isTriggered ||
-                        !optimizer.isEnabled(session) && isVerboseOptimizerInfoEnabled(session) &&
-                                optimizer.isApplicable(oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+                        !optimizer.isEnabled(session, false) && isVerboseOptimizerInfoEnabled(session) &&
+                                optimizer.isApplicable(oldNode, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator);
         boolean isCostBased = isTriggered && optimizer.isCostBased(session);
         String statsSource = optimizer.getStatsSource();
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -102,13 +102,14 @@ public class IterativeOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         // only disable new rules if we have legacy rules to fall back to
         if (!SystemSessionProperties.isNewOptimizerEnabled(session) && !legacyRules.isEmpty()) {
             boolean planChanged = false;
             for (PlanOptimizer optimizer : legacyRules) {
-                PlanOptimizerResult planOptimizerResult = optimizer.optimize(plan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector);
+                PlanOptimizerResult planOptimizerResult = optimizer.optimize(plan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, collectInformation);
                 plan = planOptimizerResult.getPlanNode();
                 planChanged = planChanged || planOptimizerResult.isOptimizerTriggered();
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -103,13 +103,13 @@ public class IterativeOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         // only disable new rules if we have legacy rules to fall back to
         if (!SystemSessionProperties.isNewOptimizerEnabled(session) && !legacyRules.isEmpty()) {
             boolean planChanged = false;
             for (PlanOptimizer optimizer : legacyRules) {
-                PlanOptimizerResult planOptimizerResult = optimizer.optimize(plan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, collectInformation);
+                PlanOptimizerResult planOptimizerResult = optimizer.optimize(plan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, forceEnableOptimizer);
                 plan = planOptimizerResult.getPlanNode();
                 planChanged = planChanged || planOptimizerResult.isOptimizerTriggered();
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -86,7 +86,7 @@ public class RemoveUnsupportedDynamicFilters
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
         Rewriter rewriter = new RemoveUnsupportedDynamicFilters.Rewriter(session);
         PlanWithConsumedDynamicFilters result = plan.accept(rewriter, ImmutableSet.of());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -85,7 +85,8 @@ public class RemoveUnsupportedDynamicFilters
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
         Rewriter rewriter = new RemoveUnsupportedDynamicFilters.Rewriter(session);
         PlanWithConsumedDynamicFilters result = plan.accept(rewriter, ImmutableSet.of());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -195,15 +195,16 @@ public class AddExchanges
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
         return !isSingleNodeExecutionEnabled(session);
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager, nativeExecution).accept(plan, PreferredProperties.any());
             boolean optimizerTriggered = PlanNodeSearcher.searchFrom(result.getNode()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isRemote()).findFirst().isPresent();
             return PlanOptimizerResult.optimizerResult(result.getNode(), optimizerTriggered);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -195,16 +195,16 @@ public class AddExchanges
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
         return !isSingleNodeExecutionEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager, nativeExecution).accept(plan, PreferredProperties.any());
             boolean optimizerTriggered = PlanNodeSearcher.searchFrom(result.getNode()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope().isRemote()).findFirst().isPresent();
             return PlanOptimizerResult.optimizerResult(result.getNode(), optimizerTriggered);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchangesForSingleNodeExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchangesForSingleNodeExecution.java
@@ -56,16 +56,16 @@ public class AddExchangesForSingleNodeExecution
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
         return isSingleNodeExecutionEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             AddExchangesForSingleNodeExecution.Rewriter rewriter = new AddExchangesForSingleNodeExecution.Rewriter(idAllocator, metadata, session);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchangesForSingleNodeExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchangesForSingleNodeExecution.java
@@ -56,15 +56,16 @@ public class AddExchangesForSingleNodeExecution
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
         return isSingleNodeExecutionEnabled(session);
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             AddExchangesForSingleNodeExecution.Rewriter rewriter = new AddExchangesForSingleNodeExecution.Rewriter(idAllocator, metadata, session);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -143,7 +143,7 @@ public class AddLocalExchanges
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         LocalExchangeParentPreferenceStrategy strategy = getLocalExchangeParentPreferenceStrategy(session);
         Optional<StatsProvider> statsProvider = Optional.empty();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -142,7 +142,8 @@ public class AddLocalExchanges
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         LocalExchangeParentPreferenceStrategy strategy = getLocalExchangeParentPreferenceStrategy(session);
         Optional<StatsProvider> statsProvider = Optional.empty();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -119,7 +119,7 @@ public class ApplyConnectorOptimization
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -118,7 +118,8 @@ public class ApplyConnectorOptimization
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -36,7 +36,8 @@ public class CheckSubqueryNodesAreRewritten
         implements PlanOptimizer
 {
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         searchFrom(plan).where(ApplyNode.class::isInstance)
                 .findFirst()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -37,7 +37,7 @@ public class CheckSubqueryNodesAreRewritten
 {
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         searchFrom(plan).where(ApplyNode.class::isInstance)
                 .findFirst()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -98,7 +98,7 @@ public class CteProjectionAndPredicatePushDown
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -97,7 +97,8 @@ public class CteProjectionAndPredicatePushDown
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/GroupInnerJoinsByConnectorRuleSet.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/GroupInnerJoinsByConnectorRuleSet.java
@@ -358,7 +358,7 @@ public class GroupInnerJoinsByConnectorRuleSet
                         TypeProvider.viewOf(variableAllocator.getVariables()),
                         variableAllocator,
                         idAllocator,
-                        context.getWarningCollector()).getPlanNode();
+                        context.getWarningCollector(), false).getPlanNode();
             }
             return node;
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -105,21 +105,21 @@ public class HashGenerationOptimizer
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || SystemSessionProperties.isOptimizeHashGenerationEnabled(session);
+        return forceEnableOptimizer || SystemSessionProperties.isOptimizeHashGenerationEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, functionAndTypeManager, session).accept(plan, new HashComputationSet());
             return PlanOptimizerResult.optimizerResult(result.getNode(), true);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -98,7 +98,6 @@ public class HashGenerationOptimizer
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
-    private boolean isEnabledForTesting;
 
     public HashGenerationOptimizer(FunctionAndTypeManager functionAndTypeManager)
     {
@@ -106,26 +105,21 @@ public class HashGenerationOptimizer
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || SystemSessionProperties.isOptimizeHashGenerationEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || SystemSessionProperties.isOptimizeHashGenerationEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             PlanWithProperties result = new Rewriter(idAllocator, variableAllocator, functionAndTypeManager, session).accept(plan, new HashComputationSet());
             return PlanOptimizerResult.optimizerResult(result.getNode(), true);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -59,7 +59,6 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
             ImmutableSet.of(TopNNode.class, LimitNode.class, DistinctLimitNode.class, TopNRowNumberNode.class);
     private static final List<Class<? extends PlanNode>> PRECOMPUTE_PLAN_NODES = ImmutableList.of(JoinNode.class, SemiJoinNode.class, AggregationNode.class);
     private final StatsCalculator statsCalculator;
-    private boolean isEnabledForTesting;
 
     public HistoricalStatisticsEquivalentPlanMarkingOptimizer(StatsCalculator statsCalculator)
     {
@@ -67,19 +66,14 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || useHistoryBasedPlanStatisticsEnabled(session) || trackHistoryBasedPlanStatisticsEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || useHistoryBasedPlanStatisticsEnabled(session) || trackHistoryBasedPlanStatisticsEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -87,7 +81,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (!isEnabled(session)) {
+        if (!isEnabled(session, collectInformation)) {
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HistoricalStatisticsEquivalentPlanMarkingOptimizer.java
@@ -66,14 +66,14 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || useHistoryBasedPlanStatisticsEnabled(session) || trackHistoryBasedPlanStatisticsEnabled(session);
+        return forceEnableOptimizer || useHistoryBasedPlanStatisticsEnabled(session) || trackHistoryBasedPlanStatisticsEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -81,7 +81,7 @@ public class HistoricalStatisticsEquivalentPlanMarkingOptimizer
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (!isEnabled(session, collectInformation)) {
+        if (!isEnabled(session, forceEnableOptimizer)) {
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -113,7 +113,7 @@ public class ImplementIntersectAndExceptAsUnion
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -112,7 +112,8 @@ public class ImplementIntersectAndExceptAsUnion
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -95,7 +95,7 @@ public class IndexJoinOptimizer
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -94,7 +94,8 @@ public class IndexJoinOptimizer
             TypeProvider type,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -80,7 +80,6 @@ public class JoinPrefilter
         implements PlanOptimizer
 {
     private final Metadata metadata;
-    private boolean isEnabledForTesting;
 
     public JoinPrefilter(Metadata metadata)
     {
@@ -88,21 +87,16 @@ public class JoinPrefilter
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isJoinPrefilterEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isJoinPrefilterEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator, metadata.getFunctionAndTypeManager());
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -87,16 +87,16 @@ public class JoinPrefilter
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isJoinPrefilterEnabled(session);
+        return forceEnableOptimizer || isJoinPrefilterEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator, metadata.getFunctionAndTypeManager());
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -75,20 +75,20 @@ public class KeyBasedSampler
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isKeyBasedSamplingEnabled(session);
+        return forceEnableOptimizer || isKeyBasedSamplingEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             List<String> sampledFields = new ArrayList<>(2);
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata.getFunctionAndTypeManager(), idAllocator, sampledFields), plan, null);
 
-            if (!collectInformation) {
+            if (!forceEnableOptimizer) {
                 if (!sampledFields.isEmpty()) {
                     warningCollector.add(new PrestoWarning(SAMPLED_FIELDS, String.format("Sampled the following columns/derived columns at %s percent:%n\t%s", getKeyBasedSamplingPercentage(session) * 100., String.join("\n\t", sampledFields))));
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -68,7 +68,6 @@ public class KeyBasedSampler
         implements PlanOptimizer
 {
     private final Metadata metadata;
-    private boolean isEnabledForTesting;
 
     public KeyBasedSampler(Metadata metadata)
     {
@@ -76,25 +75,20 @@ public class KeyBasedSampler
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isKeyBasedSamplingEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isKeyBasedSamplingEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             List<String> sampledFields = new ArrayList<>(2);
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata.getFunctionAndTypeManager(), idAllocator, sampledFields), plan, null);
 
-            if (!isEnabledForTesting) {
+            if (!collectInformation) {
                 if (!sampledFields.isEmpty()) {
                     warningCollector.add(new PrestoWarning(SAMPLED_FIELDS, String.format("Sampled the following columns/derived columns at %s percent:%n\t%s", getKeyBasedSamplingPercentage(session) * 100., String.join("\n\t", sampledFields))));
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -47,7 +47,7 @@ public class LimitPushDown
 {
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -46,7 +46,8 @@ public class LimitPushDown
         implements PlanOptimizer
 {
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
@@ -97,7 +97,8 @@ public class LogicalCteOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LogicalCteOptimizer.java
@@ -98,7 +98,7 @@ public class LogicalCteOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
@@ -47,7 +47,6 @@ public class MergeJoinForSortedInputOptimizer
     private final Metadata metadata;
     private final boolean nativeExecution;
     private final boolean prestoOnSpark;
-    private boolean isEnabledForTesting;
 
     public MergeJoinForSortedInputOptimizer(Metadata metadata, boolean nativeExecution, boolean prestoOnSpark)
     {
@@ -57,26 +56,21 @@ public class MergeJoinForSortedInputOptimizer
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || nativeExecution && (isGroupedExecutionEnabled(session) || prestoOnSpark) && preferMergeJoinForSortedInputs(session) && !isSingleNodeExecutionEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || nativeExecution && (isGroupedExecutionEnabled(session) || prestoOnSpark) && preferMergeJoinForSortedInputs(session) && !isSingleNodeExecutionEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new MergeJoinForSortedInputOptimizer.Rewriter(idAllocator, metadata, session, prestoOnSpark);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
@@ -56,21 +56,21 @@ public class MergeJoinForSortedInputOptimizer
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || nativeExecution && (isGroupedExecutionEnabled(session) || prestoOnSpark) && preferMergeJoinForSortedInputs(session) && !isSingleNodeExecutionEnabled(session);
+        return forceEnableOptimizer || nativeExecution && (isGroupedExecutionEnabled(session) || prestoOnSpark) && preferMergeJoinForSortedInputs(session) && !isSingleNodeExecutionEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new MergeJoinForSortedInputOptimizer.Rewriter(idAllocator, metadata, session, prestoOnSpark);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -99,16 +99,16 @@ public class MergePartialAggregationsWithFilter
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isMergeAggregationsWithAndWithoutFilter(session);
+        return forceEnableOptimizer || isMergeAggregationsWithAndWithoutFilter(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new Context());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -92,7 +92,6 @@ public class MergePartialAggregationsWithFilter
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
-    private boolean isEnabledForTesting;
 
     public MergePartialAggregationsWithFilter(FunctionAndTypeManager functionAndTypeManager)
     {
@@ -100,21 +99,16 @@ public class MergePartialAggregationsWithFilter
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isMergeAggregationsWithAndWithoutFilter(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isMergeAggregationsWithAndWithoutFilter(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(session, variableAllocator, idAllocator, functionAndTypeManager);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new Context());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataDeleteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataDeleteOptimizer.java
@@ -62,7 +62,7 @@ public class MetadataDeleteOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         Optimizer optimizer = new Optimizer(session, metadata, idAllocator);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(optimizer, plan, null);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataDeleteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataDeleteOptimizer.java
@@ -61,7 +61,8 @@ public class MetadataDeleteOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         Optimizer optimizer = new Optimizer(session, metadata, idAllocator);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(optimizer, plan, null);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -103,7 +103,7 @@ public class MetadataQueryOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         if (!SystemSessionProperties.isOptimizeMetadataQueries(session) && !SystemSessionProperties.isOptimizeMetadataQueriesIgnoreStats(session)) {
             return PlanOptimizerResult.optimizerResult(plan, false);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -102,7 +102,8 @@ public class MetadataQueryOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         if (!SystemSessionProperties.isOptimizeMetadataQueries(session) && !SystemSessionProperties.isOptimizeMetadataQueriesIgnoreStats(session)) {
             return PlanOptimizerResult.optimizerResult(plan, false);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -90,16 +90,16 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isOptimizeDistinctAggregationEnabled(session);
+        return forceEnableOptimizer || isOptimizeDistinctAggregationEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Optimizer optimizer = new Optimizer(idAllocator, variableAllocator, metadata, functionResolution);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(optimizer, plan, Optional.empty());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, optimizer.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -82,7 +82,6 @@ public class OptimizeMixedDistinctAggregations
 {
     private final Metadata metadata;
     private final StandardFunctionResolution functionResolution;
-    private boolean isEnabledForTesting;
 
     public OptimizeMixedDistinctAggregations(Metadata metadata)
     {
@@ -91,21 +90,16 @@ public class OptimizeMixedDistinctAggregations
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isOptimizeDistinctAggregationEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isOptimizeDistinctAggregationEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Optimizer optimizer = new Optimizer(idAllocator, variableAllocator, metadata, functionResolution);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(optimizer, plan, Optional.empty());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, optimizer.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
@@ -93,7 +93,8 @@ public class OptimizeRowInPredicate
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         if (!isOptimizeRowInPredicate(session)) {
             return PlanOptimizerResult.optimizerResult(plan, false);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeRowInPredicate.java
@@ -94,7 +94,7 @@ public class OptimizeRowInPredicate
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         if (!isOptimizeRowInPredicate(session)) {
             return PlanOptimizerResult.optimizerResult(plan, false);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -96,16 +96,16 @@ public class OptimizeTopNUsingRowId
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isOptimizeTopNUsingRowIdEnabled(session);
+        return forceEnableOptimizer || isOptimizeTopNUsingRowIdEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator);
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeTopNUsingRowId.java
@@ -89,7 +89,6 @@ public class OptimizeTopNUsingRowId
         implements PlanOptimizer
 {
     private final Metadata metadata;
-    private boolean isEnabledForTesting;
 
     public OptimizeTopNUsingRowId(Metadata metadata)
     {
@@ -97,21 +96,16 @@ public class OptimizeTopNUsingRowId
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isOptimizeTopNUsingRowIdEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isOptimizeTopNUsingRowIdEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator);
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -129,7 +129,6 @@ public class PayloadJoinOptimizer
         implements PlanOptimizer
 {
     private final Metadata metadata;
-    private boolean isEnabledForTesting;
 
     public PayloadJoinOptimizer(Metadata metadata)
     {
@@ -139,10 +138,11 @@ public class PayloadJoinOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             PlanNode flattenedPlan = flattenJoinChains(plan, idAllocator);
             Rewriter rewriter = new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, flattenedPlan, new JoinContext());
@@ -158,15 +158,9 @@ public class PayloadJoinOptimizer
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || isOptimizePayloadJoins(session);
+        return collectInformation || isOptimizePayloadJoins(session);
     }
 
     private static class Rewriter

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PayloadJoinOptimizer.java
@@ -139,10 +139,10 @@ public class PayloadJoinOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             PlanNode flattenedPlan = flattenJoinChains(plan, idAllocator);
             Rewriter rewriter = new PayloadJoinOptimizer.Rewriter(session, this.metadata, types, functionAndTypeManager, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, flattenedPlan, new JoinContext());
@@ -158,9 +158,9 @@ public class PayloadJoinOptimizer
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isOptimizePayloadJoins(session);
+        return forceEnableOptimizer || isOptimizePayloadJoins(session);
     }
 
     private static class Rewriter

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
@@ -76,7 +76,7 @@ public class PhysicalCteOptimizer
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
@@ -75,7 +75,8 @@ public class PhysicalCteOptimizer
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
@@ -23,13 +23,14 @@ import com.facebook.presto.sql.planner.TypeProvider;
 public interface PlanOptimizer
 {
     PlanOptimizerResult optimize(PlanNode plan,
-            Session session,
-            TypeProvider types,
-            VariableAllocator variableAllocator,
-            PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector);
+                                 Session session,
+                                 TypeProvider types,
+                                 VariableAllocator variableAllocator,
+                                 PlanNodeIdAllocator idAllocator,
+                                 WarningCollector warningCollector,
+                                 boolean collectInformation);
 
-    default boolean isEnabled(Session session)
+    default boolean isEnabled(Session session, boolean collectInformation)
     {
         return true;
     }
@@ -45,28 +46,19 @@ public interface PlanOptimizer
         return null;
     }
 
-    default void setEnabledForTesting(boolean isSet)
-    {
-        return;
-    }
-
     default boolean isApplicable(PlanNode plan,
             Session session,
             TypeProvider types,
             VariableAllocator variableAllocator,
-            PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            PlanNodeIdAllocator idAllocator)
     {
-        setEnabledForTesting(true);
-
         boolean isApplicable = false;
         try {
             // wrap in try/catch block in case optimization throws an error
-            PlanOptimizerResult optimizerResult = optimize(plan, session, types, variableAllocator, idAllocator, warningCollector);
+            PlanOptimizerResult optimizerResult = optimize(plan, session, types, variableAllocator, idAllocator, WarningCollector.NOOP, true);
             isApplicable = optimizerResult.isOptimizerTriggered();
         }
         finally {
-            setEnabledForTesting(false);
             return isApplicable;
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanOptimizer.java
@@ -28,9 +28,9 @@ public interface PlanOptimizer
                                  VariableAllocator variableAllocator,
                                  PlanNodeIdAllocator idAllocator,
                                  WarningCollector warningCollector,
-                                 boolean collectInformation);
+                                 boolean forceEnableOptimizer);
 
-    default boolean isEnabled(Session session, boolean collectInformation)
+    default boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
         return true;
     }
@@ -44,22 +44,5 @@ public interface PlanOptimizer
     {
         // source of statistics used for this optimizer: reimplement accordingly for each cost-based optimizer
         return null;
-    }
-
-    default boolean isApplicable(PlanNode plan,
-            Session session,
-            TypeProvider types,
-            VariableAllocator variableAllocator,
-            PlanNodeIdAllocator idAllocator)
-    {
-        boolean isApplicable = false;
-        try {
-            // wrap in try/catch block in case optimization throws an error
-            PlanOptimizerResult optimizerResult = optimize(plan, session, types, variableAllocator, idAllocator, WarningCollector.NOOP, true);
-            isApplicable = optimizerResult.isOptimizerTriggered();
-        }
-        finally {
-            return isApplicable;
-        }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -144,7 +144,8 @@ public class PredicatePushDown
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -145,7 +145,7 @@ public class PredicatePushDown
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -99,7 +99,6 @@ public class PrefilterForLimitingAggregation
 
     private final Metadata metadata;
     private final StatsCalculator statsCalculator;
-    private boolean isEnabledForTesting;
 
     public PrefilterForLimitingAggregation(Metadata metadata, StatsCalculator statsCalculator)
     {
@@ -108,15 +107,9 @@ public class PrefilterForLimitingAggregation
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || SystemSessionProperties.isPrefilterForGroupbyLimit(session);
+        return collectInformation || SystemSessionProperties.isPrefilterForGroupbyLimit(session);
     }
 
     @Override
@@ -126,9 +119,10 @@ public class PrefilterForLimitingAggregation
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(session, metadata, types, statsCalculator, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -107,9 +107,9 @@ public class PrefilterForLimitingAggregation
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || SystemSessionProperties.isPrefilterForGroupbyLimit(session);
+        return forceEnableOptimizer || SystemSessionProperties.isPrefilterForGroupbyLimit(session);
     }
 
     @Override
@@ -120,9 +120,9 @@ public class PrefilterForLimitingAggregation
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(session, metadata, types, statsCalculator, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -117,7 +117,8 @@ public class PruneUnreferencedOutputs
         implements PlanOptimizer
 {
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -118,7 +118,7 @@ public class PruneUnreferencedOutputs
 {
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -125,7 +125,6 @@ public class PushdownSubfields
 {
     private final Metadata metadata;
     private final ExpressionOptimizerProvider expressionOptimizerProvider;
-    private boolean isEnabledForTesting;
 
     public PushdownSubfields(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
@@ -134,25 +133,20 @@ public class PushdownSubfields
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isPushdownSubfieldsEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || isPushdownSubfieldsEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
 
-        if (!isEnabled(session)) {
+        if (!isEnabled(session, collectInformation)) {
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -133,20 +133,20 @@ public class PushdownSubfields
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isPushdownSubfieldsEnabled(session);
+        return forceEnableOptimizer || isPushdownSubfieldsEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
 
-        if (!isEnabled(session, collectInformation)) {
+        if (!isEnabled(session, forceEnableOptimizer)) {
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -157,9 +157,9 @@ public class RandomizeNullKeyInOuterJoin
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || getJoinDistributionType(session).canPartition() && !getRandomizeOuterJoinNullKeyStrategy(session).equals(DISABLED);
+        return forceEnableOptimizer || getJoinDistributionType(session).canPartition() && !getRandomizeOuterJoinNullKeyStrategy(session).equals(DISABLED);
     }
 
     @Override
@@ -170,9 +170,9 @@ public class RandomizeNullKeyInOuterJoin
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
             Rewriter rewriter = new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator, statsProvider);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new HashSet<>());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RandomizeNullKeyInOuterJoin.java
@@ -149,7 +149,6 @@ public class RandomizeNullKeyInOuterJoin
 {
     private final FunctionAndTypeManager functionAndTypeManager;
     private final StatsCalculator statsCalculator;
-    private boolean isEnabledForTesting;
 
     public RandomizeNullKeyInOuterJoin(FunctionAndTypeManager functionAndTypeManager, StatsCalculator statsCalculator)
     {
@@ -158,15 +157,9 @@ public class RandomizeNullKeyInOuterJoin
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || getJoinDistributionType(session).canPartition() && !getRandomizeOuterJoinNullKeyStrategy(session).equals(DISABLED);
+        return collectInformation || getJoinDistributionType(session).canPartition() && !getRandomizeOuterJoinNullKeyStrategy(session).equals(DISABLED);
     }
 
     @Override
@@ -176,9 +169,10 @@ public class RandomizeNullKeyInOuterJoin
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
             Rewriter rewriter = new Rewriter(session, functionAndTypeManager, idAllocator, variableAllocator, statsProvider);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new HashSet<>());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
@@ -55,16 +55,16 @@ public class RemoveRedundantDistinctAggregation
         implements PlanOptimizer
 {
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isRemoveRedundantDistinctAggregationEnabled(session);
+        return forceEnableOptimizer || isRemoveRedundantDistinctAggregationEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new RemoveRedundantDistinctAggregation.Rewriter();
             PlanWithProperties result = rewriter.accept(plan);
             return PlanOptimizerResult.optimizerResult(result.getNode(), rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RemoveRedundantDistinctAggregation.java
@@ -54,24 +54,17 @@ import static java.util.Objects.requireNonNull;
 public class RemoveRedundantDistinctAggregation
         implements PlanOptimizer
 {
-    private boolean isEnabledForTesting;
-
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isRemoveRedundantDistinctAggregationEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isRemoveRedundantDistinctAggregationEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new RemoveRedundantDistinctAggregation.Rewriter();
             PlanWithProperties result = rewriter.accept(plan);
             return PlanOptimizerResult.optimizerResult(result.getNode(), rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -119,7 +119,8 @@ public class ReplaceConstantVariableReferencesWithConstants
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         if (isRewriteExpressionWithConstantEnabled(session)) {
             Rewriter rewriter = new Rewriter(idAllocator, functionAndTypeManager);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -120,7 +120,7 @@ public class ReplaceConstantVariableReferencesWithConstants
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         if (isRewriteExpressionWithConstantEnabled(session)) {
             Rewriter rewriter = new Rewriter(idAllocator, functionAndTypeManager);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
@@ -31,7 +31,8 @@ public class ReplicateSemiJoinInDelete
         implements PlanOptimizer
 {
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         if (isBroadcastSemiJoinForDeleteEnabled(session)) {
             requireNonNull(plan, "plan is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
@@ -32,7 +32,7 @@ public class ReplicateSemiJoinInDelete
 {
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         if (isBroadcastSemiJoinForDeleteEnabled(session)) {
             requireNonNull(plan, "plan is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
@@ -94,9 +94,9 @@ public class RewriteIfOverAggregation
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isOptimizeConditionalAggregationEnabled(session);
+        return forceEnableOptimizer || isOptimizeConditionalAggregationEnabled(session);
     }
 
     @Override
@@ -106,9 +106,9 @@ public class RewriteIfOverAggregation
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager));
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, ImmutableMap.of());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteIfOverAggregation.java
@@ -87,7 +87,6 @@ public class RewriteIfOverAggregation
         implements PlanOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
-    private boolean isEnabledForTesting;
 
     public RewriteIfOverAggregation(FunctionAndTypeManager functionAndTypeManager)
     {
@@ -95,15 +94,9 @@ public class RewriteIfOverAggregation
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isEnabledForTesting || isOptimizeConditionalAggregationEnabled(session);
+        return collectInformation || isOptimizeConditionalAggregationEnabled(session);
     }
 
     @Override
@@ -112,9 +105,10 @@ public class RewriteIfOverAggregation
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, new RowExpressionDeterminismEvaluator(functionAndTypeManager));
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, ImmutableMap.of());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteWriterTarget.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteWriterTarget.java
@@ -60,7 +60,8 @@ public class RewriteWriterTarget
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         Rewriter rewriter = new Rewriter(session, metadata, accessControl);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, Optional.empty());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteWriterTarget.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RewriteWriterTarget.java
@@ -61,7 +61,7 @@ public class RewriteWriterTarget
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         Rewriter rewriter = new Rewriter(session, metadata, accessControl);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, Optional.empty());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -106,7 +106,8 @@ public class RpcFunctionOptimizer
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/RpcFunctionOptimizer.java
@@ -107,7 +107,7 @@ public class RpcFunctionOptimizer
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -40,7 +40,8 @@ public class SetFlatteningOptimizer
         implements PlanOptimizer
 {
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -41,7 +41,7 @@ public class SetFlatteningOptimizer
 {
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ShardJoins.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ShardJoins.java
@@ -81,7 +81,6 @@ public class ShardJoins
     private final Metadata metadata;
     private final FunctionAndTypeManager functionAndTypeManager;
     private final StatsCalculator statsCalculator;
-    private boolean isEnabledForTesting;
 
     public ShardJoins(Metadata metadata, FunctionAndTypeManager functionAndTypeManager, StatsCalculator statsCalculator)
     {
@@ -91,21 +90,16 @@ public class ShardJoins
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || !getShardedJoinStrategy(session).equals(DISABLED);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || !getShardedJoinStrategy(session).equals(DISABLED);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(session, metadata, functionAndTypeManager, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new HashSet<>());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ShardJoins.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ShardJoins.java
@@ -90,16 +90,16 @@ public class ShardJoins
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || !getShardedJoinStrategy(session).equals(DISABLED);
+        return forceEnableOptimizer || !getShardedJoinStrategy(session).equals(DISABLED);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(session, metadata, functionAndTypeManager, idAllocator, variableAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new HashSet<>());
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -113,24 +113,17 @@ import static java.util.function.Function.identity;
 public class SimplifyPlanWithEmptyInput
         implements PlanOptimizer
 {
-    private boolean isEnabledForTesting;
-
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
+        return collectInformation || isSimplifyPlanWithEmptyInputEnabled(session);
     }
 
     @Override
-    public boolean isEnabled(Session session)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
-        return isEnabledForTesting || isSimplifyPlanWithEmptyInputEnabled(session);
-    }
-
-    @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
-    {
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(idAllocator, session);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(rewriter, plan);
             return PlanOptimizerResult.optimizerResult(rewrittenNode, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -114,16 +114,16 @@ public class SimplifyPlanWithEmptyInput
         implements PlanOptimizer
 {
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return collectInformation || isSimplifyPlanWithEmptyInputEnabled(session);
+        return forceEnableOptimizer || isSimplifyPlanWithEmptyInputEnabled(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(idAllocator, session);
             PlanNode rewrittenNode = SimplePlanRewriter.rewriteWith(rewriter, plan);
             return PlanOptimizerResult.optimizerResult(rewrittenNode, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortMergeJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortMergeJoinOptimizer.java
@@ -52,22 +52,22 @@ public class SortMergeJoinOptimizer
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
         // TODO: Consider group execution and single node execution.
-        return collectInformation || preferSortMergeJoin(session);
+        return forceEnableOptimizer || preferSortMergeJoin(session);
     }
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new SortMergeJoinOptimizer.Rewriter(idAllocator, metadata, session);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortMergeJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortMergeJoinOptimizer.java
@@ -44,7 +44,6 @@ public class SortMergeJoinOptimizer
 {
     private final Metadata metadata;
     private final boolean nativeExecution;
-    private boolean isEnabledForTesting;
 
     public SortMergeJoinOptimizer(Metadata metadata, boolean nativeExecution)
     {
@@ -53,27 +52,22 @@ public class SortMergeJoinOptimizer
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
-    {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
         // TODO: Consider group execution and single node execution.
-        return isEnabledForTesting || preferSortMergeJoin(session);
+        return collectInformation || preferSortMergeJoin(session);
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider type, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new SortMergeJoinOptimizer.Rewriter(idAllocator, metadata, session);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortedExchangeRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortedExchangeRule.java
@@ -61,9 +61,9 @@ public class SortedExchangeRule
     }
 
     @Override
-    public boolean isEnabled(Session session, boolean collectInformation)
+    public boolean isEnabled(Session session, boolean forceEnableOptimizer)
     {
-        return (isSortedExchangeEnabled(session) && isPrestoSparkExecution) || collectInformation;
+        return (isSortedExchangeEnabled(session) && isPrestoSparkExecution) || forceEnableOptimizer;
     }
 
     @Override
@@ -74,7 +74,7 @@ public class SortedExchangeRule
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -83,7 +83,7 @@ public class SortedExchangeRule
         requireNonNull(idAllocator, "idAllocator is null");
         requireNonNull(warningCollector, "warningCollector is null");
 
-        if (isEnabled(session, collectInformation)) {
+        if (isEnabled(session, forceEnableOptimizer)) {
             Rewriter rewriter = new Rewriter(idAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortedExchangeRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/SortedExchangeRule.java
@@ -49,7 +49,6 @@ public class SortedExchangeRule
         implements PlanOptimizer
 {
     private final boolean isPrestoSparkExecution;
-    private boolean isEnabledForTesting;
 
     /**
      * Constructor that accepts a flag indicating whether this is a Presto Spark execution environment.
@@ -62,15 +61,9 @@ public class SortedExchangeRule
     }
 
     @Override
-    public void setEnabledForTesting(boolean isSet)
+    public boolean isEnabled(Session session, boolean collectInformation)
     {
-        isEnabledForTesting = isSet;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return (isSortedExchangeEnabled(session) && isPrestoSparkExecution) || isEnabledForTesting;
+        return (isSortedExchangeEnabled(session) && isPrestoSparkExecution) || collectInformation;
     }
 
     @Override
@@ -80,7 +73,8 @@ public class SortedExchangeRule
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
@@ -89,7 +83,7 @@ public class SortedExchangeRule
         requireNonNull(idAllocator, "idAllocator is null");
         requireNonNull(warningCollector, "warningCollector is null");
 
-        if (isEnabled(session)) {
+        if (isEnabled(session, collectInformation)) {
             Rewriter rewriter = new Rewriter(idAllocator);
             PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -49,13 +49,14 @@ public final class StatsRecordingPlanOptimizer
             TypeProvider types,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean collectInformation)
     {
         PlanOptimizerResult result;
         long duration;
         try {
             long start = System.nanoTime();
-            result = delegate.optimize(plan, session, types, variableAllocator, idAllocator, warningCollector);
+            result = delegate.optimize(plan, session, types, variableAllocator, idAllocator, warningCollector, collectInformation);
             duration = System.nanoTime() - start;
         }
         catch (RuntimeException e) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StatsRecordingPlanOptimizer.java
@@ -50,13 +50,13 @@ public final class StatsRecordingPlanOptimizer
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             WarningCollector warningCollector,
-            boolean collectInformation)
+            boolean forceEnableOptimizer)
     {
         PlanOptimizerResult result;
         long duration;
         try {
             long start = System.nanoTime();
-            result = delegate.optimize(plan, session, types, variableAllocator, idAllocator, warningCollector, collectInformation);
+            result = delegate.optimize(plan, session, types, variableAllocator, idAllocator, warningCollector, forceEnableOptimizer);
             duration = System.nanoTime() - start;
         }
         catch (RuntimeException e) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -88,7 +88,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         Rewriter rewriter = new Rewriter(functionResolution, idAllocator, variableAllocator, logicalRowExpressions);
         PlanNode rewrittenPlan = rewriteWith(rewriter, plan, null);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -87,7 +87,8 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         Rewriter rewriter = new Rewriter(functionResolution, idAllocator, variableAllocator, logicalRowExpressions);
         PlanNode rewrittenPlan = rewriteWith(rewriter, plan, null);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -133,7 +133,8 @@ public class UnaliasSymbolReferences
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -134,7 +134,7 @@ public class UnaliasSymbolReferences
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -78,7 +78,8 @@ public class WindowFilterPushDown
     }
 
     @Override
-    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -79,7 +79,7 @@ public class WindowFilterPushDown
 
     @Override
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator,
-                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean collectInformation)
+                                        PlanNodeIdAllocator idAllocator, WarningCollector warningCollector, boolean forceEnableOptimizer)
     {
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -141,7 +141,7 @@ public class OptimizerAssert
 
     private Plan applyRules()
     {
-        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(), idAllocator, WarningCollector.NOOP).getPlanNode();
+        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(), idAllocator, WarningCollector.NOOP, false).getPlanNode();
 
         if (!ImmutableSet.copyOf(plan.getOutputVariables()).equals(ImmutableSet.copyOf(actual.getOutputVariables()))) {
             fail(String.format(

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestGroupInnerJoinsByConnectorRuleSet.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestGroupInnerJoinsByConnectorRuleSet.java
@@ -352,7 +352,7 @@ public class TestGroupInnerJoinsByConnectorRuleSet
     private RuleAssert assertGroupInnerJoinsByConnectorRuleSet()
     {
         // For testing, we do not wish to push down pulled up predicates
-        return tester.assertThat(new GroupInnerJoinsByConnectorRuleSet.OnlyJoinRule(tester.getMetadata(), (plan, session, types, variableAllocator, idAllocator, warningCollector) -> PlanOptimizerResult.optimizerResult(plan, false)),
+        return tester.assertThat(new GroupInnerJoinsByConnectorRuleSet.OnlyJoinRule(tester.getMetadata(), (plan, session, types, variableAllocator, idAllocator, warningCollector, collectInformation) -> PlanOptimizerResult.optimizerResult(plan, false)),
                 ImmutableList.of(CATALOG_SUPPORTING_JOIN_PUSHDOWN, OTHER_CATALOG_SUPPORTING_JOIN_PUSHDOWN));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestGroupInnerJoinsByConnectorRuleSet.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestGroupInnerJoinsByConnectorRuleSet.java
@@ -352,7 +352,7 @@ public class TestGroupInnerJoinsByConnectorRuleSet
     private RuleAssert assertGroupInnerJoinsByConnectorRuleSet()
     {
         // For testing, we do not wish to push down pulled up predicates
-        return tester.assertThat(new GroupInnerJoinsByConnectorRuleSet.OnlyJoinRule(tester.getMetadata(), (plan, session, types, variableAllocator, idAllocator, warningCollector, collectInformation) -> PlanOptimizerResult.optimizerResult(plan, false)),
+        return tester.assertThat(new GroupInnerJoinsByConnectorRuleSet.OnlyJoinRule(tester.getMetadata(), (plan, session, types, variableAllocator, idAllocator, warningCollector, forceEnableOptimizer) -> PlanOptimizerResult.optimizerResult(plan, false)),
                 ImmutableList.of(CATALOG_SUPPORTING_JOIN_PUSHDOWN, OTHER_CATALOG_SUPPORTING_JOIN_PUSHDOWN));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
@@ -626,13 +626,13 @@ public class TestConnectorOptimization
     private static PlanNode optimize(PlanNode plan, Map<ConnectorId, Set<ConnectorPlanOptimizer>> optimizers)
     {
         ApplyConnectorOptimization optimizer = new ApplyConnectorOptimization(() -> optimizers);
-        return optimizer.optimize(plan, TEST_SESSION, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
+        return optimizer.optimize(plan, TEST_SESSION, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, false).getPlanNode();
     }
 
     private static PlanNode optimize(PlanNode plan, Map<ConnectorId, Set<ConnectorPlanOptimizer>> optimizers, Session session)
     {
         ApplyConnectorOptimization optimizer = new ApplyConnectorOptimization(() -> optimizers);
-        return optimizer.optimize(plan, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
+        return optimizer.optimize(plan, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, false).getPlanNode();
     }
 
     private static ConnectorPlanOptimizer filterPushdown()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
@@ -21,15 +21,20 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.plan.MergeProcessorNode;
 import com.facebook.presto.sql.planner.plan.MergeWriterNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static java.util.Collections.emptyList;
 
 /**
  * Regression tests for {@link PushdownSubfields#visitMergeWriter} and
@@ -48,10 +53,16 @@ public class TestPushdownSubfields
 {
     private static final SchemaTableName TARGET_TABLE = new SchemaTableName("schema", "table");
 
+    @BeforeClass
+    @Override
+    public void setUp()
+    {
+        tester = new RuleTester(emptyList(), ImmutableMap.of(PUSHDOWN_SUBFIELDS_ENABLED, "true"));
+    }
+
     private PushdownSubfields newOptimizer()
     {
         PushdownSubfields optimizer = new PushdownSubfields(tester().getMetadata(), tester().getExpressionManager());
-        optimizer.setEnabledForTesting(true);
         return optimizer;
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -286,7 +286,7 @@ public class TestRemoveUnsupportedDynamicFilters
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, false).getPlanNode();
             new DynamicFiltersChecker().validate(rewrittenPlan, session, metadata, WarningCollector.NOOP);
             return rewrittenPlan;
         });
@@ -301,7 +301,7 @@ public class TestRemoveUnsupportedDynamicFilters
                 .build();
         return getQueryRunner().inTransaction(sessionWithProp, transactionSession -> {
             transactionSession.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(transactionSession, catalog));
-            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, transactionSession, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
+            PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, transactionSession, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP, false).getPlanNode();
             new DynamicFiltersChecker().validate(rewrittenPlan, transactionSession, metadata, WarningCollector.NOOP);
             return rewrittenPlan;
         });

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRpcFunctionOptimizer.java
@@ -349,7 +349,8 @@ public class TestRpcFunctionOptimizer
                 TypeProvider.empty(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         assertTrue(result.isOptimizerTriggered(), "Plan should be optimized when TRY wraps an RPC function");
         assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
@@ -411,7 +412,8 @@ public class TestRpcFunctionOptimizer
                 TypeProvider.empty(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         assertFalse(result.isOptimizerTriggered(), "Plan should not be optimized when TRY does not wrap an RPC function");
         assertFalse(containsPlanNode(result.getPlanNode(), RPCNode.class),
@@ -458,7 +460,8 @@ public class TestRpcFunctionOptimizer
                 TypeProvider.empty(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for direct RPC function calls");
         assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
@@ -558,7 +561,7 @@ public class TestRpcFunctionOptimizer
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
-                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
 
         assertTrue(result.isOptimizerTriggered(), "Plan should be optimized for multi-param TRY");
         assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class),
@@ -591,7 +594,7 @@ public class TestRpcFunctionOptimizer
         Session session = TestingSession.testSessionBuilder().build();
 
         return optimizer.optimize(
-                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
     }
 
     @Test
@@ -631,7 +634,7 @@ public class TestRpcFunctionOptimizer
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult rpcResult = optimizer.optimize(
-                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
         assertTrue(rpcResult.isOptimizerTriggered());
 
         int rpcCount = countPlanNodes(rpcResult.getPlanNode(), RPCNode.class);
@@ -650,7 +653,7 @@ public class TestRpcFunctionOptimizer
 
         PruneUnreferencedOutputs pruner = new PruneUnreferencedOutputs();
         PlanOptimizerResult pruneResult = pruner.optimize(
-                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
 
         PlanNode prunedPlan = pruneResult.getPlanNode();
         assertEquals(countPlanNodes(prunedPlan, RPCNode.class), 3,
@@ -749,7 +752,7 @@ public class TestRpcFunctionOptimizer
         Session session = TestingSession.testSessionBuilder().build();
 
         PlanOptimizerResult result = optimizer.optimize(
-                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
 
         assertTrue(result.isOptimizerTriggered());
         assertTrue(containsPlanNode(result.getPlanNode(), RPCNode.class));
@@ -794,7 +797,7 @@ public class TestRpcFunctionOptimizer
                 rpcPlan.getOutputVariables());
         PruneUnreferencedOutputs pruner = new PruneUnreferencedOutputs();
         PlanOptimizerResult pruneResult = pruner.optimize(
-                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                outputNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
         assertEquals(countPlanNodes(pruneResult.getPlanNode(), RPCNode.class), 1,
                 "RPCNode must survive pruning for a TRY(CAST(rpc_fn())) body");
     }
@@ -885,7 +888,7 @@ public class TestRpcFunctionOptimizer
         RpcFunctionOptimizer optimizer = new RpcFunctionOptimizer(() -> ImmutableSet.of("test_rpc_function"), null, policy);
 
         PlanOptimizerResult result = optimizer.optimize(
-                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP);
+                projectNode, session, TypeProvider.empty(), variableAllocator, idAllocator, WarningCollector.NOOP, false);
 
         RPCNode rpcNode = (RPCNode) findPlanNode(result.getPlanNode(), RPCNode.class);
         assertTrue(rpcNode != null, "Optimized plan should contain an RPCNode");

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSortedExchangeRule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSortedExchangeRule.java
@@ -73,7 +73,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // Plan should remain unchanged - still has SortNode
         assertTrue(result.getPlanNode() instanceof SortNode);
@@ -111,7 +112,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // SortNode should be removed and ordering moved to ExchangeNode
         assertTrue(result.getPlanNode() instanceof ExchangeNode);
@@ -161,7 +163,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // Verify ordering moved to exchange
         assertTrue(result.getPlanNode() instanceof ExchangeNode);
@@ -201,7 +204,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // Plan should remain unchanged since exchange is not remote
         assertTrue(result.getPlanNode() instanceof SortNode);
@@ -234,7 +238,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // Plan should remain unchanged since exchange is REPLICATE type
         assertTrue(result.getPlanNode() instanceof SortNode);
@@ -296,7 +301,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // Expected result after optimization:
         // Sort1 -> Project -> Exchange1 (NO ordering) -> Project -> Exchange2 (WITH ordering) -> Values
@@ -381,7 +387,8 @@ public class TestSortedExchangeRule
                 builder.getTypes(),
                 variableAllocator,
                 idAllocator,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
 
         // The sort should NOT be pushed down because varX is not in source output [a, b]
         assertTrue(result.getPlanNode() instanceof SortNode, "Sort should remain because ordering variable not in source output");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -348,7 +348,7 @@ public class PrestoSparkAdaptiveQueryExecution
             // Re-optimize plan.
             PlanNode optimizedPlan = planAndFragments.getRemainingPlan().get();
             for (PlanOptimizer optimizer : adaptivePlanOptimizers) {
-                optimizedPlan = optimizer.optimize(optimizedPlan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector).getPlanNode();
+                optimizedPlan = optimizer.optimize(optimizedPlan, session, TypeProvider.viewOf(variableAllocator.getVariables()), variableAllocator, idAllocator, warningCollector, false).getPlanNode();
             }
 
             if (!optimizedPlan.equals(planAndFragments.getRemainingPlan().get())) {


### PR DESCRIPTION
## Description

This PR makes the following changes:

- Remove the `setEnabledForTesting(boolean isSet)` method from the `PlanOptimizer` interface to keep `PlanOptimizer` and its concrete implementations immutable. In Presto, optimizers are singleton services managed via dependency injection and are used concurrently by multiple queries across multiple threads.
- Modify the `optimize(...)` and `isEnable(...)` methods in the `PlanOptimizer` interface to take an extra `boolean forceEnableOptimizer` parameter. Then, within the `isApplicable(...)` method, enable the "collect optimizer information" mode by passing this parameter through the call chain, instead of mutating the optimizer's internal state flag.
- Update the concrete implementations of `PlanOptimizer` and the corresponding test cases accordingly.

These changes also address issue #26910, where `KeyBasedSampler` was occasionally enabled due to state pollution interference, which cause the test to fail.


## Motivation and Context

Closes #26910 

## Impact

N/A

## Test Plan

Make sure this change do not affect any existing tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Make plan optimizer enablement explicit and immutable to ensure thread-safe concurrent query planning.

Bug Fixes:
- Prevent optimizer state pollution and intermittent optimizer activation by removing mutable testing state from plan optimizers.

Enhancements:
- Make PlanOptimizer implementations immutable and safe for concurrent use by passing forced-enablement context explicitly through optimization calls.
- Update optimizer invocation paths and tests to use the new enablement contract, including concurrent CTE test execution.

Tests:
- Update optimizer tests and test configuration for explicit enablement and concurrent execution.