### PR TITLE
chore(ci): Advance velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2498,16 +2498,30 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   outputTypes.push_back(resultType);
   auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
 
+  // Build CallTypedExpr inputs: FieldAccess for columns, Constant for literals
+  // (Velox #18267 folds RPCNode args into CallTypedExpr: field refs vs
+  // constants)
+  std::vector<core::TypedExprPtr> callInputs;
+  callInputs.reserve(argumentColumns.size());
+  for (size_t i = 0; i < argumentColumns.size(); ++i) {
+    if (constantInputs[i] != nullptr) {
+      callInputs.push_back(
+          std::make_shared<core::ConstantTypedExpr>(constantInputs[i]));
+    } else {
+      callInputs.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              argumentTypes[i], argumentColumns[i]));
+    }
+  }
+  auto call = std::make_shared<core::CallTypedExpr>(
+      resultType, std::move(callInputs), node->functionName);
+
   return std::make_shared<core::RPCNode>(
       node->id,
       sourceNode,
-      node->functionName,
-      resultType,
+      std::move(call),
       node->outputVariable.name,
       std::move(outputType),
-      std::move(argumentColumns),
-      std::move(argumentTypes),
-      std::move(constantInputs),
       veloxStreamingMode,
       dispatchBatchSize);
 }


### PR DESCRIPTION
Advance velox from 1d9c83a941f569adbccb091bd4772ee9f3cd6a01 to deca9543ffb2a08ac16d759a415ef9d89a5afa8e

Fixes build failure from Velox refactor https://github.com/facebookincubator/velox/pull/18267 (87f381979 Fold RPCNode call arguments into a CallTypedExpr). Old RPCNode constructor with flattened args is only available under VELOX_ENABLE_BACKWARD_COMPATIBILITY (Prestissimo only). Adapt PrestoToVeloxQueryPlan.cpp to build CallTypedExpr from FieldAccess / Constant args and use new RPCNode API.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adapt Presto-to-Velox query plan conversion to the updated Velox RPCNode and CallTypedExpr APIs after advancing the Velox submodule revision.

Enhancements:
- Construct CallTypedExpr inputs from field accesses and constant literals before creating RPCNode instances to match the new Velox API.

CI:
- Advance the Velox dependency revision to deca9543ffb2a08ac16d759a415ef9d89a5afa8e in the native execution tree.