### PR TITLE
fix(native): Revert RPCNode invariant check that aborts plan conversion

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2500,19 +2500,10 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
 
   // Build CallTypedExpr inputs: FieldAccess for columns, Constant for literals
   // (Velox #18267 folds RPCNode args into CallTypedExpr: field refs vs
-  // constants). Planner emits one entry per argument, so argumentColumns,
-  // argumentTypes, and constantInputs must be aligned. Enforce with checks to
-  // fail loudly if planner contract drifts.
-  VELOX_CHECK_EQ(argumentColumns.size(), argumentTypes.size());
-  VELOX_CHECK_EQ(argumentColumns.size(), constantInputs.size());
+  // constants)
   std::vector<core::TypedExprPtr> callInputs;
   callInputs.reserve(argumentColumns.size());
   for (size_t i = 0; i < argumentColumns.size(); ++i) {
-    // Exactly one of column ref or constant must be set per argument.
-    VELOX_CHECK(
-        (argumentColumns[i] != nullptr) ^ (constantInputs[i] != nullptr),
-        "Expected exactly one of argumentColumns or constantInputs to be set at position {}",
-        i);
     if (constantInputs[i] != nullptr) {
       callInputs.push_back(
           std::make_shared<core::ConstantTypedExpr>(constantInputs[i]));


### PR DESCRIPTION
Summary:
Reverts the invariant check added by D115337913 (diff-train sync of prestodb/presto#28296), which aborts the process for every `RPCNode` with at least one argument.

The added check is:

  VELOX_CHECK(
      (argumentColumns[i] != nullptr) ^ (constantInputs[i] != nullptr), ...);

`argumentColumns` is a `std::vector<std::string>`, so `argumentColumns[i] != nullptr` compares a `std::string` against `nullptr`. That compiles, but not into what it looks like:

- All of libstdc++'s `std::string` vs `const char*` comparison operators are function templates, and deducing `const _CharT*` from `std::nullptr_t` fails, so none of them are viable candidates.
- `PrestoToVeloxQueryPlan.cpp` has `using namespace facebook::velox;`, which makes the non-template `operator==(const Variant&, const Variant&)` from `velox/type/Variant.h` visible, and `velox::Variant` has implicit converting constructors from both `std::string` and `const char*`.
- C++20 rewrites `!=` from `==`, so overload resolution picks the `Variant` comparison and converts `nullptr` via `Variant(const char*)`.

At runtime `Variant(const char* str)` does `new std::string{str}` with `str == nullptr`, throwing `std::logic_error: basic_string::_M_construct null not valid`. It escapes the converter and terminates the process:

  terminate called after throwing an instance of 'std::logic_error'
    what():  basic_string::_M_construct null not valid
    @ facebook::velox::Variant::Variant(char const*)          velox/type/Variant.h:238
    @ VeloxQueryPlanConverterBase::toVeloxQueryPlan(RPCNode)  PrestoToVeloxQueryPlan.cpp:2512

This is deterministic, not flaky, and breaks the `RPCNode` plan-conversion path in production, not just in tests.

This diff is content-identical to the revert PR being opened against prestodb/presto, so the eventual diff-train sync of that PR is a clean match.

Why OSS CI was green on prestodb/presto#28296: `RPCPlanConverterTest.cpp` has been in the repo since prestodb/presto#27555, but the only build rule referencing it is the Meta-internal `presto_cpp/main/types/tests/BUCK` target added in D100676410 ("These are Meta-internal build system changes not present in the OSS GitHub repo"). No `CMakeLists.txt` ever referenced it, so the OSS CMake build never compiled or ran it. Wiring that test into the OSS CMake build is a separate follow-up and is deliberately not part of this diff.

```
== NO RELEASE NOTE ==
```



