### PR TITLE
feat(planner): Add support for pushing partial aggregations through outer joins

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -533,10 +533,11 @@ The corresponding configuration property is :ref:`admin/properties:\`\`optimizer
 * **Default value:** ``false``
 
 When enabled alongside ``push_partial_aggregation_through_join``, extends partial
-aggregation pushdown to the preserved (non-null-generating) side of outer joins,
-provided all aggregation inputs come from that side and the aggregation functions
-are safe to evaluate on null-extended rows. This can further reduce the amount of
-data flowing into the join operator for outer join queries.
+aggregation pushdown to outer joins.
+The aggregation can always be pushed to a side whose rows the join preserves exactly.
+It can be pushed to a side the join may null-extend, only if the aggregation function
+ignores null inputs (for example ``SUM``, ``MIN``, ``MAX``, ``COUNT(col)``)
+Aggregation that do not ignore null inputs, such as ``COUNT(*)`` or ``ARRAY_AGG``, are not pushed
 
 ``push_semi_join_through_union``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -526,6 +526,18 @@ performance by allowing the aggregation to pre-reduce data before the join is pe
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.push-partial-aggregation-through-join\`\``.
 
+``push_partial_aggregation_through_outer_join``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+When enabled alongside ``push_partial_aggregation_through_join``, extends partial
+aggregation pushdown to the preserved (non-null-generating) side of outer joins,
+provided all aggregation inputs come from that side and the aggregation functions
+are safe to evaluate on null-extended rows. This can further reduce the amount of
+data flowing into the join operator for outer join queries.
+
 ``push_semi_join_through_union``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -189,6 +189,7 @@ public final class SystemSessionProperties
     public static final String PUSHDOWN_THROUGH_UNNEST = "pushdown_through_unnest";
     public static final String SIMPLIFY_AGGREGATIONS_OVER_CONSTANT = "simplify_aggregations_over_constant";
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
+    public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN = "push_partial_aggregation_through_outer_join";
     public static final String PRE_AGGREGATE_BEFORE_GROUPING_SETS = "pre_aggregate_before_grouping_sets";
     public static final String PUSH_PROJECTION_THROUGH_CROSS_JOIN = "push_projection_through_cross_join";
     public static final String PARSE_DECIMAL_LITERALS_AS_DOUBLE = "parse_decimal_literals_as_double";
@@ -1029,6 +1030,11 @@ public final class SystemSessionProperties
                         PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN,
                         "Push partial aggregations below joins",
                         featuresConfig.isPushPartialAggregationThroughJoin(),
+                        false),
+                booleanProperty(
+                        PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN,
+                        "Push partial aggregations below the preserved or null-ignoring side of outer joins (requires push_partial_aggregation_through_join)",
+                        false,
                         false),
                 booleanProperty(
                         PRE_AGGREGATE_BEFORE_GROUPING_SETS,
@@ -3008,6 +3014,11 @@ public final class SystemSessionProperties
     public static boolean isPushAggregationThroughJoin(Session session)
     {
         return session.getSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, Boolean.class);
+    }
+
+    public static boolean isPushPartialAggregationThroughOuterJoin(Session session)
+    {
+        return session.getSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, Boolean.class);
     }
 
     public static boolean isSimplifyAggregationsOverConstant(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -1173,7 +1173,7 @@ public class PlanOptimizers
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(
-                                new PushPartialAggregationThroughJoin(),
+                                new PushPartialAggregationThroughJoin(metadata.getFunctionAndTypeManager()),
                                 new PushPartialAggregationThroughExchange(metadata.getFunctionAndTypeManager(), featuresConfig.isNativeExecutionEnabled()))),
                 // MergePartialAggregationsWithFilter should immediately follow PushPartialAggregationThroughExchange
                 new MergePartialAggregationsWithFilter(metadata.getFunctionAndTypeManager()),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -17,6 +17,10 @@ import com.facebook.presto.Session;
 import com.facebook.presto.matching.Capture;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinNode;
@@ -30,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +42,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isPushAggregationThroughJoin;
+import static com.facebook.presto.SystemSessionProperties.isPushPartialAggregationThroughOuterJoin;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
@@ -46,11 +53,19 @@ import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.intersection;
+import static java.util.Objects.requireNonNull;
 
 public class PushPartialAggregationThroughJoin
         implements Rule<AggregationNode>
 {
     private static final Capture<JoinNode> JOIN_NODE = Capture.newCapture();
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public PushPartialAggregationThroughJoin(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
 
     private static final Pattern<AggregationNode> PATTERN = aggregation()
             .matching(PushPartialAggregationThroughJoin::isSupportedAggregationNode)
@@ -87,21 +102,71 @@ public class PushPartialAggregationThroughJoin
     {
         JoinNode joinNode = captures.get(JOIN_NODE);
 
-        if (joinNode.getType() != JoinType.INNER) {
+        JoinType joinType = joinNode.getType();
+        if (joinType != JoinType.INNER && joinType != JoinType.LEFT && joinType != JoinType.RIGHT && joinType != JoinType.FULL) {
+            return Result.empty();
+        }
+        if (joinType != JoinType.INNER && !isPushPartialAggregationThroughOuterJoin(context.getSession())) {
             return Result.empty();
         }
 
-        // TODO: leave partial aggregation above Join?
-        if (allAggregationsOn(aggregationNode.getAggregations(), joinNode.getLeft().getOutputVariables(), TypeProvider.viewOf(context.getVariableAllocator().getVariables()))) {
+        TypeProvider types = TypeProvider.viewOf(context.getVariableAllocator().getVariables());
+
+        // A join input whose rows the join preserves exactly (both inputs of an INNER join, the
+        // left input of a LEFT join, the right input of a RIGHT join) can accept any partial
+        // aggregation. A null-extended input (the right input of a LEFT join, the left input of a
+        // RIGHT join, both inputs of a FULL join) can only accept aggregations that ignore rows
+        // whose inputs are null: for those, the null intermediate state carried by a null-extended
+        // row contributes exactly what the original null arguments would have — nothing. Anything
+        // else (e.g. count(*), which counts null-extended rows) would produce wrong results.
+        boolean leftIsNullExtended = joinType == JoinType.RIGHT || joinType == JoinType.FULL;
+        boolean rightIsNullExtended = joinType == JoinType.LEFT || joinType == JoinType.FULL;
+
+        if (allAggregationsOn(aggregationNode.getAggregations(), joinNode.getLeft().getOutputVariables(), types)
+                && (!leftIsNullExtended || allAggregationsIgnoreNullInputs(aggregationNode.getAggregations().values()))) {
             return Result.ofPlanNode(pushPartialToLeftChild(aggregationNode, joinNode, context));
         }
-        else {
-            if (allAggregationsOn(aggregationNode.getAggregations(), joinNode.getRight().getOutputVariables(), TypeProvider.viewOf(context.getVariableAllocator().getVariables()))) {
-                return Result.ofPlanNode(pushPartialToRightChild(aggregationNode, joinNode, context));
-            }
+        if (allAggregationsOn(aggregationNode.getAggregations(), joinNode.getRight().getOutputVariables(), types)
+                && (!rightIsNullExtended || allAggregationsIgnoreNullInputs(aggregationNode.getAggregations().values()))) {
+            return Result.ofPlanNode(pushPartialToRightChild(aggregationNode, joinNode, context));
         }
 
         return Result.empty();
+    }
+
+    /**
+     * Determines whether every aggregation contributes nothing for a null-extended join row.
+     * That requires the function to skip rows with null inputs (e.g. min, max, sum, count(col),
+     * avg) and every argument to be a column reference, so that a null-extended row implies null
+     * arguments. count(*) fails the argument-count check, count(1) and sum(col + 1) fail the
+     * column-reference check, and functions like array_agg (which aggregates nulls) or checksum
+     * (which folds nulls into the hash) fail the null-input check.
+     */
+    private boolean allAggregationsIgnoreNullInputs(Collection<AggregationNode.Aggregation> aggregations)
+    {
+        return aggregations.stream().allMatch(aggregation ->
+                !aggregation.getArguments().isEmpty()
+                        && aggregation.getArguments().stream().allMatch(VariableReferenceExpression.class::isInstance)
+                        && ignoresNullInputs(aggregation.getFunctionHandle()));
+    }
+
+    /**
+     * FunctionMetadata#isCalledOnNullInput cannot be used here: for many built-in aggregations,
+     * SqlAggregationFunction inherits BuiltInFunction#isCalledOnNullInput (always false), regardless
+     * of the accumulator's actual null handling. The accumulator's parameter metadata is the
+     * authoritative source: input functions only observe null rows through a
+     * NULLABLE_BLOCK_INPUT_CHANNEL parameter. Implementations we cannot introspect are
+     * conservatively assumed to process nulls.
+     */
+    private boolean ignoresNullInputs(FunctionHandle functionHandle)
+    {
+        AggregationFunctionImplementation implementation = functionAndTypeManager.getAggregateFunctionImplementation(functionHandle);
+        if (!(implementation instanceof BuiltInAggregationFunctionImplementation)) {
+            return false;
+        }
+        return ((BuiltInAggregationFunctionImplementation) implementation).getAggregationMetadata()
+                .getValueInputMetadata().stream()
+                .noneMatch(parameterMetadata -> parameterMetadata.getParameterType() == NULLABLE_BLOCK_INPUT_CHANNEL);
     }
 
     private boolean allAggregationsOn(Map<VariableReferenceExpression, AggregationNode.Aggregation> aggregations, List<VariableReferenceExpression> variables, TypeProvider types)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughJoin.java
@@ -13,9 +13,15 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
@@ -23,9 +29,14 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.spi.plan.JoinType.FULL;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.spi.plan.JoinType.RIGHT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
@@ -40,35 +51,167 @@ public class TestPushPartialAggregationThroughJoin
     @Test
     public void testPushesPartialAggregationThroughJoin()
     {
-        tester().assertThat(new PushPartialAggregationThroughJoin())
+        assertPushesToLeftChild(INNER, "avg");
+    }
+
+    @Test
+    public void testPushesPartialAggregationToRightChildOfInnerJoin()
+    {
+        assertPushesToRightChild(INNER, "avg");
+    }
+
+    @Test
+    public void testPushesPartialAggregationToLeftChildOfLeftJoin()
+    {
+        assertPushesToLeftChild(LEFT, "avg");
+    }
+
+    @Test
+    public void testPushesPartialAggregationToRightChildOfRightJoin()
+    {
+        assertPushesToRightChild(RIGHT, "avg");
+    }
+
+    @Test
+    public void testPushesNullIgnoringAggregationToNullProducingSideOfLeftJoin()
+    {
+        assertPushesToRightChild(LEFT, "sum");
+    }
+
+    @Test
+    public void testPushesNullIgnoringAggregationToNullProducingSideOfRightJoin()
+    {
+        assertPushesToLeftChild(RIGHT, "sum");
+    }
+
+    @Test
+    public void testPushesNullIgnoringAggregationThroughFullJoin()
+    {
+        assertPushesToLeftChild(FULL, "min");
+        assertPushesToRightChild(FULL, "max");
+    }
+
+    @Test
+    public void testDoesNotPushNonNullIgnoringAggregationToNullProducingSide()
+    {
+        // The right side of a LEFT join (and the left side of a RIGHT join) is null-extended,
+        // so array_agg (which aggregates nulls) cannot be pushed to that side.
+        tester().assertThat(newRule())
                 .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
-                .on(p -> p.aggregation(ab -> ab
-                        .source(
-                                p.join(
-                                        INNER,
-                                        p.values(p.variable("LEFT_EQUI"), p.variable("LEFT_NON_EQUI"), p.variable("LEFT_GROUP_BY"), p.variable("LEFT_AGGR"), p.variable("LEFT_HASH")),
-                                        p.values(p.variable("RIGHT_EQUI"), p.variable("RIGHT_NON_EQUI"), p.variable("RIGHT_GROUP_BY"), p.variable("RIGHT_HASH")),
-                                        ImmutableList.of(new EquiJoinClause(p.variable("LEFT_EQUI"), p.variable("RIGHT_EQUI"))),
-                                        ImmutableList.of(p.variable("LEFT_GROUP_BY"), p.variable("LEFT_AGGR"), p.variable("RIGHT_GROUP_BY")),
-                                        Optional.of(p.rowExpression("LEFT_NON_EQUI <= RIGHT_NON_EQUI")),
-                                        Optional.of(p.variable("LEFT_HASH")),
-                                        Optional.of(p.variable("RIGHT_HASH"))))
-                        .addAggregation(p.variable("AVG", DOUBLE), p.rowExpression("AVG(LEFT_AGGR)"))
-                        .singleGroupingSet(p.variable("LEFT_GROUP_BY"), p.variable("RIGHT_GROUP_BY"))
-                        .step(PARTIAL)))
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true")
+                .on(p -> buildAggregationOverJoin(p, LEFT, "ARRAY_AGG(RIGHT_AGGR)", new ArrayType(DOUBLE)))
+                .doesNotFire();
+
+        tester().assertThat(newRule())
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true")
+                .on(p -> buildAggregationOverJoin(p, RIGHT, "ARRAY_AGG(LEFT_AGGR)", new ArrayType(DOUBLE)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotPushCountStarToNullProducingSide()
+    {
+        // count(*) counts null-extended rows, so it can only be pushed to an exactly
+        // preserved side; in a FULL join no side qualifies
+        tester().assertThat(newRule())
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true")
+                .on(p -> buildAggregationOverJoin(p, FULL, "COUNT()", BIGINT))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotPushAggregationOverExpressionToNullProducingSide()
+    {
+        // a non-column argument may evaluate to a non-null value on a null-extended row
+        tester().assertThat(newRule())
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true")
+                .on(p -> buildAggregationOverJoin(p, LEFT, "SUM(RIGHT_AGGR + 1E0)", DOUBLE))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForOuterJoinWhenOuterJoinPushdownDisabled()
+    {
+        // push_partial_aggregation_through_outer_join defaults to false
+        tester().assertThat(newRule())
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .on(p -> buildAggregationOverJoin(p, LEFT, "AVG(LEFT_AGGR)", DOUBLE))
+                .doesNotFire();
+    }
+
+    private RuleAssert newRuleAssert(JoinType joinType)
+    {
+        RuleAssert ruleAssert = tester().assertThat(newRule())
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true");
+        if (joinType != INNER) {
+            ruleAssert = ruleAssert.setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true");
+        }
+        return ruleAssert;
+    }
+
+    private PushPartialAggregationThroughJoin newRule()
+    {
+        return new PushPartialAggregationThroughJoin(tester().getMetadata().getFunctionAndTypeManager());
+    }
+
+    private void assertPushesToLeftChild(JoinType joinType, String function)
+    {
+        newRuleAssert(joinType)
+                .on(p -> buildAggregationOverJoin(p, joinType, function.toUpperCase() + "(LEFT_AGGR)", DOUBLE))
                 .matches(project(ImmutableMap.of(
                         "LEFT_GROUP_BY", PlanMatchPattern.expression("LEFT_GROUP_BY"),
                         "RIGHT_GROUP_BY", PlanMatchPattern.expression("RIGHT_GROUP_BY"),
-                        "AVG", PlanMatchPattern.expression("AVG")),
-                        join(INNER, ImmutableList.of(equiJoinClause("LEFT_EQUI", "RIGHT_EQUI")),
+                        "AGGR_OUT", PlanMatchPattern.expression("AGGR_OUT")),
+                        join(joinType, ImmutableList.of(equiJoinClause("LEFT_EQUI", "RIGHT_EQUI")),
                                 Optional.of("LEFT_NON_EQUI <= RIGHT_NON_EQUI"),
                                 aggregation(
                                         singleGroupingSet("LEFT_EQUI", "LEFT_NON_EQUI", "LEFT_GROUP_BY", "LEFT_HASH"),
-                                        ImmutableMap.of(Optional.of("AVG"), functionCall("avg", ImmutableList.of("LEFT_AGGR"))),
+                                        ImmutableMap.of(Optional.of("AGGR_OUT"), functionCall(function, ImmutableList.of("LEFT_AGGR"))),
                                         ImmutableMap.of(),
                                         Optional.empty(),
                                         PARTIAL,
                                         values("LEFT_EQUI", "LEFT_NON_EQUI", "LEFT_GROUP_BY", "LEFT_AGGR", "LEFT_HASH")),
-                                values("RIGHT_EQUI", "RIGHT_NON_EQUI", "RIGHT_GROUP_BY", "RIGHT_HASH"))));
+                                values("RIGHT_EQUI", "RIGHT_NON_EQUI", "RIGHT_GROUP_BY", "RIGHT_AGGR", "RIGHT_HASH"))));
+    }
+
+    private void assertPushesToRightChild(JoinType joinType, String function)
+    {
+        newRuleAssert(joinType)
+                .on(p -> buildAggregationOverJoin(p, joinType, function.toUpperCase() + "(RIGHT_AGGR)", DOUBLE))
+                .matches(project(ImmutableMap.of(
+                        "LEFT_GROUP_BY", PlanMatchPattern.expression("LEFT_GROUP_BY"),
+                        "RIGHT_GROUP_BY", PlanMatchPattern.expression("RIGHT_GROUP_BY"),
+                        "AGGR_OUT", PlanMatchPattern.expression("AGGR_OUT")),
+                        join(joinType, ImmutableList.of(equiJoinClause("LEFT_EQUI", "RIGHT_EQUI")),
+                                Optional.of("LEFT_NON_EQUI <= RIGHT_NON_EQUI"),
+                                values("LEFT_EQUI", "LEFT_NON_EQUI", "LEFT_GROUP_BY", "LEFT_AGGR", "LEFT_HASH"),
+                                aggregation(
+                                        singleGroupingSet("RIGHT_EQUI", "RIGHT_NON_EQUI", "RIGHT_GROUP_BY", "RIGHT_HASH"),
+                                        ImmutableMap.of(Optional.of("AGGR_OUT"), functionCall(function, ImmutableList.of("RIGHT_AGGR"))),
+                                        ImmutableMap.of(),
+                                        Optional.empty(),
+                                        PARTIAL,
+                                        values("RIGHT_EQUI", "RIGHT_NON_EQUI", "RIGHT_GROUP_BY", "RIGHT_AGGR", "RIGHT_HASH")))));
+    }
+
+    private static PlanNode buildAggregationOverJoin(PlanBuilder p, JoinType joinType, String aggregationExpression, Type outputType)
+    {
+        return p.aggregation(ab -> ab
+                .source(
+                        p.join(
+                                joinType,
+                                p.values(p.variable("LEFT_EQUI"), p.variable("LEFT_NON_EQUI"), p.variable("LEFT_GROUP_BY"), p.variable("LEFT_AGGR", DOUBLE), p.variable("LEFT_HASH")),
+                                p.values(p.variable("RIGHT_EQUI"), p.variable("RIGHT_NON_EQUI"), p.variable("RIGHT_GROUP_BY"), p.variable("RIGHT_AGGR", DOUBLE), p.variable("RIGHT_HASH")),
+                                ImmutableList.of(new EquiJoinClause(p.variable("LEFT_EQUI"), p.variable("RIGHT_EQUI"))),
+                                ImmutableList.of(p.variable("LEFT_GROUP_BY"), p.variable("LEFT_AGGR", DOUBLE), p.variable("RIGHT_GROUP_BY"), p.variable("RIGHT_AGGR", DOUBLE)),
+                                Optional.of(p.rowExpression("LEFT_NON_EQUI <= RIGHT_NON_EQUI")),
+                                Optional.of(p.variable("LEFT_HASH")),
+                                Optional.of(p.variable("RIGHT_HASH"))))
+                .addAggregation(p.variable("AGGR_OUT", outputType), p.rowExpression(aggregationExpression))
+                .singleGroupingSet(p.variable("LEFT_GROUP_BY"), p.variable("RIGHT_GROUP_BY"))
+                .step(PARTIAL));
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_R
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS;
 import static com.facebook.presto.SystemSessionProperties.PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE;
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN;
 import static com.facebook.presto.common.predicate.Marker.Bound.EXACTLY;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -65,6 +66,7 @@ public class TestLocalQueries
                 .setCatalog("local")
                 .setSchema(TINY_SCHEMA_NAME)
                 .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true")
                 .build();
 
         LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestPartialAggregationPushdown.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestPartialAggregationPushdown.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
+import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN;
+
+public class TestPartialAggregationPushdown
+        extends AbstractTestAggregations
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder()
+                .amendSession(builder -> builder
+                        .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, "true")
+                        .setSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_OUTER_JOIN, "true"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Description
Build on the idea in https://github.com/prestodb/presto/pull/28105, but use the existing PushPartialAggregationThroughJoin

## Motivation and Context
Aggregate push down through outer joins _may_ be cheaper for some queries. See https://github.com/prestodb/presto/pull/28105 for an example from TPCH Q13

## Impact
None

## Test Plan
New unit & integration tests added

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add ability to push down partial aggregations through outer joins
```
## Summary by Sourcery

Extend partial aggregation pushdown to supported outer joins with null-safety controls and a new session property gate.

New Features:
- Add session property `push_partial_aggregation_through_outer_join` to enable partial aggregation pushdown on preserved or null-ignoring sides of outer joins.
- Support pushing partial aggregations through LEFT, RIGHT, and FULL joins when aggregates safely ignore null-extended rows.

Enhancements:
- Refine `PushPartialAggregationThroughJoin` to use function metadata for determining null-input behavior and to distinguish preserved vs null-extended join sides.
- Wire `PushPartialAggregationThroughJoin` with `FunctionAndTypeManager` and register it in `PlanOptimizers` for more precise aggregation handling.

Tests:
- Expand rule tests for `PushPartialAggregationThroughJoin` to cover inner and outer joins, including negative cases for unsafe aggregations.
- Add TPCH-based integration tests (`TestPartialAggregationPushdown`) with session properties enabled to validate end-to-end behavior.

## Summary by Sourcery

Enable planner to push eligible partial aggregations through certain outer joins under a new guarded session property and extend coverage of the existing inner-join rule.

New Features:
- Introduce the push_partial_aggregation_through_outer_join session property to control partial aggregation pushdown across outer joins.
- Allow partial aggregations to be pushed through LEFT, RIGHT, and FULL joins when aggregates safely ignore null-extended rows.

Enhancements:
- Extend PushPartialAggregationThroughJoin to distinguish preserved vs null-extended join sides and consult function metadata to ensure aggregations ignore null inputs before pushing through outer joins.
- Wire PushPartialAggregationThroughJoin with FunctionAndTypeManager and register the updated rule in PlanOptimizers.
- Expand rule-level tests to cover inner and outer join cases, including negative scenarios where pushdown must not occur.
- Add TPCH-based integration tests and enable the new session property in local test query runners to validate partial aggregation pushdown end-to-end.

Tests:
- Add unit tests for PushPartialAggregationThroughJoin covering LEFT, RIGHT, FULL, and inner joins and various aggregation functions with respect to null handling.
- Introduce TestPartialAggregationPushdown integration test suite using TPCH queries with partial aggregation pushdown enabled.