### PR TITLE
feat(native): Expose GPU and native-memory metrics on /v1/status for autoscaling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/IBM/velox.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/IBM/velox.git
+	url = https://github.com/jurossiar/velox.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/jurossiar/velox.git
+	url = https://github.com/IBM/velox.git

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -47,7 +47,7 @@ public class NodeStatus
     private final long gpuMemoryCapacityBytes;
     private final long gpuPoolAllocatedBytes;
     private final long gpuUtilizationPercent;
-    private final long gpuMemoryUtilizationPercent;
+    private final long gpuMemoryBandwidthPercent;
 
     @ThriftConstructor
     @JsonCreator
@@ -72,7 +72,7 @@ public class NodeStatus
             @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
             @JsonProperty("gpuPoolAllocatedBytes") long gpuPoolAllocatedBytes,
             @JsonProperty("gpuUtilizationPercent") long gpuUtilizationPercent,
-            @JsonProperty("gpuMemoryUtilizationPercent") long gpuMemoryUtilizationPercent)
+            @JsonProperty("gpuMemoryBandwidthPercent") long gpuMemoryBandwidthPercent)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -94,7 +94,7 @@ public class NodeStatus
         this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
         this.gpuPoolAllocatedBytes = gpuPoolAllocatedBytes;
         this.gpuUtilizationPercent = gpuUtilizationPercent;
-        this.gpuMemoryUtilizationPercent = gpuMemoryUtilizationPercent;
+        this.gpuMemoryBandwidthPercent = gpuMemoryBandwidthPercent;
     }
 
     @ThriftField(1)
@@ -239,8 +239,8 @@ public class NodeStatus
 
     @ThriftField(21)
     @JsonProperty
-    public long getGpuMemoryUtilizationPercent()
+    public long getGpuMemoryBandwidthPercent()
     {
-        return gpuMemoryUtilizationPercent;
+        return gpuMemoryBandwidthPercent;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -46,6 +46,8 @@ public class NodeStatus
     private final long gpuMemoryUsedBytes;
     private final long gpuMemoryCapacityBytes;
     private final long gpuPoolAllocatedBytes;
+    private final long gpuUtilizationPercent;
+    private final long gpuMemoryUtilizationPercent;
 
     @ThriftConstructor
     @JsonCreator
@@ -68,7 +70,9 @@ public class NodeStatus
             @JsonProperty("queryMemoryBytes") long queryMemoryBytes,
             @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
             @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
-            @JsonProperty("gpuPoolAllocatedBytes") long gpuPoolAllocatedBytes)
+            @JsonProperty("gpuPoolAllocatedBytes") long gpuPoolAllocatedBytes,
+            @JsonProperty("gpuUtilizationPercent") long gpuUtilizationPercent,
+            @JsonProperty("gpuMemoryUtilizationPercent") long gpuMemoryUtilizationPercent)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -89,6 +93,8 @@ public class NodeStatus
         this.gpuMemoryUsedBytes = gpuMemoryUsedBytes;
         this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
         this.gpuPoolAllocatedBytes = gpuPoolAllocatedBytes;
+        this.gpuUtilizationPercent = gpuUtilizationPercent;
+        this.gpuMemoryUtilizationPercent = gpuMemoryUtilizationPercent;
     }
 
     @ThriftField(1)
@@ -222,5 +228,19 @@ public class NodeStatus
     public long getGpuPoolAllocatedBytes()
     {
         return gpuPoolAllocatedBytes;
+    }
+
+    @ThriftField(20)
+    @JsonProperty
+    public long getGpuUtilizationPercent()
+    {
+        return gpuUtilizationPercent;
+    }
+
+    @ThriftField(21)
+    @JsonProperty
+    public long getGpuMemoryUtilizationPercent()
+    {
+        return gpuMemoryUtilizationPercent;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -45,6 +45,7 @@ public class NodeStatus
     private final long queryMemoryBytes;
     private final long gpuMemoryUsedBytes;
     private final long gpuMemoryCapacityBytes;
+    private final long gpuPoolAllocatedBytes;
 
     @ThriftConstructor
     @JsonCreator
@@ -66,7 +67,8 @@ public class NodeStatus
             @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
             @JsonProperty("queryMemoryBytes") long queryMemoryBytes,
             @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
-            @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes)
+            @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
+            @JsonProperty("gpuPoolAllocatedBytes") long gpuPoolAllocatedBytes)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -86,6 +88,7 @@ public class NodeStatus
         this.queryMemoryBytes = queryMemoryBytes;
         this.gpuMemoryUsedBytes = gpuMemoryUsedBytes;
         this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
+        this.gpuPoolAllocatedBytes = gpuPoolAllocatedBytes;
     }
 
     @ThriftField(1)
@@ -212,5 +215,12 @@ public class NodeStatus
     public long getGpuMemoryCapacityBytes()
     {
         return gpuMemoryCapacityBytes;
+    }
+
+    @ThriftField(19)
+    @JsonProperty
+    public long getGpuPoolAllocatedBytes()
+    {
+        return gpuPoolAllocatedBytes;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -41,6 +41,8 @@ public class NodeStatus
     private final long heapUsed;
     private final long heapAvailable;
     private final long nonHeapUsed;
+    private final long asyncDataCacheBytes;
+    private final long queryMemoryBytes;
 
     @ThriftConstructor
     @JsonCreator
@@ -58,7 +60,9 @@ public class NodeStatus
             @JsonProperty("systemCpuLoad") double systemCpuLoad,
             @JsonProperty("heapUsed") long heapUsed,
             @JsonProperty("heapAvailable") long heapAvailable,
-            @JsonProperty("nonHeapUsed") long nonHeapUsed)
+            @JsonProperty("nonHeapUsed") long nonHeapUsed,
+            @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
+            @JsonProperty("queryMemoryBytes") long queryMemoryBytes)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -74,6 +78,8 @@ public class NodeStatus
         this.heapUsed = heapUsed;
         this.heapAvailable = heapAvailable;
         this.nonHeapUsed = nonHeapUsed;
+        this.asyncDataCacheBytes = asyncDataCacheBytes;
+        this.queryMemoryBytes = queryMemoryBytes;
     }
 
     @ThriftField(1)
@@ -172,5 +178,19 @@ public class NodeStatus
     public long getNonHeapUsed()
     {
         return nonHeapUsed;
+    }
+
+    @ThriftField(15)
+    @JsonProperty
+    public long getAsyncDataCacheBytes()
+    {
+        return asyncDataCacheBytes;
+    }
+
+    @ThriftField(16)
+    @JsonProperty
+    public long getQueryMemoryBytes()
+    {
+        return queryMemoryBytes;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -43,6 +43,8 @@ public class NodeStatus
     private final long nonHeapUsed;
     private final long asyncDataCacheBytes;
     private final long queryMemoryBytes;
+    private final long gpuMemoryUsedBytes;
+    private final long gpuMemoryCapacityBytes;
 
     @ThriftConstructor
     @JsonCreator
@@ -62,7 +64,9 @@ public class NodeStatus
             @JsonProperty("heapAvailable") long heapAvailable,
             @JsonProperty("nonHeapUsed") long nonHeapUsed,
             @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
-            @JsonProperty("queryMemoryBytes") long queryMemoryBytes)
+            @JsonProperty("queryMemoryBytes") long queryMemoryBytes,
+            @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
+            @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -80,6 +84,8 @@ public class NodeStatus
         this.nonHeapUsed = nonHeapUsed;
         this.asyncDataCacheBytes = asyncDataCacheBytes;
         this.queryMemoryBytes = queryMemoryBytes;
+        this.gpuMemoryUsedBytes = gpuMemoryUsedBytes;
+        this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
     }
 
     @ThriftField(1)
@@ -192,5 +198,19 @@ public class NodeStatus
     public long getQueryMemoryBytes()
     {
         return queryMemoryBytes;
+    }
+
+    @ThriftField(17)
+    @JsonProperty
+    public long getGpuMemoryUsedBytes()
+    {
+        return gpuMemoryUsedBytes;
+    }
+
+    @ThriftField(18)
+    @JsonProperty
+    public long getGpuMemoryCapacityBytes()
+    {
+        return gpuMemoryCapacityBytes;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -385,17 +385,22 @@ public abstract class BasePlanFragmenter
         setDistributionForExchange(exchange.getType(), partitioningScheme, context);
 
         // Use ANY (e.g. UCX) for worker-to-worker exchanges, but fall back to
-        // HTTP when a child fragment runs on the coordinator (which only speaks HTTP).
+        // HTTP when either side touches the coordinator (which only speaks HTTP):
+        //  - a child (producer) fragment contains coordinator-only nodes, OR
+        //  - the current (consumer) fragment runs on the coordinator.
         TransportType transportType = TransportType.HTTP;
-        boolean anyChildOnCoordinator = exchange.getSources().stream()
+        boolean producerOnCoordinator = exchange.getSources().stream()
                 .anyMatch(PlannerUtils::containsCoordinatorOnlyNode);
-        if (!anyChildOnCoordinator) {
+        boolean consumerOnCoordinator = context.get().hasCoordinatorOnlyDistribution();
+        if (!producerOnCoordinator && !consumerOnCoordinator) {
             transportType = TransportType.ANY;
         }
-        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s",
+        log.debug("[ANY_EXCHANGE] exchange=%s transport=%s partitioning=%s producerOnCoord=%s consumerOnCoord=%s",
                 exchange.getId(),
                 transportType,
-                context.get().getPartitioningHandle());
+                context.get().getPartitioningHandle(),
+                producerOnCoordinator,
+                consumerOnCoordinator);
 
         ImmutableList.Builder<SubPlan> builder = ImmutableList.builder();
         for (int sourceIndex = 0; sourceIndex < exchange.getSources().size(); sourceIndex++) {
@@ -662,6 +667,11 @@ public abstract class BasePlanFragmenter
             partitioningHandle = Optional.of(COORDINATOR_DISTRIBUTION);
 
             return this;
+        }
+
+        public boolean hasCoordinatorOnlyDistribution()
+        {
+            return partitioningHandle.isPresent() && partitioningHandle.get().isCoordinatorOnly();
         }
 
         public FragmentProperties addPartitionedSource(PlanNodeId source)

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -631,6 +631,7 @@ public class TestResourceManagerClusterStateProvider
                 0,
                 0,
                 0,
+                0,
                 0);
     }
 
@@ -651,6 +652,7 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
                 0,
                 0,
                 0,

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -627,7 +627,9 @@ public class TestResourceManagerClusterStateProvider
                 2.0,
                 1,
                 2,
-                3);
+                3,
+                0,
+                0);
     }
 
     private NodeStatus createCoordinatorNodeStatus(String nodeId)
@@ -646,7 +648,9 @@ public class TestResourceManagerClusterStateProvider
                 2.0,
                 1,
                 2,
-                3);
+                3,
+                0,
+                0);
     }
 
     private MemoryPoolInfo createMemoryPoolInfo(int maxBytes, int reservedBytes, int reservedRevocableBytes)

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -629,6 +629,8 @@ public class TestResourceManagerClusterStateProvider
                 2,
                 3,
                 0,
+                0,
+                0,
                 0);
     }
 
@@ -649,6 +651,8 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
+                0,
                 0,
                 0);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -632,6 +632,8 @@ public class TestResourceManagerClusterStateProvider
                 0,
                 0,
                 0,
+                0,
+                0,
                 0);
     }
 
@@ -652,6 +654,8 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
+                0,
                 0,
                 0,
                 0,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestBasePlanFragmenterTransportType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestBasePlanFragmenterTransportType.java
@@ -192,6 +192,31 @@ public class TestBasePlanFragmenterTransportType
         assertEquals(props.getOutputTransportType(), TransportType.ANY);
     }
 
+    @Test
+    public void testHasCoordinatorOnlyDistribution()
+    {
+        BasePlanFragmenter.FragmentProperties props = new BasePlanFragmenter.FragmentProperties(
+                new com.facebook.presto.spi.plan.PartitioningScheme(
+                        com.facebook.presto.spi.plan.Partitioning.create(
+                                SystemPartitioningHandle.SINGLE_DISTRIBUTION,
+                                ImmutableList.of()),
+                        ImmutableList.of(col)));
+        // Default is not coordinator-only
+        assertFalse(props.hasCoordinatorOnlyDistribution());
+
+        // After setting coordinator-only distribution via a coordinator-only node, it returns true
+        ValuesNode source = planBuilder.values(col);
+        ExplainAnalyzeNode explainAnalyze = new ExplainAnalyzeNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                source,
+                col,
+                false,
+                ExplainFormat.Type.TEXT);
+        props.setCoordinatorOnlyDistribution(explainAnalyze);
+        assertTrue(props.hasCoordinatorOnlyDistribution());
+    }
+
     // -----------------------------------------------------------------------
     // Tests for PlanFragment transport type serialization
     // -----------------------------------------------------------------------

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -97,6 +97,6 @@ public class StatusResource
                 -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
                 -1L, // gpuPoolAllocatedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
                 -1L, // gpuUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
-                -1L); // gpuMemoryUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L); // gpuMemoryBandwidthPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -95,6 +95,8 @@ public class StatusResource
                 0L, // queryMemoryBytes: native-only; JVM query memory is on-heap
                 -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
                 -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
-                -1L); // gpuPoolAllocatedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuPoolAllocatedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L); // gpuMemoryUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -92,6 +92,8 @@ public class StatusResource
                 memoryMXBean.getHeapMemoryUsage().getMax(),
                 memoryMXBean.getNonHeapMemoryUsage().getUsed(),
                 0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
-                0L); // queryMemoryBytes: native-only; JVM query memory is on-heap
+                0L, // queryMemoryBytes: native-only; JVM query memory is on-heap
+                -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L); // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -94,6 +94,7 @@ public class StatusResource
                 0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
                 0L, // queryMemoryBytes: native-only; JVM query memory is on-heap
                 -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
-                -1L); // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L); // gpuPoolAllocatedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -90,6 +90,8 @@ public class StatusResource
                 operatingSystemMXBean == null ? 0 : operatingSystemMXBean.getSystemCpuLoad(),
                 memoryMXBean.getHeapMemoryUsage().getUsed(),
                 memoryMXBean.getHeapMemoryUsage().getMax(),
-                memoryMXBean.getNonHeapMemoryUsage().getUsed());
+                memoryMXBean.getNonHeapMemoryUsage().getUsed(),
+                0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
+                0L); // queryMemoryBytes: native-only; JVM query memory is on-heap
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -316,6 +316,7 @@ public class TestHttpResourceManagerClient
                 0,
                 0,
                 0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -312,6 +312,8 @@ public class TestHttpResourceManagerClient
                 1,
                 1,
                 1,
-                1);
+                1,
+                0,
+                0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -317,6 +317,8 @@ public class TestHttpResourceManagerClient
                 0,
                 0,
                 0,
+                0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -314,6 +314,8 @@ public class TestHttpResourceManagerClient
                 1,
                 1,
                 0,
+                0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -59,6 +59,8 @@ public class TestResourceManagerClusterStatusSender
             2,
             3,
             0,
+            0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -61,6 +61,7 @@ public class TestResourceManagerClusterStatusSender
             0,
             0,
             0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -57,7 +57,9 @@ public class TestResourceManagerClusterStatusSender
             2.0,
             1,
             2,
-            3);
+            3,
+            0,
+            0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;
     private static final int TARGET_HEARTBEATS = SLEEP_DURATION / HEARTBEAT_INTERVAL;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -62,6 +62,8 @@ public class TestResourceManagerClusterStatusSender
             0,
             0,
             0,
+            0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1);
+                1, 1, 1, 1, 1, 1, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -11,6 +11,38 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.24)
 
+# Use rapids-cmake to configure CUDA architectures
+if(PRESTO_ENABLE_CUDF)
+  file(
+    READ
+    "${CMAKE_SOURCE_DIR}/velox/CMake/resolve_dependency_modules/cudf.cmake"
+    _dep_cmake_content
+  )
+  string(REGEX MATCH "VELOX_rapids_cmake_VERSION ([0-9.]+)" _match "${_dep_cmake_content}")
+  set(PRESTO_rapids_cmake_VERSION "${CMAKE_MATCH_1}")
+  message(STATUS "Rapids CMake version: ${PRESTO_rapids_cmake_VERSION}")
+  string(REGEX MATCH "VELOX_rapids_cmake_COMMIT ([0-9a-fA-F]+)" _match "${_dep_cmake_content}")
+  set(PRESTO_rapids_cmake_COMMIT "${CMAKE_MATCH_1}")
+  message(STATUS "Rapids CMake commit: ${PRESTO_rapids_cmake_COMMIT}")
+
+  set(rapids-cmake-version ${PRESTO_rapids_cmake_VERSION})
+  set(
+    rapids-cmake-url
+    "https://github.com/rapidsai/rapids-cmake/archive/${PRESTO_rapids_cmake_COMMIT}.tar.gz"
+  )
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/PrestoCpp_RAPIDS.cmake)
+    file(
+      DOWNLOAD
+        https://raw.githubusercontent.com/rapidsai/rapids-cmake/${PRESTO_rapids_cmake_COMMIT}/RAPIDS.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/PrestoCpp_RAPIDS.cmake
+    )
+  endif()
+  include(${CMAKE_CURRENT_BINARY_DIR}/PrestoCpp_RAPIDS.cmake)
+  include(rapids-cuda)
+  rapids_cuda_init_architectures(PrestoCpp)
+  enable_language(CUDA)
+endif()
+
 # set the project name
 project(PrestoCpp)
 
@@ -108,6 +140,11 @@ set(VELOX_ENABLE_CUDF ${PRESTO_ENABLE_CUDF} CACHE BOOL "Enable cuDF support")
 if(PRESTO_ENABLE_CUDF)
   add_compile_definitions(PRESTO_ENABLE_CUDF)
   enable_language(CUDA)
+  # Conda fmt is found by find_package() in a parent scope; rapids-cmake then
+  # tries to promote the imported fmt::fmt target to GLOBAL from a nested
+  # add_subdirectory (rapids_logger), which CMake forbids. Creating imported
+  # targets as GLOBAL up front makes rapids' make_global() a no-op.
+  set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)
   # Determine CUDA_ARCHITECTURES automatically.
   cmake_policy(SET CMP0104 NEW)
 endif()

--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -58,6 +58,6 @@ services:
         # A few files in Velox require significant memory to compile and link.
         # Build requires 18GB of memory for 2 threads.
         - NUM_THREADS=2 # default value for NUM_THREADS
-        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_CUDF=${GPU:-OFF}
+        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_CUDF=${GPU:-OFF} -DVELOX_ENABLE_UCX_EXCHANGE=${GPU:-OFF}
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile

--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile
 
+  # ==========================================
+  # CentOS services
+  # ==========================================
   centos-native-dependency:
     # Usage:
     #   docker compose build centos-native-dependency

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -117,6 +117,13 @@ if(PRESTO_ENABLE_CUDF)
   # the nvml.h include dir and links the driver stub (real lib comes from the
   # NVIDIA runtime at run time).
   find_package(CUDAToolkit REQUIRED)
+  # CUDAToolkit can be found (nvcc, cuda_runtime.h) yet NOT create the CUDA::nvml target when the
+  # NVML stub (libnvidia-ml.so from cuda-nvml-dev) is missing from the build image. Without this
+  # guard, linking would silently no-op and produce a presto_server with zero NVML symbols
+  # (gpuUtilizationPercent stays -1 at runtime). Fail the build loudly instead.
+  if(NOT TARGET CUDA::nvml)
+    message(FATAL_ERROR "CUDA::nvml target not found. Install cuda-nvml-dev (or ensure libnvidia-ml.so is in the CUDA toolkit lib/stubs directory) in the build image.")
+  endif()
   target_link_libraries(presto_server_lib CUDA::nvml)
 endif()
 

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -113,6 +113,11 @@ target_link_libraries(
 
 if(PRESTO_ENABLE_CUDF)
   target_link_libraries(presto_server_lib velox_cudf_exec)
+  # NVML (libnvidia-ml) for GPU utilization in /v1/status. CUDA::nvml provides
+  # the nvml.h include dir and links the driver stub (real lib comes from the
+  # NVIDIA runtime at run time).
+  find_package(CUDAToolkit REQUIRED)
+  target_link_libraries(presto_server_lib CUDA::nvml)
 endif()
 
 # Enabling Parquet causes build errors with missing symbols on MacOS. This is

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1957,8 +1957,25 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
 
   const double cpuLoadPct{cpuMon_.getCPULoadPct()};
 
-  // TODO(spershin): As 'nonHeapUsed' we could export the cache memory.
-  const int64_t nonHeapUsed{0};
+  // 'nonHeapUsed' is a JVM/GC concept and does not apply to native workers.
+  const int64_t nonHeapUsed = -1;
+
+  // In-memory AsyncDataCache footprint (evictable/reclaimable). SSD-resident
+  // bytes are excluded as they do not contribute to RAM pressure.
+  int64_t asyncDataCacheBytes = 0;
+  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
+    const auto cacheStats = cache->refreshStats();
+    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
+        cacheStats.tinyPadding + cacheStats.largePadding;
+  }
+
+  // Query memory (non-evictable): sum of per-query pool reservations, already
+  // aggregated per memory pool in populateMemAndCPUInfo().
+  const auto memoryInfo = **memoryInfo_.rlock();
+  int64_t queryMemoryBytes = 0;
+  for (const auto& pool : memoryInfo.pools) {
+    queryMemoryBytes += pool.second.reservedBytes;
+  }
 
   protocol::NodeStatus nodeStatus{
       nodeId_,
@@ -1968,13 +1985,15 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       getUptime(start_),
       address_,
       address_,
-      **memoryInfo_.rlock(),
+      memoryInfo,
       (int)folly::available_concurrency(),
       cpuLoadPct,
       cpuLoadPct,
       pool_ ? pool_->usedBytes() : 0,
       nodeMemoryGb * 1024 * 1024 * 1024,
-      nonHeapUsed};
+      nonHeapUsed,
+      asyncDataCacheBytes,
+      queryMemoryBytes};
 
   return nodeStatus;
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -85,6 +85,7 @@
 
 #ifdef PRESTO_ENABLE_CUDF
 #include <cuda_runtime.h>
+#include <nvml.h>
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
@@ -1993,6 +1994,14 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // queries free their allocations, so it distinguishes idle from busy.
   // -1 sentinel when cuDF is disabled or not registered.
   int64_t gpuPoolAllocatedBytes = -1;
+  // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
+  // "GPU-Util". Complements the memory signals: it says whether the GPU is
+  // actually computing, not how full VRAM is. NOTE: NVML reports the whole
+  // physical device; under fractional/shared GPU (time-slicing/MPS) this
+  // reflects the shared GPU, not just this worker (see plan Annex A3).
+  // -1 sentinel when unavailable.
+  int64_t gpuUtilizationPercent = -1;
+  int64_t gpuMemoryUtilizationPercent = -1;
 #ifdef PRESTO_ENABLE_CUDF
   if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
     size_t gpuFree = 0;
@@ -2002,6 +2011,21 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
     }
     gpuPoolAllocatedBytes = velox::cudf_velox::cudfAllocatedBytes();
+
+    // NVML init once for the server lifetime (process exit reclaims it).
+    static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
+    if (nvmlReady) {
+      nvmlDevice_t nvmlDevice;
+      nvmlUtilization_t util;
+      // Index 0: inside the container NVML sees only the GPU(s) exposed to this
+      // pod, so device 0 is this worker's GPU. Multi-GPU-visible containers
+      // would need PCI-bus-id mapping to the active CUDA device.
+      if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
+          nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
+        gpuUtilizationPercent = static_cast<int64_t>(util.gpu);
+        gpuMemoryUtilizationPercent = static_cast<int64_t>(util.memory);
+      }
+    }
   }
 #endif
 
@@ -2024,7 +2048,9 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       queryMemoryBytes,
       gpuMemoryUsedBytes,
       gpuMemoryCapacityBytes,
-      gpuPoolAllocatedBytes};
+      gpuPoolAllocatedBytes,
+      gpuUtilizationPercent,
+      gpuMemoryUtilizationPercent};
 
   return nodeStatus;
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -86,6 +86,7 @@
 #ifdef PRESTO_ENABLE_CUDF
 #include <cuda_runtime.h>
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #endif
@@ -1986,6 +1987,12 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // is the right notion for "how full is the GPU".
   int64_t gpuMemoryUsedBytes = -1;
   int64_t gpuMemoryCapacityBytes = -1;
+  // Live bytes currently allocated inside the RMM pool, via a statistics
+  // adaptor around the cuDF memory resource. Unlike gpuMemoryUsedBytes (the
+  // retained RMM pool high-water mark from cudaMemGetInfo), this drops when
+  // queries free their allocations, so it distinguishes idle from busy.
+  // -1 sentinel when cuDF is disabled or not registered.
+  int64_t gpuPoolAllocatedBytes = -1;
 #ifdef PRESTO_ENABLE_CUDF
   if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
     size_t gpuFree = 0;
@@ -1994,6 +2001,7 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuMemoryCapacityBytes = static_cast<int64_t>(gpuTotal);
       gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
     }
+    gpuPoolAllocatedBytes = velox::cudf_velox::cudfAllocatedBytes();
   }
 #endif
 
@@ -2015,7 +2023,8 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       asyncDataCacheBytes,
       queryMemoryBytes,
       gpuMemoryUsedBytes,
-      gpuMemoryCapacityBytes};
+      gpuMemoryCapacityBytes,
+      gpuPoolAllocatedBytes};
 
   return nodeStatus;
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -2012,8 +2012,8 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuPoolAllocatedBytes_.load(std::memory_order_relaxed);
   const int64_t gpuUtilizationPercent =
       gpuUtilizationPercent_.load(std::memory_order_relaxed);
-  const int64_t gpuMemoryUtilizationPercent =
-      gpuMemoryUtilizationPercent_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryBandwidthPercent =
+      gpuMemoryBandwidthPercent_.load(std::memory_order_relaxed);
 
   protocol::NodeStatus nodeStatus{
       nodeId_,
@@ -2036,7 +2036,7 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuMemoryCapacityBytes,
       gpuPoolAllocatedBytes,
       gpuUtilizationPercent,
-      gpuMemoryUtilizationPercent};
+      gpuMemoryBandwidthPercent};
 
   return nodeStatus;
 }
@@ -2082,7 +2082,7 @@ void PrestoServer::updateGpuStatusCache() {
         nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
       gpuUtilizationPercent_.store(
           static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
-      gpuMemoryUtilizationPercent_.store(
+      gpuMemoryBandwidthPercent_.store(
           static_cast<int64_t>(util.memory), std::memory_order_relaxed);
     }
   }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1302,6 +1302,21 @@ void PrestoServer::addServerPeriodicTasks() {
       1'000'000, // 1 second
       "populate_mem_cpu_info");
 
+#ifdef PRESTO_ENABLE_CUDF
+  // Sample GPU metrics off the serving path so fetchNodeStatus() (RM heartbeat)
+  // only reads cached atomics — never runs synchronous CUDA/NVML probes.
+  // updateGpuStatusCache() is a no-op unless cuDF is enabled at runtime, so
+  // scheduling it unconditionally here is safe regardless of init ordering.
+  const uint64_t gpuStatusIntervalMs =
+      SystemConfig::instance()->gpuStatusUpdateIntervalMs();
+  if (gpuStatusIntervalMs > 0) {
+    periodicTaskManager_->addTask(
+        [server = this]() { server->updateGpuStatusCache(); },
+        gpuStatusIntervalMs * 1'000, // ms -> micros
+        "update_gpu_status");
+  }
+#endif
+
   periodicTaskManager_->addTask(
       [start = start_]() {
         const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
@@ -1980,54 +1995,25 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
     queryMemoryBytes += pool.second.reservedBytes;
   }
 
-  // GPU device memory. cuDF/RMM allocations do not flow through Velox
-  // MemoryPools (see facebookincubator/velox#16138), so we query the device
-  // directly. Populated only when cuDF is compiled AND enabled at runtime;
-  // -1 sentinel otherwise (same convention as 'nonHeapUsed'). cudaMemGetInfo
-  // reports the whole device: 'used' reflects the RMM pool reservation, which
-  // is the right notion for "how full is the GPU".
-  int64_t gpuMemoryUsedBytes = -1;
-  int64_t gpuMemoryCapacityBytes = -1;
-  // Live bytes currently allocated inside the RMM pool, via a statistics
-  // adaptor around the cuDF memory resource. Unlike gpuMemoryUsedBytes (the
-  // retained RMM pool high-water mark from cudaMemGetInfo), this drops when
-  // queries free their allocations, so it distinguishes idle from busy.
-  // -1 sentinel when cuDF is disabled or not registered.
-  int64_t gpuPoolAllocatedBytes = -1;
-  // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
-  // "GPU-Util". Complements the memory signals: it says whether the GPU is
-  // actually computing, not how full VRAM is. NOTE: NVML reports the whole
-  // physical device; under fractional/shared GPU (time-slicing/MPS) this
-  // reflects the shared GPU, not just this worker (see plan Annex A3).
-  // -1 sentinel when unavailable.
-  int64_t gpuUtilizationPercent = -1;
-  int64_t gpuMemoryUtilizationPercent = -1;
-#ifdef PRESTO_ENABLE_CUDF
-  if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
-    size_t gpuFree = 0;
-    size_t gpuTotal = 0;
-    if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
-      gpuMemoryCapacityBytes = static_cast<int64_t>(gpuTotal);
-      gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
-    }
-    gpuPoolAllocatedBytes = velox::cudf_velox::cudfAllocatedBytes();
-
-    // NVML init once for the server lifetime (process exit reclaims it).
-    static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
-    if (nvmlReady) {
-      nvmlDevice_t nvmlDevice;
-      nvmlUtilization_t util;
-      // Index 0: inside the container NVML sees only the GPU(s) exposed to this
-      // pod, so device 0 is this worker's GPU. Multi-GPU-visible containers
-      // would need PCI-bus-id mapping to the active CUDA device.
-      if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
-          nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
-        gpuUtilizationPercent = static_cast<int64_t>(util.gpu);
-        gpuMemoryUtilizationPercent = static_cast<int64_t>(util.memory);
-      }
-    }
-  }
-#endif
+  // GPU metrics. cuDF/RMM allocations do not flow through Velox MemoryPools
+  // (see facebookincubator/velox#16138), so these are sampled directly from
+  // the device/NVML. To keep the synchronous CUDA/NVML probes off this path
+  // (fetchNodeStatus feeds the RM heartbeat — a stalled probe here can get the
+  // worker declared dead), sampling runs on the periodic 'update_gpu_status'
+  // task and we only read the cached atomics here. -1 sentinel when cuDF is
+  // disabled/not registered or a probe has not succeeded yet (same convention
+  // as 'nonHeapUsed'). Semantics of each value are documented on
+  // updateGpuStatusCache().
+  const int64_t gpuMemoryUsedBytes =
+      gpuMemoryUsedBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryCapacityBytes =
+      gpuMemoryCapacityBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuPoolAllocatedBytes =
+      gpuPoolAllocatedBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuUtilizationPercent =
+      gpuUtilizationPercent_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryUtilizationPercent =
+      gpuMemoryUtilizationPercent_.load(std::memory_order_relaxed);
 
   protocol::NodeStatus nodeStatus{
       nodeId_,
@@ -2053,6 +2039,54 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuMemoryUtilizationPercent};
 
   return nodeStatus;
+}
+
+void PrestoServer::updateGpuStatusCache() {
+#ifdef PRESTO_ENABLE_CUDF
+  if (!velox::cudf_velox::CudfConfig::getInstance().enabled) {
+    return;
+  }
+  // cudaMemGetInfo reports the whole device: 'used' reflects the retained RMM
+  // pool reservation (high-water mark) — the right notion for "how full is the
+  // GPU". Stored into gpuMemory{Used,Capacity}Bytes_.
+  size_t gpuFree = 0;
+  size_t gpuTotal = 0;
+  if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
+    gpuMemoryCapacityBytes_.store(
+        static_cast<int64_t>(gpuTotal), std::memory_order_relaxed);
+    gpuMemoryUsedBytes_.store(
+        static_cast<int64_t>(gpuTotal - gpuFree), std::memory_order_relaxed);
+  }
+
+  // Live bytes currently allocated inside the RMM pool, via a statistics
+  // adaptor around the cuDF memory resource. Unlike gpuMemoryUsedBytes_ (the
+  // retained high-water mark), this drops when queries free their allocations,
+  // so it distinguishes idle from busy.
+  gpuPoolAllocatedBytes_.store(
+      velox::cudf_velox::cudfAllocatedBytes(), std::memory_order_relaxed);
+
+  // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
+  // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM
+  // is. NOTE: NVML reports the whole physical device; under fractional/shared
+  // GPU (time-slicing/MPS) this reflects the shared GPU, not just this worker
+  // (see plan Annex A3).
+  // NVML init once for the server lifetime (process exit reclaims it).
+  static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
+  if (nvmlReady) {
+    nvmlDevice_t nvmlDevice;
+    nvmlUtilization_t util;
+    // Index 0: inside the container NVML sees only the GPU(s) exposed to this
+    // pod, so device 0 is this worker's GPU. Multi-GPU-visible containers
+    // would need PCI-bus-id mapping to the active CUDA device.
+    if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
+        nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
+      gpuUtilizationPercent_.store(
+          static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
+      gpuMemoryUtilizationPercent_.store(
+          static_cast<int64_t>(util.memory), std::memory_order_relaxed);
+    }
+  }
+#endif
 }
 
 void PrestoServer::registerDynamicFunctions() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -86,6 +86,7 @@
 #ifdef PRESTO_ENABLE_CUDF
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/ucx-exchange/Communicator.h"
 #endif
 
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
@@ -178,7 +179,8 @@ bool isSharedLibrary(const fs::path& path) {
   return pathExt == kLinuxSharedLibExt || pathExt == kMacOSSharedLibExt;
 }
 
-void registerVeloxCudf() {
+std::shared_ptr<std::thread> registerVeloxCudf() {
+  std::shared_ptr<std::thread> serverThread = nullptr;
 #ifdef PRESTO_ENABLE_CUDF
   // Disable by default.
   velox::cudf_velox::CudfConfig::getInstance().enabled = false;
@@ -191,13 +193,26 @@ void registerVeloxCudf() {
         systemConfig->values());
     if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
       velox::cudf_velox::registerCudf();
+      if (velox::cudf_velox::CudfConfig::getInstance().exchange) {
+        auto server = facebook::velox::ucx_exchange::Communicator::initAndGet(
+            SystemConfig::instance()->cudfServerPort(),
+            SystemConfig::instance()->discoveryUri().value());
+        if (server) {
+          PRESTO_STARTUP_LOG(INFO) << "cuDF exchange server started";
+          serverThread = std::make_shared<std::thread>(
+              &velox::ucx_exchange::Communicator::run, server.get());
+        } else {
+          PRESTO_STARTUP_LOG(ERROR) << "cuDF exchange server could not start";
+        }
+      }
       PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
     }
   }
 #endif
+  return serverThread;
 }
 
-void unregisterVeloxCudf() {
+void unregisterVeloxCudf(std::shared_ptr<std::thread> serverThread) {
 #ifdef PRESTO_ENABLE_CUDF
   auto systemConfig = SystemConfig::instance();
   if (systemConfig->values().contains(
@@ -205,6 +220,14 @@ void unregisterVeloxCudf() {
       velox::cudf_velox::CudfConfig::getInstance().enabled) {
     velox::cudf_velox::unregisterCudf();
     PRESTO_SHUTDOWN_LOG(INFO) << "cuDF is unregistered.";
+    if (serverThread) {
+      auto server = facebook::velox::ucx_exchange::Communicator::getInstance();
+      server->stop();
+      server.reset();
+      PRESTO_SHUTDOWN_LOG(INFO)
+          << "Joining UCX Communicator thread for shutdown.";
+      serverThread->join();
+    }
   }
 #endif
 }
@@ -299,7 +322,7 @@ void PrestoServer::run() {
 
   // We need to register cuDF before the connectors so that the cuDF connector
   // factories can be used.
-  registerVeloxCudf();
+  auto communicatorThread = registerVeloxCudf();
 
   // Register Presto connector factories and connectors
   registerConnectors();
@@ -370,7 +393,7 @@ void PrestoServer::run() {
   // down.
   startServer(catalogNames);
 
-  shutdownServer();
+  shutdownServer(communicatorThread);
 }
 
 void PrestoServer::initializeConfigs() {
@@ -888,7 +911,8 @@ void PrestoServer::joinExecutors() {
   }
 }
 
-void PrestoServer::shutdownServer() {
+void PrestoServer::shutdownServer(
+    std::shared_ptr<std::thread> communicatorThread) {
   stopAnnouncer();
 
   PRESTO_SHUTDOWN_LOG(INFO) << "Stopping all periodic tasks";
@@ -911,7 +935,7 @@ void PrestoServer::shutdownServer() {
   unregisterFileReadersAndWriters();
   unregisterFileSystems();
   unregisterConnectors();
-  unregisterVeloxCudf();
+  unregisterVeloxCudf(communicatorThread);
 
   joinExecutors();
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -84,6 +84,7 @@
 #include "velox/serializers/UnsafeRowSerializer.h"
 
 #ifdef PRESTO_ENABLE_CUDF
+#include <cuda_runtime.h>
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
@@ -1977,6 +1978,25 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
     queryMemoryBytes += pool.second.reservedBytes;
   }
 
+  // GPU device memory. cuDF/RMM allocations do not flow through Velox
+  // MemoryPools (see facebookincubator/velox#16138), so we query the device
+  // directly. Populated only when cuDF is compiled AND enabled at runtime;
+  // -1 sentinel otherwise (same convention as 'nonHeapUsed'). cudaMemGetInfo
+  // reports the whole device: 'used' reflects the RMM pool reservation, which
+  // is the right notion for "how full is the GPU".
+  int64_t gpuMemoryUsedBytes = -1;
+  int64_t gpuMemoryCapacityBytes = -1;
+#ifdef PRESTO_ENABLE_CUDF
+  if (velox::cudf_velox::CudfConfig::getInstance().enabled) {
+    size_t gpuFree = 0;
+    size_t gpuTotal = 0;
+    if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
+      gpuMemoryCapacityBytes = static_cast<int64_t>(gpuTotal);
+      gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
+    }
+  }
+#endif
+
   protocol::NodeStatus nodeStatus{
       nodeId_,
       {nodeVersion_},
@@ -1993,7 +2013,9 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed,
       asyncDataCacheBytes,
-      queryMemoryBytes};
+      queryMemoryBytes,
+      gpuMemoryUsedBytes,
+      gpuMemoryCapacityBytes};
 
   return nodeStatus;
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1757,6 +1757,19 @@ void PrestoServer::populateMemAndCPUInfo() {
   cpuMon_.update();
   checkOverload();
   **memoryInfo_.wlock() = std::move(memoryInfo);
+
+  // In-memory AsyncDataCache footprint (evictable/reclaimable); SSD-resident
+  // bytes are excluded as they do not contribute to RAM pressure. Computed here
+  // (this task runs periodically) rather than in fetchNodeStatus(), because
+  // refreshStats() walks the cache shards and fetchNodeStatus() feeds the RM
+  // heartbeat. 0 when no cache instance exists (classic JVM behaviour).
+  int64_t asyncDataCacheBytes = 0;
+  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
+    const auto cacheStats = cache->refreshStats();
+    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
+        cacheStats.tinyPadding + cacheStats.largePadding;
+  }
+  asyncDataCacheBytes_.store(asyncDataCacheBytes, std::memory_order_relaxed);
 }
 
 void PrestoServer::checkOverload() {
@@ -1978,14 +1991,11 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // 'nonHeapUsed' is a JVM/GC concept and does not apply to native workers.
   const int64_t nonHeapUsed = -1;
 
-  // In-memory AsyncDataCache footprint (evictable/reclaimable). SSD-resident
-  // bytes are excluded as they do not contribute to RAM pressure.
-  int64_t asyncDataCacheBytes = 0;
-  if (auto* cache = velox::cache::AsyncDataCache::getInstance()) {
-    const auto cacheStats = cache->refreshStats();
-    asyncDataCacheBytes = cacheStats.tinySize + cacheStats.largeSize +
-        cacheStats.tinyPadding + cacheStats.largePadding;
-  }
+  // In-memory AsyncDataCache footprint (evictable/reclaimable), sampled off the
+  // serving path by populateMemAndCPUInfo() — read the cached value here so the
+  // refreshStats() cache-shard walk never runs on the RM heartbeat path.
+  const int64_t asyncDataCacheBytes =
+      asyncDataCacheBytes_.load(std::memory_order_relaxed);
 
   // Query memory (non-evictable): sum of per-query pool reservations, already
   // aggregated per memory pool in populateMemAndCPUInfo().

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -232,7 +232,7 @@ class PrestoServer {
 
   /// Shuts down all server components in the correct order after the HTTP
   /// server stops.
-  void shutdownServer();
+  void shutdownServer(std::shared_ptr<std::thread> communicatorThread);
 
   /// Logs thread pool sizes for all executors.
   void logExecutorInfo();

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -358,6 +358,12 @@ class PrestoServer {
   // We update these members asynchronously and return in http requests w/o
   // delay.
   folly::Synchronized<std::unique_ptr<protocol::MemoryInfo>> memoryInfo_;
+  // AsyncDataCache footprint (evictable). Refreshed off the serving path by
+  // populateMemAndCPUInfo() and read by fetchNodeStatus(), so the cache-shard
+  // walk in AsyncDataCache::refreshStats() stays off the RM heartbeat path
+  // (its cost otherwise scales with shards × workers × poll frequency). 0 until
+  // the first sample and when no cache instance exists (classic JVM behaviour).
+  std::atomic<int64_t> asyncDataCacheBytes_{0};
   CPUMon cpuMon_;
 
   // Cached GPU metrics. Sampled off the serving path by the periodic

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -369,7 +369,7 @@ class PrestoServer {
   std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
   std::atomic<int64_t> gpuPoolAllocatedBytes_{-1};
   std::atomic<int64_t> gpuUtilizationPercent_{-1};
-  std::atomic<int64_t> gpuMemoryUtilizationPercent_{-1};
+  std::atomic<int64_t> gpuMemoryBandwidthPercent_{-1};
 
   std::string environment_;
   std::string nodeVersion_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <atomic>
+
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -259,6 +261,11 @@ class PrestoServer {
 
   void populateMemAndCPUInfo();
 
+  // Samples GPU device/pool/utilization metrics and stores them into the
+  // gpu*_ atomics. Runs on the periodic-task executor (never on the heartbeat
+  // path). No-op unless built with cuDF and enabled at runtime.
+  void updateGpuStatusCache();
+
   // Periodically yield tasks if there are tasks queued.
   void yieldTasks();
 
@@ -352,6 +359,17 @@ class PrestoServer {
   // delay.
   folly::Synchronized<std::unique_ptr<protocol::MemoryInfo>> memoryInfo_;
   CPUMon cpuMon_;
+
+  // Cached GPU metrics. Sampled off the serving path by the periodic
+  // 'update_gpu_status' task (updateGpuStatusCache) and read by
+  // fetchNodeStatus(). This keeps the synchronous CUDA/NVML probes off the
+  // heartbeat path: fetchNodeStatus() feeds the RM heartbeat, and a stalled
+  // probe there can get the worker declared dead. -1 = unavailable.
+  std::atomic<int64_t> gpuMemoryUsedBytes_{-1};
+  std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
+  std::atomic<int64_t> gpuPoolAllocatedBytes_{-1};
+  std::atomic<int64_t> gpuUtilizationPercent_{-1};
+  std::atomic<int64_t> gpuMemoryUtilizationPercent_{-1};
 
   std::string environment_;
   std::string nodeVersion_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -257,6 +257,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLogNumZombieTasks, 20),
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 30s
           NUM_PROP(kHeartbeatFrequencyMs, 0),
+          NUM_PROP(kGpuStatusUpdateIntervalMs, 1'000), // 1s
           BOOL_PROP(kHttpClientHttp2Enabled, false),
           NUM_PROP(kHttpClientHttp2MaxStreamsPerConnection, 8),
           NUM_PROP(kHttpClientHttp2InitialStreamWindow, 1 << 23 /*8MB*/),
@@ -1032,6 +1033,10 @@ uint64_t SystemConfig::announcementMaxFrequencyMs() const {
 
 uint64_t SystemConfig::heartbeatFrequencyMs() const {
   return optionalProperty<uint64_t>(kHeartbeatFrequencyMs).value();
+}
+
+uint64_t SystemConfig::gpuStatusUpdateIntervalMs() const {
+  return optionalProperty<uint64_t>(kGpuStatusUpdateIntervalMs).value();
 }
 
 bool SystemConfig::httpClientHttp2Enabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -169,6 +169,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NONE_PROP(kHttpsClientCaFile),
+          NONE_PROP(kCudfServerPort),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
@@ -318,6 +319,10 @@ SystemConfig* SystemConfig::instance() {
 
 int SystemConfig::httpServerHttpPort() const {
   return requiredProperty<int>(kHttpServerHttpPort);
+}
+
+int SystemConfig::cudfServerPort() const {
+  return requiredProperty<int>(kCudfServerPort);
 }
 
 bool SystemConfig::httpServerReusePort() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -763,6 +763,14 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHeartbeatFrequencyMs{
       "heartbeat-frequency-ms"};
 
+  /// Period (ms) of the background task that samples GPU memory/utilization
+  /// metrics into the cache read by /v1/status (see PrestoServer::
+  /// updateGpuStatusCache). Keeps CUDA/NVML probes off the heartbeat path.
+  /// 0 disables sampling (GPU fields stay at the -1 sentinel). Only effective
+  /// on cuDF-enabled builds/workers.
+  static constexpr std::string_view kGpuStatusUpdateIntervalMs{
+      "gpu.status-update-interval-ms"};
+
   /// Whether HTTP/2 is enabled for HTTP client connections.
   static constexpr std::string_view kHttpClientHttp2Enabled{
       "http-client.http2-enabled"};
@@ -1262,6 +1270,8 @@ class SystemConfig : public ConfigBase {
   uint64_t announcementMaxFrequencyMs() const;
 
   uint64_t heartbeatFrequencyMs() const;
+
+  uint64_t gpuStatusUpdateIntervalMs() const;
 
   bool httpClientHttp2Enabled() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -788,6 +788,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpClientConnectionReuseCounterEnabled{
       "http-client.connection-reuse-counter-enabled"};
 
+  static constexpr std::string_view kCudfServerPort{
+      "cudf.exchange.server.port"};
+
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
@@ -983,6 +986,8 @@ class SystemConfig : public ConfigBase {
   static SystemConfig* instance();
 
   int httpServerHttpPort() const;
+
+  int cudfServerPort() const;
 
   bool httpServerReusePort() const;
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -241,6 +241,21 @@ TEST_F(ConfigTest, asyncCacheNumShards) {
   ASSERT_EQ(config.asyncCacheNumShards(), 8);
 }
 
+TEST_F(ConfigTest, gpuStatusUpdateIntervalMs) {
+  SystemConfig config;
+  init(config, {});
+  // Default is 1s.
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 1'000);
+
+  // Custom value (e.g. faster sampling).
+  init(config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "250"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 250);
+
+  // 0 disables the GPU sampling task.
+  init(config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "0"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 0);
+}
+
 TEST_F(ConfigTest, asyncCacheSsdFlushThresholdBytes) {
   SystemConfig config;
   init(config, {});

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -26,7 +26,7 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
 endif()
 
 if(PRESTO_ENABLE_CUDF)
-  target_link_libraries(presto_connectors velox_cudf_hive_connector cudf::cudf)
+  target_link_libraries(presto_connectors velox_cudf_hive_connector ucxx::ucxx cudf::cudf)
 endif()
 
 target_link_libraries(

--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -30,6 +30,7 @@
 #ifdef PRESTO_ENABLE_CUDF
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
+#include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h"
 #endif
 
 namespace facebook::presto {
@@ -112,6 +113,16 @@ void registerConnectors() {
       std::make_unique<HivePrestoToVeloxConnector>(kHiveHadoop2ConnectorName));
   registerPrestoToVeloxConnector(
       std::make_unique<IcebergPrestoToVeloxConnector>(kIcebergConnectorName));
+#ifdef PRESTO_ENABLE_CUDF
+  // The cuDF Iceberg connector speaks the same Presto protocol as the CPU
+  // Iceberg connector; only the underlying data source differs. Register the
+  // same protocol translator under the cuDF Iceberg connector name so catalogs
+  // with connector.name=cudf-iceberg coexist with CPU iceberg catalogs.
+  registerPrestoToVeloxConnector(
+      std::make_unique<IcebergPrestoToVeloxConnector>(
+          velox::cudf_velox::connector::hive::iceberg::
+              CudfIcebergConnectorFactory::kCudfIcebergConnectorName));
+#endif
   registerPrestoToVeloxConnector(
       std::make_unique<TpchPrestoToVeloxConnector>(
           velox::connector::tpch::TpchConnectorFactory::kTpchConnectorName));
@@ -185,6 +196,15 @@ void registerConnectorFactories() {
   facebook::presto::registerConnectorFactory(
       std::make_shared<facebook::velox::connector::hive::iceberg::
                            IcebergConnectorFactory>());
+
+#ifdef PRESTO_ENABLE_CUDF
+  // Register the cuDF Iceberg connector factory under its own name
+  // ("cudf-iceberg") so it coexists with the CPU Iceberg connector. Catalogs
+  // opt into GPU-accelerated Iceberg reads via connector.name=cudf-iceberg.
+  facebook::presto::registerConnectorFactory(
+      std::make_shared<facebook::velox::cudf_velox::connector::hive::iceberg::
+                           CudfIcebergConnectorFactory>());
+#endif
 
 #ifdef PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR
   // Note: ArrowFlightConnectorFactory would need to be implemented in Presto

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -388,6 +388,22 @@ std::string toVeloxSerdeKind(protocol::ExchangeEncoding encoding) {
   VELOX_UNSUPPORTED("Unsupported encoding: {}.", fmt::underlying(encoding));
 }
 
+// The coordinator sends ANY when the worker supports UCX transport.
+// In practice ANY means "use the fastest available transport" which is UCX.
+std::string_view toVeloxTransportType(
+    const std::shared_ptr<protocol::TransportType>& t) {
+  if (!t) {
+    return core::TransportKind::kHttp;
+  }
+  switch (*t) {
+    case protocol::TransportType::HTTP:
+      return core::TransportKind::kHttp;
+    case protocol::TransportType::ANY:
+      return core::TransportKind::kUcx;
+  }
+  VELOX_UNSUPPORTED("Unsupported transport type: {}.", fmt::underlying(*t));
+}
+
 std::shared_ptr<core::LocalPartitionNode> buildLocalSystemPartitionNode(
     const std::shared_ptr<const protocol::ExchangeNode>& node,
     core::LocalPartitionNode::Type type,
@@ -2344,6 +2360,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
   core::PlanFragment planFragment;
+  planFragment_ = &planFragment;
 
   // Convert the fragment info first.
   const auto& descriptor = fragment.stageExecutionDescriptor;
@@ -2398,6 +2415,8 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   auto outputType = toRowType(partitioningScheme.outputLayout, typeParser_);
   const auto partitionedOutputNodeId =
       toPartitionedOutputNodeId(fragment.root->id);
+  planFragment.outputTransportTypes[partitionedOutputNodeId] =
+      toVeloxTransportType(fragment.outputTransportType);
 
   if (auto systemPartitioningHandle =
           std::dynamic_pointer_cast<protocol::SystemPartitioningHandle>(
@@ -2549,6 +2568,8 @@ core::PlanNodePtr VeloxInteractiveQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RemoteSourceNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
     const protocol::TaskId& taskId) {
+  planFragment_->inputTransportTypes[node->id] =
+      toVeloxTransportType(node->transportType);
   auto rowType = toRowType(node->outputVariables, typeParser_);
   if (node->orderingScheme) {
     std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
@@ -2706,6 +2727,8 @@ core::PlanNodePtr VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::RemoteSourceNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& /* tableWriteInfo */,
     const protocol::TaskId& taskId) {
+  planFragment_->inputTransportTypes[node->id] =
+      toVeloxTransportType(node->transportType);
   auto rowType = toRowType(node->outputVariables, typeParser_);
   // Broadcast exchange source.
   if (node->exchangeType == protocol::ExchangeNodeType::REPLICATE) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -254,6 +254,7 @@ class VeloxQueryPlanConverterBase {
   velox::core::QueryCtx* const queryCtx_;
   VeloxExprConverter exprConverter_;
   TypeParser typeParser_;
+  velox::core::PlanFragment* planFragment_{nullptr};
 };
 
 class VeloxInteractiveQueryPlanConverter : public VeloxQueryPlanConverterBase {

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -26,6 +26,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/main/types/tests/TestUtils.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanFragment.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::presto;
@@ -78,6 +79,19 @@ std::shared_ptr<const core::PlanNode> assertToBatchVeloxQueryPlan(
           prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3")
       .planNode;
 }
+const core::ExchangeNode* findExchangeNode(
+    const std::shared_ptr<const core::PlanNode>& node) {
+  if (auto* exchange = dynamic_cast<const core::ExchangeNode*>(node.get())) {
+    return exchange;
+  }
+  for (const auto& source : node->sources()) {
+    if (auto* found = findExchangeNode(source)) {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
 } // namespace
 
 class PlanConverterTest : public ::testing::Test {
@@ -303,4 +317,88 @@ TEST_F(PlanConverterTest, batchPlanConversionExchangeWrite) {
       std::dynamic_pointer_cast<const operators::MaterializedExchangeNode>(
           curNode);
   ASSERT_NE(materializedExchangeNode, nullptr);
+}
+
+TEST_F(PlanConverterTest, transportTypeAbsentDefaultsToHttp) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  ASSERT_FALSE(j.count("outputTransportType"));
+  ASSERT_FALSE(j["root"]["source"]["sources"][0].count("transportType"));
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kHttp);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kHttp);
+}
+
+TEST_F(PlanConverterTest, transportTypeAny) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  j["outputTransportType"] = "ANY";
+  j["root"]["source"]["sources"][0]["transportType"] = "ANY";
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kUcx);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kUcx);
+}
+
+TEST_F(PlanConverterTest, transportTypeHttp) {
+  std::string fragment = slurp(test::utils::getDataPath("FinalAgg.json"));
+  json j = json::parse(fragment);
+
+  j["outputTransportType"] = "HTTP";
+  j["root"]["source"]["sources"][0]["transportType"] = "HTTP";
+
+  protocol::PlanFragment prestoPlan = j;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create();
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  auto veloxFragment = converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+
+  auto* partitionedOutput = dynamic_cast<const core::PartitionedOutputNode*>(
+      veloxFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(
+      veloxFragment.outputTransportType(partitionedOutput->id()),
+      core::TransportKind::kHttp);
+
+  auto* exchange = findExchangeNode(veloxFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(
+      veloxFragment.inputTransportType(exchange->id()),
+      core::TransportKind::kHttp);
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8141,6 +8141,20 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "queryMemoryBytes");
+  to_json_key(
+      j,
+      "gpuMemoryUsedBytes",
+      p.gpuMemoryUsedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryUsedBytes");
+  to_json_key(
+      j,
+      "gpuMemoryCapacityBytes",
+      p.gpuMemoryCapacityBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryCapacityBytes");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8213,6 +8227,20 @@ void from_json(const json& j, NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "queryMemoryBytes");
+  from_json_key(
+      j,
+      "gpuMemoryUsedBytes",
+      p.gpuMemoryUsedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryUsedBytes");
+  from_json_key(
+      j,
+      "gpuMemoryCapacityBytes",
+      p.gpuMemoryCapacityBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryCapacityBytes");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8162,6 +8162,20 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "gpuPoolAllocatedBytes");
+  to_json_key(
+      j,
+      "gpuUtilizationPercent",
+      p.gpuUtilizationPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuUtilizationPercent");
+  to_json_key(
+      j,
+      "gpuMemoryUtilizationPercent",
+      p.gpuMemoryUtilizationPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryUtilizationPercent");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8264,6 +8278,24 @@ void from_json(const json& j, NodeStatus& p) {
         "NodeStatus",
         "int64_t",
         "gpuPoolAllocatedBytes");
+  }
+  if (j.count("gpuUtilizationPercent")) {
+    from_json_key(
+        j,
+        "gpuUtilizationPercent",
+        p.gpuUtilizationPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuUtilizationPercent");
+  }
+  if (j.count("gpuMemoryUtilizationPercent")) {
+    from_json_key(
+        j,
+        "gpuMemoryUtilizationPercent",
+        p.gpuMemoryUtilizationPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryUtilizationPercent");
   }
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8127,6 +8127,20 @@ void to_json(json& j, const NodeStatus& p) {
       "heapAvailable");
   to_json_key(
       j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+  to_json_key(
+      j,
+      "asyncDataCacheBytes",
+      p.asyncDataCacheBytes,
+      "NodeStatus",
+      "int64_t",
+      "asyncDataCacheBytes");
+  to_json_key(
+      j,
+      "queryMemoryBytes",
+      p.queryMemoryBytes,
+      "NodeStatus",
+      "int64_t",
+      "queryMemoryBytes");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8185,6 +8199,20 @@ void from_json(const json& j, NodeStatus& p) {
       "heapAvailable");
   from_json_key(
       j, "nonHeapUsed", p.nonHeapUsed, "NodeStatus", "int64_t", "nonHeapUsed");
+  from_json_key(
+      j,
+      "asyncDataCacheBytes",
+      p.asyncDataCacheBytes,
+      "NodeStatus",
+      "int64_t",
+      "asyncDataCacheBytes");
+  from_json_key(
+      j,
+      "queryMemoryBytes",
+      p.queryMemoryBytes,
+      "NodeStatus",
+      "int64_t",
+      "queryMemoryBytes");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8171,11 +8171,11 @@ void to_json(json& j, const NodeStatus& p) {
       "gpuUtilizationPercent");
   to_json_key(
       j,
-      "gpuMemoryUtilizationPercent",
-      p.gpuMemoryUtilizationPercent,
+      "gpuMemoryBandwidthPercent",
+      p.gpuMemoryBandwidthPercent,
       "NodeStatus",
       "int64_t",
-      "gpuMemoryUtilizationPercent");
+      "gpuMemoryBandwidthPercent");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8288,14 +8288,14 @@ void from_json(const json& j, NodeStatus& p) {
         "int64_t",
         "gpuUtilizationPercent");
   }
-  if (j.count("gpuMemoryUtilizationPercent")) {
+  if (j.count("gpuMemoryBandwidthPercent")) {
     from_json_key(
         j,
-        "gpuMemoryUtilizationPercent",
-        p.gpuMemoryUtilizationPercent,
+        "gpuMemoryBandwidthPercent",
+        p.gpuMemoryBandwidthPercent,
         "NodeStatus",
         "int64_t",
-        "gpuMemoryUtilizationPercent");
+        "gpuMemoryBandwidthPercent");
   }
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8155,6 +8155,13 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "gpuMemoryCapacityBytes");
+  to_json_key(
+      j,
+      "gpuPoolAllocatedBytes",
+      p.gpuPoolAllocatedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuPoolAllocatedBytes");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8227,20 +8234,37 @@ void from_json(const json& j, NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "queryMemoryBytes");
-  from_json_key(
-      j,
-      "gpuMemoryUsedBytes",
-      p.gpuMemoryUsedBytes,
-      "NodeStatus",
-      "int64_t",
-      "gpuMemoryUsedBytes");
-  from_json_key(
-      j,
-      "gpuMemoryCapacityBytes",
-      p.gpuMemoryCapacityBytes,
-      "NodeStatus",
-      "int64_t",
-      "gpuMemoryCapacityBytes");
+  // Backward compatible: guard with j.count() so payloads from older workers
+  // that lack these GPU fields still deserialize (default to 0 via the struct).
+  if (j.count("gpuMemoryUsedBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryUsedBytes",
+        p.gpuMemoryUsedBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryUsedBytes");
+  }
+  if (j.count("gpuMemoryCapacityBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryCapacityBytes",
+        p.gpuMemoryCapacityBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryCapacityBytes");
+  }
+  // Backward compatible: guard with j.count() so payloads from older workers
+  // that lack this field still deserialize (defaults to 0 via the struct).
+  if (j.count("gpuPoolAllocatedBytes")) {
+    from_json_key(
+        j,
+        "gpuPoolAllocatedBytes",
+        p.gpuPoolAllocatedBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuPoolAllocatedBytes");
+  }
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1992,7 +1992,7 @@ struct NodeStatus {
   int64_t gpuMemoryCapacityBytes = {};
   int64_t gpuPoolAllocatedBytes = {};
   int64_t gpuUtilizationPercent = {};
-  int64_t gpuMemoryUtilizationPercent = {};
+  int64_t gpuMemoryBandwidthPercent = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1990,6 +1990,7 @@ struct NodeStatus {
   int64_t queryMemoryBytes = {};
   int64_t gpuMemoryUsedBytes = {};
   int64_t gpuMemoryCapacityBytes = {};
+  int64_t gpuPoolAllocatedBytes = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1991,6 +1991,8 @@ struct NodeStatus {
   int64_t gpuMemoryUsedBytes = {};
   int64_t gpuMemoryCapacityBytes = {};
   int64_t gpuPoolAllocatedBytes = {};
+  int64_t gpuUtilizationPercent = {};
+  int64_t gpuMemoryUtilizationPercent = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1988,6 +1988,8 @@ struct NodeStatus {
   int64_t nonHeapUsed = {};
   int64_t asyncDataCacheBytes = {};
   int64_t queryMemoryBytes = {};
+  int64_t gpuMemoryUsedBytes = {};
+  int64_t gpuMemoryCapacityBytes = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1986,6 +1986,8 @@ struct NodeStatus {
   int64_t heapUsed = {};
   int64_t heapAvailable = {};
   int64_t nonHeapUsed = {};
+  int64_t asyncDataCacheBytes = {};
+  int64_t queryMemoryBytes = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -15,16 +15,20 @@ FROM quay.io/centos/centos:stream9
 # Set this when build arm with common flags
 # from https://github.com/facebookincubator/velox/pull/14366
 ARG ARM_BUILD_TARGET
-
-# This defaults to 12.9 but can be overridden with a build arg
 ARG CUDA_VERSION
+
+# This defaults to 13.0 but can be overridden with a build arg
+ARG CUDA_VERSION
+
+# This defaults to 1.20.1 but can be overridden with a build arg
+ARG UCX_VERSION
 
 ENV PROMPT_ALWAYS_RESPOND=y
 ENV CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-12/root/bin/g++
 ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
-ENV CUDA_VERSION=${CUDA_VERSION:-12.9}
-ENV UCX_VERSION="1.19.0"
+ENV CUDA_VERSION=${CUDA_VERSION:-13.0}
+ENV UCX_VERSION=${UCX_VERSION:-1.20.1}
 
 RUN mkdir -p /scripts /velox/scripts
 COPY scripts /scripts
@@ -49,6 +53,13 @@ RUN bash -c "mkdir build && \
                  install_cuda ${CUDA_VERSION} && \
                  install_ucx) && \
     rm -rf build"
+
+# Install sccache for optional S3-backed compile caching
+# See: https://github.com/mozilla/sccache
+ARG SCCACHE_VERSION="0.13.0"
+RUN wget -q -O- "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" \
+    | tar -C /usr/bin -zf - --wildcards --strip-components=1 -x '*/sccache' && \
+    chmod +x /usr/bin/sccache
 
 # put CUDA binaries on the PATH
 ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} ${COMPILER_LAUNCHER_FLAGS}" \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then (sccache --stop-server && sccache --show-stats) || true ; echo "===== sccache server log (/tmp/sccache-server.log) ====="; cat /tmp/sccache-server.log 2>/dev/null || true ; else ccache -sz -v; fi'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -v libcuda) && \
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -vE "libcuda|libnvidia-ml") && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 
 RUN cp -rf /usr/local/lib/ucx /runtime-libraries/ucx

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -12,13 +12,24 @@
 
 ARG DEPENDENCY_IMAGE=presto/prestissimo-dependency:centos9
 ARG BASE_IMAGE=quay.io/centos/centos:stream9
+
+# ==========================================
+# Stage 1: Build prestissimo from source
+# ==========================================
 FROM ${DEPENDENCY_IMAGE} as prestissimo-image
 
 ARG OSNAME=centos
 ARG BUILD_TYPE=Release
 ARG EXTRA_CMAKE_FLAGS=''
 ARG NUM_THREADS=8
-ARG CUDA_ARCHITECTURES=70
+ARG CUDA_ARCHITECTURES=""
+ENV CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
+
+# Optional: sccache with S3 backend for shared compile caching across builds
+# Set SCCACHE_BUCKET to enable (e.g., --build-arg SCCACHE_BUCKET=my-bucket)
+ARG SCCACHE_BUCKET=""
+ARG SCCACHE_REGION=""
+ARG SCCACHE_S3_KEY_PREFIX=""
 
 ENV PROMPT_ALWAYS_RESPOND=n
 ENV BUILD_BASE_DIR=_build
@@ -27,26 +38,56 @@ ENV BUILD_DIR=""
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
-    /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
-    EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
+    /bin/bash -c '\
+    if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
+    COMPILER_LAUNCHER_FLAGS="" && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then \
+        export SCCACHE_BUCKET="${SCCACHE_BUCKET}" SCCACHE_CACHE_SIZE=2G SCCACHE_IDLE_TIMEOUT=0 SCCACHE_ERROR_LOG=/tmp/sccache-server.log SCCACHE_LOG=warn; \
+        [ -n "${SCCACHE_REGION}" ] && export SCCACHE_REGION="${SCCACHE_REGION}"; \
+        [ -n "${SCCACHE_S3_KEY_PREFIX}" ] && export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX}"; \
+        sccache --start-server && \
+        COMPILER_LAUNCHER_FLAGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache"; \
+        echo "Using sccache with S3 backend: s3://${SCCACHE_BUCKET}/${SCCACHE_S3_KEY_PREFIX:-}"; \
+    else \
+        echo "Using ccache (local)"; \
+    fi && \
+    EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} ${COMPILER_LAUNCHER_FLAGS}" \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
-    ccache -sz -v'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then (sccache --stop-server && sccache --show-stats) || true ; echo "===== sccache server log (/tmp/sccache-server.log) ====="; cat /tmp/sccache-server.log 2>/dev/null || true ; else ccache -sz -v; fi'
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | grep "not found" | grep -v libcuda) && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 
-#/////////////////////////////////////////////
-#          prestissimo-runtime
-#//////////////////////////////////////////////
+RUN cp -rf /usr/local/lib/ucx /runtime-libraries/ucx
+RUN echo "${CUDA_VERSION}" > /cuda_version
 
-FROM ${BASE_IMAGE}
+# ==========================================
+# Stage 2: Runtime image (minimal, production-ready)
+# ==========================================
+FROM ${BASE_IMAGE} as prestissimo-runtime
 
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
 
+# Copy scripts and CUDA version from build stage
+COPY --from=prestissimo-image /prestissimo/velox/scripts/ /tmp/scripts/
+COPY --from=prestissimo-image /cuda_version /tmp/
+
+# Install CUDA runtime packages and RDMA libraries
+RUN CUDA_VERSION=$(cat /tmp/cuda_version) && \
+    source /tmp/scripts/setup-centos-adapters.sh && \
+    install_cuda_runtime "${CUDA_VERSION}" && \
+    dnf install -y librdmacm libibverbs && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /tmp/scripts /tmp/cuda_version
+
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/
+COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/ucx /usr/lib64/prestissimo-libs/ucx
 COPY --chmod=0755 ./etc /opt/presto-server/etc
 COPY --chmod=0775 ./entrypoint.sh /opt/entrypoint.sh
-RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && ldconfig
+RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/lib64/prestissimo-libs/ucx" >> /etc/ld.so.conf.d/prestissimo.conf && \
+    echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
 
 ENTRYPOINT ["/opt/entrypoint.sh"]


### PR DESCRIPTION
## Description

Adds per-worker GPU and native-memory signals to the Prestissimo worker's `/v1/status`
(`NodeStatus`), so the coordinator / an autoscaler can reason about GPU and host memory:

- **Native host memory**: `asyncDataCacheBytes` (evictable cache) and `queryMemoryBytes`
  (non-evictable), split out from the allocator total.
- **GPU device memory**: `gpuMemoryUsedBytes`, `gpuMemoryCapacityBytes` (via `cudaMemGetInfo`).
- **GPU live pool**: `gpuPoolAllocatedBytes` — live RMM-allocated bytes; drops when queries free,
  unlike the sticky `cudaMemGetInfo` value. (Depends on the velox change below.)
- **GPU utilization**: `gpuUtilizationPercent`, `gpuMemoryBandwidthPercent` (NVML).

Supporting changes:
- Build: fail the build if `CUDA::nvml` is not linkable; the runtime image's missing-lib check
  excludes the driver-provided `libnvidia-ml`.
- Serving-path hygiene: all GPU probes (`cudaMemGetInfo` / `cudfAllocatedBytes` / NVML) and the
  `AsyncDataCache::refreshStats()` cache-shard walk are sampled by periodic tasks into caches;
  `fetchNodeStatus()` (which feeds the RM heartbeat) only reads cached values. The GPU sample
  interval is configurable via `gpu.status-update-interval-ms` (default `1000`, `0` disables).

**Depends on** IBM/velox#/2357 (adds `cudfAllocatedBytes()`, required by `gpuPoolAllocatedBytes`).
The velox submodule in this branch currently points at a fork; it will be re-pointed to IBM/velox
once #2354 merges. Keeping this as a **draft** until then.

**Relationship to prestodb/presto#27783**: that PR upstreams the native memory-pressure split
(`asyncDataCacheBytes` / `queryMemoryBytes` and the `refreshStats` off-path caching) to `master`.
This PR carries an equivalent port of the same onto `ibm-research-preview` (distinct commits) because
the GPU worker image needs it now. Overlapping files: `NodeStatus`, `PrestoServer`
(`fetchNodeStatus` / `populateMemAndCPUInfo`). When #27783 lands and `ibm-research-preview` syncs
`master`, the two reconcile (equivalent changes).

## Motivation and Context

GPU-aware autoscaling needs to know whether a worker's GPU memory is actually free (not merely
whether the retained RMM pool looks full) and whether the GPU is busy. `cudaMemGetInfo` alone is
sticky and can't distinguish idle-with-retained-pool from active work; NVML adds compute/bandwidth
utilization. Exposing these on `/v1/status` lets the coordinator/autoscaler make correct scale-in /
scale-out decisions for GPU workers, mirroring the existing host-memory signals.

## Impact

- New `NodeStatus` fields (all `-1`/absent on classic JVM workers and when cuDF/NVML are
  unavailable, so existing tooling is unaffected).
- New native config property `gpu.status-update-interval-ms` (default `1000`).
- No behavior change for non-GPU / non-cuDF builds. GPU probes run off the heartbeat path, so the
  RM heartbeat is not exposed to synchronous CUDA/NVML/refreshStats latency.

## Test Plan

- `TestNodeStatus` (Java): serialization round-trip of the new fields.
- `ConfigTest` (native): default and override of `gpu.status-update-interval-ms`.
- Runtime validation on an L40S GPU worker: `gpuPoolAllocatedBytes` rises during a query and returns
  to ~0 when idle (vs. the sticky `cudaMemGetInfo` value); `gpuUtilizationPercent` /
  `gpuMemoryBandwidthPercent` report 0–100 (not `-1`) once NVML is linked.

## Contributor checklist

- [x] Please make sure your submission complies with our contributing guide, in particular code style and commit standards.
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new properties (`gpu.status-update-interval-ms`, default `1000`).
- [ ] If release notes are required, they follow the release notes guidelines.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an OpenSSF Scorecard score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
- Expose GPU and native-memory metrics on the native worker's /v1/status (NodeStatus):
asyncDataCacheBytes, queryMemoryBytes, gpuMemoryUsedBytes, gpuMemoryCapacityBytes,
gpuPoolAllocatedBytes, gpuUtilizationPercent, gpuMemoryBandwidthPercent.
- Add native config property gpu.status-update-interval-ms (default 1000) controlling the
GPU-metrics sampling period.

## Summary by Sourcery

Expose GPU and native-memory metrics from native workers on /v1/status and sample them off the heartbeat path for autoscaling and monitoring.

New Features:
- Add AsyncDataCache and query memory usage fields to NodeStatus and surface them in /v1/status for native workers.
- Add GPU memory, pool allocation, and utilization metrics to NodeStatus and expose them via /v1/status on cuDF-enabled native workers.
- Introduce configurable gpu.status-update-interval-ms to control background sampling of GPU metrics.

Enhancements:
- Sample native AsyncDataCache and GPU metrics via periodic background tasks so RM heartbeats only read cached values.
- Update JVM NodeStatus and StatusResource to carry the new fields with neutral defaults, preserving compatibility across worker types.

Build:
- Require CUDA::nvml at build time and link NVML into the native server binary for GPU utilization reporting.
- Extend the runtime image missing-library check to allow driver-provided libnvidia-ml while still failing on other unresolved libraries.

Tests:
- Add configuration tests for gpu.status-update-interval-ms defaults and overrides.
- Update resource manager and HTTP client tests to construct NodeStatus instances with the new memory and GPU fields.