### PR TITLE
fix(connector): Sanitize session user in the JDBC pushdown query comment

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -143,7 +143,7 @@ public class QueryBuilder
             sql.append(" WHERE ")
                     .append(Joiner.on(" AND ").join(clauses));
         }
-        sql.append(format("/* %s : %s */", session.getUser(), session.getQueryId()));
+        sql.append(format("/* %s : %s */", sanitizeComment(session.getUser()), session.getQueryId()));
         PreparedStatement statement = client.getPreparedStatement(session, connection, sql.toString());
 
         for (int i = 0; i < accumulator.size(); i++) {
@@ -316,6 +316,13 @@ public class QueryBuilder
     {
         name = name.replace(identifierQuote, identifierQuote + identifierQuote);
         return identifierQuote + name + identifierQuote;
+    }
+
+    // The trailing comment is passed verbatim to the remote database. Break up the block comment
+    // terminator so an attacker-controlled user name cannot close the comment and append SQL.
+    private static String sanitizeComment(String value)
+    {
+        return value.replace("*/", "* /");
     }
 
     private static void bindValue(Object value, JdbcColumnHandle columnHandle, List<TypeAndValue> accumulator)

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -212,6 +213,31 @@ public class TestJdbcQueryBuilder
                 builder.add((Long) resultSet.getObject("col_0"));
             }
             assertEquals(builder.build(), ImmutableSet.of(68L, 180L, 196L));
+        }
+    }
+
+    @Test
+    public void testBuildSqlWithCommentInjectionInUser()
+            throws SQLException
+    {
+        // The session user is embedded in the trailing /* */ comment sent to the remote database.
+        // A user name that closes the comment must not be able to append its own predicate and
+        // widen the result set beyond the single matching row.
+        ConnectorSession injectionSession = new TestingConnectorSession(
+                new ConnectorIdentity("*/ OR \"col_0\" >= 0 -- ", Optional.empty(), Optional.empty()),
+                ImmutableList.of());
+
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(columns.get(0), Domain.singleValue(BIGINT, 128L)));
+
+        Connection connection = database.getConnection();
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, injectionSession, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
+            while (resultSet.next()) {
+                builder.add((Long) resultSet.getObject("col_0"));
+            }
+            assertEquals(builder.build(), ImmutableSet.of(128L));
         }
     }
 

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/QueryBuilder.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/QueryBuilder.java
@@ -171,7 +171,7 @@ public class QueryBuilder
                 sql.append(simpleExpression.get());
             }
 
-            sql.append(String.format("/* %s : %s */", session.getUser(), session.getQueryId()));
+            sql.append(String.format("/* %s : %s */", sanitizeComment(session.getUser()), session.getQueryId()));
             statement = client.getPreparedStatement(connection, sql.toString());
         }
 
@@ -325,6 +325,13 @@ public class QueryBuilder
     {
         name = name.replace(quote, quote + quote);
         return quote + name + quote;
+    }
+
+    // The trailing comment is passed verbatim to the remote database. Break up the block comment
+    // terminator so an attacker-controlled user name cannot close the comment and append SQL.
+    private static String sanitizeComment(String value)
+    {
+        return value.replace("*/", "* /");
     }
 
     private static void bindValue(Object value, Type type, List<TypeAndValue> accumulator)


### PR DESCRIPTION
## Description

The JDBC connectors append a trailing `/* user : queryId */` comment to every
statement they push down, and the user portion is read from the session
identity. On the coordinator that identity comes from the `X-Presto-User`
header, and nothing removes the block-comment terminator before the name is
concatenated into the SQL. A user named `*/ OR 1=1 --` therefore closes the
comment early and the remainder is parsed as SQL by the backend, running under
the connector's own credentials and sidestepping the predicate that `buildSql`
otherwise binds through placeholders. `buildSql` already routes identifiers
through `quote` and constants through `?`; the comment was the one place raw
session text reached the statement. The change breaks the `*/` sequence in the
user name inside `buildSql`, so the comment can no longer be terminated early,
and applies the same fix to the ClickHouse connector's copy of `QueryBuilder`.

## Motivation and Context

The user string crosses a trust boundary: a client that can set `X-Presto-User`
(or a principal whose name happens to contain `*/`) can inject SQL into a
JDBC-backed connector's remote query, which executes with the connector's
credentials rather than the caller's, bypassing the access control Presto
applies on its side. Identifiers and constants were already safe, leaving the
query comment as the remaining injection point.

## Impact

No behaviour change for valid queries. The informational comment still carries
the user and query id; only the comment-terminator sequence inside the user
name is neutralised.

## Test Plan

- Added `testBuildSqlWithCommentInjectionInUser` in `TestJdbcQueryBuilder`. It
  runs `buildSql` against H2 with a user name that closes the comment and
  asserts the result stays the single matching row. It fails on master (the
  injected `OR` returns the whole table) and passes with this change.
- `./mvnw -pl presto-base-jdbc test -Dtest=TestJdbcQueryBuilder`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix SQL injection in JDBC-based connectors by escaping the session user in the comment appended to pushed-down queries.
```

## Summary by Sourcery

Sanitize session users embedded in connector pushdown query comments to prevent SQL injection.

Bug Fixes:
- Prevent SQL injection through session users embedded in JDBC and ClickHouse pushdown query comments by neutralizing block-comment terminators.
- Add regression coverage confirming malicious session users cannot widen JDBC query results.

Tests:
- Add a JDBC query-builder regression test covering comment injection in the session user.