### PR TITLE
feat(parser): Allow field name declaration in row literal

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -258,6 +258,48 @@ accessed with the field reference operator ``.``
 
 Example: ``CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))``
 
+Field names may also be declared directly in the row constructor, which avoids
+repeating the field types. The ``AS`` keyword is optional, as it is in a
+``SELECT`` clause::
+
+    SELECT ROW(1 AS x, 2.0 AS y)
+    SELECT ROW(1 x, 2.0 y)
+
+Both declare the same field names as the ``CAST`` above. The field types are
+inferred from the expressions rather than declared, so here they are
+``INTEGER`` and ``DECIMAL(2,1)`` rather than ``BIGINT`` and ``DOUBLE``. This is
+useful when the field types are not known in advance, for example in generated
+SQL::
+
+    SELECT ROW(m[1] AS f1, m[2] AS f2, m[3] AS f3)
+
+Fields may be named individually; any field without a name stays anonymous::
+
+    SELECT ROW(1 AS x, 2.0)
+
+Field names follow the same rules as in the ``CAST`` form. An undelimited name
+is folded to lower case, while a delimited name keeps its spelling, so
+``ROW(1 AS Abc)`` and ``CAST(ROW(1) AS ROW(Abc INTEGER))`` produce the same
+type ``ROW("abc" INTEGER)``, and ``ROW(1 AS "Abc")`` produces
+``ROW("Abc" INTEGER)``.
+Two fields of the same row may not resolve to the same name. Field access
+remains case insensitive.
+
+When a row constructor is used directly in ``VALUES``, its field names become
+the column names of the relation::
+
+    SELECT x, y FROM (VALUES ROW(1 AS x, 2.0 AS y))
+
+If the rows of a ``VALUES`` list do not all declare the same name for a field,
+that column is left unnamed.
+
+.. note::
+
+    Declaring field names in a row constructor is an extension to the SQL
+    standard, which allows only ``ROW(<expression>, ...)``. The parenthesized
+    form, ``(1, 2.0)``, always produces an anonymous row and cannot declare
+    field names.
+
 Network Address
 ---------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -668,8 +668,15 @@ class AggregationAnalyzer
         @Override
         public Boolean visitRow(Row node, final Void context)
         {
-            return node.getItems().stream()
-                    .allMatch(item -> process(item, context));
+            return node.getFields().stream()
+                    .allMatch(field -> process(field, context));
+        }
+
+        @Override
+        public Boolean visitRowField(Row.Field node, final Void context)
+        {
+            // A declared field name is not a reference, so only the value expression is checked.
+            return process(node.getExpression(), context);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -123,6 +123,7 @@ import io.airlift.slice.SliceUtf8;
 import jakarta.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -166,6 +167,7 @@ import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessC
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.isTopMostReference;
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.isUnusedArgumentForAccessControl;
 import static com.facebook.presto.sql.analyzer.FunctionArgumentCheckerForAccessControlUtils.resolveSubfield;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_ORDER_BY;
@@ -423,12 +425,31 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitRow(Row node, StackableAstVisitorContext<Context> context)
         {
-            List<Type> types = node.getItems().stream()
-                    .map((child) -> process(child, context))
-                    .collect(toImmutableList());
+            ImmutableList.Builder<RowType.Field> fields = ImmutableList.builder();
+            Set<String> declaredNames = new HashSet<>();
+            for (Row.Field field : node.getFields()) {
+                Type fieldType = process(field.getExpression(), context);
+                Optional<Identifier> name = field.getName();
+                if (!name.isPresent()) {
+                    fields.add(RowType.field(fieldType));
+                    continue;
+                }
+                // Fold the name the same way CAST(... AS ROW(...)) does. Cast.transformCase
+                // lowercases everything outside double quotes, so an undelimited name is folded to
+                // lower case and a delimited one is kept verbatim. Doing the same here keeps
+                // ROW(1 AS Abc) and CAST(ROW(1) AS ROW(Abc integer)) producing the same type.
+                // Note this is deliberately not getCanonicalValue(), which upper cases instead.
+                Identifier identifier = name.get();
+                String fieldName = identifier.isDelimited() ? identifier.getValue() : identifier.getValueLowerCase();
+                // Duplicates are rejected because a row type with repeated field names cannot be
+                // round-tripped through its TypeSignature, which the native worker relies on.
+                if (!declaredNames.add(fieldName)) {
+                    throw new SemanticException(DUPLICATE_COLUMN_NAME, node, "Duplicate field name '%s' in ROW", fieldName);
+                }
+                fields.add(RowType.field(fieldName, fieldType, identifier.isDelimited()));
+            }
 
-            Type type = RowType.anonymous(types);
-            return setExpressionType(node, type);
+            return setExpressionType(node, RowType.from(fields.build()));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -215,7 +215,9 @@ public final class ExpressionTreeUtils
 
         // ROW an MAP are special so we explicitly do that here.
         if (tempExpression instanceof Row) {
-            return (((Row) tempExpression).getItems().stream().allMatch(ExpressionTreeUtils::isConstant));
+            return ((Row) tempExpression).getFields().stream()
+                    .map(Row.Field::getExpression)
+                    .allMatch(ExpressionTreeUtils::isConstant);
         }
 
         if (tempExpression instanceof FunctionCall) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -407,6 +407,7 @@ import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Map.Entry;
 import static java.util.Objects.requireNonNull;
@@ -626,7 +627,7 @@ class StatementAnalyzer
                     node = rows.get(0);
                     if (node instanceof Row) {
                         int columnIndex = Math.min(i, queryColumnTypes.size() - 1);
-                        node = ((Row) rows.get(0)).getItems().get(columnIndex);
+                        node = ((Row) rows.get(0)).getFields().get(columnIndex).getExpression();
                     }
                 }
                 if (i == expectedColumns.size()) {
@@ -4033,13 +4034,16 @@ class StatementAnalyzer
         {
             checkState(node.getRows().size() >= 1);
 
-            List<List<Type>> rowTypes = node.getRows().stream()
+            List<Type> analyzedRowTypes = node.getRows().stream()
                     .map(row -> analyzeExpression(row, createScope(scope)).getType(row))
+                    .collect(toImmutableList());
+
+            List<List<Type>> rowTypes = analyzedRowTypes.stream()
                     .map(type -> {
                         if (type instanceof RowType) {
                             return type.getTypeParameters();
                         }
-                        return ImmutableList.of(type);
+                        return ImmutableList.<Type>of(type);
                     })
                     .collect(toImmutableList());
 
@@ -4071,13 +4075,33 @@ class StatementAnalyzer
                 }
             }
 
+            // A field name declared consistently by every row becomes the relation's column name.
+            // Merged separately from the types so that the type merge stays a per-field scalar
+            // operation: merging whole RowTypes instead would build a RowType, and with it a
+            // TypeSignature, for every row of the VALUES.
+            List<Optional<String>> fieldNames = new ArrayList<>(nCopies(fieldTypes.size(), Optional.empty()));
+            boolean firstRow = true;
+            for (Type type : analyzedRowTypes) {
+                List<RowType.Field> rowFields = type instanceof RowType ? ((RowType) type).getFields() : null;
+                for (int i = 0; i < fieldTypes.size(); i++) {
+                    Optional<String> name = rowFields == null ? Optional.empty() : rowFields.get(i).getName();
+                    if (firstRow) {
+                        fieldNames.set(i, name);
+                    }
+                    else if (!fieldNames.get(i).equals(name)) {
+                        fieldNames.set(i, Optional.empty());
+                    }
+                }
+                firstRow = false;
+            }
+
             // add coercions for the rows
             for (Expression row : node.getRows()) {
                 if (row instanceof Row) {
-                    List<Expression> items = ((Row) row).getItems();
-                    for (int i = 0; i < items.size(); i++) {
+                    List<Row.Field> rowFields = ((Row) row).getFields();
+                    for (int i = 0; i < rowFields.size(); i++) {
                         Type expectedType = fieldTypes.get(i);
-                        Expression item = items.get(i);
+                        Expression item = rowFields.get(i).getExpression();
                         Type actualType = analysis.getType(item);
                         if (!actualType.equals(expectedType)) {
                             analysis.addCoercion(item, expectedType, functionAndTypeResolver.isTypeOnlyCoercion(actualType, expectedType));
@@ -4093,9 +4117,11 @@ class StatementAnalyzer
                 }
             }
 
-            List<Field> fields = fieldTypes.stream()
-                    .map(valueType -> Field.newUnqualified(node.getLocation(), Optional.empty(), valueType))
-                    .collect(toImmutableList());
+            ImmutableList.Builder<Field> fieldsBuilder = ImmutableList.builder();
+            for (int i = 0; i < fieldTypes.size(); i++) {
+                fieldsBuilder.add(Field.newUnqualified(node.getLocation(), fieldNames.get(i), fieldTypes.get(i)));
+            }
+            List<Field> fields = fieldsBuilder.build();
 
             return createAndAssignScope(node, scope, fields);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -1203,15 +1203,20 @@ public class ExpressionInterpreter
         {
             RowType rowType = (RowType) type(node);
             List<Type> parameterTypes = rowType.getTypeParameters();
-            List<Expression> arguments = node.getItems();
+            List<Row.Field> fields = node.getFields();
 
-            int cardinality = arguments.size();
+            int cardinality = fields.size();
             List<Object> values = new ArrayList<>(cardinality);
-            for (Expression argument : arguments) {
-                values.add(process(argument, context));
+            for (Row.Field field : fields) {
+                values.add(process(field.getExpression(), context));
             }
             if (hasUnresolvedValue(values)) {
-                return new Row(toExpressions(values, parameterTypes));
+                List<Expression> expressions = toExpressions(values, parameterTypes);
+                ImmutableList.Builder<Row.Field> rewritten = ImmutableList.builder();
+                for (int i = 0; i < cardinality; i++) {
+                    rewritten.add(new Row.Field(fields.get(i).getLocation(), fields.get(i).getName(), expressions.get(i)));
+                }
+                return new Row(rewritten.build());
             }
             else {
                 BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, null, 1);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -640,7 +640,7 @@ public class QueryPlanner
         mergeRowFields.add(new GenericLiteral("TINYINT", String.valueOf(UPDATE_OPERATION_NUMBER)));
         // case_number INTEGER = 0 (there is only the implicit "UPDATE all matched" case)
         mergeRowFields.add(new GenericLiteral("INTEGER", "0"));
-        Row mergeRowExpression = new Row(mergeRowFields.build());
+        Row mergeRowExpression = Row.unnamed(mergeRowFields.build());
 
         List<VariableReferenceExpression> mergeColumnVariables = mergeColumnVariablesBuilder.build();
         RowType mergeRowType = createMergeRowType(dataColumns);
@@ -859,7 +859,7 @@ public class QueryPlanner
                 mergeCondition = LogicalBinaryExpression.and(mergeCondition, rewrittenCondition);
             }
 
-            whenClauses.add(new WhenClause(mergeCondition, new Row(joinResultBuilder.build())));
+            whenClauses.add(new WhenClause(mergeCondition, Row.unnamed(joinResultBuilder.build())));
         }
 
         // Build the "else" clause for the SearchedCaseExpression
@@ -872,7 +872,7 @@ public class QueryPlanner
         // The case number column value: -1
         joinElseBuilder.add(new GenericLiteral("INTEGER", "-1"));
 
-        SearchedCaseExpression caseExpression = new SearchedCaseExpression(whenClauses.build(), Optional.of(new Row(joinElseBuilder.build())));
+        SearchedCaseExpression caseExpression = new SearchedCaseExpression(whenClauses.build(), Optional.of(Row.unnamed(joinElseBuilder.build())));
 
         RowType mergeRowType = createMergeRowType(mergeAnalysis.getTargetColumnsMetadata());
         Table targetTable = mergeAnalysis.getTargetTable();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -1145,8 +1145,8 @@ class RelationPlanner
         for (Expression row : node.getRows()) {
             ImmutableList.Builder<RowExpression> values = ImmutableList.builder();
             if (row instanceof Row) {
-                for (Expression item : ((Row) row).getItems()) {
-                    values.add(rewriteRow(item, context));
+                for (Row.Field field : ((Row) row).getFields()) {
+                    values.add(rewriteRow(field.getExpression(), context));
                 }
             }
             else {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -1105,8 +1105,8 @@ public final class SqlToRowExpressionTranslator
         @Override
         protected RowExpression visitRow(Row node, Context context)
         {
-            List<RowExpression> arguments = node.getItems().stream()
-                    .map(value -> process(value, context))
+            List<RowExpression> arguments = node.getFields().stream()
+                    .map(field -> process(field.getExpression(), context))
                     .collect(toImmutableList());
             Type returnType = getType(node);
             return specialForm(ROW_CONSTRUCTOR, returnType, arguments);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -333,7 +333,7 @@ public class ShowStatsRewrite
                 rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMax)));
             }
             rowValues.add(columnStatistics.getHistogram().map(Objects::toString).<Expression>map(StringLiteral::new).orElse(NULL_VARCHAR));
-            return new Row(rowValues.build());
+            return Row.unnamed(rowValues.build());
         }
 
         private Expression createEmptyColumnStatsRow(String columnName)
@@ -347,7 +347,7 @@ public class ShowStatsRewrite
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
-            return new Row(rowValues.build());
+            return Row.unnamed(rowValues.build());
         }
 
         private static Row createTableStatsRow(TableStatistics tableStatistics)
@@ -361,7 +361,7 @@ public class ShowStatsRewrite
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
             rowValues.add(NULL_VARCHAR);
-            return new Row(rowValues.build());
+            return Row.unnamed(rowValues.build());
         }
 
         private static Expression createEstimateRepresentation(Estimate estimate)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1088,6 +1088,29 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testRowWithDuplicateFieldNames()
+    {
+        // a row type with duplicate field names cannot be round-tripped through its TypeSignature,
+        // so it has to be rejected during analysis rather than surfacing later
+        assertFails(DUPLICATE_COLUMN_NAME, "SELECT ROW(1 AS a, 2 AS a)");
+        assertFails(DUPLICATE_COLUMN_NAME, "SELECT ROW(1 AS \"a\", 2 AS a)");
+        // undelimited names are folded to lower case, exactly as CAST(... AS ROW(a integer, A integer))
+        // is, so these collide too
+        assertFails(DUPLICATE_COLUMN_NAME, "SELECT ROW(1 AS a, 2 AS A)");
+        // duplicates need not be adjacent
+        assertFails(DUPLICATE_COLUMN_NAME, "SELECT ROW(1 AS a, 2 AS b, 3 AS a)");
+        // and are detected independently in a nested row
+        assertFails(DUPLICATE_COLUMN_NAME, "SELECT ROW(ROW(1 AS a, 2 AS a) AS r)");
+        // a name repeated across nesting levels is not a duplicate
+        analyze("SELECT ROW(ROW(1 AS a) AS a)");
+
+        // a delimited name is kept verbatim, so it does not collide with the folded one
+        analyze("SELECT ROW(1 AS a, 2 AS \"A\")");
+        analyze("SELECT ROW(1 AS a, 2)");
+        analyze("SELECT ROW(1, 2)");
+    }
+
+    @Test
     public void testCaseInsensitiveDuplicateWithQuery()
     {
         assertFails(DUPLICATE_RELATION,

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -13,6 +13,7 @@
  */
 #include <gtest/gtest.h>
 #include <array>
+#include <sstream>
 
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/tests/MutableConfigs.h"
@@ -53,6 +54,32 @@ class RowExpressionTest : public ::testing::Test {
 
     ASSERT_EQ(cexpr->type()->toString(), type);
     ASSERT_EQ(cexpr->value().toJson(cexpr->type()), value);
+  }
+
+  // Builds a ROW_CONSTRUCTOR special form over bigint variables and returns the
+  // Velox type the converter produces for it.
+  TypePtr rowConstructorType(
+      const std::string& returnType,
+      const std::vector<std::string>& argumentNames) {
+    std::ostringstream args;
+    for (size_t i = 0; i < argumentNames.size(); ++i) {
+      if (i > 0) {
+        args << ",";
+      }
+      args << R"({"@type":"variable","name":")" << argumentNames[i]
+           << R"(","type":"bigint"})";
+    }
+    std::ostringstream str;
+    str << R"({"@type":"special","form":"ROW_CONSTRUCTOR","returnType":")"
+        << returnType << R"(","arguments":[)" << args.str() << "]}";
+
+    json j = json::parse(str.str());
+    std::shared_ptr<protocol::RowExpression> p = j;
+    auto call = std::dynamic_pointer_cast<const CallTypedExpr>(
+        converter_->toVeloxExpr(p));
+    VELOX_CHECK_NOT_NULL(call);
+    VELOX_CHECK_EQ(call->name(), "row_constructor");
+    return call->type();
   }
 
   std::string makeCastToVarchar(
@@ -1403,4 +1430,44 @@ TEST_F(RowExpressionTest, dereference) {
   ASSERT_NE(fieldAccess, nullptr);
 
   ASSERT_EQ(fieldAccess->name(), "partkey");
+}
+
+// The declared field names travel to Velox in the ROW_CONSTRUCTOR return type,
+// so they must survive the type signature round trip. RowType::equals compares
+// field names and is case sensitive, so these are exact checks.
+TEST_F(RowExpressionTest, rowConstructorWithFieldNames) {
+  ASSERT_EQ(
+      *rowConstructorType("row(nk bigint,nm bigint)", {"nationkey", "name"}),
+      *ROW({"nk", "nm"}, {BIGINT(), BIGINT()}));
+}
+
+TEST_F(RowExpressionTest, rowConstructorWithPartialFieldNames) {
+  // A row may name only some of its fields.
+  ASSERT_EQ(
+      *rowConstructorType("row(nk bigint,bigint)", {"nationkey", "regionkey"}),
+      *ROW({"nk", ""}, {BIGINT(), BIGINT()}));
+}
+
+TEST_F(RowExpressionTest, rowConstructorWithDelimitedFieldName) {
+  // Names needing quoting are emitted delimited by RowFieldName::toString(),
+  // and keep their spelling.
+  ASSERT_EQ(
+      *rowConstructorType(R"(row(\"Mixed Case\" bigint))", {"nationkey"}),
+      *ROW({"Mixed Case"}, {BIGINT()}));
+}
+
+TEST_F(RowExpressionTest, rowConstructorWithMixedCaseFieldName) {
+  // An undelimited name is folded to lower case by the coordinator before it
+  // reaches the worker, so it arrives already normalized. A delimited name that
+  // happens to be mixed case must not be folded.
+  ASSERT_EQ(
+      *rowConstructorType("row(abc bigint)", {"nationkey"}),
+      *ROW({"abc"}, {BIGINT()}));
+  ASSERT_EQ(
+      *rowConstructorType(R"(row(\"Abc\" bigint))", {"nationkey"}),
+      *ROW({"Abc"}, {BIGINT()}));
+  // Case is significant on the Velox side: the two are different types.
+  ASSERT_FALSE(
+      *rowConstructorType("row(abc bigint)", {"nationkey"}) ==
+      *rowConstructorType(R"(row(\"Abc\" bigint))", {"nationkey"}));
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -757,6 +757,20 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testRowWithFieldNames()
+    {
+        // A named ROW type has to survive planning, the Presto -> Velox type signature round trip,
+        // and the row_constructor special form. The projections below are anchored on a table scan
+        // so they are evaluated on the worker rather than folded away on the coordinator.
+        assertQuery("SELECT ROW(nationkey AS nk, name AS nm) FROM nation");
+        assertQuery("SELECT ROW(nationkey AS nk, regionkey) FROM nation");
+        assertQuery("SELECT r.nk FROM (SELECT ROW(nationkey AS nk) AS r FROM nation)");
+        assertQuery("SELECT ROW(orderkey AS ok, custkey AS ck) FROM orders WHERE orderkey < 100");
+        assertQuery("SELECT ROW(x AS a, y AS b) FROM (VALUES (1, 'x')) t(x, y)");
+        assertQuery("SELECT a, b FROM (VALUES ROW(1 AS a, 'x' AS b))");
+    }
+
+    @Test
     public void testValues()
     {
         assertQuery("SELECT 1, 0.24, ceil(4.5), 'A not too short ASCII string'");

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -424,7 +424,7 @@ primaryExpression
     | '?'                                                                                 #parameter
     | POSITION '(' valueExpression IN valueExpression ')'                                 #position
     | '(' expression (',' expression)+ ')'                                                #rowConstructor
-    | ROW '(' expression (',' expression)* ')'                                            #rowConstructor
+    | ROW '(' fieldConstructor (',' fieldConstructor)* ')'                                #rowConstructor
     | qualifiedName '(' ASTERISK ')' filter? over?                                        #functionCall
     | qualifiedName '(' (setQuantifier? expression (',' expression)*)?
         (ORDER BY sortItem (',' sortItem)*)? ')' filter? (nullTreatment? over)?           #functionCall
@@ -479,6 +479,10 @@ comparisonQuantifier
 
 booleanValue
     : TRUE | FALSE
+    ;
+
+fieldConstructor
+    : expression (AS? identifier)?
     ;
 
 interval

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -145,9 +145,19 @@ public final class ExpressionFormatter
         @Override
         protected String visitRow(Row node, Void context)
         {
-            return "ROW (" + Joiner.on(", ").join(node.getItems().stream()
-                    .map((child) -> process(child, context))
+            return "ROW (" + Joiner.on(", ").join(node.getFields().stream()
+                    .map((field) -> process(field, context))
                     .collect(toList())) + ")";
+        }
+
+        @Override
+        protected String visitRowField(Row.Field node, Void context)
+        {
+            String expression = process(node.getExpression(), context);
+            if (node.getName().isPresent()) {
+                return expression + " AS " + process(node.getName().get(), context);
+            }
+            return expression;
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -151,7 +151,7 @@ public final class QueryUtil
 
     public static Row row(Expression... values)
     {
-        return new Row(ImmutableList.copyOf(values));
+        return Row.unnamed(ImmutableList.copyOf(values));
     }
 
     public static Relation aliased(Relation relation, String alias)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1655,14 +1655,22 @@ public final class SqlFormatter
         {
             builder.append("ROW(");
             boolean firstItem = true;
-            for (Expression item : node.getItems()) {
+            for (Row.Field field : node.getFields()) {
                 if (!firstItem) {
                     builder.append(", ");
                 }
-                process(item, indent);
+                process(field, indent);
                 firstItem = false;
             }
             builder.append(")");
+            return null;
+        }
+
+        @Override
+        protected Void visitRowField(Row.Field node, Integer indent)
+        {
+            builder.append(formatExpression(node.getExpression(), parameters));
+            node.getName().ifPresent(name -> builder.append(" AS ").append(formatExpression(name, parameters)));
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2088,7 +2088,20 @@ class AstBuilder
     @Override
     public Node visitRowConstructor(SqlBaseParser.RowConstructorContext context)
     {
-        return new Row(getLocation(context), visit(context.expression(), Expression.class));
+        // The parenthesized form -- (a, b) -- cannot declare field names.
+        if (context.fieldConstructor().isEmpty()) {
+            return Row.unnamed(getLocation(context), visit(context.expression(), Expression.class));
+        }
+        return new Row(getLocation(context), visit(context.fieldConstructor(), Row.Field.class));
+    }
+
+    @Override
+    public Node visitFieldConstructor(SqlBaseParser.FieldConstructorContext context)
+    {
+        return new Row.Field(
+                getLocation(context),
+                visitIfPresent(context.identifier(), Identifier.class),
+                (Expression) visit(context.expression()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -472,6 +472,11 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
+    protected R visitRowField(Row.Field node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitTableSubquery(TableSubquery node, C context)
     {
         return visitQueryBody(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -373,7 +373,17 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     protected R visitRow(Row node, C context)
     {
-        node.getItems().forEach(expression -> process(expression, context));
+        node.getFields().forEach(field -> process(field, context));
+        return null;
+    }
+
+    @Override
+    protected R visitRowField(Row.Field node, C context)
+    {
+        // Only the value expression is traversed. A declared field name is a declaration, not a
+        // reference, so visitors that collect identifiers (e.g. FreeLambdaReferenceExtractor,
+        // VariablesExtractor, SubqueryPlanner) must not mistake it for a column reference.
+        process(node.getExpression(), context);
         return null;
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -95,10 +95,17 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            List<Expression> items = rewrite(node.getItems(), context);
+            ImmutableList.Builder<Row.Field> builder = ImmutableList.builder();
+            for (Row.Field field : node.getFields()) {
+                Expression expression = rewrite(field.getExpression(), context.get());
+                builder.add(field.getExpression() == expression
+                        ? field
+                        : new Row.Field(field.getLocation(), field.getName(), expression));
+            }
+            List<Row.Field> fields = builder.build();
 
-            if (!sameElements(node.getItems(), items)) {
-                return new Row(items);
+            if (!sameElements(node.getFields(), fields)) {
+                return new Row(fields);
             }
 
             return node;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Row.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Row.java
@@ -19,33 +19,58 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public final class Row
         extends Expression
 {
-    private final List<Expression> items;
+    private final List<Field> fields;
 
-    public Row(List<Expression> items)
+    public Row(List<Field> fields)
     {
-        this(Optional.empty(), items);
+        this(Optional.empty(), fields);
     }
 
-    public Row(NodeLocation location, List<Expression> items)
+    public Row(NodeLocation location, List<Field> fields)
     {
-        this(Optional.of(location), items);
+        this(Optional.of(location), fields);
     }
 
-    private Row(Optional<NodeLocation> location, List<Expression> items)
+    private Row(Optional<NodeLocation> location, List<Field> fields)
     {
         super(location);
-        requireNonNull(items, "items is null");
-        this.items = ImmutableList.copyOf(items);
+        requireNonNull(fields, "fields is null");
+        this.fields = ImmutableList.copyOf(fields);
     }
 
-    public List<Expression> getItems()
+    /**
+     * Creates a row where no field declares a name, e.g. {@code ROW(1, 2)}.
+     */
+    public static Row unnamed(List<Expression> items)
     {
-        return items;
+        return new Row(toUnnamedFields(items));
+    }
+
+    /**
+     * Creates a row where no field declares a name, e.g. {@code ROW(1, 2)}.
+     */
+    public static Row unnamed(NodeLocation location, List<Expression> items)
+    {
+        return new Row(location, toUnnamedFields(items));
+    }
+
+    private static List<Field> toUnnamedFields(List<Expression> items)
+    {
+        requireNonNull(items, "items is null");
+        return items.stream()
+                .map(Field::new)
+                .collect(toImmutableList());
+    }
+
+    public List<Field> getFields()
+    {
+        return fields;
     }
 
     @Override
@@ -57,13 +82,13 @@ public final class Row
     @Override
     public List<? extends Node> getChildren()
     {
-        return items;
+        return fields;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(items);
+        return Objects.hash(fields);
     }
 
     @Override
@@ -76,6 +101,104 @@ public final class Row
             return false;
         }
         Row other = (Row) obj;
-        return Objects.equals(this.items, other.items);
+        return Objects.equals(this.fields, other.fields);
+    }
+
+    /**
+     * A single field of a row constructor: an expression with an optionally declared field name,
+     * e.g. the {@code 1 AS a} in {@code ROW(1 AS a, 2)}.
+     */
+    public static final class Field
+            extends Node
+    {
+        private final Optional<Identifier> name;
+        private final Expression expression;
+
+        /**
+         * The field takes the location of its expression. {@link Row#getChildren()} returns fields
+         * rather than the expressions themselves, so without this a field would hide the only
+         * location available to helpers that recover a location from a node's children, such as
+         * {@code ExpressionTreeUtils#getSourceLocation}.
+         */
+        public Field(Expression expression)
+        {
+            this(locationOf(expression), Optional.empty(), expression);
+        }
+
+        public Field(Optional<Identifier> name, Expression expression)
+        {
+            this(locationOf(expression), name, expression);
+        }
+
+        public Field(NodeLocation location, Optional<Identifier> name, Expression expression)
+        {
+            this(Optional.of(location), name, expression);
+        }
+
+        public Field(Optional<NodeLocation> location, Optional<Identifier> name, Expression expression)
+        {
+            super(location);
+            this.name = requireNonNull(name, "name is null");
+            this.expression = requireNonNull(expression, "expression is null");
+        }
+
+        private static Optional<NodeLocation> locationOf(Expression expression)
+        {
+            return requireNonNull(expression, "expression is null").getLocation();
+        }
+
+        public Optional<Identifier> getName()
+        {
+            return name;
+        }
+
+        public Expression getExpression()
+        {
+            return expression;
+        }
+
+        @Override
+        protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+        {
+            return visitor.visitRowField(this, context);
+        }
+
+        @Override
+        public List<? extends Node> getChildren()
+        {
+            ImmutableList.Builder<Node> children = ImmutableList.builder();
+            name.ifPresent(children::add);
+            children.add(expression);
+            return children.build();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, expression);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Field other = (Field) obj;
+            return Objects.equals(this.name, other.name) &&
+                    Objects.equals(this.expression, other.expression);
+        }
+
+        @Override
+        public String toString()
+        {
+            if (name.isPresent()) {
+                return expression + " AS " + name.get();
+            }
+            return expression.toString();
+        }
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/TestExpressionFormatter.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/TestExpressionFormatter.java
@@ -244,4 +244,28 @@ public class TestExpressionFormatter
                 ExpressionFormatter.formatExpression(reparsed, Optional.empty()),
                 "Comparison expression must be semantically preserved through format/parse cycle");
     }
+
+    @Test
+    public void testFormatRowWithFieldNames()
+    {
+        assertFormatted("ROW(1 AS a, 2 AS b)", "ROW (1 AS a, 2 AS b)");
+        // the optional AS is always emitted
+        assertFormatted("ROW(1 a, 2 b)", "ROW (1 AS a, 2 AS b)");
+        assertFormatted("ROW(1 AS a, 2)", "ROW (1 AS a, 2)");
+        assertFormatted("ROW(1, 2)", "ROW (1, 2)");
+        // delimited names must stay quoted so that the output re-parses to the same field name
+        assertFormatted("ROW(1 AS \"Mixed Case\")", "ROW (1 AS \"Mixed Case\")");
+        assertFormatted("ROW(ROW(1 AS a) AS b)", "ROW (ROW (1 AS a) AS b)");
+    }
+
+    private static void assertFormatted(String expression, String expectedFormat)
+    {
+        Expression parsed = SQL_PARSER.createExpression(expression, new ParsingOptions());
+        String formatted = ExpressionFormatter.formatExpression(parsed, Optional.empty());
+        assertEquals(formatted, expectedFormat);
+
+        // formatted SQL must round-trip: CREATE VIEW relies on this via SqlFormatterUtil
+        Expression reparsed = SQL_PARSER.createExpression(formatted, new ParsingOptions());
+        assertEquals(reparsed, parsed, "row expression must survive a format/parse cycle");
+    }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -363,8 +363,47 @@ public class TestSqlParser
     public void testRowSubscript()
     {
         assertExpression("ROW (1, 'a', true)[1]", new SubscriptExpression(
-                new Row(ImmutableList.of(new LongLiteral("1"), new StringLiteral("a"), new BooleanLiteral("true"))),
+                Row.unnamed(ImmutableList.of(new LongLiteral("1"), new StringLiteral("a"), new BooleanLiteral("true"))),
                 new LongLiteral("1")));
+    }
+
+    @Test
+    public void testRowFieldNames()
+    {
+        // all fields named, with and without the optional AS
+        assertExpression("ROW(1 AS a, 2 AS b)", new Row(ImmutableList.of(
+                rowField("a", new LongLiteral("1")),
+                rowField("b", new LongLiteral("2")))));
+        assertExpression("ROW(1 a, 2 b)", new Row(ImmutableList.of(
+                rowField("a", new LongLiteral("1")),
+                rowField("b", new LongLiteral("2")))));
+
+        // partially named
+        assertExpression("ROW(1 AS a, 2)", new Row(ImmutableList.of(
+                rowField("a", new LongLiteral("1")),
+                new Row.Field(new LongLiteral("2")))));
+
+        // no names at all is equivalent to the historical form
+        assertExpression("ROW(1, 2)", Row.unnamed(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))));
+
+        // the parenthesized form cannot declare names, so it stays anonymous
+        assertExpression("(1, 2)", Row.unnamed(ImmutableList.of(new LongLiteral("1"), new LongLiteral("2"))));
+
+        // case is preserved as written, and delimited identifiers stay delimited
+        assertExpression("ROW(1 AS \"Mixed Case\")", new Row(ImmutableList.of(
+                new Row.Field(Optional.of(new Identifier("Mixed Case", true)), new LongLiteral("1")))));
+        assertExpression("ROW(1 AS Abc)", new Row(ImmutableList.of(
+                new Row.Field(Optional.of(new Identifier("Abc", false)), new LongLiteral("1")))));
+
+        // single field, and nesting
+        assertExpression("ROW(1 AS a)", new Row(ImmutableList.of(rowField("a", new LongLiteral("1")))));
+        assertExpression("ROW(ROW(1 AS a) AS b)", new Row(ImmutableList.of(
+                rowField("b", new Row(ImmutableList.of(rowField("a", new LongLiteral("1"))))))));
+    }
+
+    private static Row.Field rowField(String name, Expression expression)
+    {
+        return new Row.Field(Optional.of(new Identifier(name)), expression);
     }
 
     @Test
@@ -931,7 +970,7 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new DereferenceExpression(new Cast(new Row(Lists.newArrayList(new LongLiteral("11"), new LongLiteral("12"))), "ROW(COL0 INTEGER,COL1 INTEGER)"), identifier("col0"))),
+                                        new DereferenceExpression(new Cast(Row.unnamed(Lists.newArrayList(new LongLiteral("11"), new LongLiteral("12"))), "ROW(COL0 INTEGER,COL1 INTEGER)"), identifier("col0"))),
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -42,6 +42,11 @@ public class TestStatementBuilder
         printStatement("explain (type distributed, format graphviz) select * from foo");
 
         printStatement("select * from foo /* end */");
+
+        printStatement("select row(1 as a, 2 as b)");
+        printStatement("select row(1 a, 2)");
+        printStatement("select row(1 as \"Mixed Case\")");
+        printStatement("values row(1 as a, 'x' as b)");
         printStatement("/* start */ select * from foo");
         printStatement("/* start */ select * /* middle */ from foo /* end */");
         printStatement("-- start\nselect * -- junk\n-- hi\nfrom foo -- done");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -726,6 +726,51 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testRowWithFieldNames()
+    {
+        // field names can be declared without repeating the field types
+        assertQuery("SELECT r.a, r.b FROM (SELECT ROW(1 AS a, 'x' AS b) AS r)", "SELECT 1, 'x'");
+
+        // the optional AS may be omitted, as in a SELECT list
+        assertQuery("SELECT r.a FROM (SELECT ROW(1 a) AS r)", "SELECT 1");
+
+        // equivalent to spelling the type out in a CAST
+        assertQuery("SELECT ROW(1 AS a, 2 AS b) = CAST(ROW(1, 2) AS ROW(a integer, b integer))", "SELECT true");
+
+        // rows may be partially named
+        assertQuery("SELECT r.a FROM (SELECT ROW(1 AS a, 2) AS r)", "SELECT 1");
+
+        // named and anonymous rows remain comparable
+        assertQuery("SELECT ROW(1 AS a) = ROW(1)", "SELECT true");
+
+        // field access stays case insensitive, matching CAST(... AS ROW(...))
+        assertQuery("SELECT r.A FROM (SELECT ROW(1 AS a) AS r)", "SELECT 1");
+
+        // declaring a name must produce exactly the same type as spelling it out in a cast:
+        // undelimited names fold to lower case, delimited names are kept verbatim
+        assertQuery("SELECT typeof(ROW(1 AS Abc)) = typeof(CAST(ROW(1) AS ROW(Abc integer)))", "SELECT true");
+        assertQuery("SELECT typeof(ROW(1 AS Abc))", "SELECT 'row(\"abc\" integer)'");
+        assertQuery("SELECT typeof(ROW(1 AS \"Abc\"))", "SELECT 'row(\"Abc\" integer)'");
+
+        // the same equivalence has to hold for the observable JSON rendering
+        assertQuery(
+                "SELECT CAST(ROW(1 AS Abc) AS JSON) = CAST(CAST(ROW(1) AS ROW(Abc integer)) AS JSON)",
+                "SELECT true");
+
+        // VALUES takes its column names from the row field names
+        assertQuery("SELECT a, b FROM (VALUES ROW(1 AS a, 'x' AS b))", "SELECT 1, 'x'");
+        assertQuery("SELECT a FROM (VALUES ROW(1 AS a), ROW(2 AS a))", "SELECT 1 UNION ALL SELECT 2");
+
+        // when rows disagree about a field name, the column stays unnamed.
+        // (?s) is required because some runners, notably Presto on Spark, put the stack trace in
+        // the message and assertQueryFails matches against the whole string.
+        assertQueryFails("SELECT a FROM (VALUES ROW(1 AS a), ROW(2 AS b))", "(?s).*'a' cannot be resolved.*");
+        // the column is still there, just not addressable by name. It cannot be selected as _col0
+        // either: that is only the output label, not an identifier that resolves.
+        assertQuery("SELECT * FROM (VALUES ROW(1 AS a), ROW(2 AS b))", "VALUES 1, 2");
+    }
+
+    @Test
     public void testPullRowLocalChainAboveExchange()
     {
         // Result-equality (enabled vs disabled) over CROSS JOIN UNNEST shapes where a repartitioning

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -498,12 +498,19 @@ public class DefaultTreeRewriter<C>
     @Override
     protected Node visitRow(Row node, C context)
     {
-        List<Expression> items = process(node.getItems(), context);
-        if (sameElements(node.getItems(), items)) {
+        List<Expression> items = node.getFields().stream()
+                .map(Row.Field::getExpression)
+                .collect(ImmutableList.toImmutableList());
+        List<Expression> rewritten = process(items, context);
+        if (sameElements(items, rewritten)) {
             return node;
         }
 
-        return new Row(items);
+        ImmutableList.Builder<Row.Field> fields = ImmutableList.builder();
+        for (int i = 0; i < rewritten.size(); i++) {
+            fields.add(new Row.Field(node.getFields().get(i).getLocation(), node.getFields().get(i).getName(), rewritten.get(i)));
+        }
+        return new Row(fields.build());
     }
 
     @Override


### PR DESCRIPTION
## Description

**Backport of [trinodb/trino#25261](https://github.com/trinodb/trino/pull/25261)** ("Allow field name declaration in row literal", Trino 479).

- Original author: **Dain Sundstrom** ([@dain](https://github.com/dain))
- Ported commit: [`f7e05ac`](https://github.com/trinodb/trino/commit/f7e05ac7d8be796a0eebba1d9881b4946723d288), the third of that PR's three commits. The preceding empty-row-type and `visitRowDataTypeField` rename commits are not ported; see *Differences from upstream*.
- Following the [backport guidance in CONTRIBUTING.md](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#backport-commits), the commit carries a `Cherry-pick of` link and `Co-authored-by: Dain Sundstrom`, and keeps the original commit headline.

Allow field names to be declared directly in a row constructor, so a named `ROW` type can be built without repeating the field types:

```sql
SELECT ROW(m[1] AS f1, m[2] AS f2, m[3] AS f3)
```

Previously the only way to name row fields was to spell the whole type out in a cast — `CAST(ROW(m[1], m[2]) AS ROW(f1 real, f2 real))` — which is awkward for tools that generate SQL without knowing the field types up front (the motivating case in #26205).

The syntax follows the `SELECT` clause, so `AS` is optional: `ROW(<expr> (AS? <identifier>)?, ...)`. The parenthesized form `(a, b)` continues to produce an anonymous row.

## Motivation and Context

Fixes #26205. Syntax agreed on the issue: rschlussel suggested adopting Trino's approach, and mbasmanova confirmed martint's `ROW(m[1] as f1, ...)` form.

## Impact

Three behaviors worth reviewer attention:

**1. Field names are folded exactly the way the cast form folds them.** `Cast.transformCase` lowercases everything outside double quotes, so an undelimited name becomes lower case and a delimited name is kept verbatim. Doing the same in the analyzer keeps the two syntaxes equivalent:

```
typeof(ROW(1 AS Abc))                    -> row("abc" integer)
typeof(CAST(ROW(1) AS ROW(Abc integer))) -> row("abc" integer)
```

Trino canonicalizes the alias differently from its cast, so the two forms disagree there (trinodb/trino#28126). Following Presto's existing cast behavior avoids that. There is a regression test asserting the two forms produce identical types, including the delimited case.

**2. Duplicate field names are rejected during analysis**, compared *after* folding, so `ROW(1 AS a, 2 AS A)` is rejected exactly as `CAST(ROW(1, 2) AS ROW(a integer, A integer))` already is (`Duplicate field: a`). The check is required rather than cosmetic: a row type with duplicate names cannot be round-tripped through its `TypeSignature`, and row types are serialized as signature strings into `RowExpression` JSON for native execution — so without it the failure would surface on the C++ worker instead of at the SQL layer.

**3. `VALUES` derives column names from the field names declared by a row constructor** — `SELECT a FROM (VALUES ROW(1 AS a))` resolves. Rows that disagree about a name fall back to an unnamed column, via the existing name merging in `TypeCoercer.typeCompatibilityForRow`.

This covers the **syntactic** `ROW(... AS ...)` form only. A row-valued expression such as `VALUES CAST(ROW(1, 2) AS ROW(a integer, b integer))` still fails with `Cannot cast row(a integer,b integer) to integer`, because `ValuesNode` carries one expression per output column while `StatementAnalyzer` coerces such a row to its first field type. That limitation predates this PR and fixing it is planner work I've deliberately left out of scope. An earlier revision of this description wrongly claimed it was fixed.

## Implementation notes

`Row.Field` carries the optional name alongside the expression, mirroring Trino's AST shape.

A `Row.Field` created without an explicit `NodeLocation` inherits its expression's location. `Row.getChildren()` now returns fields rather than the expressions, so without this a field would hide the only location available to helpers that recover one from a node's children, such as `ExpressionTreeUtils#getSourceLocation`.

`Row.getItems()` is replaced by `Row.getFields()` and the `Row` constructor now takes `Row.Field`. That is source-incompatible for code outside the engine that builds `presto-parser` AST nodes; it is not an SPI change.

One deliberate deviation from Trino: `DefaultTraversalVisitor` does **not** traverse the name identifier. A declared field name is a declaration, not a reference, and Presto has three visitors that collect identifiers — `FreeLambdaReferenceExtractor`, `VariablesExtractor` and `SubqueryPlanner` — which would otherwise treat a field name as a column reference.

**No native/prestissimo change is needed.** The named row type reaches Velox in the `ROW_CONSTRUCTOR` return type and is used verbatim: `ExprCompiler` passes `expr->type()` straight to `RowConstructorCallToSpecialForm::constructSpecialForm`, and `RowFunction::apply` builds the `RowVector` from that `outputType`. Velox's `resolveType` (which would fabricate empty names) is never consulted on this path.

## Differences from upstream

Parts of the Trino change do not apply to Presto and are deliberately omitted:

| Upstream | Presto |
|---|---|
| IR `Row` record gains a type | N/A — Presto's IR is `SpecialFormExpression(ROW_CONSTRUCTOR, type, args)`, already type-carrying |
| `PushCastIntoRow` rule rewrite | N/A — no such rule in Presto |
| `visitRowField` → `visitRowDataTypeField` rename | N/A — Presto has no `RowDataType` AST node; types are signature strings |
| Empty row type / `RowBlock` with 0 fields | N/A — Presto's grammar requires at least one field, and `RowType.makeSignature` rejects size 0 |

Two behavioral deviations, both covered above: field-name folding follows Presto's existing cast (avoiding trinodb/trino#28126), and `DefaultTraversalVisitor` does not traverse the name identifier.

## Documentation

`presto-docs/src/main/sphinx/language/types.rst` (the `ROW` section) documents the syntax with and without the optional `AS`, partial naming, the case-folding rules with worked examples, `VALUES` column naming and its fallback, and a note that declaring field names is an extension to the SQL standard.

## Test Plan

Verified locally:
- `presto-parser` — full suite green (241 tests), including new `TestSqlParser#testRowFieldNames` and `TestExpressionFormatter#testFormatRowWithFieldNames`. The latter asserts the format/parse round-trip that `CREATE VIEW` depends on via `SqlFormatterUtil`. Also added `TestStatementBuilder` cases.
- `presto-main-base` — `TestAnalyzer#testRowWithDuplicateFieldNames`.
- `presto-tests` — `TestLocalQueries`, 543 tests, 0 failures, including new `AbstractTestQueries#testRowWithFieldNames` covering VALUES naming, partial naming, named/anonymous comparison and case-insensitive access.

Relying on CI (could not be run locally):
- `AbstractTestNativeGeneralQueries#testRowWithFieldNames` — smoke coverage that a named ROW type plans, compiles through `row_constructor` and executes on a native worker, anchored on table scans so the projection is not folded on the coordinator.
- Three new `RowExpressionTest` cases in `presto_cpp` asserting the Presto→Velox type conversion preserves field names exactly (`RowType::equals` is name- and case-sensitive), including partially named and delimited names. This file previously had no `row_constructor` coverage.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new properties (with unit tests to validate correctness).
- [x] If adding new dependencies, verified they are compatible with the project's license.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add support for declaring field names in a row constructor, for example ``ROW(1 AS a, 2 AS b)``. :pr:`28298`
* Update ``VALUES`` to derive column names from row field names, so ``SELECT a FROM (VALUES ROW(1 AS a))`` resolves. Previously such columns were named ``_col0``. :pr:`28298`
```

## Summary by Sourcery

Allow declaring field names directly in ROW constructors and propagate them through analysis, formatting, planning, and native execution.

New Features:
- Support field name declarations in ROW constructors with optional AS syntax, including partially named rows.
- Derive VALUES output column names from row field names when consistently declared across rows.

Enhancements:
- Extend the Row AST node to carry per-field names and update visitors, rewriters, and formatters to handle named row fields.
- Ensure ROW field names are folded and validated consistently with CAST-to-ROW semantics, rejecting duplicate field names after case folding.
- Preserve named ROW types and field names through SQL-to-RowExpression translation and Presto-to-Velox type conversion.

Tests:
- Add parser, formatter, analyzer, planner, and verifier tests covering named and partially named ROW constructors, VALUES column naming, and duplicate field name rejection.
- Add native execution tests to verify named ROW types are preserved and executed correctly through row_constructor in Velox.

