### PR TITLE
fix(native): Add invariant checks for RPCNode and advance velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2500,10 +2500,19 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
 
   // Build CallTypedExpr inputs: FieldAccess for columns, Constant for literals
   // (Velox #18267 folds RPCNode args into CallTypedExpr: field refs vs
-  // constants)
+  // constants). Planner emits one entry per argument, so argumentColumns,
+  // argumentTypes, and constantInputs must be aligned. Enforce with checks to
+  // fail loudly if planner contract drifts.
+  VELOX_CHECK_EQ(argumentColumns.size(), argumentTypes.size());
+  VELOX_CHECK_EQ(argumentColumns.size(), constantInputs.size());
   std::vector<core::TypedExprPtr> callInputs;
   callInputs.reserve(argumentColumns.size());
   for (size_t i = 0; i < argumentColumns.size(); ++i) {
+    // Exactly one of column ref or constant must be set per argument.
+    VELOX_CHECK(
+        (argumentColumns[i] != nullptr) ^ (constantInputs[i] != nullptr),
+        "Expected exactly one of argumentColumns or constantInputs to be set at position {}",
+        i);
     if (constantInputs[i] != nullptr) {
       callInputs.push_back(
           std::make_shared<core::ConstantTypedExpr>(constantInputs[i]));


### PR DESCRIPTION
Address review comment from #28292 (https://github.com/prestodb/presto/pull/28292#discussion_r3738626610):

- Sourcery flagged bug_risk: loop iterates `argumentColumns.size()` but indexes `argumentTypes` and `constantInputs` with same `i` without size validation → OOB risk.
- Reviewer zhichenxu-meta agreed: vectors are aligned by construction (planner emits one column per argument), but invariant is implicit. Add `VELOX_CHECK_EQ` for sizes.

This PR:
- Adds `VELOX_CHECK_EQ(argumentColumns.size(), argumentTypes.size())` and `VELOX_CHECK_EQ(argumentColumns.size(), constantInputs.size())` before loop to fail loudly if planner contract drifts.
- Adds per-position XOR check `VELOX_CHECK((col != nullptr) ^ (const != nullptr))` ensuring exactly one input kind per argument.
- Adds proper comments explaining planner contract and why checks exist (planner emits one entry per arg, aligned vectors).

Also:
- Advances Velox from `deca9543ffb2a08ac16d759a415ef9d89a5afa8e` to `1d6881b4efe0e4ccf0d68fd2fdb51a2313814f5b` (`refactor(writer): Rename VeloxWriter to Writer (#18431)`) – no Presto references to `VeloxWriter` found, safe.

All tests run with `plan-consistency-check-enabled=true` by default (merged #28275).

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add invariant checks around RPCNode argument inputs and advance the Velox submodule version.

Bug Fixes:
- Add size and per-position input-kind checks for RPCNode argument vectors to prevent out-of-bounds access and invalid argument configurations.

Enhancements:
- Clarify planner contract around RPCNode argument alignment with explanatory comments in the query plan converter.

Deployment:
- Update the embedded Velox dependency to commit 1d6881b4efe0e4ccf0d68fd2fdb51a2313814f5b.