### PR TITLE
fix(ci): Fix always() usage in product-tests-specific-environment workflow

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -76,7 +76,7 @@ jobs:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro,mixed_case
       - name: Product Tests Specific 1.2
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
@@ -84,17 +84,17 @@ jobs:
       # - name: Product Tests Specific 1.3
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.4
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.6
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
@@ -143,22 +143,22 @@ jobs:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-ldap -g ldap -x simba_jdbc
       - name: Product Tests Specific 2.2
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls -g smoke,cli,group-by,join,tls
       - name: Product Tests Specific 2.3
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
       - name: Product Tests Specific 2.4
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
@@ -166,12 +166,12 @@ jobs:
       # - name: Product Tests Specific 2.6
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kafka -g kafka
       - name: Product Tests Specific 2.8
-        if: needs.changes.outputs.codechange == 'true' && ${{ always() }}
+        if: always() && needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-sqlserver -g sqlserver


### PR DESCRIPTION
## Motivation and Context

The intent of commit f084a04c7e (#24571) was to ensure certain product test steps run even when a prior step in the same job fails, using the GitHub Actions \`always()\` status-check function.

However, wrapping it in \`${{ }}\` causes it to be evaluated at expression-interpolation time and inlined as the string \`"true"\` before GitHub evaluates the \`if:\` condition. This strips \`always()\` of its status-check semantics entirely. The implicit \`success()\` gate is never overridden, so these steps are still silently skipped when a prior step fails — defeating the original intent.

Affected steps: **1.2, 1.4, 1.5, 1.6, 2.2, 2.3, 2.4, 2.5, 2.7, 2.8**

## Fix

Move \`always()\` out of \`${{ }}\` and place it as the leading term of the \`if:\` expression so GitHub Actions treats it as a proper status-check function.

\`\`\`yaml
# Before (broken — always() is interpolated as string "true", success() gate remains)
if: needs.changes.outputs.codechange == 'true' && ${{ always() }}

# After (correct — always() overrides the implicit success() gate)
if: always() && needs.changes.outputs.codechange == 'true'
\`\`\`

## Behaviour

| Prior step status | \`codechange\` | Before (broken) | After (fixed) |
|---|---|---|---|
| success | \`'true'\` | ✅ runs | ✅ runs |
| success | \`'false'\` | ❌ skipped | ❌ skipped |
| **failed** | \`'true'\` | ❌ **skipped** | ✅ **runs** |
| failed | \`'false'\` | ❌ skipped | ❌ skipped |

## Release Notes:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Correct GitHub Actions always() usage in product-tests-specific-environment workflow conditions so designated test steps are not skipped after prior failures.