### PR TITLE
fix(native): Type RPCNode column arguments from the source schema (#28309)

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2434,17 +2434,15 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   // Parse the result type from the protocol output variable.
   auto resultType = typeParser_.parse(node->outputVariable.type);
 
-  // Extract argument types and constant values from the protocol argument
-  // expressions. The Java planner sends both `arguments` (original
-  // expressions for type/constant extraction) and `argumentColumns`
-  // (column names for runtime reads by RPCOperator).
-  std::vector<TypePtr> argumentTypes;
+  // Extract constant values from the protocol argument expressions. The Java
+  // planner sends both `arguments` (original expressions, used here to detect
+  // constant literals) and `argumentColumns` (column names for runtime reads by
+  // RPCOperator). Column-argument types come from the source schema below, not
+  // from the argument expression's declared type.
   std::vector<VectorPtr> constantInputs;
-  argumentTypes.reserve(node->arguments.size());
   constantInputs.reserve(node->arguments.size());
   for (const auto& arg : node->arguments) {
     auto veloxExpr = exprConverter_.toVeloxExpr(arg);
-    argumentTypes.push_back(veloxExpr->type());
 
     // Extract constant value. Unwrap CastTypedExpr if present — the Java
     // planner wraps string literals in CAST(x AS VARCHAR) which hides the
@@ -2501,6 +2499,9 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   // Build CallTypedExpr inputs: FieldAccess for columns, Constant for literals
   // (Velox #18267 folds RPCNode args into CallTypedExpr: field refs vs
   // constants)
+  // argumentColumns and constantInputs are parallel per-argument arrays; the
+  // loop indexes both, so they must stay aligned.
+  VELOX_CHECK_EQ(argumentColumns.size(), constantInputs.size());
   std::vector<core::TypedExprPtr> callInputs;
   callInputs.reserve(argumentColumns.size());
   for (size_t i = 0; i < argumentColumns.size(); ++i) {
@@ -2508,9 +2509,18 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       callInputs.push_back(
           std::make_shared<core::ConstantTypedExpr>(constantInputs[i]));
     } else {
+      // A column argument's FieldAccess must carry the SOURCE column's actual
+      // type, not the argument expression's declared type: RPCOperator reads
+      // this column by name at runtime, so a CAST-wrapped argument would
+      // otherwise misdeclare the vector that is actually read.
+      const auto childIdx = sourceType->getChildIdxIfExists(argumentColumns[i]);
+      VELOX_CHECK(
+          childIdx.has_value(),
+          "RPCNode argument column '{}' not found in source schema",
+          argumentColumns[i]);
       callInputs.push_back(
           std::make_shared<core::FieldAccessTypedExpr>(
-              argumentTypes[i], argumentColumns[i]));
+              sourceType->childAt(*childIdx), argumentColumns[i]));
     }
   }
   auto call = std::make_shared<core::CallTypedExpr>(

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -106,6 +106,27 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+add_executable(presto_rpc_plan_converter_test RPCPlanConverterTest.cpp)
+
+add_test(
+  NAME presto_rpc_plan_converter_test
+  COMMAND presto_rpc_plan_converter_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+  presto_rpc_plan_converter_test
+  presto_connectors
+  presto_operators
+  presto_protocol
+  presto_type_converter
+  presto_types
+  velox
+  velox_async_rpc_function_registry
+  GTest::gtest
+  GTest::gtest_main
+)
+
 # RemoteFunctionHandleTest.cpp only contains tests cases related to
 # RestFunctionHandle, therefore it is only enabled when remote functions are
 # enabled.

--- a/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RPCPlanConverterTest.cpp
@@ -15,6 +15,7 @@
 
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
 
@@ -159,15 +160,101 @@ TEST_F(RPCPlanConverterTest, rpcNodeWithRegisteredFunction) {
   EXPECT_EQ(veloxRpcNode->functionName(), "fb_llm_inference");
   EXPECT_EQ(veloxRpcNode->outputColumn(), "__rpc_result");
 
-  // Verify argumentColumns are passed through.
-  ASSERT_EQ(veloxRpcNode->argumentColumns().size(), 1);
-  EXPECT_EQ(veloxRpcNode->argumentColumns()[0], "comment");
+  // Verify the call argument: a single column reference to "comment", typed
+  // VARCHAR. A variable reference is not a constant, so it becomes a
+  // FieldAccessTypedExpr column argument rather than a ConstantTypedExpr.
+  ASSERT_EQ(veloxRpcNode->call()->inputs().size(), 1);
+  auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      veloxRpcNode->call()->inputs()[0].get());
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->name(), "comment");
+  EXPECT_EQ(field->type()->kind(), TypeKind::VARCHAR);
+}
 
-  // Verify argumentTypes are extracted from argument expressions.
-  ASSERT_EQ(veloxRpcNode->argumentTypes().size(), 1);
-  EXPECT_EQ(veloxRpcNode->argumentTypes()[0]->kind(), TypeKind::VARCHAR);
+// A column argument's FieldAccess must carry the SOURCE column's actual type,
+// not the argument expression's declared type. In production the Java planner
+// hoists the argument expression (e.g. a CAST) into the source column, so the
+// two normally agree; this test forces them to differ (source column "num" is
+// BIGINT while the argument expression is declared VARCHAR) to pin that the
+// converter uses the authoritative source-schema type. RPCOperator reads that
+// column by name at runtime, so a FieldAccess typed from the argument
+// expression would misdeclare the vector actually read.
+TEST_F(RPCPlanConverterTest, columnArgUsesSourceColumnType) {
+  exec_rpc::AsyncRPCFunctionRegistry::testingClear();
+  exec_rpc::AsyncRPCFunctionRegistry::registerFunction(
+      "fb_llm_inference", []() { return nullptr; });
 
-  // Verify constantInputs: arg 0 is a variable reference (nullptr).
-  ASSERT_EQ(veloxRpcNode->constantInputs().size(), 1);
-  EXPECT_EQ(veloxRpcNode->constantInputs()[0], nullptr);
+  // Source produces column "num" of type BIGINT.
+  auto valuesNode = std::make_shared<protocol::ValuesNode>();
+  valuesNode->_type = "com.facebook.presto.sql.planner.plan.ValuesNode";
+  valuesNode->id = "0";
+  protocol::VariableReferenceExpression numVar;
+  numVar.name = "num";
+  numVar.type = "bigint";
+  valuesNode->outputVariables.push_back(numVar);
+
+  // The RPC argument references "num" but with a DIFFERENT declared type
+  // (varchar), as a hoisted CAST(num AS varchar) would present it.
+  // argumentColumns names the source column the operator actually reads.
+  auto rpcNode = std::make_shared<protocol::RPCNode>();
+  rpcNode->_type = "com.facebook.presto.sql.planner.plan.RPCNode";
+  rpcNode->id = "8";
+  rpcNode->source = valuesNode;
+  rpcNode->functionName = "fb_llm_inference";
+  auto arg = std::make_shared<protocol::VariableReferenceExpression>();
+  arg->_type = "variable";
+  arg->name = "num";
+  arg->type = "varchar"; // differs from the source column's BIGINT
+  rpcNode->arguments.push_back(arg);
+  rpcNode->argumentColumns = {"num"};
+  rpcNode->outputVariable.name = "__rpc_result";
+  rpcNode->outputVariable.type = "varchar";
+  rpcNode->streamingMode = protocol::RPCNodeStreamingMode::PER_ROW;
+  rpcNode->dispatchBatchSize = 0;
+
+  VeloxInteractiveQueryPlanConverter converter(queryCtx_.get(), pool_.get());
+  auto veloxPlan = converter.toVeloxQueryPlan(
+      std::dynamic_pointer_cast<protocol::PlanNode>(rpcNode),
+      nullptr,
+      "20260124_042527_00001_gp3te.1.0.0.0");
+  auto veloxRpcNode = std::dynamic_pointer_cast<const core::RPCNode>(veloxPlan);
+  ASSERT_NE(veloxRpcNode, nullptr);
+
+  ASSERT_EQ(veloxRpcNode->call()->inputs().size(), 1);
+  auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      veloxRpcNode->call()->inputs()[0].get());
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->name(), "num");
+  // Authoritative source-column type (BIGINT), NOT the argument's declared
+  // VARCHAR: this is the column RPCOperator reads by name at runtime.
+  EXPECT_EQ(field->type()->kind(), TypeKind::BIGINT);
+}
+
+// A column argument that names a column absent from the source schema must fail
+// fast with a clear message. In production the Java planner hoists argument
+// expressions into source columns so this cannot happen, but a malformed plan
+// should surface an actionable error rather than a generic lookup failure.
+TEST_F(RPCPlanConverterTest, columnArgNotInSourceThrows) {
+  exec_rpc::AsyncRPCFunctionRegistry::testingClear();
+  exec_rpc::AsyncRPCFunctionRegistry::registerFunction(
+      "fb_llm_inference", []() { return nullptr; });
+
+  // Source produces column "comment"; the RPC column argument names a column
+  // that does not exist in the source schema.
+  auto valuesNode = makeValuesNode();
+  auto rpcNode = makeRPCNode(valuesNode);
+  rpcNode->argumentColumns = {"missing_col"};
+
+  VeloxInteractiveQueryPlanConverter converter(queryCtx_.get(), pool_.get());
+  try {
+    converter.toVeloxQueryPlan(
+        std::dynamic_pointer_cast<protocol::PlanNode>(rpcNode),
+        nullptr,
+        "20260124_042527_00001_gp3te.1.0.0.0");
+    FAIL() << "expected conversion to throw for a missing source column";
+  } catch (const VeloxException& e) {
+    EXPECT_NE(
+        std::string(e.what()).find("not found in source schema"),
+        std::string::npos);
+  }
 }


### PR DESCRIPTION
Summary:

Fold of D113578838 + D113617918, reduced to the residue that is not
already in master -- the RPCNode CallTypedExpr migration itself landed
via prestodb/presto #28292.

The migrated converter typed each column argument's FieldAccessTypedExpr
from the argument expression's declared type (argumentTypes[i] =
veloxExpr->type()). For a CAST-wrapped column argument (e.g.
CAST(num AS VARCHAR) over a BIGINT source column) that declares the
FieldAccess VARCHAR, while RPCOperator reads the BIGINT source column by
name at runtime -- an expr-compilation type mismatch. Type the
FieldAccess from the source schema instead
(sourceType->findChild(argumentColumns[i])), the authoritative type of
the column actually read. argumentTypes is then unused and removed. A
VELOX_CHECK_EQ pins the argumentColumns/constantInputs parallel-array
invariant.

```
== NO RELEASE NOTE ==
```
Differential Revision: D115438463
