### PR TITLE
fix(connector): Fix handling of hyphenated struct field names when sanitizing HMS type strings

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveColumnConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveColumnConverter.java
@@ -19,6 +19,8 @@ import com.facebook.presto.hive.HiveType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.emptyToNull;
 
@@ -27,10 +29,32 @@ public class HiveColumnConverter
 {
     public HiveColumnConverter() {}
 
+    // Matches struct field-name tokens (before ':') in an HMS type string.
+    // Used to sanitize names with special chars (e.g. hyphens) that Hive's
+    // TypeInfoParser cannot handle.
+    private static final Pattern STRUCT_FIELD_NAME_PATTERN =
+            Pattern.compile("(?<=struct<|(?<=,))([^<>,:]+)(?=:)");
+
+    // Replaces non-[a-zA-Z0-9_] characters in struct field-name positions with '_'
+    // so that HiveType.valueOf() does not crash on HMS type strings written by external
+    // engines (e.g. Spark) with hyphenated field names. Safe because the HMS type string
+    // is not used for query execution — actual field names come from Iceberg metadata JSON.
+    static String sanitizeHmsTypeString(String typeString)
+    {
+        StringBuffer result = new StringBuffer();
+        Matcher matcher = STRUCT_FIELD_NAME_PATTERN.matcher(typeString);
+        while (matcher.find()) {
+            matcher.appendReplacement(result,
+                    Matcher.quoteReplacement(matcher.group(1).replaceAll("[^a-zA-Z0-9_]", "_")));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
     @Override
     public Column toColumn(FieldSchema fieldSchema)
     {
-        return new Column(fieldSchema.getName(), HiveType.valueOf(fieldSchema.getType()), Optional.ofNullable(emptyToNull(fieldSchema.getComment())), Optional.empty());
+        return new Column(fieldSchema.getName(), HiveType.valueOf(sanitizeHmsTypeString(fieldSchema.getType())), Optional.ofNullable(emptyToNull(fieldSchema.getComment())), Optional.empty());
     }
 
     @Override


### PR DESCRIPTION
## Description

When an Iceberg table is created/ingested by Spark, the HMS type string is written with raw field names such as 'name-test' or 'aws-region'. Hive's `TypeInfoParser` treats '-' as an arithmetic operator, so reading that type string via `HiveType.valueOf()` throws:

`  IllegalArgumentException: Error: ':' expected at position N but '-' found`

This crash happens in `HiveColumnConverter.toColumn()` on every query that loads table metadata from HMS, before any Iceberg or Parquet code is reached.  The existing `sanitizeTypeString()` in `IcebergUtil` only runs on the Presto write path
(CREATE TABLE / commit) and does not cover externally-ingested tables.

so added `sanitizeHmsTypeString()` in `HiveColumnConverter` which replaces non-alphanumeric/underscore characters in struct field-name positions (tokens before`':' `inside `struct<>`) with '_' before passing the string to `HiveType.valueOf()`.

This is safe because the HMS type string is not used for query execution in the Iceberg connector; actual field names and types come from the Iceberg metadata JSON, which is preserved unchanged.


## Motivation and Context

<img width="1125" height="532" alt="Screenshot 2026-08-10 at 12 51 41 PM" src="https://github.com/user-attachments/assets/9e58bc3f-1a76-4d6f-b106-e47423cd6192" />


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Sanitize HMS type string to handle hyphenated struct field names
