### PR TITLE
fix(security): Escape reflected error code in the OAuth2 failure page

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.server.security.oauth2.TokenPairSerializer.Tok
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.hash.Hashing.sha256;
+import static com.google.common.html.HtmlEscapers.htmlEscaper;
 import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
@@ -256,12 +257,12 @@ public class OAuth2Service
 
     public String getCallbackErrorHtml(String errorCode)
     {
-        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, getOAuth2ErrorMessage(errorCode));
+        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, htmlEscaper().escape(getOAuth2ErrorMessage(errorCode)));
     }
 
     public String getInternalFailureHtml(String errorMessage)
     {
-        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, nullToEmpty(errorMessage));
+        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, htmlEscaper().escape(nullToEmpty(errorMessage)));
     }
 
     private static byte[] secureRandomBytes(int count)

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestOAuth2Service.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestOAuth2Service.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security.oauth2;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.server.security.oauth2.TokenPairSerializer.ACCESS_TOKEN_CLAIMS_ONLY_SERIALIZER;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestOAuth2Service
+{
+    private static OAuth2Service createService()
+            throws IOException
+    {
+        return new OAuth2Service(
+                new OAuth2Client()
+                {
+                    @Override
+                    public void load() {}
+
+                    @Override
+                    public OAuth2Client.Request createAuthorizationRequest(String state, URI callbackUri)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public OAuth2Client.Response getOAuth2Response(String code, URI callbackUri, Optional<String> nonce)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public Optional<Map<String, Object>> getClaims(String accessToken)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public OAuth2Client.Response refreshTokens(String refreshToken)
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+                },
+                new OAuth2Config(),
+                new OAuth2TokenHandler()
+                {
+                    @Override
+                    public void setAccessToken(String hashedState, String accessToken) {}
+
+                    @Override
+                    public void setTokenExchangeError(String hashedState, String errorMessage) {}
+                },
+                ACCESS_TOKEN_CLAIMS_ONLY_SERIALIZER,
+                Optional.empty());
+    }
+
+    @Test
+    public void testCallbackErrorHtmlEscapesUnknownErrorCode()
+            throws IOException
+    {
+        String payload = "<script>alert('xss')</script>";
+        String html = createService().getCallbackErrorHtml(payload);
+
+        assertFalse(html.contains(payload), "error code was reflected into the failure page without escaping");
+        assertFalse(html.contains("<script>"), "unescaped <script> tag present in the failure page");
+        assertTrue(html.contains("&lt;script&gt;"), "escaped error code missing from the failure page");
+    }
+
+    @Test
+    public void testCallbackErrorHtmlKeepsKnownErrorCodeMessage()
+            throws IOException
+    {
+        String html = createService().getCallbackErrorHtml("access_denied");
+        assertTrue(html.contains("OAuth2 server denied the login"), "known error message must be rendered unchanged");
+    }
+
+    @Test
+    public void testInternalFailureHtmlEscapesMessage()
+            throws IOException
+    {
+        String html = createService().getInternalFailureHtml("<img src=x onerror=alert(1)>");
+        assertFalse(html.contains("<img src=x onerror=alert(1)>"), "message was reflected without escaping");
+        assertTrue(html.contains("&lt;img src=x onerror=alert(1)&gt;"), "escaped message missing from the failure page");
+    }
+}


### PR DESCRIPTION
## Description

The OAuth2 callback failure page reflects the OAuth server `error` code into an HTML body without escaping. `OAuth2CallbackResource.callback` reads `@QueryParam("error")` and, through `OAuth2Service.handleOAuth2Error`, renders it with `getCallbackErrorHtml`:

    GET /oauth2/callback?state=<valid-state>&error=<script>alert(document.domain)</script>

For any value that is not a known `OAuth2ErrorCode`, `getOAuth2ErrorMessage` returns it verbatim as `OAuth2 unknown error code: <error>`, and `getCallbackErrorHtml` splices that into `failure.html` at the `<!-- ERROR_MESSAGE -->` placeholder, which sits inside `<h4>...</h4>`. The resource is `@Produces(TEXT_HTML)`, so the injected markup executes in the browser (reflected XSS).

The failure page is only reached after `parseState` accepts the `state` token, but a valid signed state is returned to the client at the start of any login flow, so it can be harvested and used to build the link. `getInternalFailureHtml` writes into the same placeholder and has the same gap.

The change escapes the replacement text with Guava `htmlEscaper()` at both splice points. Known error messages carry no markup, so rendered output for a normal login is byte-for-byte the same.

## Motivation and Context

`error` crosses a trust boundary: an attacker-influenced query parameter reaches an HTML response served by the coordinator. Escaping where the value enters the template keeps the page safe without relying on the caller.

## Impact

No behaviour change for valid logins. Only the reflected error text is now HTML-escaped.

## Test Plan

- Added `TestOAuth2Service`. `getCallbackErrorHtml("<script>...</script>")` no longer emits the raw tag and instead emits `&lt;script&gt;`; a known code (`access_denied`) still renders `OAuth2 server denied the login` unchanged; `getInternalFailureHtml` is covered too. The escaping assertions fail on master and pass with this change.
- `./mvnw -pl presto-main test -Dtest=TestOAuth2Service`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix reflected XSS in the OAuth2 authentication failure page by escaping the reflected error code.
```

## Summary by Sourcery

Escape OAuth2 callback and internal failure error messages before rendering them into the HTML failure page to prevent reflected XSS.

Bug Fixes:
- Ensure OAuth2 callback failure page HTML-escapes unknown error codes reflected in the error message placeholder.
- Ensure internal failure messages in the OAuth2 failure page are HTML-escaped before being injected into the template.

Tests:
- Add unit tests for OAuth2Service to verify HTML escaping of unknown error codes and internal failure messages while preserving known error messages.
