### PR TITLE
chore(build): Add @kaikalur as module committer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,10 +104,10 @@ CODEOWNERS @prestodb/team-tsc
 # Presto core
 
 # Presto analyzer and optimizer
-/presto-main-base/src/*/java/com/facebook/presto/sql @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
+/presto-main-base/src/*/java/com/facebook/presto/sql @jaystarshot @feilong-liu @ClarenceThreepwood @kaikalur @prestodb/committers
 
 # Presto cost based optimizer framework
-/presto-main-base/src/*/java/com/facebook/presto/cost @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
+/presto-main-base/src/*/java/com/facebook/presto/cost @jaystarshot @feilong-liu @ClarenceThreepwood @kaikalur @prestodb/committers
 
 # Testing module
 # Note: all code owners in Presto core should be included here as well


### PR DESCRIPTION
## Description
The TSC voted and approved @kaikalur (Sreeni) to be a module committer for Presto analyzer and optimizer and cost based optimizer framework. Updating the codeowner file to reflect that.

## Motivation and Context
Expand the folks who can help merge code in analyzer/optimizer areas.

## Impact

## Test Plan

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Chores:
- Grant codeowner permissions to @kaikalur for Presto analyzer, optimizer, and cost-based optimizer framework paths.