### PR TITLE
feat: Add ability to start native worker using containers

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -416,6 +416,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-jdbc</artifactId>
             <scope>test</scope>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerBackedProcess.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerBackedProcess.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Adapts a Testcontainers {@link GenericContainer} to the {@link Process} interface,
+ * allowing containerized native workers to be managed by
+ * {@link com.facebook.presto.tests.DistributedQueryRunner} which expects
+ * external workers as {@link Process} instances.
+ * <p>
+ * This adapter enables the existing external worker launcher mechanism
+ * ({@code BiFunction<Integer, URI, Process>}) to work with container-based
+ * workers without modifying {@code DistributedQueryRunner}.
+ * <p>
+ * Log output is captured via Testcontainers log consumers configured on the
+ * container before starting, not via {@link #getInputStream()} or
+ * {@link #getErrorStream()}, which return empty streams.
+ */
+class ContainerBackedProcess
+        extends Process
+{
+    private final GenericContainer<?> container;
+
+    ContainerBackedProcess(GenericContainer<?> container)
+    {
+        this.container = container;
+    }
+
+    GenericContainer<?> getContainer()
+    {
+        return container;
+    }
+
+    @Override
+    public OutputStream getOutputStream()
+    {
+        // Container processes don't support stdin from the host
+        return new OutputStream()
+        {
+            @Override
+            public void write(int b)
+            {
+                // no-op
+            }
+        };
+    }
+
+    @Override
+    public InputStream getInputStream()
+    {
+        // Logs are captured via Testcontainers log consumers, not via process streams
+        return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public InputStream getErrorStream()
+    {
+        return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public int waitFor()
+            throws InterruptedException
+    {
+        while (container.isRunning()) {
+            Thread.sleep(500);
+        }
+        return 0;
+    }
+
+    @Override
+    public int exitValue()
+    {
+        if (container.isRunning()) {
+            throw new IllegalThreadStateException("Container is still running");
+        }
+        return 0;
+    }
+
+    @Override
+    public void destroy()
+    {
+        if (container.isRunning()) {
+            container.stop();
+        }
+    }
+
+    @Override
+    public Process destroyForcibly()
+    {
+        if (container.isRunning()) {
+            container.stop();
+        }
+        return this;
+    }
+
+    @Override
+    public boolean isAlive()
+    {
+        return container.isRunning();
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
@@ -33,7 +33,10 @@ public class HiveExternalWorkerQueryRunner
         NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
         javaQueryRunner.close();
 
-        // Launch distributed runner.
+        // Launch distributed runner
+        // Set the `workerImage` property (e.g. -DworkerImage=<image>
+        // or the `workerImage` environment variable) to run native workers inside containers
+        // instead of the presto_server binary on the host.
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder().build();
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -32,6 +32,7 @@ import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.github.dockerjava.api.model.HostConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -39,14 +40,21 @@ import com.google.common.io.Resources;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -136,6 +144,7 @@ public class PrestoNativeQueryRunnerUtils
         private boolean failOnNestedLoopJoin;
         private boolean implicitCastCharNToVarchar;
         private boolean enableCudf;
+        private Optional<String> workerImage = Optional.empty();
         // External worker launcher is applicable only for the native hive query runner, since it depends on other
         // properties it should be created once all the other query runner configs are set. This variable indicates
         // whether the query runner returned by builder should use an external worker launcher, it will be true only
@@ -163,6 +172,9 @@ public class PrestoNativeQueryRunnerUtils
                         .build());
                 this.security = "legacy";
                 this.useExternalWorkerLauncher = true;
+                // Run native workers in containers when a `workerImage` property is set;
+                // otherwise launch the presto_server binary directly on the host.
+                this.workerImage = getProperty("workerImage");
             }
             else {
                 this.extraProperties.putAll(ImmutableMap.of(
@@ -305,8 +317,11 @@ public class PrestoNativeQueryRunnerUtils
         {
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher = Optional.empty();
             if (this.useExternalWorkerLauncher) {
+                Path effectiveDataDirectory = Paths.get(addStorageFormatToPath ? dataDirectory.toString() + "/" + storageFormat : dataDirectory.toString());
                 externalWorkerLauncher = getExternalWorkerLauncher("hive", "hive", serverBinary, cacheMaxSize, remoteFunctionServerUds,
-                        pluginDirectory, failOnNestedLoopJoin, coordinatorSidecarEnabled, builtInWorkerFunctionsEnabled, enableRuntimeMetricsCollection, enableSsdCache, implicitCastCharNToVarchar, enableCudf);
+                        pluginDirectory, failOnNestedLoopJoin, coordinatorSidecarEnabled, builtInWorkerFunctionsEnabled,
+                        enableRuntimeMetricsCollection, enableSsdCache, implicitCastCharNToVarchar, enableCudf, workerImage,
+                        effectiveDataDirectory);
             }
             return HiveQueryRunner.createQueryRunner(
                     ImmutableList.of(),
@@ -356,6 +371,7 @@ public class PrestoNativeQueryRunnerUtils
         private boolean useExternalWorkerLauncher;
         private boolean addJmxPlugin;
         private boolean coordinatorSidecarEnabled;
+        private Optional<String> workerImage = Optional.empty();
 
         private IcebergQueryRunnerBuilder(QueryRunnerType queryRunnerType)
         {
@@ -366,6 +382,9 @@ public class PrestoNativeQueryRunnerUtils
                         .putAll(getNativeWorkerSystemProperties())
                         .build());
                 this.useExternalWorkerLauncher = true;
+                // Run native workers in containers when a `workerImage` property is set;
+                // otherwise launch the presto_server binary directly on the host.
+                this.workerImage = getProperty("workerImage");
             }
             else {
                 this.extraProperties.putAll(ImmutableMap.of(
@@ -453,7 +472,7 @@ public class PrestoNativeQueryRunnerUtils
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher = Optional.empty();
             if (this.useExternalWorkerLauncher) {
                 externalWorkerLauncher = getExternalWorkerLauncher("iceberg", "iceberg", serverBinary, cacheMaxSize, remoteFunctionServerUds,
-                        Optional.empty(), false, coordinatorSidecarEnabled, false, false, false, false, false);
+                        Optional.empty(), false, coordinatorSidecarEnabled, false, false, false, false, false, workerImage, dataDirectory);
             }
             IcebergQueryRunner.Builder builder = IcebergQueryRunner.builder()
                     .setExtraProperties(extraProperties)
@@ -519,6 +538,7 @@ public class PrestoNativeQueryRunnerUtils
         private Optional<String> remoteFunctionServerUds = Optional.empty();
         private TimeZoneKey timeZoneKey = TimeZoneKey.getTimeZoneKey(TimeZone.getDefault().getID());
         private boolean caseSensitiveParitions;
+        private Optional<String> workerImage = Optional.empty();
         // External worker launcher is applicable only for the native iceberg query runner, since it depends on other
         // properties it should be created once all the other query runner configs are set. This variable indicates
         // whether the query runner returned by builder should use an external worker launcher, it will be true only
@@ -534,6 +554,9 @@ public class PrestoNativeQueryRunnerUtils
                         .putAll(getNativeWorkerSystemProperties())
                         .build());
                 this.useExternalWorkerLauncher = true;
+                // Run native workers in containers when a `workerImage` property is set;
+                // otherwise launch the presto_server binary directly on the host.
+                this.workerImage = getProperty("workerImage");
             }
             else {
                 this.extraProperties.putAll(ImmutableMap.of(
@@ -576,7 +599,7 @@ public class PrestoNativeQueryRunnerUtils
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher = Optional.empty();
             if (this.useExternalWorkerLauncher) {
                 externalWorkerLauncher = getExternalWorkerLauncher("delta", "delta", serverBinary, cacheMaxSize, remoteFunctionServerUds,
-                        Optional.empty(), false, false, false, false, false, false, false);
+                        Optional.empty(), false, false, false, false, false, false, false, workerImage, dataDirectory);
             }
             DeltaQueryRunner.Builder builder = DeltaQueryRunner.builder()
                     .setExtraProperties(extraProperties)
@@ -651,8 +674,7 @@ public class PrestoNativeQueryRunnerUtils
                 .toAbsolutePath();
         Optional<Integer> workerCount = getProperty("WORKER_COUNT").map(Integer::parseInt);
 
-        assertTrue(Files.exists(prestoServerPath), format("Native worker binary at %s not found. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.", prestoServerPath));
-        log.info("Using PRESTO_SERVER binary at %s", prestoServerPath);
+        log.info("Using PRESTO_SERVER binary at [%s], or if using a native container, the `presto_server` binary on container PATH", prestoServerPath);
 
         if (!Files.exists(dataDirectory)) {
             assertTrue(dataDirectory.toFile().mkdirs());
@@ -683,7 +705,9 @@ public class PrestoNativeQueryRunnerUtils
             boolean enableRuntimeMetricsCollection,
             boolean enableSsdCache,
             boolean implicitCastCharNToVarchar,
-            boolean enableCudf)
+            boolean enableCudf,
+            Optional<String> workerImage,
+            Path dataDirectory)
     {
         return externalWorkerLauncherBuilder()
                 .setCatalogName(catalogName)
@@ -699,6 +723,8 @@ public class PrestoNativeQueryRunnerUtils
                 .setEnableSsdCache(enableSsdCache)
                 .setImplicitCastCharNToVarchar(implicitCastCharNToVarchar)
                 .setEnableCudf(enableCudf)
+                .setWorkerImage(workerImage)
+                .setDataDirectory(dataDirectory)
                 .build();
     }
 
@@ -736,6 +762,8 @@ public class PrestoNativeQueryRunnerUtils
         private boolean enableSsdCache;
         private boolean implicitCastCharNToVarchar;
         private boolean enableCudf;
+        private Optional<String> workerImage = Optional.empty();
+        private Path dataDirectory;
 
         private ExternalWorkerLauncherBuilder() {}
 
@@ -817,9 +845,23 @@ public class PrestoNativeQueryRunnerUtils
             return this;
         }
 
+        public ExternalWorkerLauncherBuilder setWorkerImage(Optional<String> workerImage)
+        {
+            this.workerImage = requireNonNull(workerImage, "workerImage is null");
+            return this;
+        }
+
+        public ExternalWorkerLauncherBuilder setDataDirectory(Path dataDirectory)
+        {
+            this.dataDirectory = requireNonNull(dataDirectory, "dataDirectory is null");
+            return this;
+        }
+
         public Optional<BiFunction<Integer, URI, Process>> build()
         {
-            requireNonNull(prestoServerPath, "prestoServerPath must be set");
+            if (workerImage.isEmpty()) {
+                assertTrue(Files.exists(Path.of(prestoServerPath)), format("Native worker binary at %s not found. Add -DPRESTO_SERVER=<path/to/presto_server> to your JVM arguments.", prestoServerPath));
+            }
 
             return Optional.of((workerIndex, discoveryUri) -> {
                 try {
@@ -828,12 +870,27 @@ public class PrestoNativeQueryRunnerUtils
                     Path tempDirectoryPath = Files.createTempDirectory(dir, "worker");
                     log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
 
-                    // Write config file - use an ephemeral port for the worker.
+                    boolean useContainer = workerImage.isPresent();
+                    int workerPort = 0; // ephemeral port for bare-metal mode
+                    String nodeInternalAddress = "127.0.0.1";
+
+                    if (useContainer) {
+                        // The container runs with host networking, so it shares the host's network
+                        // namespace: the coordinator, discovery service, and peer workers are all
+                        // reachable over 127.0.0.1 exactly as in bare-metal mode. We only need to
+                        // pre-allocate a fixed port for the worker to bind to, since the announced
+                        // address (127.0.0.1:<workerPort>) must be known before the container starts.
+                        try (ServerSocket serverSocket = new ServerSocket(0)) {
+                            workerPort = serverSocket.getLocalPort();
+                        }
+                    }
+
+                    // Write config file - use an ephemeral port (0) for bare-metal, pre-allocated port for container.
                     String configProperties = format("discovery.uri=%s%n" +
                             "presto.version=testversion%n" +
                             "plan-consistency-check-enabled=true%n" +
                             "system-memory-gb=4%n" +
-                            "http-server.http.port=0%n", discoveryUri);
+                            "http-server.http.port=%d%n", discoveryUri, workerPort);
 
                     if (coordinatorSidecarEnabled) {
                         configProperties = format("%s%n" +
@@ -887,9 +944,9 @@ public class PrestoNativeQueryRunnerUtils
                     Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
                     Files.write(tempDirectoryPath.resolve("node.properties"),
                             format("node.id=%s%n" +
-                                    "node.internal-address=127.0.0.1%n" +
+                                    "node.internal-address=%s%n" +
                                     "node.environment=testing%n" +
-                                    "node.location=test-location", UUID.randomUUID()).getBytes());
+                                    "node.location=test-location", UUID.randomUUID(), nodeInternalAddress).getBytes());
 
                     Path catalogDirectoryPath = tempDirectoryPath.resolve("catalog");
                     Files.createDirectory(catalogDirectoryPath);
@@ -918,17 +975,104 @@ public class PrestoNativeQueryRunnerUtils
                     Files.write(catalogDirectoryPath.resolve("tpcds.properties"),
                             format("connector.name=tpcds%n").getBytes());
 
-                    return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1", "--velox_ssd_odirect=false")
-                            .directory(tempDirectoryPath.toFile())
-                            .redirectErrorStream(true)
-                            .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                            .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                            .start();
+                    if (useContainer) {
+                        return launchWorkerContainer(tempDirectoryPath, workerIndex, workerPort);
+                    }
+                    else {
+                        return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1", "--velox_ssd_odirect=false")
+                                .directory(tempDirectoryPath.toFile())
+                                .redirectErrorStream(true)
+                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
+                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
+                                .start();
+                    }
                 }
                 catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
             });
+        }
+
+        /**
+         * Launches the native worker inside a container using Testcontainers.
+         * <p>
+         * The container is configured with bind mounts at the same paths as the host so that
+         * all absolute paths in the generated config files resolve correctly inside the container.
+         * It runs with host networking ({@code --network host}), so the worker binds directly to
+         * {@code workerPort} on the host and is reachable at its announced address
+         * ({@code 127.0.0.1:<workerPort>}) with no port mapping.
+         * <p>
+         * The worker image must have {@code presto_server} on its {@code PATH}.
+         */
+        private Process launchWorkerContainer(Path tempDirectoryPath, int workerIndex, int workerPort)
+        {
+            GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(workerImage.get()));
+
+            // Bind-mount the temp directory at the same path (config, catalog, node properties, SSD cache)
+            container.withFileSystemBind(tempDirectoryPath.toString(), tempDirectoryPath.toString(), BindMode.READ_WRITE);
+
+            // Bind-mount the data directory at the same path (table data files)
+            container.withFileSystemBind(dataDirectory.toString(), dataDirectory.toString(), BindMode.READ_WRITE);
+
+            // Bind-mount optional directories at the same paths
+            if (pluginDirectory.isPresent()) {
+                container.withFileSystemBind(pluginDirectory.get(), pluginDirectory.get(), BindMode.READ_ONLY);
+            }
+            if (remoteFunctionServerUds.isPresent()) {
+                Path udsParentDir = Paths.get(remoteFunctionServerUds.get()).getParent();
+                if (udsParentDir != null) {
+                    container.withFileSystemBind(udsParentDir.toString(), udsParentDir.toString(), BindMode.READ_WRITE);
+                }
+            }
+
+            // Override the image entrypoint and run with host networking so the worker binds
+            // directly to workerPort on the host, reachable at 127.0.0.1:<workerPort>.
+            container.withCreateContainerCmdModifier(cmd -> {
+                cmd.withEntrypoint("presto_server");
+                HostConfig hostConfig = cmd.getHostConfig();
+                if (hostConfig == null) {
+                    hostConfig = new HostConfig();
+                    cmd.withHostConfig(hostConfig);
+                }
+                hostConfig.withNetworkMode("host");
+                // Opt the container out of SELinux confinement (e.g. Podman on Fedora). Without
+                // this, the container process (container_t) is denied access to the bind-mounted
+                // host files, which are labelled user_tmp_t (see AVC "denied { open }" errors).
+                // Relabelling the mounts with the "z" option is not sufficient here because the
+                // worker also reads fixture files written by the host-side Java runner, so we
+                // disable labelling for the container entirely. No-op on hosts without SELinux.
+                hostConfig.withSecurityOpts(ImmutableList.of("label=disable"));
+            });
+
+            container.withCommand(
+                    "--etc_dir=" + tempDirectoryPath.toString(),
+                    "--logtostderr=1",
+                    "--v=1",
+                    "--velox_ssd_odirect=false");
+
+            // Capture container logs to the same file as bare-metal mode
+            Path logFile = tempDirectoryPath.resolve("worker." + workerIndex + ".out");
+            container.withLogConsumer(frame -> {
+                try {
+                    String line = frame.getUtf8String();
+                    if (line != null) {
+                        Files.write(logFile, line.getBytes(),
+                                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+                    }
+                }
+                catch (IOException ignored) {
+                }
+            });
+
+            // Wait for the worker to register with the coordinator's discovery service
+            container.waitingFor(Wait.forLogMessage(".*Announcement succeeded.*", 1));
+            container.withStartupTimeout(Duration.ofSeconds(120));
+
+            container.start();
+            log.info("Started container worker #%d (port %d, container %s)",
+                    workerIndex, workerPort, container.getContainerId());
+
+            return new ContainerBackedProcess(container);
         }
     }
 

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -304,6 +304,30 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -284,6 +284,30 @@
             <version>${dep.parquet.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-plan-checker-router-plugin/pom.xml
+++ b/presto-plan-checker-router-plugin/pom.xml
@@ -230,6 +230,30 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <!-- Build configurations -->


### PR DESCRIPTION
## Description

  Adds the ability to run native workers inside containers when
  standing up the test query runners, instead of always executing the
  `presto_server` binary directly on the host

  The behavior is opt-in via a `workerImage` property -

  - When `workerImage` is set, each external worker is launched from that image via Testcontainers.
  - When it is absent, behavior is unchanged — the worker runs as a host process from the `presto_server` binary.

  The decision is made in the native builders at the point where the external
  worker launcher is enabled, so no new setter or CLI argument is needed.
  Support
  is wired into the Hive, Iceberg, and Delta native query runner builders
  through
  the shared `getExternalWorkerLauncher(...)` / `ExternalWorkerLauncherBuilder`.

  ## Motivation and Context

  Native worker end-to-end tests currently require a locally built  `presto_server`  binary on the host. This change lets the same test runners exercise native  workers from a prebuilt container image, which makes it possible to test
  against  published/CI-built native images. This is very helpful for Java dev's who may not have Presto native built/installed



  ## Impact

  The change is test-infrastructure only; there is no change to any product code path.
  

  ## Test Plan
  - CI
  - Existing native worker tests pass unchanged (no `workerImage` set → host
    `presto_server` path, same as before).
  - Ran `HiveExternalWorkerQueryRunner` with `-DworkerImage=<native-image>` and
    confirmed the coordinator starts, workers register (`Announcement
  succeeded`),
    and TPC-H/queries execute against the containerized workers.
  - Verified container logs are captured to `worker.<n>.out` and containers are
    stopped on shutdown via `ContainerBackedProcess.destroy()`.
  - Smoke tested a few of the integ tests, all pass -
```
./mvnw test -pl presto-native-tests -Dtest=TestOrderByQueries  -DworkerImage='docker.io/prestodb/presto-native:latest' -Duser.timezone=America/Bahia_Banderas
./mvnw test -pl presto-native-execution -Dtest=TestPrestoNativeJoinQueries  -DworkerImage='docker.io/prestodb/presto-native:latest' -Duser.timezone=America/Bahia_Banderas

```

  ## Contributor checklist

  - [ ] Please make sure your submission complies with our [contributing 
  guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in
  particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIB
  UTING.md#code-style) and [commit standards](https://github.com/prestodb/presto
  /blob/master/CONTRIBUTING.md#commit-standards).
  - [ ] PR description addresses the issue accurately and concisely.  If the
  change is non-trivial, a GitHub Issue is referenced.
  - [ ] Documented new properties (with its default value), SQL syntax,
  functions, or other functionality.
  - [ ] If release notes are required, they follow the [release notes 
  guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
  - [ ] Adequate tests were added if applicable.
  - [ ] CI passed.
  - [ ] If adding new dependencies, verified they have an [OpenSSF 
  Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher
  (or obtained explicit TSC approval for lower scores).

  ## Release Notes

  == NO RELEASE NOTE ==

## Summary by Sourcery

Enable native worker test query runners to launch external workers as Docker containers via Testcontainers when a worker image is provided, while preserving existing host-based behavior by default.

New Features:
- Add optional container-backed native worker execution for Hive, Iceberg, and Delta external worker query runners controlled by a workerImage property.

Enhancements:
- Introduce an ExternalWorkerLauncherBuilder extension that supports containerized workers, including host-networking, port preallocation, and bind-mounted config/data paths.
- Adapt Testcontainers GenericContainer to java.lang.Process via a ContainerBackedProcess so DistributedQueryRunner can manage containerized workers transparently.
- Extend native query runner logging and configuration to handle both bare-metal and container modes, including consistent worker log capture and node addressing.

Tests:
- Document in HiveExternalWorkerQueryRunner how to configure workerImage to exercise container-based native worker tests.

## Summary by Sourcery

Enable native worker test query runners to optionally launch external workers as containerized processes when a worker image is provided, while preserving existing host-based execution by default.

New Features:
- Add optional container-backed native worker execution for Hive, Iceberg, and Delta external worker query runners controlled by a workerImage property.

Enhancements:
- Extend the external worker launcher builder to support containerized workers with host networking, bind-mounted config/data paths, and port preallocation.
- Introduce a ContainerBackedProcess adapter so DistributedQueryRunner can manage Testcontainers-based workers via the existing Process interface.
- Update native worker configuration and logging to handle both bare-metal and container modes, including shared log files for container and host workers.

Documentation:
- Document in HiveExternalWorkerQueryRunner how to configure the workerImage property to run native workers inside containers for testing.