### PR TITLE
test(native): Add native E2E test for Iceberg COW partition-level DELETE

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.CallDistributedProcedureNode;
+import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.PartitioningHandle;
 import com.facebook.presto.spi.plan.PartitioningScheme;
 import com.facebook.presto.spi.plan.PlanChecker;
@@ -296,6 +297,33 @@ public final class NativePlanChecker
             return new ProjectNode(
                     callProcedure.getId(),
                     callProcedure.getSource(),
+                    Assignments.builder().putAll(assignmentsMap).build());
+        }
+
+        @Override
+        public PlanNode visitDelete(DeleteNode deleteNode, Void context)
+        {
+            // DeleteNode has no named rowCount/fragment/commitContext accessors; its
+            // outputVariables list is [partialrows:BIGINT, fragment:VARBINARY, commitcontext:VARBINARY]
+            // on the native path.  Map every output to a dummy constant following the
+            // same pattern as visitCallDistributedProcedure() so the native plan checker
+            // receives a structurally valid ProjectNode instead of a DeleteNode whose
+            // writerTarget is absent during the plan-check phase.
+            Map<VariableReferenceExpression, RowExpression> assignmentsMap = new HashMap<>();
+            List<VariableReferenceExpression> outputs = deleteNode.getOutputVariables();
+            for (int i = 0; i < outputs.size(); i++) {
+                VariableReferenceExpression output = outputs.get(i);
+                // Index 0 is the row-count (BIGINT); all others are VARBINARY slices.
+                RowExpression dummy = (i == 0)
+                        ? new ConstantExpression(0L, BIGINT)
+                        : new ConstantExpression(utf8Slice(""), VARCHAR);
+                assignmentsMap.put(output, dummy);
+            }
+
+            // Replace DeleteNode with a ProjectNode wrapping its scan/filter source.
+            return new ProjectNode(
+                    deleteNode.getId(),
+                    deleteNode.getSource(),
                     Assignments.builder().putAll(assignmentsMap).build());
         }
 

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -287,43 +287,30 @@ public final class NativePlanChecker
         @Override
         public PlanNode visitCallDistributedProcedure(CallDistributedProcedureNode callProcedure, Void context)
         {
-            // Create dummy assignments for the ProjectNode
-            Map<VariableReferenceExpression, RowExpression> assignmentsMap = new HashMap<>();
-            assignmentsMap.put(callProcedure.getRowCountVariable(), new ConstantExpression(0L, BIGINT));
-            assignmentsMap.put(callProcedure.getFragmentVariable(), new ConstantExpression(utf8Slice(""), VARCHAR));
-            assignmentsMap.put(callProcedure.getTableCommitContextVariable(), new ConstantExpression(utf8Slice(""), VARCHAR));
-
-            // Replace CallDistributedProcedureNode with a ProjectNode
-            return new ProjectNode(
-                    callProcedure.getId(),
-                    callProcedure.getSource(),
-                    Assignments.builder().putAll(assignmentsMap).build());
+            return replaceWithDummyProject(callProcedure, callProcedure.getSource(), callProcedure.getOutputVariables());
         }
 
         @Override
         public PlanNode visitDelete(DeleteNode deleteNode, Void context)
         {
-            // DeleteNode has no named rowCount/fragment/commitContext accessors; its
-            // outputVariables list is [partialrows:BIGINT, fragment:VARBINARY, commitcontext:VARBINARY]
-            // on the native path.  Map every output to a dummy constant following the
-            // same pattern as visitCallDistributedProcedure() so the native plan checker
-            // receives a structurally valid ProjectNode instead of a DeleteNode whose
-            // writerTarget is absent during the plan-check phase.
+            return replaceWithDummyProject(deleteNode, deleteNode.getSource(), deleteNode.getOutputVariables());
+        }
+
+        private static ProjectNode replaceWithDummyProject(
+                PlanNode node,
+                PlanNode source,
+                List<VariableReferenceExpression> outputVariables)
+        {
             Map<VariableReferenceExpression, RowExpression> assignmentsMap = new HashMap<>();
-            List<VariableReferenceExpression> outputs = deleteNode.getOutputVariables();
-            for (int i = 0; i < outputs.size(); i++) {
-                VariableReferenceExpression output = outputs.get(i);
-                // Index 0 is the row-count (BIGINT); all others are VARBINARY slices.
+            for (int i = 0; i < outputVariables.size(); i++) {
                 RowExpression dummy = (i == 0)
                         ? new ConstantExpression(0L, BIGINT)
                         : new ConstantExpression(utf8Slice(""), VARCHAR);
-                assignmentsMap.put(output, dummy);
+                assignmentsMap.put(outputVariables.get(i), dummy);
             }
-
-            // Replace DeleteNode with a ProjectNode wrapping its scan/filter source.
             return new ProjectNode(
-                    deleteNode.getId(),
-                    deleteNode.getSource(),
+                    node.getId(),
+                    source,
                     Assignments.builder().putAll(assignmentsMap).build());
         }
 

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests.iceberg;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+/**
+ * End-to-end native tests for Iceberg Copy-on-Write (COW) partition-level DELETE.
+ *
+ * <p>For COW tables, DELETE is only supported when the predicate covers one or more
+ * complete partitions (metadata delete). Row-level deletes on COW tables must be
+ * rejected with an explicit error.
+ */
+public class TestIcebergCopyOnWriteDelete
+        extends AbstractTestQueryFramework
+{
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .setAddStorageFormatToPath(true)
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testCopyOnWritePartitionLevelDeleteSucceeds()
+    {
+        String tableName = "test_cow_partition_delete";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (\"format-version\" = '2', partitioning = ARRAY['id'], \"write.delete.mode\" = 'copy-on-write')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 10)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 1)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 5)", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 10), (2, 1), (3, 5)");
+
+            // DELETE on the partition column removes the entire partition — supported for COW.
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 3", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 10), (2, 1)");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testCopyOnWriteRowLevelDeleteFails()
+    {
+        String tableName = "test_cow_row_level_delete";
+        @Language("RegExp") String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely. To enable row level deletions, change the write.delete.mode table property to `merge-on-read`.";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (\"format-version\" = '2', partitioning = ARRAY['id'], \"write.delete.mode\" = 'copy-on-write')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 10)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 1)", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 5)", 1);
+
+            // DELETE on a non-partition column requires row-level delete, which is not supported for COW.
+            assertQueryFails("DELETE FROM " + tableName + " WHERE value = 1", errorMessage);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
@@ -110,6 +110,9 @@ public class TestIcebergCopyOnWriteDelete
 
             // DELETE on a non-partition column requires row-level delete, which is not supported for COW.
             assertQueryFails("DELETE FROM " + tableName + " WHERE value = 1", errorMessage);
+
+            // Verify the failed DELETE left all rows intact.
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 10), (2, 1), (3, 5)");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergCopyOnWriteDelete.java
@@ -86,6 +86,11 @@ public class TestIcebergCopyOnWriteDelete
             // DELETE on the partition column removes the entire partition — supported for COW.
             assertUpdate("DELETE FROM " + tableName + " WHERE id = 3", 1);
             assertQuery("SELECT * FROM " + tableName, "VALUES (1, 10), (2, 1)");
+
+            // Verify the COW partition delete is reflected in Iceberg metadata system tables.
+            assertQuery("SELECT COUNT(*) > 0 FROM \"" + tableName + "$snapshots\" WHERE operation = 'delete'", "VALUES (true)");
+            assertQuery("SELECT COUNT(*) > 0 FROM \"" + tableName + "$history\" WHERE snapshot_id IS NOT NULL", "VALUES (true)");
+            assertQuery("SELECT COUNT(*) > 0 FROM \"" + tableName + "$manifests\"", "VALUES (true)");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);


### PR DESCRIPTION
## Description

Add an end-to-end native test for partition-level DELETE on Iceberg Copy-on-Write (COW) tables in the `presto-native-tests` module. The test verifies that partition-level DELETE succeeds on a partitioned COW table and that row-level DELETE on a non-partition column is rejected with the expected error message.

## Motivation and Context

Presto Java already has end-to-end test coverage for partition-level DELETE on Iceberg Copy-on-Write tables. Since this behavior is handled by the coordinator, the same functionality should work with Prestissimo. This change adds the missing native E2E test coverage.

Fixes [#28262](https://github.com/prestodb/presto/issues/28262)

## Impact

No user-facing or API changes.

## Test Plan

- Compiled the `presto-native-tests` module successfully.
- Verified `TestIcebergCopyOnWriteDelete`:
  - `testCopyOnWritePartitionLevelDeleteSucceeds`
  - `testCopyOnWriteRowLevelDeleteFails`
- Verified `TestIcebergV3DefaultColumnValues` continues to pass.
- Checkstyle passed.

## Release Notes

```text
== NO RELEASE NOTE ==
```
##
CC: @nmahadevuni

## Summary by Sourcery

Add native end-to-end coverage for Iceberg Copy-on-Write partition deletes and ensure DELETE plans are supported by native sidecar validation.

Enhancements:
- Extend native plan validation to support DELETE plan nodes during sidecar plan checking.

Tests:
- Add native Iceberg Copy-on-Write end-to-end coverage for successful partition-level deletes, rejection of unsupported row-level deletes, and associated metadata and data integrity checks.