### PR TITLE
perf(planner): Generalize optimize_join_fan_out to more join shapes

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -433,12 +433,21 @@ The corresponding configuration property is :ref:`admin/properties:\`\`optimizer
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-Collapse a fan-out equi-join whose preserved side is itself an aggregation grouped by, or an
-inner join keyed on, a strict superset of the join keys. The preserved side's non-key columns
-are packed with ``array_agg(row(...))`` so the join becomes ``N``-to-``1`` (unique on the join
-key), and a local ``UNNEST`` above the join re-expands them, reproducing the original rows.
-This moves the row multiplication out of the distributed join (smaller build, less shuffle of
-duplicated rows) into a streaming local ``UNNEST``.
+Collapse a fan-out equi-join, that is a join one of whose sides is not unique on the join keys
+but is unique on a strict superset of them. That side's non-key columns are packed with
+``array_agg(row(...))`` so the join becomes ``N``-to-``1`` (unique on the join key), and a local
+``UNNEST`` above the join re-expands them, reproducing the original rows. This moves the row
+multiplication out of the distributed join (smaller build, less shuffle of duplicated rows)
+into a streaming local ``UNNEST``.
+
+The fan-out is detected at the join node, from the grouping that the side reports through its derived
+properties: an aggregation (including ``DISTINCT``) advertises its grouping keys, and those carry
+up through intervening filters, projections, sorts and limits, and across an inner join from its
+probe. A side grouped on a strict superset of the join keys holds several rows per join key. This
+uses only property derivation and does not depend on ``exploit_constraints``. A side whose
+grouping keys are projected away before the join is not detected. Either side of an ``INNER``, ``LEFT``
+or ``RIGHT`` join can be collapsed, including the null-supplying side of an outer join;
+``FULL`` outer and cross joins are never collapsed.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.optimize-join-fan-out\`\``.
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -945,12 +945,14 @@ The corresponding session property is :ref:`admin/properties-session:\`\`optimiz
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-Collapse a fan-out equi-join whose preserved side is itself an aggregation grouped by, or an
-inner join keyed on, a strict superset of the join keys. The preserved side's non-key columns
-are packed with ``array_agg(row(...))`` so the join becomes ``N``-to-``1`` (unique on the join
-key), and a local ``UNNEST`` above the join re-expands them, reproducing the original rows.
-This moves the row multiplication out of the distributed join (smaller build, less shuffle of
-duplicated rows) into a streaming local ``UNNEST``.
+Collapse a fan-out equi-join, that is a join one of whose sides is not unique on the join keys
+but is unique on a strict superset of them. That side's non-key columns are packed with
+``array_agg(row(...))`` so the join becomes ``N``-to-``1`` (unique on the join key), and a local
+``UNNEST`` above the join re-expands them, reproducing the original rows. This moves the row
+multiplication out of the distributed join (smaller build, less shuffle of duplicated rows)
+into a streaming local ``UNNEST``. Either side of an ``INNER``, ``LEFT`` or ``RIGHT`` join can be
+collapsed, including the null-supplying side of an outer join; ``FULL`` outer and cross joins are
+never collapsed.
 
 The corresponding session property is :ref:`admin/properties-session:\`\`optimize_join_fan_out\`\``.
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -721,7 +721,7 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 estimatedExchangesCostCalculator,
-                ImmutableSet.of(new CollapseFanoutJoinWithArrayAggUnnest(metadata.getFunctionAndTypeManager()))));
+                ImmutableSet.of(new CollapseFanoutJoinWithArrayAggUnnest(metadata))));
 
         // In RewriteIfOverAggregation, we can only optimize when the aggregation output is used in only one IF expression, and not used in any other expressions (excluding
         // identity assignments). Hence we need to simplify projection assignments to combine/inline expressions in assignments so as to identify the candidate IF expressions.

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CollapseFanoutJoinWithArrayAggUnnest.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CollapseFanoutJoinWithArrayAggUnnest.java
@@ -19,11 +19,13 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConstantProperty;
+import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.EquiJoinClause;
-import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -34,6 +36,10 @@ import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.ActualProperties;
+import com.facebook.presto.sql.planner.optimizations.PropertyDerivations;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -49,19 +55,22 @@ import static com.facebook.presto.SystemSessionProperties.isOptimizeJoinFanOut;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CONSTRUCTOR;
 import static com.facebook.presto.sql.planner.PlannerUtils.createArrayAggregation;
+import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Collapses a fan-out equi-join whose preserved side resolves (possibly through intervening
- * {@link ProjectNode}/{@link FilterNode}s) to either an {@link AggregationNode} grouped by, or an
- * {@code INNER} {@link JoinNode} keyed on, a strict superset of that side's join keys — turning the
- * {@code 1-to-N} join into a {@code N-to-1} join plus a cheap local {@code UNNEST}.
+ * Collapses a fan-out equi-join: a join one of whose sides is provably non-unique on its join keys
+ * while being unique on some strict superset of them — turning the {@code 1-to-N} join into a
+ * {@code N-to-1} join plus a cheap local {@code UNNEST}.
  *
  * <p>The canonical aggregation shape is:
  * <pre>
@@ -90,28 +99,50 @@ import static java.util.Objects.requireNonNull;
  * column per field. The Java engine handles both forms; the native (Velox) engine currently only
  * supports the legacy single-{@code ROW} form for array-of-rows {@code UNNEST}.
  *
- * <p>The same fan-out arises when the preserved side is itself an {@code INNER} join keyed on a
- * strict superset of the outer join key, e.g. {@code a JOIN (b JOIN c USING (k1, k2)) USING (k1)}:
- * the inner join produces {@code N} rows per {@code k1}, so the outer join on {@code k1} is
- * {@code 1-to-N}. The same {@code array_agg(row(...))} + {@code UNNEST} collapse applies, packing
- * every non-key column the preserved side produces.
- *
- * <p>The collapse transformation is independent of the preserved side's node type: given the
+ * <p>The collapse transformation is independent of the collapsed side's node type: given the
  * resolved side {@code S}, the outer join keys {@code J}, and {@code R = S.outputs − J}, the rewrite
  * always (1) projects {@code row(R...)} and {@code array_agg}s it grouped by {@code J} (now unique on
  * {@code J}), (2) rebuilds the outer join {@code N-to-1}, (3) {@code UNNEST}s the array into one
  * {@code ROW} column, and (4) dereferences that row back into {@code R}. Only the eligibility
- * detection differs per type.
+ * detection varies.
  *
  * <p>The rewrite is losslessly semantics-preserving: {@code array_agg} packs the non-key columns
  * and {@code UNNEST} unpacks them, reproducing the same multiset of rows. The row multiplication
  * moves out of the distributed join (smaller build, unique-key join, less shuffle of duplicated
  * rows) into a streaming local {@code UNNEST}.
  *
- * <p>Because the only available unnest is {@code CROSS JOIN UNNEST} (there is no outer/left
- * unnest), the collapsed side must be the <em>preserved</em> side so that every join output row
- * carries a non-empty array: INNER (either side, build preferred), LEFT (left only), RIGHT (right
- * only). FULL outer and cross joins never fire.
+ * <h2>Eligibility: is the side a fan-out?</h2>
+ *
+ * <p>Correctness does not depend on the side fanning out — the pack/unpack pair is an identity for
+ * any side. Fan-out detection is a <em>profitability</em> guard: with one row per join key the
+ * rewrite only adds an aggregation and an unnest.
+ *
+ * <p>It is answered at the join node from the grouping the side advertises through
+ * {@code PropertyDerivations}, which is applied node by node so that a node type it does not cover
+ * (a {@code UnionNode}, a CTE node) reports unknown properties instead of failing the derivation. An {@link AggregationNode} (including a {@code DISTINCT}) reports
+ * {@code LocalProperties.grouped(groupingKeys)}, and {@code ActualProperties} carry that up through
+ * the filters, projections, sorts and limits that sit between it and the join, and across an inner
+ * join from its probe. A side grouped on a strict superset of the join keys holds several rows per
+ * join key. Deliberately NOT the {@code LogicalProperties} constraints framework: that is gated
+ * behind {@code exploit_constraints}, and nothing here may depend on it. The cost is that a side
+ * whose grouping keys are projected away before the join is not detected, and that grouping carries
+ * no cardinality, so an at-most-one-row side may be collapsed pointlessly (harmless).
+ *
+ * <h2>Outer joins</h2>
+ *
+ * <p>The collapsed side may be either the preserved or the null-supplying side of an outer join.
+ * A preserved side always carries a non-empty array, so it unnests directly. A null-supplying side
+ * produces a {@code NULL} array for every unmatched preserved row, and since the only available
+ * unnest is {@code CROSS JOIN UNNEST} (there is no outer/left unnest) that row would be dropped.
+ * The array is therefore wrapped in {@code COALESCE(data, ARRAY[CAST(NULL AS row(...))])} above the
+ * join, so an unmatched row unnests to exactly one row whose packed columns all dereference to
+ * {@code NULL} — precisely the null-extended row the outer join must emit. {@code array_agg} over a
+ * group never returns an empty array, so a {@code NULL} array is the only unmatched signal.
+ *
+ * <p>The null-supplying side is tried first, since that is where a fan-out build sits in the common
+ * {@code a LEFT JOIN (SELECT ... GROUP BY k1, k2) b ON a.k1 = b.k1} shape. FULL outer joins are not
+ * collapsed: a side that fans out on both sides of a FULL join is almost always a modelling bug
+ * rather than a shape worth optimizing. Cross joins have no equi-criteria to collapse on.
  *
  * <p>This rule is gated behind {@code optimize_join_fan_out} and is disabled by default.
  */
@@ -119,12 +150,21 @@ public class CollapseFanoutJoinWithArrayAggUnnest
         implements Rule<JoinNode>
 {
     private static final Pattern<JoinNode> PATTERN = join();
+    private static final String ARRAY_CONSTRUCTOR = "ARRAY";
 
+    // The order in which the two sides are considered for collapse, as values of collapseLeft.
+    private static final List<Boolean> RIGHT_SIDE_FIRST = ImmutableList.of(false, true);
+    private static final List<Boolean> LEFT_SIDE_FIRST = ImmutableList.of(true, false);
+
+    private final Metadata metadata;
     private final FunctionAndTypeManager functionAndTypeManager;
+    private final FunctionResolution functionResolution;
 
-    public CollapseFanoutJoinWithArrayAggUnnest(FunctionAndTypeManager functionAndTypeManager)
+    public CollapseFanoutJoinWithArrayAggUnnest(Metadata metadata)
     {
-        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.functionAndTypeManager = metadata.getFunctionAndTypeManager();
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
     }
 
     @Override
@@ -158,20 +198,25 @@ public class CollapseFanoutJoinWithArrayAggUnnest
             return Result.empty();
         }
 
-        // Try the preserved side(s). For INNER prefer the build (right) side, then probe (left).
-        if (type == JoinType.INNER || type == JoinType.RIGHT) {
-            Result result = tryCollapseSide(join, false, context);
-            if (!result.isEmpty()) {
-                return result;
-            }
-        }
-        if (type == JoinType.INNER || type == JoinType.LEFT) {
-            Result result = tryCollapseSide(join, true, context);
+        // Either side of an INNER, LEFT or RIGHT join can be collapsed. Prefer the build side of an
+        // INNER join, and the null-supplying side of an outer join, since that is where a fan-out
+        // build normally sits.
+        for (boolean collapseLeft : type == JoinType.RIGHT ? LEFT_SIDE_FIRST : RIGHT_SIDE_FIRST) {
+            Result result = tryCollapseSide(join, collapseLeft, context);
             if (!result.isEmpty()) {
                 return result;
             }
         }
         return Result.empty();
+    }
+
+    /**
+     * Whether the chosen side supplies nulls, i.e. the join emits a row with all of that side's
+     * columns set to {@code NULL} when the other (preserved) side finds no match.
+     */
+    private static boolean isNullSupplyingSide(JoinType type, boolean collapseLeft)
+    {
+        return (type == JoinType.LEFT && !collapseLeft) || (type == JoinType.RIGHT && collapseLeft);
     }
 
     /**
@@ -194,9 +239,8 @@ public class CollapseFanoutJoinWithArrayAggUnnest
             joinKeys.add(collapseLeft ? clause.getLeft() : clause.getRight());
         }
 
-        // Eligibility: peer through project/filter down to an aggregation grouped by, or an inner
-        // join keyed on, a strict superset of the outer join keys.
-        if (!isCollapsibleFanout(resolved, joinKeys, context)) {
+        // Eligibility: the side must fan out over the join keys.
+        if (!isFanoutSide(collapseSideNode, joinKeys, context)) {
             return Result.empty();
         }
 
@@ -244,7 +288,8 @@ public class CollapseFanoutJoinWithArrayAggUnnest
         // no ORDER BY or cross-array coordination is needed; the array's order is irrelevant since
         // the join output is a multiset.
         Aggregation arrayAggregation = createArrayAggregation(functionAndTypeManager, rowVariable);
-        VariableReferenceExpression arrayVariable = context.getVariableAllocator().newVariable("data", arrayAggregation.getCall().getType());
+        Type arrayType = arrayAggregation.getCall().getType();
+        VariableReferenceExpression arrayVariable = context.getVariableAllocator().newVariable("data", arrayType);
         AggregationNode collapseAggregation = new AggregationNode(
                 resolved.getSourceLocation(),
                 context.getIdAllocator().getNextId(),
@@ -307,26 +352,53 @@ public class CollapseFanoutJoinWithArrayAggUnnest
                 join.getDistributionType(),
                 join.getDynamicFilters());
 
-        // 4. Re-expand the packed array(row) locally with UNNEST above the join, emitting the form
+        // 4. When the collapsed side supplies nulls, an unmatched row of the preserved side carries a
+        // NULL array, and CROSS JOIN UNNEST (the only unnest available) would drop that row. Replace
+        // the NULL with a single-element array holding a NULL row, so the row survives the unnest with
+        // every packed column dereferencing to NULL — exactly the null-extended row the outer join
+        // must emit. An array_agg group always has at least one row, so NULL is the only such signal.
+        List<VariableReferenceExpression> replicateVariables = newJoinOutputs.stream()
+                .filter(variable -> !variable.equals(arrayVariable))
+                .collect(toImmutableList());
+
+        PlanNode unnestSource = newJoin;
+        VariableReferenceExpression unnestVariable = arrayVariable;
+        if (isNullSupplyingSide(join.getType(), collapseLeft)) {
+            RowExpression nullRowArray = call(
+                    ARRAY_CONSTRUCTOR,
+                    functionResolution.arrayConstructor(ImmutableList.of(rowType)),
+                    arrayType,
+                    constantNull(rowType));
+            unnestVariable = context.getVariableAllocator().newVariable("data", arrayType);
+            Assignments.Builder coalesceAssignments = Assignments.builder();
+            for (VariableReferenceExpression replicateVariable : replicateVariables) {
+                coalesceAssignments.put(replicateVariable, replicateVariable);
+            }
+            coalesceAssignments.put(unnestVariable, new SpecialFormExpression(COALESCE, arrayType, arrayVariable, nullRowArray));
+            unnestSource = new ProjectNode(
+                    newJoin.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newJoin,
+                    coalesceAssignments.build(),
+                    LOCAL);
+        }
+
+        // 5. Re-expand the packed array(row) locally with UNNEST above the join, emitting the form
         // that matches the session's unnest semantics so it executes correctly under either:
         //   - legacy_unnest:  a single ROW column, with fields recovered via DEREFERENCE (row[i]).
         //   - non-legacy:     one flattened column per row field, mapped directly.
         // The Java engine handles both; the native (Velox) engine currently only supports the legacy
         // single-ROW form for array-of-rows UNNEST (support for the flattened form is planned).
-        List<VariableReferenceExpression> replicateVariables = newJoinOutputs.stream()
-                .filter(variable -> !variable.equals(arrayVariable))
-                .collect(toImmutableList());
-
         UnnestNode unnest;
         Assignments.Builder topAssignments = Assignments.builder();
         if (isLegacyUnnest(context.getSession())) {
             VariableReferenceExpression unnestedRow = context.getVariableAllocator().newVariable("row", rowType);
             unnest = new UnnestNode(
-                    newJoin.getSourceLocation(),
+                    unnestSource.getSourceLocation(),
                     context.getIdAllocator().getNextId(),
-                    newJoin,
+                    unnestSource,
                     replicateVariables,
-                    ImmutableMap.of(arrayVariable, ImmutableList.of(unnestedRow)),
+                    ImmutableMap.of(unnestVariable, ImmutableList.of(unnestedRow)),
                     Optional.empty());
 
             // Rebuild each packed column as a DEREFERENCE of the unnested row by its field index
@@ -360,11 +432,11 @@ public class CollapseFanoutJoinWithArrayAggUnnest
                 unnestedFields.add(unnestedField);
             }
             unnest = new UnnestNode(
-                    newJoin.getSourceLocation(),
+                    unnestSource.getSourceLocation(),
                     context.getIdAllocator().getNextId(),
-                    newJoin,
+                    unnestSource,
                     replicateVariables,
-                    ImmutableMap.of(arrayVariable, unnestedFields.build()),
+                    ImmutableMap.of(unnestVariable, unnestedFields.build()),
                     Optional.empty());
             for (VariableReferenceExpression output : join.getOutputVariables()) {
                 topAssignments.put(output, packedToField.getOrDefault(output, output));
@@ -381,84 +453,74 @@ public class CollapseFanoutJoinWithArrayAggUnnest
     }
 
     /**
-     * Recursively determines whether {@code node} (already resolved or to-be-resolved) is a
-     * collapsible fan-out source relative to {@code trackedKeys} — the set of outer join key
-     * variables as they appear at this level of the plan. Peers through {@link ProjectNode}
-     * (identity/rename only) and {@link FilterNode}, remapping the tracked keys as needed.
+     * Determines whether the chosen side fans out over the join keys, i.e. whether it can produce
+     * more than one row per distinct join key value.
      *
-     * <ul>
-     *   <li>{@link AggregationNode}: eligible iff its grouping keys are a strict superset of the
-     *       tracked keys (with the usual single-step/single-grouping-set guards).
-     *   <li>{@code INNER} {@link JoinNode}: eligible iff its equi-key variables cover the tracked
-     *       keys and at least one clause introduces an extra key (neither side in the tracked set),
-     *       which is the strict-superset / fan-out signal.
-     *   <li>{@link ProjectNode}: bail if any tracked key maps to a non-variable expression;
-     *       otherwise recurse with the remapped underlying variables.
-     *   <li>{@link FilterNode}: recurse with the tracked keys unchanged.
-     *   <li>anything else: not collapsible.
-     * </ul>
+     * <p>The answer comes from the grouping the side reports through {@link #deriveProperties}: a
+     * side grouped on a strict superset of the join keys holds several rows per join key. Local
+     * properties are hierarchical, so the columns of any prefix together form a grouping and are
+     * accumulated in order before comparing; constants are skipped, since a column pinned to a
+     * single value adds no grouping.
      */
-    private boolean isCollapsibleFanout(PlanNode node, Set<VariableReferenceExpression> trackedKeys, Context context)
+    private boolean isFanoutSide(PlanNode collapseSideNode, Set<VariableReferenceExpression> joinKeys, Context context)
     {
-        PlanNode resolved = context.getLookup().resolve(node);
+        // An AggregationNode advertises
+        // LocalProperties.grouped(groupingKeys), and ActualProperties carry that up through the
+        // projections and filters that routinely sit between the aggregation and the join
+        // (PropertyDerivations translates local properties across them). If the side is grouped on a
+        // strict superset of the join keys, it holds several rows per join key: a fan-out.
+        // The subtree is materialized out of the memo first because PropertyDerivations does not
+        // understand GroupReference. This runs only when the rule is enabled (default off).
+        //
+        // Deliberately NOT the LogicalProperties/constraints framework: that is gated behind
+        // exploit_constraints, which is untested at scale, so nothing here may depend on it.
+        ActualProperties sideProperties = deriveProperties(
+                resolveGroupReferences(collapseSideNode, context.getLookup()),
+                context.getSession());
 
-        if (resolved instanceof AggregationNode) {
-            AggregationNode aggregation = (AggregationNode) resolved;
-            // Mirror the structural guards used by other aggregation-rewriting rules.
-            if (aggregation.getStep() != AggregationNode.Step.SINGLE
-                    || aggregation.getGroupingSetCount() != 1
-                    || aggregation.hasEmptyGroupingSet()
-                    || aggregation.getGroupingKeys().isEmpty()
-                    || aggregation.getGroupIdVariable().isPresent()
-                    || aggregation.getHashVariable().isPresent()) {
-                return false;
+        // Local properties are hierarchical — grouped/sorted by the first, then by the second within
+        // it, and so on — so the columns of any prefix together form a grouping. Accumulate them in
+        // order: a TOP N over an aggregation, for instance, reports one SortingProperty per sort
+        // column, and only their union covers the aggregation's grouping keys. Constants are skipped;
+        // a column pinned to a single value adds no grouping.
+        LinkedHashSet<VariableReferenceExpression> grouped = new LinkedHashSet<>();
+        for (LocalProperty<VariableReferenceExpression> property : sideProperties.getLocalProperties()) {
+            if (property instanceof ConstantProperty) {
+                continue;
             }
-            // The grouping keys must be a STRICT superset of the tracked keys — otherwise the side
-            // is already unique on the join key and there is no fan-out to collapse.
-            Set<VariableReferenceExpression> groupingKeys = new LinkedHashSet<>(aggregation.getGroupingKeys());
-            return groupingKeys.containsAll(trackedKeys) && groupingKeys.size() > trackedKeys.size();
-        }
-
-        if (resolved instanceof JoinNode) {
-            JoinNode innerJoin = (JoinNode) resolved;
-            // Only an INNER join with equi-criteria fans out a superset key deterministically.
-            if (innerJoin.getType() != JoinType.INNER || innerJoin.getCriteria().isEmpty()) {
-                return false;
+            grouped.addAll(property.getColumns());
+            if (grouped.containsAll(joinKeys) && grouped.size() > joinKeys.size()) {
+                return true;
             }
-            Set<VariableReferenceExpression> keyVariables = new LinkedHashSet<>();
-            boolean hasExtraKey = false;
-            for (EquiJoinClause clause : innerJoin.getCriteria()) {
-                keyVariables.add(clause.getLeft());
-                keyVariables.add(clause.getRight());
-                if (!trackedKeys.contains(clause.getLeft()) && !trackedKeys.contains(clause.getRight())) {
-                    hasExtraKey = true;
-                }
-            }
-            // Cover the tracked keys and introduce at least one extra key (the strict-superset signal).
-            return keyVariables.containsAll(trackedKeys) && hasExtraKey;
         }
-
-        if (resolved instanceof ProjectNode) {
-            ProjectNode project = (ProjectNode) resolved;
-            Assignments assignments = project.getAssignments();
-            LinkedHashSet<VariableReferenceExpression> remappedKeys = new LinkedHashSet<>();
-            for (VariableReferenceExpression trackedKey : trackedKeys) {
-                RowExpression assignment = assignments.getMap().get(trackedKey);
-                // A tracked key produced by a non-identity expression (e.g. COALESCE, arithmetic)
-                // cannot be traced down — bail conservatively rather than peering through it.
-                if (!(assignment instanceof VariableReferenceExpression)) {
-                    return false;
-                }
-                remappedKeys.add((VariableReferenceExpression) assignment);
-            }
-            return isCollapsibleFanout(project.getSource(), remappedKeys, context);
-        }
-
-        if (resolved instanceof FilterNode) {
-            // Filters do not rename variables, so the tracked keys carry through unchanged.
-            return isCollapsibleFanout(((FilterNode) resolved).getSource(), trackedKeys, context);
-        }
-
         return false;
+    }
+
+    /**
+     * Derives {@link ActualProperties} for a resolved subtree, tolerating node types the derivation
+     * does not cover.
+     *
+     * <p>{@code PropertyDerivations} is exhaustive only over the node types the physical planner
+     * sees, and its {@code visitPlan} throws for everything else — {@link UnionNode} and the CTE
+     * nodes among them, because {@code AddExchanges} derives those itself. An iterative rule runs
+     * long before that and meets them routinely, so an unsupported node reports unknown properties
+     * and derivation continues above it: an aggregation sitting on top of a union is still visible.
+     *
+     * <p>This must never fail planning. The derivation is advisory — it only decides whether the
+     * collapse is worth doing — and {@code IterativeOptimizer} calls {@code apply()} even for a
+     * DISABLED rule when {@code verbose_optimizer_info} is on, so an escaping exception would break
+     * queries that do not use this optimization at all.
+     */
+    private ActualProperties deriveProperties(PlanNode node, Session session)
+    {
+        List<ActualProperties> inputProperties = node.getSources().stream()
+                .map(source -> deriveProperties(source, session))
+                .collect(toImmutableList());
+        try {
+            return PropertyDerivations.deriveProperties(node, inputProperties, metadata, session);
+        }
+        catch (UnsupportedOperationException | VerifyException e) {
+            return ActualProperties.builder().build();
+        }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCollapseFanoutJoinWithArrayAggUnnest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCollapseFanoutJoinWithArrayAggUnnest.java
@@ -13,17 +13,27 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -33,8 +43,12 @@ import static com.facebook.presto.SystemSessionProperties.LEGACY_UNNEST;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_JOIN_FAN_OUT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestCollapseFanoutJoinWithArrayAggUnnest
         extends BaseRuleTest
@@ -43,7 +57,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     public void testFiresCollapsingBuildSideOfInnerJoin()
     {
         // a JOIN (SELECT k1, k2, sum(v) measure FROM t GROUP BY k1, k2) b ON a.k1 = b.k1
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -77,7 +91,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
         // a JOIN (SELECT k1, k2, sum(v) measure FROM t GROUP BY k1, k2) b ON a.ak1 = b.k1 AND a.ak1 > 0
         // The filter references only a preserved column (probe ak1), so the rule fires and the filter
         // is carried over onto the rewritten join.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -110,7 +124,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     {
         // The join filter references a packed (collapsed) column (b.measure), which is unavailable at
         // the collapsed join, so the rule must decline.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -135,7 +149,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     {
         // The rewrite replaces a side of the join (and its variables); any dynamic filter referencing
         // that side would be invalidated, so the rule must decline when dynamic filters are present.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -168,7 +182,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     public void testFiresCollapsingProbeSideOfInnerJoin()
     {
         // (SELECT k1, k2, sum(v) measure FROM t GROUP BY k1, k2) a JOIN b ON a.k1 = b.bk1
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -199,7 +213,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     @Test
     public void testFiresOnLeftJoinWhenAggregationOnLeft()
     {
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -230,7 +244,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     @Test
     public void testFiresOnRightJoinWhenAggregationOnRight()
     {
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -259,10 +273,13 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     }
 
     @Test
-    public void testDoesNotFireOnLeftJoinWhenAggregationOnRight()
+    public void testFiresOnLeftJoinCollapsingNullSupplyingSide()
     {
-        // LEFT join preserves only the left side; the build (right) aggregation is not collapsible.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // a LEFT JOIN (SELECT k1, k2, sum(v) measure FROM t GROUP BY k1, k2) b ON a.ak1 = b.k1
+        // The fan-out is on the null-supplying (right) side. The extra ProjectNode between the join
+        // and the UNNEST is the COALESCE that turns the NULL array of an unmatched probe row into a
+        // single-element array holding a NULL row, so that row survives the CROSS JOIN UNNEST.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -279,6 +296,180 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                             .source(p.values(k1, k2, v)));
                     return p.join(JoinType.LEFT, left, right, new EquiJoinClause(ak1, k1));
                 })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(ProjectNode.class,
+                                                node(JoinNode.class,
+                                                        node(ValuesNode.class),
+                                                        node(AggregationNode.class,
+                                                                node(ProjectNode.class,
+                                                                        node(AggregationNode.class,
+                                                                                node(ValuesNode.class)))))))));
+    }
+
+    @Test
+    public void testNullSupplyingSideWrapsThePackedArrayInCoalesceOfANullRow()
+    {
+        // The extra projection above an outer join is only correct if it actually rewrites the packed
+        // array as COALESCE(data, ARRAY[CAST(NULL AS row(...))]); asserting the node shape alone would
+        // still pass if a refactor kept the projection but changed or dropped that expression.
+        PlanNode plan = tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode left = p.values(10, ak1);
+                    AggregationNode right = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(10, k1, k2, v)));
+                    return p.join(JoinType.LEFT, left, right, new EquiJoinClause(ak1, k1));
+                })
+                .get();
+
+        UnnestNode unnest = (UnnestNode) ((ProjectNode) plan).getSource();
+        ProjectNode coalesceProject = (ProjectNode) unnest.getSource();
+        VariableReferenceExpression unnestedArray = unnest.getUnnestVariables().keySet().stream().collect(onlyElement());
+
+        RowExpression assignment = coalesceProject.getAssignments().get(unnestedArray);
+        assertTrue(assignment instanceof SpecialFormExpression, "expected the unnested array to be assigned an expression");
+        SpecialFormExpression coalesce = (SpecialFormExpression) assignment;
+        assertEquals(coalesce.getForm(), COALESCE);
+        assertEquals(coalesce.getArguments().size(), 2);
+
+        // First argument: the array the collapse aggregation produced. Second: a one-element array
+        // holding a NULL row, so an unmatched row survives the UNNEST with all packed columns NULL.
+        assertTrue(coalesce.getArguments().get(0) instanceof VariableReferenceExpression);
+        CallExpression nullRowArray = (CallExpression) coalesce.getArguments().get(1);
+        assertEquals(nullRowArray.getArguments().size(), 1);
+        RowExpression nullRow = nullRowArray.getArguments().stream().collect(onlyElement());
+        assertTrue(nullRow instanceof ConstantExpression, "expected a NULL row constant");
+        assertEquals(((ConstantExpression) nullRow).getValue(), null);
+        assertTrue(nullRow.getType() instanceof RowType, "expected the NULL constant to carry the packed row type");
+        assertEquals(nullRowArray.getType(), coalesce.getArguments().get(0).getType());
+    }
+
+    @Test
+    public void testFiresOnRightJoinCollapsingNullSupplyingSide()
+    {
+        // (SELECT k1, k2, sum(v) measure FROM t GROUP BY k1, k2) b RIGHT JOIN a ON b.k1 = a.ak1
+        // Mirror image of the LEFT join case: the null-supplying side is the left one.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    VariableReferenceExpression bk1 = p.variable("bk1", BIGINT);
+                    AggregationNode left = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(k1, k2, v)));
+                    ValuesNode right = p.values(bk1);
+                    return p.join(JoinType.RIGHT, left, right, new EquiJoinClause(k1, bk1));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(ProjectNode.class,
+                                                node(JoinNode.class,
+                                                        node(AggregationNode.class,
+                                                                node(ProjectNode.class,
+                                                                        node(AggregationNode.class,
+                                                                                node(ValuesNode.class)))),
+                                                        node(ValuesNode.class))))));
+    }
+
+    @Test
+    public void testDoesNotFireOnFullJoin()
+    {
+        // A side that fans out on both sides of a FULL join is almost always a modelling bug rather
+        // than a shape worth optimizing, so FULL joins are left alone.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode left = p.values(ak1);
+                    AggregationNode right = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(k1, k2, v)));
+                    return p.join(JoinType.FULL, left, right, new EquiJoinClause(ak1, k1));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testFiresOnDerivedKeyThroughLimit()
+    {
+        // The build side is a LIMIT over an aggregation grouped by (k1, k2). The structural walk
+        // stops at the LimitNode, but the derived keys carry through it: the side is unique on
+        // (k1, k2) and not on the join key k1 alone, so the directed analysis proves the fan-out.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    AggregationNode aggregation = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(10, k1, k2, v)));
+                    return p.join(INNER, probe, p.limit(10, aggregation), new EquiJoinClause(ak1, k1));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(JoinNode.class,
+                                                node(ValuesNode.class),
+                                                node(AggregationNode.class,
+                                                        node(ProjectNode.class,
+                                                                node(LimitNode.class,
+                                                                        node(AggregationNode.class,
+                                                                                node(ValuesNode.class)))))))));
+    }
+
+    @Test
+    public void testDoesNotFireOnDerivedKeyEqualToJoinKey()
+    {
+        // Same shape, but the aggregation groups by exactly the join key: the derived key is the
+        // join key itself, so the side is already unique on it and there is no fan-out to collapse.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    AggregationNode aggregation = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(10, k1, v)));
+                    return p.join(INNER, probe, p.limit(10, aggregation), new EquiJoinClause(ak1, k1));
+                })
                 .doesNotFire();
     }
 
@@ -286,7 +477,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     public void testDoesNotFireWhenJoinKeyEqualsGroupingKeys()
     {
         // Build side is already unique on the join key (grouped by exactly k1) — no fan-out.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -308,7 +499,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     @Test
     public void testDoesNotFireOnCrossJoin()
     {
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -331,7 +522,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     @Test
     public void testDoesNotFireWhenDisabled()
     {
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "false")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -356,7 +547,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     {
         // Under non-legacy unnest the rule still fires, emitting the flattened array-of-rows form
         // (one column per field) instead of the single-ROW + dereference form. Same plan shape.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "false")
                 .on(p -> {
@@ -388,8 +579,9 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     public void testFiresCollapsingInnerJoinBuildSide()
     {
         // a JOIN (b JOIN c ON b.k1=c.ck1 AND b.k2=c.ck2) ON a.ak1 = b.k1
-        // The build side is an INNER join keyed on (k1, k2), a strict superset of the outer key k1.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // The inner join's probe is grouped on (k1, k2); PropertyDerivations propagates probe local
+        // properties across an INNER join, so the side reports grouping on a superset of the outer key.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -397,13 +589,18 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                     VariableReferenceExpression k1 = p.variable("k1", BIGINT);
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression bval = p.variable("bval", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression ck1 = p.variable("ck1", BIGINT);
                     VariableReferenceExpression ck2 = p.variable("ck2", BIGINT);
-                    ValuesNode probe = p.values(ak1);
+                    ValuesNode probe = p.values(10, ak1);
                     JoinNode build = p.join(
                             INNER,
-                            p.values(k1, k2, bval),
-                            p.values(ck1, ck2),
+                            p.aggregation(agg -> agg
+                                    .addAggregation(bval, p.rowExpression("sum(v)"))
+                                    .singleGroupingSet(k1, k2)
+                                    .step(AggregationNode.Step.SINGLE)
+                                    .source(p.values(10, k1, k2, v))),
+                            p.values(10, ck1, ck2),
                             new EquiJoinClause(k1, ck1),
                             new EquiJoinClause(k2, ck2));
                     return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
@@ -416,31 +613,36 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                                                 node(AggregationNode.class,
                                                         node(ProjectNode.class,
                                                                 node(JoinNode.class,
-                                                                        node(ValuesNode.class),
+                                                                        node(AggregationNode.class, node(ValuesNode.class)),
                                                                         node(ValuesNode.class))))))));
     }
 
     @Test
     public void testFiresCollapsingInnerJoinProbeSide()
     {
-        // (b JOIN c ON b.k1=c.ck1 AND b.k2=c.ck2) a JOIN d ON a.k1 = d.dk1
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // (agg(GROUP BY k1,k2) JOIN c ON k1,k2) JOIN d ON k1 = d.dk1 — collapse on the probe side.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
                     VariableReferenceExpression k1 = p.variable("k1", BIGINT);
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression bval = p.variable("bval", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression ck1 = p.variable("ck1", BIGINT);
                     VariableReferenceExpression ck2 = p.variable("ck2", BIGINT);
                     VariableReferenceExpression dk1 = p.variable("dk1", BIGINT);
                     JoinNode probe = p.join(
                             INNER,
-                            p.values(k1, k2, bval),
-                            p.values(ck1, ck2),
+                            p.aggregation(agg -> agg
+                                    .addAggregation(bval, p.rowExpression("sum(v)"))
+                                    .singleGroupingSet(k1, k2)
+                                    .step(AggregationNode.Step.SINGLE)
+                                    .source(p.values(10, k1, k2, v))),
+                            p.values(10, ck1, ck2),
                             new EquiJoinClause(k1, ck1),
                             new EquiJoinClause(k2, ck2));
-                    ValuesNode build = p.values(dk1);
+                    ValuesNode build = p.values(10, dk1);
                     return p.join(INNER, probe, build, new EquiJoinClause(k1, dk1));
                 })
                 .matches(
@@ -450,7 +652,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                                                 node(AggregationNode.class,
                                                         node(ProjectNode.class,
                                                                 node(JoinNode.class,
-                                                                        node(ValuesNode.class),
+                                                                        node(AggregationNode.class, node(ValuesNode.class)),
                                                                         node(ValuesNode.class)))),
                                                 node(ValuesNode.class)))));
     }
@@ -458,24 +660,30 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     @Test
     public void testFiresOnLeftJoinWhenInnerJoinOnLeft()
     {
-        // LEFT join preserves the left side; the left inner join keyed on (k1, k2) is collapsible.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // LEFT join: the left side is an inner join whose probe is grouped on (k1, k2), so the
+        // grouping reaches the outer join and the preserved side collapses.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
                     VariableReferenceExpression k1 = p.variable("k1", BIGINT);
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression bval = p.variable("bval", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression ck1 = p.variable("ck1", BIGINT);
                     VariableReferenceExpression ck2 = p.variable("ck2", BIGINT);
                     VariableReferenceExpression dk1 = p.variable("dk1", BIGINT);
                     JoinNode left = p.join(
                             INNER,
-                            p.values(k1, k2, bval),
-                            p.values(ck1, ck2),
+                            p.aggregation(agg -> agg
+                                    .addAggregation(bval, p.rowExpression("sum(v)"))
+                                    .singleGroupingSet(k1, k2)
+                                    .step(AggregationNode.Step.SINGLE)
+                                    .source(p.values(10, k1, k2, v))),
+                            p.values(10, ck1, ck2),
                             new EquiJoinClause(k1, ck1),
                             new EquiJoinClause(k2, ck2));
-                    ValuesNode right = p.values(dk1);
+                    ValuesNode right = p.values(10, dk1);
                     return p.join(JoinType.LEFT, left, right, new EquiJoinClause(k1, dk1));
                 })
                 .matches(
@@ -485,7 +693,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                                                 node(AggregationNode.class,
                                                         node(ProjectNode.class,
                                                                 node(JoinNode.class,
-                                                                        node(ValuesNode.class),
+                                                                        node(AggregationNode.class, node(ValuesNode.class)),
                                                                         node(ValuesNode.class)))),
                                                 node(ValuesNode.class)))));
     }
@@ -495,13 +703,14 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     {
         // The build inner join is keyed on exactly k1 (== outer key), so it is already unique on
         // the outer key — no fan-out, no extra key, must not fire.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
                     VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
                     VariableReferenceExpression k1 = p.variable("k1", BIGINT);
                     VariableReferenceExpression bval = p.variable("bval", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression ck1 = p.variable("ck1", BIGINT);
                     ValuesNode probe = p.values(ak1);
                     JoinNode build = p.join(
@@ -518,7 +727,7 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     public void testDoesNotFireWhenInnerJoinIsNotInner()
     {
         // v1 only collapses an INNER inner-join fan-out; a LEFT inner join must not fire.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -526,13 +735,14 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                     VariableReferenceExpression k1 = p.variable("k1", BIGINT);
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression bval = p.variable("bval", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression ck1 = p.variable("ck1", BIGINT);
                     VariableReferenceExpression ck2 = p.variable("ck2", BIGINT);
                     ValuesNode probe = p.values(ak1);
                     JoinNode build = p.join(
                             JoinType.LEFT,
                             p.values(k1, k2, bval),
-                            p.values(ck1, ck2),
+                            p.values(10, ck1, ck2),
                             new EquiJoinClause(k1, ck1),
                             new EquiJoinClause(k2, ck2));
                     return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
@@ -541,10 +751,13 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     }
 
     @Test
-    public void testFiresPeeringThroughProjectIdentity()
+    public void testFiresThroughProjectAndFilterWithoutLogicalProperties()
     {
-        // a JOIN project(identity k1, measure)(agg group by (k1, k2)) ON a.ak1 = k1
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // The common shape: a JOIN project(filter(agg GROUP BY (k1, k2))) ON k1, where the side
+        // reaching the join is a projection rather than the aggregation itself. The fan-out has to
+        // come from the grouping the aggregation advertises, carried up through the filter and the
+        // projection.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -553,13 +766,125 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression measure = p.variable("measure", BIGINT);
-                    ValuesNode probe = p.values(ak1);
+                    VariableReferenceExpression derived = p.variable("derived", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
                     AggregationNode aggregation = p.aggregation(agg -> agg
                             .addAggregation(measure, p.rowExpression("sum(v)"))
                             .singleGroupingSet(k1, k2)
                             .step(AggregationNode.Step.SINGLE)
-                            .source(p.values(k1, k2, v)));
-                    ProjectNode build = p.project(assignment(k1, k1, measure, measure), aggregation);
+                            .source(p.values(10, k1, k2, v)));
+                    FilterNode filter = p.filter(p.rowExpression("measure > 0"), aggregation);
+                    ProjectNode build = p.project(
+                            Assignments.builder().put(k1, k1).put(k2, k2).put(derived, p.rowExpression("measure + 1")).build(),
+                            filter);
+                    return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(JoinNode.class,
+                                                node(ValuesNode.class),
+                                                node(AggregationNode.class,
+                                                        node(ProjectNode.class,
+                                                                node(ProjectNode.class,
+                                                                        node(FilterNode.class,
+                                                                                node(AggregationNode.class,
+                                                                                        node(ValuesNode.class))))))))));
+    }
+
+    @Test
+    public void testDoesNotFailOnNodeTypeWithoutDerivedProperties()
+    {
+        // PropertyDerivations only covers the node types the physical planner sees and throws on
+        // anything else, so the rule must treat that as "no properties" rather than letting the
+        // exception escape and fail the query. This matters even with the rule disabled: when
+        // verbose_optimizer_info is on, IterativeOptimizer calls apply() on disabled rules too.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression rowCount = p.variable("rows", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    PlanNode build = p.cteProducerNode("cte", rowCount, ImmutableList.of(k1, k2), p.values(10, k1, k2));
+                    return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testFiresWhenAnUnsupportedNodeSitsBelowTheAggregation()
+    {
+        // PropertyDerivations does not cover UnionNode, but the fan-out signal comes from the
+        // aggregation above it. The union reports unknown properties and derivation continues, so
+        // the grouping still reaches the join.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression leftK1 = p.variable("leftK1", BIGINT);
+                    VariableReferenceExpression leftK2 = p.variable("leftK2", BIGINT);
+                    VariableReferenceExpression leftV = p.variable("leftV", BIGINT);
+                    VariableReferenceExpression rightK1 = p.variable("rightK1", BIGINT);
+                    VariableReferenceExpression rightK2 = p.variable("rightK2", BIGINT);
+                    VariableReferenceExpression rightV = p.variable("rightV", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    PlanNode union = p.union(
+                            ImmutableListMultimap.<VariableReferenceExpression, VariableReferenceExpression>builder()
+                                    .putAll(k1, leftK1, rightK1)
+                                    .putAll(k2, leftK2, rightK2)
+                                    .putAll(v, leftV, rightV)
+                                    .build(),
+                            ImmutableList.of(p.values(10, leftK1, leftK2, leftV), p.values(10, rightK1, rightK2, rightV)));
+                    AggregationNode build = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(union));
+                    return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(JoinNode.class,
+                                                node(ValuesNode.class),
+                                                node(AggregationNode.class,
+                                                        node(ProjectNode.class,
+                                                                node(AggregationNode.class,
+                                                                        node(UnionNode.class,
+                                                                                node(ValuesNode.class),
+                                                                                node(ValuesNode.class)))))))));
+    }
+
+    @Test
+    public void testFiresThroughProjectIdentity()
+    {
+        // a JOIN project(identity k1, measure)(agg group by (k1, k2)) ON a.ak1 = k1
+        // The rule does not look below the side; the derived key (k1, k2) survives the projection,
+        // so the property framework is what reports the fan-out here.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    AggregationNode aggregation = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(10, k1, k2, v)));
+                    ProjectNode build = p.project(Assignments.builder().put(k1, k1).put(k2, k2).put(measure, measure).build(), aggregation);
                     return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
                 })
                 .matches(
@@ -575,10 +900,11 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     }
 
     @Test
-    public void testFiresPeeringThroughFilter()
+    public void testFiresThroughFilter()
     {
         // a JOIN filter(k1 > 0)(agg group by (k1, k2)) ON a.ak1 = k1
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // As above, the derived key survives the filter and reports the fan-out.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -587,12 +913,12 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                     VariableReferenceExpression k2 = p.variable("k2", BIGINT);
                     VariableReferenceExpression v = p.variable("v", BIGINT);
                     VariableReferenceExpression measure = p.variable("measure", BIGINT);
-                    ValuesNode probe = p.values(ak1);
+                    ValuesNode probe = p.values(10, ak1);
                     AggregationNode aggregation = p.aggregation(agg -> agg
                             .addAggregation(measure, p.rowExpression("sum(v)"))
                             .singleGroupingSet(k1, k2)
                             .step(AggregationNode.Step.SINGLE)
-                            .source(p.values(k1, k2, v)));
+                            .source(p.values(10, k1, k2, v)));
                     FilterNode build = p.filter(p.rowExpression("k1 > 0"), aggregation);
                     return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
                 })
@@ -609,11 +935,40 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
     }
 
     @Test
-    public void testDoesNotFirePeeringThroughNonIdentityProject()
+    public void testDoesNotFireWhenProjectionDropsGroupingKey()
     {
-        // The outer join key is produced by a non-identity expression (k1 + 1) over the fan-out
-        // source, so the tracked key cannot be traced down — must not fire.
-        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getFunctionManager()))
+        // The projection above the aggregation keeps only k1 and the measure, so the derived key
+        // (k1, k2) cannot be expressed in the side's outputs and no key reaches the join. The side
+        // does still fan out, but the rule decides at the join node from what the side advertises
+        // and deliberately does not look below it for a fan-out source.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(10, ak1);
+                    AggregationNode aggregation = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(10, k1, k2, v)));
+                    ProjectNode build = p.project(assignment(k1, k1, measure, measure), aggregation);
+                    return p.join(INNER, probe, build, new EquiJoinClause(ak1, k1));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireOnComputedJoinKey()
+    {
+        // The outer join key is computed (k1 + 1) and the projection drops k2, so the derived key
+        // (k1, k2) cannot be expressed in the side's outputs and no key reaches the join. The rule
+        // does not try to reconstruct one by looking below the side.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
                 .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
                 .setSystemProperty(LEGACY_UNNEST, "true")
                 .on(p -> {
@@ -633,5 +988,62 @@ public class TestCollapseFanoutJoinWithArrayAggUnnest
                     return p.join(INNER, probe, build, new EquiJoinClause(ak1, nk1));
                 })
                 .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireOnCrossJoinSide()
+    {
+        // a JOIN (b CROSS JOIN c) ON a.ak1 = b.k1 does multiply rows, but collapsing it blocks a
+        // strictly better plan: the join reordering that runs after this rule turns it into
+        // (b JOIN a) CROSS JOIN c, moving the multiplication above the join with no packing at all.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression m1 = p.variable("m1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression m2 = p.variable("m2", BIGINT);
+                    ValuesNode probe = p.values(ak1);
+                    JoinNode crossJoin = p.join(INNER, p.values(k1, m1), p.values(k2, m2));
+                    return p.join(INNER, probe, crossJoin, new EquiJoinClause(ak1, k1));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testFiresOnSingleRowLimitDespiteNoFanout()
+    {
+        // Accepted imprecision: a LIMIT 1 side holds at most one row, so collapsing buys nothing, but
+        // grouping properties carry no cardinality and this rule must not consult the constraints
+        // framework, so the side still looks grouped on a superset of the join key. Harmless.
+        tester().assertThat(new CollapseFanoutJoinWithArrayAggUnnest(getMetadata()))
+                .setSystemProperty(OPTIMIZE_JOIN_FAN_OUT, "true")
+                .setSystemProperty(LEGACY_UNNEST, "true")
+                .on(p -> {
+                    VariableReferenceExpression ak1 = p.variable("ak1", BIGINT);
+                    VariableReferenceExpression k1 = p.variable("k1", BIGINT);
+                    VariableReferenceExpression k2 = p.variable("k2", BIGINT);
+                    VariableReferenceExpression v = p.variable("v", BIGINT);
+                    VariableReferenceExpression measure = p.variable("measure", BIGINT);
+                    ValuesNode probe = p.values(ak1);
+                    AggregationNode aggregation = p.aggregation(agg -> agg
+                            .addAggregation(measure, p.rowExpression("sum(v)"))
+                            .singleGroupingSet(k1, k2)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(k1, k2, v)));
+                    return p.join(INNER, probe, p.limit(1, aggregation), new EquiJoinClause(ak1, k1));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(UnnestNode.class,
+                                        node(JoinNode.class,
+                                                node(ValuesNode.class),
+                                                node(AggregationNode.class,
+                                                        node(ProjectNode.class,
+                                                                node(LimitNode.class,
+                                                                        node(AggregationNode.class,
+                                                                                node(ValuesNode.class)))))))));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1781,6 +1781,57 @@ public abstract class AbstractTestQueries
                         "RIGHT JOIN (SELECT regionkey, nationkey, sum(nationkey) AS total FROM nation GROUP BY regionkey, nationkey) b " +
                         "  ON r.regionkey = b.regionkey " +
                         "ORDER BY b.regionkey, b.nationkey",
+                // LEFT join, aggregation on the null-supplying (right) side. The filter leaves
+                // regions 2..4 without a match, so the null-extended rows exercise the COALESCE that
+                // keeps an unmatched row alive through the UNNEST.
+                "SELECT r.regionkey, r.name, b.nationkey, b.total " +
+                        "FROM region r " +
+                        "LEFT JOIN (SELECT regionkey, nationkey, sum(nationkey) AS total FROM nation " +
+                        "           WHERE regionkey < 2 GROUP BY regionkey, nationkey) b " +
+                        "  ON r.regionkey = b.regionkey " +
+                        "ORDER BY r.regionkey, b.nationkey",
+                // RIGHT join, aggregation on the null-supplying (left) side.
+                "SELECT r.regionkey, r.name, b.nationkey, b.total " +
+                        "FROM (SELECT regionkey, nationkey, sum(nationkey) AS total FROM nation " +
+                        "      WHERE regionkey < 2 GROUP BY regionkey, nationkey) b " +
+                        "RIGHT JOIN region r " +
+                        "  ON b.regionkey = r.regionkey " +
+                        "ORDER BY r.regionkey, b.nationkey",
+                // LEFT join over a larger source, with unmatched preserved rows and several packed
+                // columns, including one that is NULL for some matched rows.
+                "SELECT o.orderkey, o.custkey, b.shipmode, b.revenue, b.lines " +
+                        "FROM orders o " +
+                        "LEFT JOIN (SELECT orderkey, shipmode, sum(extendedprice) AS revenue, count(*) AS lines " +
+                        "           FROM lineitem WHERE orderkey % 3 = 0 GROUP BY orderkey, shipmode) b " +
+                        "  ON o.orderkey = b.orderkey " +
+                        "WHERE o.orderkey < 1000 " +
+                        "ORDER BY o.orderkey, b.shipmode",
+                // A UNION below the aggregation: PropertyDerivations does not cover UnionNode, so the
+                // union reports unknown properties while the grouping above it still reaches the join.
+                "SELECT r.regionkey, b.nationkey, b.total " +
+                        "FROM region r " +
+                        "JOIN (SELECT regionkey, nationkey, sum(nationkey) AS total " +
+                        "      FROM (SELECT regionkey, nationkey FROM nation WHERE regionkey < 3 " +
+                        "            UNION ALL SELECT regionkey, nationkey FROM nation WHERE regionkey >= 3) u " +
+                        "      GROUP BY regionkey, nationkey) b " +
+                        "  ON r.regionkey = b.regionkey " +
+                        "ORDER BY r.regionkey, b.nationkey",
+                // DISTINCT build side: the derived key (regionkey, nationkey) is a strict superset of
+                // the join key, a shape the side's own node type does not reveal.
+                "SELECT r.regionkey, r.name, b.nationkey " +
+                        "FROM region r " +
+                        "JOIN (SELECT DISTINCT regionkey, nationkey FROM nation) b " +
+                        "  ON r.regionkey = b.regionkey " +
+                        "ORDER BY r.regionkey, b.nationkey",
+                // Fan-out reported by the derived keys rather than by the shape of the collapsed side:
+                // the side is a TopN over an aggregation, and the key (regionkey, nationkey) carried
+                // up through the TopN is a strict superset of the join key regionkey.
+                "SELECT r.regionkey, r.name, b.nationkey, b.total " +
+                        "FROM region r " +
+                        "JOIN (SELECT regionkey, nationkey, sum(nationkey) AS total FROM nation " +
+                        "      GROUP BY regionkey, nationkey ORDER BY regionkey, nationkey LIMIT 20) b " +
+                        "  ON r.regionkey = b.regionkey " +
+                        "ORDER BY r.regionkey, b.nationkey",
                 // Multiple measures and an extra grouping key, larger source (orders/lineitem).
                 "SELECT o.orderkey, o.custkey, b.shipmode, b.revenue, b.lines " +
                         "FROM orders o " +
@@ -1795,13 +1846,14 @@ public abstract class AbstractTestQueries
                         "JOIN (SELECT regionkey, sum(nationkey) AS total FROM nation GROUP BY regionkey) b " +
                         "  ON r.regionkey = b.regionkey " +
                         "ORDER BY r.regionkey",
-                // Nested-join fan-out: the build side is itself an INNER join keyed on
-                // (regionkey, nationkey) — a strict superset of the outer join key (regionkey).
-                "SELECT r.regionkey, r.name, j.nationkey, j.nname " +
+                // The grouping of an aggregation reaches the outer join across an inner join, since an
+                // inner join propagates its probe's local properties.
+                "SELECT r.regionkey, r.name, j.nationkey, j.total " +
                         "FROM region r " +
-                        "JOIN (SELECT n1.regionkey AS regionkey, n1.nationkey AS nationkey, n2.name AS nname " +
-                        "      FROM nation n1 " +
-                        "      JOIN nation n2 ON n1.regionkey = n2.regionkey AND n1.nationkey = n2.nationkey) j " +
+                        "JOIN (SELECT b.regionkey AS regionkey, b.nationkey AS nationkey, b.total AS total " +
+                        "      FROM (SELECT regionkey, nationkey, sum(nationkey) AS total FROM nation " +
+                        "            GROUP BY regionkey, nationkey) b " +
+                        "      JOIN nation n2 ON b.regionkey = n2.regionkey AND b.nationkey = n2.nationkey) j " +
                         "  ON r.regionkey = j.regionkey " +
                         "ORDER BY r.regionkey, j.nationkey",
         };


### PR DESCRIPTION
## Description

`optimize_join_fan_out` collapses a fan-out equi-join by packing the fanned-out side's non-key columns into `array_agg(row(...))`, making the join `N`-to-`1`, and re-expanding them with a local `UNNEST` above the join. This moves the row multiplication out of the distributed join and into a streaming local operator.

Two limitations kept it from firing on the shapes it was written for.

**Only the preserved side of a join was collapsed.** The fan-out usually sits on the build side of a `LEFT` join — `a LEFT JOIN (SELECT k1, k2, ... GROUP BY k1, k2) b ON a.k1 = b.k1` — which is the null-supplying side. That side produces a `NULL` array for every unmatched row of the preserved side, and `CROSS JOIN UNNEST` (the only unnest available) would drop the row. The packed array is now wrapped in `COALESCE(data, ARRAY[CAST(NULL AS row(...))])` above the join, so an unmatched row unnests to exactly one row whose packed columns all dereference to `NULL` — precisely the null-extended row the outer join must emit. `array_agg` over a group never returns an empty array, so a `NULL` array is the only unmatched signal. The null-supplying side is now tried first. `FULL` joins are left alone.

**Eligibility was a fixed plan shape.** The rule walked down from the join looking for an aggregation grouped by, or an inner join keyed on, a strict superset of the join keys, peering through projections and filters. Anything else in between — a sort, a limit, a projection it could not trace — hid the fan-out. Eligibility is now answered at the join node from the grouping the side reports through `PropertyDerivations`: an `AggregationNode` (including a `DISTINCT`) advertises `LocalProperties.grouped(groupingKeys)`, and `ActualProperties` carry that up through the filters, projections, sorts and limits between it and the join, and across an inner join from its probe. A side grouped on a strict superset of the join keys holds several rows per join key, which is exactly the fan-out condition.

Local properties are hierarchical, so the columns of the prefix are accumulated before comparing — a `TopN` reports one `SortingProperty` per sort column, and only their union covers the aggregation's grouping keys. `ConstantProperty` is skipped, since a column pinned to one value adds no grouping. The side's subtree is materialized out of the memo with `Plans.resolveGroupReferences` first, because `PropertyDerivations` does not understand `GroupReference`; this only runs when the rule is enabled, which it is not by default.

Correctness never depended on the fan-out detection — the pack/unpack pair is an identity for any side — so this is purely a profitability guard.

### Why not the logical property framework

`LogicalProperties` would also answer this, and additionally covers unique and primary key table constraints. It is deliberately not used: it is gated behind `exploit_constraints`, and a rule that depends on it silently does nothing wherever that is disabled. Using property derivation instead means the rule behaves the same everywhere.

Two consequences are accepted. A side whose grouping keys are projected away before the join is not detected, because a local property is discarded when any of its columns cannot be translated (#28300). And grouping carries no cardinality, so an at-most-one-row side may be collapsed pointlessly, which is harmless.

Shapes that now collapse, verified on generated plans: aggregation on either side of an inner join, the null-supplying and preserved sides of `LEFT` and `RIGHT` joins, an aggregation under a `HAVING` filter, an aggregation under a projection computing measures, `SELECT DISTINCT`, and a `TopN` over an aggregation. An aggregation grouped by exactly the join keys correctly does not collapse.

## Motivation and Context

The rule did not fire on the join it was written for, because the side reaching the join was a projection over a filter over the aggregation rather than the aggregation itself.

## Impact

None by default. `optimize_join_fan_out` remains disabled.

## Test Plan

- Unit tests in `TestCollapseFanoutJoinWithArrayAggUnnest`, covering the null-supplying side of `LEFT` and `RIGHT` joins, `FULL` and cross joins declining, detection through projections, filters, limits and an inner join, and negative cases for a side already unique on the join keys and for a computed join key.
- End-to-end tests in `AbstractTestQueries#testOptimizeJoinFanOut`, comparing the optimization enabled against disabled with the same SQL over TPC-H tables, including outer joins with unmatched rows on the preserved side, and run under both `legacy_unnest` settings.
- `mvn validate` and `TestLogicalPlanner`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with unit tests to enforce definition/default-value validity).
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== RELEASE NOTES ==

General Changes
* Improve the ``optimize_join_fan_out`` optimization to collapse the null-supplying side of an outer join, and to detect the fan-out from the grouping a join input reports rather than from a fixed plan shape.
```

## Summary by Sourcery

Generalize the join fan-out collapse optimization to handle additional join shapes, including outer joins, using derived grouping properties instead of fixed plan shapes, and keep behavior gated behind the existing session property.

New Features:
- Allow collapsing either side of INNER, LEFT, and RIGHT joins, including the null-supplying side of outer joins, while preserving correct null-extended rows via COALESCE before UNNEST.
- Use property derivation (ActualProperties and LocalProperties) to detect fan-out based on grouping keys propagated through projections, filters, limits, and inner joins rather than relying on a specific plan structure.

Enhancements:
- Wire CollapseFanoutJoinWithArrayAggUnnest to Metadata instead of directly to FunctionAndTypeManager to support property-based analysis and array construction.
- Refine the optimizer rule to avoid collapsing sides of FULL joins and cross-join-based fan-outs, and to accept some harmless cases where there is no real fan-out.
- Update end-to-end query tests to cover new fan-out detection cases and outer join scenarios, including DISTINCT and TopN over aggregation shapes.

Tests:
- Extend TestCollapseFanoutJoinWithArrayAggUnnest with new cases for collapsing the null-supplying side of LEFT and RIGHT joins, declining on FULL and cross joins, handling derived keys through limits and projections, and verifying behavior under both legacy and non-legacy UNNEST implementations.
- Broaden AbstractTestQueries#testOptimizeJoinFanOut to exercise the generalized optimization across TPC-H-style queries, including outer joins with unmatched rows, DISTINCT, and TopN shapes.