### PR TITLE
feat: Conform to the Puffin and partition-spec formats, and extend coverage

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -224,6 +224,19 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-api</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
             <version>${dep.iceberg.version}</version>
             <classifier>tests</classifier>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -39,6 +39,38 @@ const std::unordered_set<std::string> kRowLineageColumnNames = {
         kLastUpdatedSequenceNumberColumnName,
 };
 
+std::unordered_map<std::string, int32_t> parseTopLevelFieldIds(
+    const std::shared_ptr<protocol::String>& tableSchemaJson) {
+  if (tableSchemaJson == nullptr || tableSchemaJson->empty()) {
+    return {};
+  }
+
+  try {
+    const auto schema = folly::parseJson(*tableSchemaJson);
+    const auto* fields = schema.get_ptr("fields");
+    if (fields == nullptr || !fields->isArray()) {
+      return {};
+    }
+
+    std::unordered_map<std::string, int32_t> fieldIds;
+    fieldIds.reserve(fields->size());
+    for (const auto& field : *fields) {
+      const auto* id = field.get_ptr("id");
+      const auto* name = field.get_ptr("name");
+      if (id == nullptr || !id->isInt() || name == nullptr ||
+          !name->isString()) {
+        return {};
+      }
+      fieldIds.emplace(name->asString(), static_cast<int32_t>(id->asInt()));
+    }
+    return fieldIds;
+  } catch (const folly::json::parse_error&) {
+    return {};
+  } catch (const folly::TypeError&) {
+    return {};
+  }
+}
+
 velox::connector::hive::iceberg::FileContent toVeloxFileContent(
     const presto::protocol::iceberg::FileContent content) {
   if (content == protocol::iceberg::FileContent::DATA) {
@@ -118,6 +150,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
     const protocol::TableHandle& tableHandle,
     const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
         columnHandles,
+    const std::unordered_map<std::string, int32_t>& fieldIdsByName,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) {
   velox::common::SubfieldFilters subfieldFilters;
@@ -140,6 +173,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
   }
 
   velox::RowTypePtr finalDataColumns;
+  std::vector<int32_t> dataColumnFieldIds;
   if (!dataColumns.empty()) {
     std::vector<std::string> names;
     std::vector<velox::TypePtr> types;
@@ -173,6 +207,32 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
       }
     }
 
+    dataColumnFieldIds.reserve(names.size());
+    for (const auto& name : names) {
+      const auto fieldIdIt = fieldIdsByName.find(name);
+      if (fieldIdIt != fieldIdsByName.end()) {
+        dataColumnFieldIds.push_back(fieldIdIt->second);
+        continue;
+      }
+
+      const auto handleIt = kRowLineageColumnNames.count(name)
+          ? std::find_if(
+                columnHandles.begin(),
+                columnHandles.end(),
+                [&name](const auto& handle) { return handle->name() == name; })
+          : columnHandles.end();
+      const auto* icebergHandle = handleIt != columnHandles.end()
+          ? dynamic_cast<
+                const velox::connector::hive::iceberg::IcebergColumnHandle*>(
+                handleIt->get())
+          : nullptr;
+      if (icebergHandle == nullptr) {
+        dataColumnFieldIds.clear();
+        break;
+      }
+      dataColumnFieldIds.push_back(icebergHandle->field().fieldId);
+    }
+
     finalDataColumns = ROW(std::move(names), std::move(types));
   }
 
@@ -182,8 +242,12 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
       std::move(subfieldFilters),
       remainingFilter,
       finalDataColumns,
-      std::unordered_map<std::string, std::string>{},
-      columnHandles);
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      columnHandles,
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      std::move(dataColumnFieldIds));
 }
 
 velox::connector::hive::iceberg::IcebergPartitionSpec::Field
@@ -504,6 +568,7 @@ IcebergPrestoToVeloxConnector::toVeloxTableHandle(
       icebergLayout->dataColumns,
       tableHandle,
       columnHandles,
+      parseTopLevelFieldIds(icebergTableHandle->tableSchemaJson),
       exprConverter,
       typeParser);
 }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -309,11 +309,12 @@ velox::parquet::ParquetFieldId toParquetField(
 }
 
 // Extracts the Iceberg partition spec ID from the JSON-encoded spec carried on
-// each split (IcebergSplit.partitionSpecAsJson on the Java side). The JSON
-// always has a top-level "specId" integer per Iceberg's PartitionSpecParser.
-// Returns std::nullopt only when parsing fails so callers can decide whether
-// to omit the resulting info column (synthesis paths that depend on a real
-// spec_id should treat absence as a hard error).
+// each split (IcebergSplit.partitionSpecAsJson on the Java side). The producer
+// is Iceberg's PartitionSpecParser.toJson, which emits the hyphenated
+// "spec-id" key (matching "source-id" / "field-id" on each field) -- not a
+// camelCase "specId". Returns std::nullopt only when parsing fails so callers
+// can decide whether to omit the resulting info column (synthesis paths that
+// depend on a real spec_id should treat absence as a hard error).
 std::optional<int32_t> tryParsePartitionSpecId(
     const std::string& partitionSpecAsJson) {
   if (partitionSpecAsJson.empty()) {
@@ -324,7 +325,7 @@ std::optional<int32_t> tryParsePartitionSpecId(
     if (!parsed.isObject()) {
       return std::nullopt;
     }
-    const auto* specIdField = parsed.get_ptr("specId");
+    const auto* specIdField = parsed.get_ptr("spec-id");
     if (specIdField == nullptr || !specIdField->isInt()) {
       return std::nullopt;
     }
@@ -567,14 +568,7 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
       deletes,
       infoColumns,
       std::nullopt,
-      // Left at the "unassigned" default rather than
-      // 'icebergSplit->dataSequenceNumber'. Populating it would newly activate
-      // the V2 sequence-number filtering of equality deletes in
-      // IcebergSplitReader, which is a behavior change unrelated to identity
-      // partition resolution.
-      // TODO: Wire the real data sequence number through once that filtering
-      // change can be validated on its own.
-      /*dataSequenceNumber=*/0,
+      icebergSplit->dataSequenceNumber,
       parseIdentityPartitionKeys(
           icebergSplit->partitionSpecAsJson, icebergSplit->partitionKeys));
 }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -345,6 +345,8 @@ std::optional<int32_t> tryParsePartitionSpecId(
 //    "fields": [{"name": "ts_day", "transform": "day",
 //                "source-id": 3, "field-id": 1000}]}
 //
+// "field-id" is optional; V1 specs omit it.
+//
 // Only an identity partition value equals the source column's value, so only
 // identity fields may be substituted for a read of the source column. A
 // transformed field ("bucket[16]", "truncate[4]", "year"/"month"/"day"/"hour")
@@ -387,13 +389,21 @@ parseIdentityPartitionKeys(
       }
       const auto* transform = field.get_ptr("transform");
       const auto* sourceId = field.get_ptr("source-id");
-      const auto* fieldId = field.get_ptr("field-id");
       const auto* name = field.get_ptr("name");
       // Reject the whole spec rather than silently skipping a field: a
       // partially understood spec cannot prove which fields are identity.
       if (transform == nullptr || !transform->isString() ||
-          sourceId == nullptr || !sourceId->isInt() || fieldId == nullptr ||
-          !fieldId->isInt() || name == nullptr || !name->isString()) {
+          sourceId == nullptr || !sourceId->isInt() || name == nullptr ||
+          !name->isString()) {
+        return {};
+      }
+      // Iceberg's own parser treats "field-id" as optional -- V1 specs omit it
+      // and the partition field IDs are assigned from PARTITION_DATA_ID_START
+      // on read. Only "source-id" is needed to classify and look up an
+      // identity field, so absence must not disqualify the spec. Present but
+      // non-integer is still a reason to distrust it.
+      const auto* fieldId = field.get_ptr("field-id");
+      if (fieldId != nullptr && !fieldId->isInt()) {
         return {};
       }
       if (transform->asString() != "identity") {
@@ -402,7 +412,7 @@ parseIdentityPartitionKeys(
 
       const auto sourceFieldId = static_cast<int32_t>(sourceId->asInt());
       auto valueIt = partitionKeys.find(sourceFieldId);
-      if (valueIt == partitionKeys.end()) {
+      if (valueIt == partitionKeys.end() && fieldId != nullptr) {
         valueIt = partitionKeys.find(static_cast<int32_t>(fieldId->asInt()));
       }
       if (valueIt == partitionKeys.end()) {

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -336,6 +336,91 @@ std::optional<int32_t> tryParsePartitionSpecId(
   }
 }
 
+// Maps the Iceberg source-column field ID of every explicitly identity
+// partition field to that field's partition value for this split.
+//
+// 'partitionSpecAsJson' is Iceberg's PartitionSpecParser.toJson() output:
+//   {"spec-id": 0,
+//    "fields": [{"name": "ts_day", "transform": "day",
+//                "source-id": 3, "field-id": 1000}]}
+//
+// Only an identity partition value equals the source column's value, so only
+// identity fields may be substituted for a read of the source column. A
+// transformed field ("bucket[16]", "truncate[4]", "year"/"month"/"day"/"hour")
+// stores the transform result, not the source value. "void" is the dangerous
+// case that name matching cannot catch: it always stores null and, unlike the
+// other transforms, keeps the source column's name by default, so a
+// name-keyed lookup would happily substitute a null for live source data.
+//
+// The Java producer (IcebergUtil.getPartitionKeys) keys every partition field
+// by 'PartitionField.fieldId()' and additionally duplicates identity fields
+// under 'PartitionField.sourceId()'. Prefer the source-ID entry, and fall back
+// to the partition-field-ID entry only after the spec has proven the transform
+// is identity.
+//
+// Returns an empty map when the spec is absent or malformed so callers read
+// source columns from the data file instead of inferring identity by name.
+std::unordered_map<int32_t, std::optional<std::string>>
+parseIdentityPartitionKeys(
+    const std::string& partitionSpecAsJson,
+    const protocol::Map<protocol::Integer, protocol::hive::HivePartitionKey>&
+        partitionKeys) {
+  if (partitionSpecAsJson.empty() || partitionKeys.empty()) {
+    return {};
+  }
+
+  try {
+    const auto spec = folly::parseJson(partitionSpecAsJson);
+    if (!spec.isObject()) {
+      return {};
+    }
+    const auto* fields = spec.get_ptr("fields");
+    if (fields == nullptr || !fields->isArray()) {
+      return {};
+    }
+
+    std::unordered_map<int32_t, std::optional<std::string>> identityKeys;
+    for (const auto& field : *fields) {
+      if (!field.isObject()) {
+        return {};
+      }
+      const auto* transform = field.get_ptr("transform");
+      const auto* sourceId = field.get_ptr("source-id");
+      const auto* fieldId = field.get_ptr("field-id");
+      const auto* name = field.get_ptr("name");
+      // Reject the whole spec rather than silently skipping a field: a
+      // partially understood spec cannot prove which fields are identity.
+      if (transform == nullptr || !transform->isString() ||
+          sourceId == nullptr || !sourceId->isInt() || fieldId == nullptr ||
+          !fieldId->isInt() || name == nullptr || !name->isString()) {
+        return {};
+      }
+      if (transform->asString() != "identity") {
+        continue;
+      }
+
+      const auto sourceFieldId = static_cast<int32_t>(sourceId->asInt());
+      auto valueIt = partitionKeys.find(sourceFieldId);
+      if (valueIt == partitionKeys.end()) {
+        valueIt = partitionKeys.find(static_cast<int32_t>(fieldId->asInt()));
+      }
+      if (valueIt == partitionKeys.end()) {
+        continue;
+      }
+      identityKeys.emplace(
+          sourceFieldId,
+          valueIt->second.value == nullptr
+              ? std::nullopt
+              : std::optional<std::string>{*valueIt->second.value});
+    }
+    return identityKeys;
+  } catch (const folly::json::parse_error&) {
+    return {};
+  } catch (const folly::TypeError&) {
+    return {};
+  }
+}
+
 // Builds the Velox Iceberg V3 type-attribute tree (IcebergFieldMetadata) from
 // the protocol ColumnIdentity, walked in lockstep with toParquetField(). Each
 // protocol field is nullable; an absent typeAttributes (the common case) yields
@@ -480,7 +565,18 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
       nullptr,
       splitContext->cacheable,
       deletes,
-      infoColumns);
+      infoColumns,
+      std::nullopt,
+      // Left at the "unassigned" default rather than
+      // 'icebergSplit->dataSequenceNumber'. Populating it would newly activate
+      // the V2 sequence-number filtering of equality deletes in
+      // IcebergSplitReader, which is a behavior change unrelated to identity
+      // partition resolution.
+      // TODO: Wire the real data sequence number through once that filtering
+      // change can be validated on its own.
+      /*dataSequenceNumber=*/0,
+      parseIdentityPartitionKeys(
+          icebergSplit->partitionSpecAsJson, icebergSplit->partitionKeys));
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -874,3 +874,176 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitTranslatesDeletionVectorDelete) {
   EXPECT_EQ(deleteFile.contentLength, 64);
   EXPECT_EQ(deleteFile.referencedDataFile, "/path/to/data/file.dwrf");
 }
+
+namespace {
+
+// Builds a PartitionSpecParser.toJson() payload. Iceberg uses hyphenated key
+// names ("spec-id", "source-id", "field-id"), which is what a real split
+// carries.
+std::string makePartitionSpecJson(const std::string& fieldsJson) {
+  return fmt::format(R"({{"spec-id":0,"fields":[{}]}})", fieldsJson);
+}
+
+protocol::hive::HivePartitionKey makePartitionKey(
+    const std::string& name,
+    const std::optional<std::string>& value) {
+  protocol::hive::HivePartitionKey key;
+  key.name = name;
+  if (value.has_value()) {
+    key.value = std::make_shared<protocol::String>(*value);
+  }
+  return key;
+}
+
+} // namespace
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitRetainsOnlyIdentityPartitions) {
+  // A spec mixing identity, bucket, and void. Both transformed fields are
+  // deliberately named after a real source column so that any name-based
+  // classification would misidentify them: 'void' keeps the source name by
+  // default, and a bucket field can be explicitly named anything.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1,"field-id":1000},)"
+      R"({"name":"name","transform":"bucket[4]","source-id":2,"field-id":1001},)"
+      R"({"name":"ts","transform":"void","source-id":3,"field-id":1002})");
+  // Java keys every field by its partition-field ID and duplicates identity
+  // fields under the source ID.
+  split.partitionKeys = {
+      {1, makePartitionKey("id", "7")},
+      {1000, makePartitionKey("id", "7")},
+      {1001, makePartitionKey("name", "3")},
+      {1002, makePartitionKey("ts", std::nullopt)},
+  };
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  // Only source field ID 1 is substitutable. The bucket ordinal and the void
+  // null must not be offered as source-column values.
+  const std::unordered_map<int32_t, std::optional<std::string>> expected = {
+      {1, std::optional<std::string>{"7"}}};
+  EXPECT_EQ(hiveIceberg->identityPartitionKeys, expected);
+
+  // The raw name-keyed map is unchanged and still carries every field.
+  EXPECT_EQ(hiveIceberg->partitionKeys.size(), 3);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitKeepsNullIdentityPartition) {
+  // A null identity value is still substitutable — the source column really
+  // is null for every row in this partition.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1,"field-id":1000})");
+  split.partitionKeys = {
+      {1, makePartitionKey("id", std::nullopt)},
+      {1000, makePartitionKey("id", std::nullopt)},
+  };
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  const std::unordered_map<int32_t, std::optional<std::string>> expected = {
+      {1, std::nullopt}};
+  EXPECT_EQ(hiveIceberg->identityPartitionKeys, expected);
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    toVeloxSplitIdentityPartitionFallsBackToFieldId) {
+  // Defensive: if a producer emits only the partition-field-ID entry, the
+  // value is still recoverable because the spec already proved the transform
+  // is identity. The result stays keyed by the source ID.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1,"field-id":1000})");
+  split.partitionKeys = {{1000, makePartitionKey("id", "7")}};
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  const std::unordered_map<int32_t, std::optional<std::string>> expected = {
+      {1, std::optional<std::string>{"7"}}};
+  EXPECT_EQ(hiveIceberg->identityPartitionKeys, expected);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitSkipsIdentityWithNoValue) {
+  // An identity field whose value is absent under both its source ID and its
+  // partition-field ID is skipped rather than guessed at, so the reader falls
+  // back to reading the source column from the file.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1,"field-id":1000})");
+  // Only an unrelated field's value is present.
+  split.partitionKeys = {{4242, makePartitionKey("other", "9")}};
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  EXPECT_TRUE(hiveIceberg->identityPartitionKeys.empty());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitRejectsUnusablePartitionSpec) {
+  // Absent, unparseable, and structurally incomplete specs must all yield an
+  // empty map so the reader falls back to reading source columns from the
+  // file rather than guessing identity from a name match.
+  const std::vector<std::string> unusableSpecs = {
+      "",
+      "not json at all",
+      // Valid JSON, but not an object.
+      "[1, 2, 3]",
+      R"({"spec-id":0})",
+      // "fields" present but its entries are not objects.
+      R"({"spec-id":0,"fields":[1,2]})",
+      // A field missing "source-id" cannot be classified, so the whole spec
+      // is rejected rather than partially trusted.
+      makePartitionSpecJson(
+          R"({"name":"id","transform":"identity","field-id":1000})"),
+  };
+
+  for (const auto& specJson : unusableSpecs) {
+    protocol::iceberg::IcebergSplit split;
+    split.path = "/path/to/data/file.dwrf";
+    split.fileFormat = protocol::iceberg::FileFormat::ORC;
+    split.partitionSpecAsJson = specJson;
+    split.partitionKeys = {
+        {1, makePartitionKey("id", "7")},
+        {1000, makePartitionKey("id", "7")},
+    };
+
+    protocol::SplitContext context;
+    IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+    auto veloxSplit =
+        icebergConnector.toVeloxSplit("iceberg", &split, &context);
+    auto* hiveIceberg =
+        dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+            veloxSplit.get());
+    ASSERT_NE(hiveIceberg, nullptr);
+    EXPECT_TRUE(hiveIceberg->identityPartitionKeys.empty())
+        << "spec should have been rejected: " << specJson;
+  }
+}

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -161,6 +161,38 @@ TEST_F(PrestoToVeloxConnectorTest, icebergPreservesColumnNameCase) {
   EXPECT_EQ(dataColumnsType->nameOf(1), kColumnName2);
 }
 
+TEST_F(PrestoToVeloxConnectorTest, icebergTableSchemaFieldIds) {
+  auto dataColumns = createTestDataColumns();
+  auto layout = std::make_shared<protocol::iceberg::IcebergTableLayoutHandle>();
+  setCommonLayoutProperties(layout, dataColumns, createTrueConstant());
+
+  auto icebergHandle =
+      std::make_shared<protocol::iceberg::IcebergTableHandle>();
+  icebergHandle->schemaName = "test_schema";
+  icebergHandle->icebergTableName.tableName = "test_table";
+  icebergHandle->tableSchemaJson = std::make_shared<std::string>(
+      R"({"schema-id":7,"fields":[{"id":11,"name":"MixedCaseCol1","required":false,"type":"int"},{"id":29,"name":"UPPERCASECOL2","required":false,"type":"string"}]})");
+
+  protocol::TableHandle tableHandle;
+  tableHandle.connectorId = "iceberg";
+  tableHandle.connectorHandle = icebergHandle;
+  tableHandle.connectorTableLayout = layout;
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result = icebergConnector.toVeloxTableHandle(
+      tableHandle, *exprConverter_, *typeParser_);
+  auto* handle = dynamic_cast<connector::hive::HiveTableHandle*>(result.get());
+  ASSERT_NE(handle, nullptr);
+  EXPECT_EQ(handle->dataColumnFieldIds(), (std::vector<int32_t>{11, 29}));
+
+  icebergHandle->tableSchemaJson.reset();
+  result = icebergConnector.toVeloxTableHandle(
+      tableHandle, *exprConverter_, *typeParser_);
+  handle = dynamic_cast<connector::hive::HiveTableHandle*>(result.get());
+  ASSERT_NE(handle, nullptr);
+  EXPECT_TRUE(handle->dataColumnFieldIds().empty());
+}
+
 TEST_F(PrestoToVeloxConnectorTest, hiveLowercasesColumnNames) {
   auto dataColumns = createTestDataColumns();
   auto trueConstant = createTrueConstant();

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -1153,3 +1153,441 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitKeepsUnassignedSequenceNumber) {
 
   EXPECT_EQ(hiveIceberg->dataSequenceNumber, 0);
 }
+
+namespace {
+
+// One REGULAR integer column named "id", used as both an input column and the
+// source of the partition field below.
+protocol::iceberg::IcebergColumnHandle makeIcebergIdColumn() {
+  protocol::iceberg::IcebergColumnHandle column;
+  column.columnIdentity.name = "id";
+  column.columnIdentity.id = 1;
+  column.columnIdentity.typeCategory =
+      protocol::iceberg::TypeCategory::PRIMITIVE;
+  column.type = "integer";
+  column.columnType = protocol::hive::ColumnType::REGULAR;
+  return column;
+}
+
+// A one-field identity partition spec over "id".
+//
+// toVeloxIcebergPartitionField resolves each field's Velox type by matching
+// the *partition field* name against the schema's column names, so the schema
+// must carry a column of the same name or the conversion throws.
+protocol::iceberg::PrestoIcebergPartitionSpec makeIdentityPartitionSpec() {
+  protocol::iceberg::PrestoIcebergNestedField schemaColumn;
+  schemaColumn.id = 1;
+  schemaColumn.name = "id";
+  schemaColumn.prestoType = "integer";
+  schemaColumn.optional = true;
+
+  protocol::iceberg::PrestoIcebergSchema schema;
+  schema.schemaId = 0;
+  schema.columns = {schemaColumn};
+
+  protocol::iceberg::IcebergPartitionField field;
+  field.sourceId = 1;
+  field.fieldId = 1000;
+  field.name = "id";
+  field.transform = protocol::iceberg::PartitionTransformType::IDENTITY;
+
+  protocol::iceberg::PrestoIcebergPartitionSpec spec;
+  spec.specId = 3;
+  spec.schema = schema;
+  spec.fields = {field};
+  return spec;
+}
+
+// Asserts the parts every write handle shares: a partitioned Iceberg insert
+// handle whose location points at "<outputPath>/data".
+void verifyIcebergWriteHandle(
+    const std::unique_ptr<connector::ConnectorInsertTableHandle>& result,
+    connector::hive::LocationHandle::TableType expectedTableType,
+    connector::hive::iceberg::IcebergInsertTableHandle::WriteKind
+        expectedWriteKind) {
+  ASSERT_NE(result, nullptr);
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+
+  EXPECT_EQ(icebergInsert->writeKind(), expectedWriteKind);
+  EXPECT_EQ(
+      icebergInsert->locationHandle()->targetPath(), "/path/to/table/data");
+  EXPECT_EQ(icebergInsert->locationHandle()->tableType(), expectedTableType);
+
+  ASSERT_EQ(icebergInsert->inputColumns().size(), 1);
+  EXPECT_EQ(icebergInsert->inputColumns()[0]->name(), "id");
+
+  // The partition spec round-trips, including the identity transform and the
+  // field's Velox type resolved from the schema.
+  const auto& partitionSpec = icebergInsert->partitionSpec();
+  ASSERT_NE(partitionSpec, nullptr);
+  EXPECT_EQ(partitionSpec->specId, 3);
+  ASSERT_EQ(partitionSpec->fields.size(), 1);
+  EXPECT_EQ(partitionSpec->fields[0].name, "id");
+  EXPECT_EQ(
+      partitionSpec->fields[0].transformType,
+      connector::hive::iceberg::TransformType::kIdentity);
+}
+
+} // namespace
+
+TEST_F(PrestoToVeloxConnectorTest, icebergCreateTableHandle) {
+  // CREATE TABLE AS: the target does not exist yet, so the location handle
+  // must be in "new" mode.
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergOutputTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->schemaName = "test_schema";
+  protoHandle->tableName.tableName = "test_table";
+  protoHandle->outputPath = "/path/to/table";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->inputColumns = {makeIcebergIdColumn()};
+  protoHandle->partitionSpec = makeIdentityPartitionSpec();
+
+  protocol::CreateHandle createHandle;
+  createHandle.handle.connectorHandle = protoHandle;
+  createHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&createHandle, *typeParser_);
+
+  verifyIcebergWriteHandle(
+      result,
+      connector::hive::LocationHandle::TableType::kNew,
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kData);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, icebergInsertTableHandle) {
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergInsertTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->schemaName = "test_schema";
+  protoHandle->tableName.tableName = "test_table";
+  protoHandle->outputPath = "/path/to/table";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->inputColumns = {makeIcebergIdColumn()};
+  protoHandle->partitionSpec = makeIdentityPartitionSpec();
+
+  protocol::InsertHandle insertHandle;
+  insertHandle.handle.connectorHandle = protoHandle;
+  insertHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&insertHandle, *typeParser_);
+
+  verifyIcebergWriteHandle(
+      result,
+      connector::hive::LocationHandle::TableType::kExisting,
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kData);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, icebergMergeTableHandle) {
+  // MERGE unwraps the nested insert handle and tags the result kMerge, which
+  // is what routes the write to IcebergMergeSink rather than IcebergDataSink.
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergMergeTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->insertTableHandle.schemaName = "test_schema";
+  protoHandle->insertTableHandle.tableName.tableName = "test_table";
+  protoHandle->insertTableHandle.outputPath = "/path/to/table";
+  protoHandle->insertTableHandle.fileFormat =
+      protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->insertTableHandle.compressionCodec =
+      protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->insertTableHandle.inputColumns = {makeIcebergIdColumn()};
+  protoHandle->insertTableHandle.partitionSpec = makeIdentityPartitionSpec();
+
+  protocol::MergeHandle mergeHandle;
+  mergeHandle.connectorMergeTableHandle = protoHandle;
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&mergeHandle, *typeParser_);
+
+  verifyIcebergWriteHandle(
+      result,
+      connector::hive::LocationHandle::TableType::kExisting,
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kMerge);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, icebergDistributedProcedureHandle) {
+  auto protoHandle = std::make_shared<
+      protocol::iceberg::IcebergDistributedProcedureHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->schemaName = "test_schema";
+  protoHandle->tableName.tableName = "test_table";
+  protoHandle->outputPath = "/path/to/table";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->inputColumns = {makeIcebergIdColumn()};
+  protoHandle->partitionSpec = makeIdentityPartitionSpec();
+
+  protocol::ExecuteProcedureHandle procedureHandle;
+  procedureHandle.handle.connectorHandle = protoHandle;
+  procedureHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result = icebergConnector.toVeloxInsertTableHandle(
+      &procedureHandle, *typeParser_);
+
+  verifyIcebergWriteHandle(
+      result,
+      connector::hive::LocationHandle::TableType::kExisting,
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kData);
+}
+
+namespace {
+
+protocol::iceberg::DeleteFile makeProtocolDeleteFile(
+    protocol::iceberg::FileContent content,
+    protocol::iceberg::FileFormat format,
+    const std::string& path) {
+  protocol::iceberg::DeleteFile deleteFile;
+  deleteFile.content = content;
+  deleteFile.format = format;
+  deleteFile.path = path;
+  deleteFile.recordCount = 3;
+  deleteFile.fileSizeInBytes = 128;
+  deleteFile.dataSequenceNumber = 4;
+  return deleteFile;
+}
+
+} // namespace
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitMapsEveryDeleteFileContent) {
+  // Each Iceberg delete-file content type routes to a different reader, so a
+  // mis-mapping here silently applies the wrong delete semantics.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.deletes = {
+      makeProtocolDeleteFile(
+          protocol::iceberg::FileContent::DATA,
+          protocol::iceberg::FileFormat::PARQUET,
+          "/deletes/data.parquet"),
+      makeProtocolDeleteFile(
+          protocol::iceberg::FileContent::POSITION_DELETES,
+          protocol::iceberg::FileFormat::PARQUET,
+          "/deletes/pos.parquet"),
+      makeProtocolDeleteFile(
+          protocol::iceberg::FileContent::EQUALITY_DELETES,
+          protocol::iceberg::FileFormat::PARQUET,
+          "/deletes/eq.parquet"),
+      makeProtocolDeleteFile(
+          protocol::iceberg::FileContent::DELETION_VECTOR,
+          protocol::iceberg::FileFormat::PARQUET,
+          "/deletes/dv.parquet"),
+  };
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  using FC = connector::hive::iceberg::FileContent;
+  ASSERT_EQ(hiveIceberg->deleteFiles.size(), 4);
+  EXPECT_EQ(hiveIceberg->deleteFiles[0].content, FC::kData);
+  EXPECT_EQ(hiveIceberg->deleteFiles[1].content, FC::kPositionalDeletes);
+  EXPECT_EQ(hiveIceberg->deleteFiles[2].content, FC::kEqualityDeletes);
+  EXPECT_EQ(hiveIceberg->deleteFiles[3].content, FC::kDeletionVector);
+
+  // The delete file's own sequence number drives V2 delete applicability and
+  // must survive the conversion independently of the split's.
+  EXPECT_EQ(hiveIceberg->deleteFiles[0].dataSequenceNumber, 4);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitTreatsPuffinDeleteAsDeletionVector) {
+  // Older iceberg-api releases report deletion vectors as POSITION_DELETES in
+  // Puffin format. Routing on content alone would send them to the positional
+  // reader, which has no Puffin reader factory registered.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.deletes = {makeProtocolDeleteFile(
+      protocol::iceberg::FileContent::POSITION_DELETES,
+      protocol::iceberg::FileFormat::PUFFIN,
+      "/deletes/legacy-dv.puffin")};
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  ASSERT_EQ(hiveIceberg->deleteFiles.size(), 1);
+  EXPECT_EQ(
+      hiveIceberg->deleteFiles[0].content,
+      connector::hive::iceberg::FileContent::kDeletionVector);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitCarriesFirstRowId) {
+  // V3 row lineage: firstRowId defaults to -1 and is only surfaced when the
+  // planner assigned one.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.firstRowId = 900;
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  const auto it = hiveIceberg->infoColumns.find(
+      connector::hive::iceberg::IcebergMetadataColumn::kFirstRowIdInfoColumn);
+  ASSERT_NE(it, hiveIceberg->infoColumns.end());
+  EXPECT_EQ(it->second, "900");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitOmitsUnassignedFirstRowId) {
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  // Left at the -1 default.
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  EXPECT_EQ(
+      hiveIceberg->infoColumns.count(
+          connector::hive::iceberg::IcebergMetadataColumn::
+              kFirstRowIdInfoColumn),
+      0);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitMapsWriteOrientedFileFormats) {
+  // DWRF and NIMBLE reach the bridge directly once the protocol enum carries
+  // them; before that regen they were silently coerced to ORC.
+  struct TestCase {
+    protocol::iceberg::FileFormat protocolFormat;
+    dwio::common::FileFormat expected;
+  };
+  const std::vector<TestCase> cases = {
+      {protocol::iceberg::FileFormat::DWRF,
+       dwio::common::FileFormat::DWRF},
+      {protocol::iceberg::FileFormat::NIMBLE,
+       dwio::common::FileFormat::NIMBLE},
+      {protocol::iceberg::FileFormat::PARQUET,
+       dwio::common::FileFormat::PARQUET},
+  };
+
+  for (const auto& testCase : cases) {
+    protocol::iceberg::IcebergSplit split;
+    split.path = "/path/to/data/file";
+    split.fileFormat = testCase.protocolFormat;
+
+    protocol::SplitContext context;
+    IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+    auto veloxSplit =
+        icebergConnector.toVeloxSplit("iceberg", &split, &context);
+    auto* hiveIceberg =
+        dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+            veloxSplit.get());
+    ASSERT_NE(hiveIceberg, nullptr);
+    EXPECT_EQ(hiveIceberg->fileFormat, testCase.expected)
+        << "protocol format ordinal "
+        << fmt::underlying(testCase.protocolFormat);
+  }
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxColumnHandleCarriesDefaultValue) {
+  // Iceberg V3 column defaults: a column added after the file was written has
+  // no physical data, so the reader materializes this constant instead.
+  protocol::iceberg::IcebergColumnHandle column;
+  column.columnIdentity.name = "added_col";
+  column.columnIdentity.id = 7;
+  column.columnIdentity.typeCategory =
+      protocol::iceberg::TypeCategory::PRIMITIVE;
+  column.type = "integer";
+  column.columnType = protocol::hive::ColumnType::REGULAR;
+  column.defaultValue = std::make_shared<protocol::String>("42");
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto handle = icebergConnector.toVeloxColumnHandle(&column, *typeParser_);
+  ASSERT_NE(handle, nullptr);
+
+  auto* icebergHandle =
+      dynamic_cast<connector::hive::iceberg::IcebergColumnHandle*>(
+          handle.get());
+  ASSERT_NE(icebergHandle, nullptr);
+  ASSERT_TRUE(icebergHandle->initialDefaultValue().has_value());
+  EXPECT_EQ(*icebergHandle->initialDefaultValue(), "42");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, icebergWriteHandleMapsOrcToDwrf) {
+  // On the write path Iceberg "ORC" means Meta's DWRF, since Velox only
+  // registers a DWRF writer. The read path deliberately maps ORC -> ORC
+  // instead, so this branch is only reachable through a write handle.
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergInsertTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->outputPath = "/path/to/table";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::ORC;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->inputColumns = {makeIcebergIdColumn()};
+
+  protocol::InsertHandle insertHandle;
+  insertHandle.handle.connectorHandle = protoHandle;
+  insertHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&insertHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+  EXPECT_EQ(icebergInsert->storageFormat(), dwio::common::FileFormat::DWRF);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxColumnHandleCarriesTypeAttributes) {
+  // Iceberg V3 type attributes ride alongside the field id and drive how the
+  // reader interprets physical values (long vs int width, timestamp unit,
+  // struct-vs-map encoding).
+  protocol::iceberg::IcebergColumnHandle column;
+  column.columnIdentity.name = "ts";
+  column.columnIdentity.id = 5;
+  column.columnIdentity.typeCategory =
+      protocol::iceberg::TypeCategory::PRIMITIVE;
+  column.type = "bigint";
+  column.columnType = protocol::hive::ColumnType::REGULAR;
+
+  auto attributes = std::make_shared<protocol::iceberg::IcebergTypeAttributes>();
+  attributes->required = std::make_shared<bool>(true);
+  attributes->longType = std::make_shared<protocol::String>("TIMESTAMP");
+  attributes->timestampUnit = std::make_shared<protocol::String>("MICROSECONDS");
+  attributes->structType = std::make_shared<protocol::String>("STRUCT");
+  column.columnIdentity.typeAttributes = attributes;
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto handle = icebergConnector.toVeloxColumnHandle(&column, *typeParser_);
+  ASSERT_NE(handle, nullptr);
+
+  auto* icebergHandle =
+      dynamic_cast<connector::hive::iceberg::IcebergColumnHandle*>(
+          handle.get());
+  ASSERT_NE(icebergHandle, nullptr);
+
+  const auto& metadata = icebergHandle->icebergMetadata();
+  EXPECT_EQ(metadata.longType, "TIMESTAMP");
+  EXPECT_EQ(metadata.timestampUnit, "MICROSECONDS");
+  EXPECT_EQ(metadata.structType, "STRUCT");
+  EXPECT_TRUE(metadata.required);
+}

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Filter.h"
@@ -880,8 +881,10 @@ namespace {
 // Builds a PartitionSpecParser.toJson() payload. Iceberg uses hyphenated key
 // names ("spec-id", "source-id", "field-id"), which is what a real split
 // carries.
-std::string makePartitionSpecJson(const std::string& fieldsJson) {
-  return fmt::format(R"({{"spec-id":0,"fields":[{}]}})", fieldsJson);
+std::string makePartitionSpecJson(
+    const std::string& fieldsJson,
+    int32_t specId = 0) {
+  return fmt::format(R"({{"spec-id":{},"fields":[{}]}})", specId, fieldsJson);
 }
 
 protocol::hive::HivePartitionKey makePartitionKey(
@@ -1046,4 +1049,107 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitRejectsUnusablePartitionSpec) {
     EXPECT_TRUE(hiveIceberg->identityPartitionKeys.empty())
         << "spec should have been rejected: " << specJson;
   }
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitPopulatesSpecIdInfoColumn) {
+  // The split's partitionSpecAsJson is produced by Iceberg's
+  // PartitionSpecParser.toJson, which emits a hyphenated "spec-id" key. The
+  // spec_id feeds the synthesized $target_table_row_id used by MERGE INTO, and
+  // IcebergSplitReader defaults it to 0 when the info column is missing — so
+  // failing to parse it silently reports spec 0 for every partition-evolved
+  // table rather than erroring.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1,"field-id":1000})",
+      /*specId=*/7);
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  const auto it = hiveIceberg->infoColumns.find(
+      connector::hive::iceberg::IcebergMetadataColumn::kSpecIdInfoColumn);
+  ASSERT_NE(it, hiveIceberg->infoColumns.end())
+      << "spec_id info column should be populated from the partition spec";
+  EXPECT_EQ(it->second, "7");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitOmitsSpecIdWhenUnparseable) {
+  // Absent or malformed spec JSON leaves the info column out entirely rather
+  // than inventing a spec id.
+  const std::vector<std::string> unusableSpecs = {
+      "", "not json at all", "[1,2,3]", R"({"fields":[]})"};
+
+  for (const auto& specJson : unusableSpecs) {
+    protocol::iceberg::IcebergSplit split;
+    split.path = "/path/to/data/file.dwrf";
+    split.fileFormat = protocol::iceberg::FileFormat::ORC;
+    split.partitionSpecAsJson = specJson;
+
+    protocol::SplitContext context;
+    IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+    auto veloxSplit =
+        icebergConnector.toVeloxSplit("iceberg", &split, &context);
+    auto* hiveIceberg =
+        dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+            veloxSplit.get());
+    ASSERT_NE(hiveIceberg, nullptr);
+    EXPECT_EQ(
+        hiveIceberg->infoColumns.count(
+            connector::hive::iceberg::IcebergMetadataColumn::kSpecIdInfoColumn),
+        0)
+        << "spec_id should be omitted for spec: " << specJson;
+  }
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitCarriesDataSequenceNumber) {
+  // The data file's sequence number gates which delete files apply to it.
+  // IcebergSplitReader::shouldSkipBySequenceNumber treats a value <= 0 as
+  // "unassigned" and disables filtering entirely, so leaving this at 0 lets an
+  // equality delete apply to data written after it.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.dataSequenceNumber = 5;
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  EXPECT_EQ(hiveIceberg->dataSequenceNumber, 5);
+
+  // The same value is also surfaced as an info column for row lineage; the two
+  // must not drift apart.
+  const auto it = hiveIceberg->infoColumns.find(
+      connector::hive::iceberg::IcebergMetadataColumn::
+          kDataSequenceNumberInfoColumn);
+  ASSERT_NE(it, hiveIceberg->infoColumns.end());
+  EXPECT_EQ(it->second, "5");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitKeepsUnassignedSequenceNumber) {
+  // V1 tables have no sequence numbers. Passing 0 through unchanged keeps
+  // filtering disabled for them, which is the documented "unassigned"
+  // behavior rather than an accidental skip.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.dataSequenceNumber = 0;
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  EXPECT_EQ(hiveIceberg->dataSequenceNumber, 0);
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -938,6 +938,63 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitRetainsOnlyIdentityPartitions) {
   EXPECT_EQ(hiveIceberg->partitionKeys.size(), 3);
 }
 
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    toVeloxSplitExcludesEveryNonIdentityTransform) {
+  // Iceberg's full transform set, each paired with a partition field that
+  // takes the source column's name -- the default for every transform except
+  // bucket and truncate, and what makes a name-keyed lookup unsafe. Only an
+  // identity field stores the source value, so every one of these must be
+  // excluded no matter how the field is named.
+  const std::vector<std::string> nonIdentityTransforms = {
+      "bucket[16]",
+      "truncate[4]",
+      "year",
+      "month",
+      "day",
+      "hour",
+      "void",
+      // Not an Iceberg transform string -- Transforms parses only bucket,
+      // truncate, identity, void and the four time transforms. Included so an
+      // unrecognized transform is proven to be skipped rather than assumed
+      // identity.
+      "unknownFutureTransform",
+  };
+
+  for (const auto& transform : nonIdentityTransforms) {
+    protocol::iceberg::IcebergSplit split;
+    split.path = "/path/to/data/file.dwrf";
+    split.fileFormat = protocol::iceberg::FileFormat::ORC;
+    // An identity field alongside the transformed one, so a regression that
+    // simply returns an empty map cannot pass this test.
+    split.partitionSpecAsJson = makePartitionSpecJson(
+        fmt::format(
+            R"({{"name":"id","transform":"identity","source-id":1,"field-id":1000}},)"
+            R"({{"name":"ts","transform":"{}","source-id":2,"field-id":1001}})",
+            transform));
+    split.partitionKeys = {
+        {1, makePartitionKey("id", "7")},
+        {1000, makePartitionKey("id", "7")},
+        {2, makePartitionKey("ts", "transformed")},
+        {1001, makePartitionKey("ts", "transformed")},
+    };
+
+    protocol::SplitContext context;
+    IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+    auto veloxSplit =
+        icebergConnector.toVeloxSplit("iceberg", &split, &context);
+    auto* hiveIceberg =
+        dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+            veloxSplit.get());
+    ASSERT_NE(hiveIceberg, nullptr);
+
+    const std::unordered_map<int32_t, std::optional<std::string>> expected = {
+        {1, std::optional<std::string>{"7"}}};
+    EXPECT_EQ(hiveIceberg->identityPartitionKeys, expected)
+        << "transform should not be substitutable: " << transform;
+  }
+}
+
 TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitKeepsNullIdentityPartition) {
   // A null identity value is still substitutable — the source column really
   // is null for every row in this partition.
@@ -1008,6 +1065,39 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitSkipsIdentityWithNoValue) {
   ASSERT_NE(hiveIceberg, nullptr);
 
   EXPECT_TRUE(hiveIceberg->identityPartitionKeys.empty());
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    toVeloxSplitAcceptsPartitionSpecWithoutFieldIds) {
+  // Iceberg's PartitionSpecParser treats "field-id" as optional: only "name",
+  // "transform" and "source-id" are required, and a spec that omits field IDs
+  // on every field gets them assigned from PARTITION_DATA_ID_START. V1 specs
+  // are written this way. Rejecting such a spec would silently disable
+  // identity substitution for those tables, so classify on "source-id" alone.
+  protocol::iceberg::IcebergSplit split;
+  split.path = "/path/to/data/file.dwrf";
+  split.fileFormat = protocol::iceberg::FileFormat::ORC;
+  split.partitionSpecAsJson = makePartitionSpecJson(
+      R"({"name":"id","transform":"identity","source-id":1},)"
+      R"({"name":"name","transform":"bucket[4]","source-id":2})");
+  split.partitionKeys = {
+      {1, makePartitionKey("id", "7")},
+      {2, makePartitionKey("name", "3")},
+  };
+
+  protocol::SplitContext context;
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto veloxSplit = icebergConnector.toVeloxSplit("iceberg", &split, &context);
+  auto* hiveIceberg = dynamic_cast<connector::hive::iceberg::HiveIcebergSplit*>(
+      veloxSplit.get());
+  ASSERT_NE(hiveIceberg, nullptr);
+
+  // Only the identity field is substitutable; the bucket field stores the
+  // transform result, not the source value.
+  const std::unordered_map<int32_t, std::optional<std::string>> expected = {
+      {1, std::optional<std::string>{"7"}}};
+  EXPECT_EQ(hiveIceberg->identityPartitionKeys, expected);
 }
 
 TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitRejectsUnusablePartitionSpec) {
@@ -1317,8 +1407,8 @@ TEST_F(PrestoToVeloxConnectorTest, icebergMergeTableHandle) {
 }
 
 TEST_F(PrestoToVeloxConnectorTest, icebergDistributedProcedureHandle) {
-  auto protoHandle = std::make_shared<
-      protocol::iceberg::IcebergDistributedProcedureHandle>();
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergDistributedProcedureHandle>();
   protoHandle->_type = "hive-iceberg";
   protoHandle->schemaName = "test_schema";
   protoHandle->tableName.tableName = "test_table";
@@ -1333,8 +1423,8 @@ TEST_F(PrestoToVeloxConnectorTest, icebergDistributedProcedureHandle) {
   procedureHandle.handle.connectorId = "iceberg";
 
   IcebergPrestoToVeloxConnector icebergConnector("iceberg");
-  auto result = icebergConnector.toVeloxInsertTableHandle(
-      &procedureHandle, *typeParser_);
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&procedureHandle, *typeParser_);
 
   verifyIcebergWriteHandle(
       result,
@@ -1404,7 +1494,9 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitMapsEveryDeleteFileContent) {
   EXPECT_EQ(hiveIceberg->deleteFiles[0].dataSequenceNumber, 4);
 }
 
-TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitTreatsPuffinDeleteAsDeletionVector) {
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    toVeloxSplitTreatsPuffinDeleteAsDeletionVector) {
   // Older iceberg-api releases report deletion vectors as POSITION_DELETES in
   // Puffin format. Routing on content alone would send them to the positional
   // reader, which has no Puffin reader factory registered.
@@ -1478,10 +1570,8 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitMapsWriteOrientedFileFormats) {
     dwio::common::FileFormat expected;
   };
   const std::vector<TestCase> cases = {
-      {protocol::iceberg::FileFormat::DWRF,
-       dwio::common::FileFormat::DWRF},
-      {protocol::iceberg::FileFormat::NIMBLE,
-       dwio::common::FileFormat::NIMBLE},
+      {protocol::iceberg::FileFormat::DWRF, dwio::common::FileFormat::DWRF},
+      {protocol::iceberg::FileFormat::NIMBLE, dwio::common::FileFormat::NIMBLE},
       {protocol::iceberg::FileFormat::PARQUET,
        dwio::common::FileFormat::PARQUET},
   };
@@ -1569,10 +1659,12 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxColumnHandleCarriesTypeAttributes) {
   column.type = "bigint";
   column.columnType = protocol::hive::ColumnType::REGULAR;
 
-  auto attributes = std::make_shared<protocol::iceberg::IcebergTypeAttributes>();
+  auto attributes =
+      std::make_shared<protocol::iceberg::IcebergTypeAttributes>();
   attributes->required = std::make_shared<bool>(true);
   attributes->longType = std::make_shared<protocol::String>("TIMESTAMP");
-  attributes->timestampUnit = std::make_shared<protocol::String>("MICROSECONDS");
+  attributes->timestampUnit =
+      std::make_shared<protocol::String>("MICROSECONDS");
   attributes->structType = std::make_shared<protocol::String>("STRUCT");
   column.columnIdentity.typeAttributes = attributes;
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
@@ -13,14 +13,45 @@
  */
 package com.facebook.presto.nativeworker.iceberg;
 
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergDistributedTestBase;
+import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.iceberg.hive.IcebergFileHiveMetastore;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.cache.CacheBuilder;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
 import static java.lang.String.format;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * End-to-end schema-evolution tests for Iceberg tables read on native (Prestissimo)
@@ -41,6 +72,8 @@ import static java.lang.String.format;
 public abstract class AbstractTestSchemaEvolution
         extends AbstractTestQueryFramework
 {
+    private static final String TEST_SCHEMA = "tpch";
+
     protected abstract String storageFormat();
 
     @Override
@@ -229,5 +262,129 @@ public abstract class AbstractTestSchemaEvolution
         finally {
             assertUpdate(format("DROP TABLE IF EXISTS %s", table));
         }
+    }
+
+    // A predicate on a column that only became a partition column later must
+    // still be evaluated row-by-row against files written under the old spec.
+    //
+    // The native split (IcebergSplit) does not carry Iceberg's per-file
+    // FileScanTask.residual(), so the concern is that a predicate Iceberg
+    // simplified away for new-spec files could be lost for old-spec files.
+    // Correctness instead rests on the table-level domain/remaining predicate,
+    // which the native worker always receives and evaluates: the old-spec file
+    // holds both rec_source values, so if the row-level predicate were dropped
+    // for it, the 'B' row would leak into a rec_source = 'A' result.
+    @Test
+    public void testPartitionEvolutionKeepsRowLevelPredicate()
+            throws Exception
+    {
+        String table = "schema_evolution_partition_evolution";
+        try {
+            assertUpdate(format(
+                    "CREATE TABLE %s (id INTEGER, rec_source VARCHAR, int_load_ts TIMESTAMP) " +
+                            "WITH (format = '%s', partitioning = ARRAY['day(int_load_ts)'])",
+                    table, storageFormat()));
+
+            // Old spec: a single file holding both rec_source values on the same
+            // day, so rec_source is not constant within the file and cannot be
+            // answered from partition metadata alone.
+            assertUpdate(format("INSERT INTO %s VALUES " +
+                    "(1, 'A', TIMESTAMP '2024-01-01 00:00:00'), " +
+                    "(2, 'B', TIMESTAMP '2024-01-01 01:00:00')", table), 2);
+
+            int oldSpecId = loadIcebergTable(table).spec().specId();
+
+            // Promote rec_source to an identity partition field. There is no
+            // Presto SQL DDL for adding an existing column to a partition spec
+            // (setTableProperties only accepts updatable table properties), so
+            // evolve through the Iceberg API.
+            loadIcebergTable(table).updateSpec().addField("rec_source").commit();
+            assertNotEquals(loadIcebergTable(table).spec().specId(), oldSpecId);
+
+            // New spec: rec_source is a partition column, so these rows land in
+            // per-value files where the predicate IS enforceable by pruning.
+            assertUpdate(format("INSERT INTO %s VALUES " +
+                    "(3, 'A', TIMESTAMP '2024-01-02 00:00:00'), " +
+                    "(4, 'B', TIMESTAMP '2024-01-02 01:00:00')", table), 2);
+
+            assertOldSpecFileHasNonTrivialResidual(table, oldSpecId);
+
+            // id = 2 is the 'B' row inside the old-spec file. Its presence here
+            // would mean the row-level predicate was lost during evolution.
+            assertQuery(format("SELECT id FROM %s WHERE rec_source = 'A' ORDER BY id", table),
+                    "VALUES 1, 3");
+            assertQuery(format("SELECT id FROM %s WHERE rec_source = 'B' ORDER BY id", table),
+                    "VALUES 2, 4");
+            assertQuery(format("SELECT count(*) FROM %s", table), "VALUES 4");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Makes the premise of testPartitionEvolutionKeepsRowLevelPredicate
+    // explicit: Iceberg itself cannot fully answer rec_source = 'A' for the
+    // old-spec file, so it leaves a non-trivial residual that something
+    // downstream must still evaluate.
+    private void assertOldSpecFileHasNonTrivialResidual(String table, int oldSpecId)
+            throws IOException
+    {
+        boolean sawOldSpecFile = false;
+        try (CloseableIterable<FileScanTask> tasks = loadIcebergTable(table).newScan()
+                .filter(Expressions.equal("rec_source", "A"))
+                .planFiles()) {
+            for (FileScanTask task : tasks) {
+                if (task.spec().specId() == oldSpecId) {
+                    assertNotEquals(
+                            task.residual().toString(),
+                            Expressions.alwaysTrue().toString(),
+                            "old-spec file should retain a residual for rec_source = 'A'");
+                    sawOldSpecFile = true;
+                }
+            }
+        }
+        assertTrue(sawOldSpecFile, "scan did not plan any old-spec file");
+    }
+
+    // Loads the live Iceberg table behind the query runner. The fixture uses the
+    // HIVE catalog backed by a file metastore, so go through
+    // IcebergUtil.getHiveIcebergTable rather than constructing a HadoopCatalog.
+    private Table loadIcebergTable(String tableName)
+    {
+        CatalogManager catalogManager = getDistributedQueryRunner().getCoordinator().getCatalogManager();
+        ConnectorId connectorId = catalogManager.getCatalog(ICEBERG_CATALOG).get().getConnectorId();
+        ConnectorSession connectorSession = getSession().toConnectorSession(connectorId);
+
+        HdfsEnvironment hdfsEnvironment = IcebergDistributedTestBase.getHdfsEnvironment(
+                new HiveClientConfig(),
+                new MetastoreClientConfig(),
+                new HiveS3Config());
+        ExtendedHiveMetastore metastore = memoizeMetastore(
+                new IcebergFileHiveMetastore(hdfsEnvironment, getCatalogDirectory().toString(), "test"),
+                false,
+                1000,
+                0);
+
+        return IcebergUtil.getHiveIcebergTable(
+                metastore,
+                hdfsEnvironment,
+                new IcebergHiveTableOperationsConfig(),
+                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024),
+                connectorSession,
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                SchemaTableName.valueOf(TEST_SCHEMA + "." + tableName));
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        // Mirrors the query-runner fixture above, which sets
+        // addStorageFormatToPath(false).
+        return getIcebergDataDirectoryPath(
+                dataDirectory,
+                HIVE.name(),
+                new IcebergConfig().getFileFormat(),
+                false)
+                .toFile();
     }
 }


### PR DESCRIPTION
Summary:
Iceberg spec-conformance fixes found by diffing our behaviour against Apache
Iceberg 1.10.1, plus the read/write coverage that surfaced them.

Puffin blob metadata. Nothing on our side parsed a Puffin footer -
DeletionVectorReader located its blob from the manifest - so the footer
DeletionVectorWriter emits had never been read by anything, and three defects
had accumulated. Checked against FileMetadataParser.blobMetadataFromJson, which
requires type, fields, snapshot-id, sequence-number, offset and length, and
reads fields via getIntegerList:
  - "fields" was a list of objects rather than a list of integers.
  - The field ID named _file (INT_MAX - 1) instead of ROW_POSITION / _pos
    (INT_MAX - 2), which is what Iceberg BaseDVFileWriter uses. This is also
    distinct from the positional-delete "pos" column that
    IcebergMetadataColumns uses elsewhere.
  - "snapshot-id" and "sequence-number" were absent; both are required, and
    Iceberg writes -1 for a vector whose snapshot is not yet assigned.
Any one of these aborts the parse, so every Puffin deletion vector we wrote was
unreadable by Spark, Trino, or Java Presto. Velox never noticed because it
bypassed the footer.

Puffin footer parsing. With no typed contentOffset/contentLength and no legacy
bounds map, the reader treated the whole file - magic and footer included - as
the bitmap, which cannot parse. It now reads the footer backwards from end of
file and selects the blob by referenced-data-file, requiring a single candidate
when no name is given. Gated on the Puffin magic so raw roaring blobs keep the
previous behaviour. Puffin constants moved to DeletionVectorFormat.h so reader
and writer agree by construction.

Optional "field-id". parseIdentityPartitionKeys required "field-id" on every
spec field and rejected the whole spec otherwise, silently disabling identity
substitution. Iceberg PartitionSpecParser treats it as optional - V1 specs omit
it - and only name, transform and source-id are required.

Coverage: writer file rotation and typed partition values, malformed
info-column handling, the full non-identity transform matrix, and the Puffin
guards mirroring TestPuffinReader.

Differential Revision: D115365708

## Summary by Sourcery

Align Iceberg native connector behavior with Apache Iceberg’s Puffin and partition-spec conventions and extend read/write and evolution coverage.

New Features:
- Surface Iceberg data column field IDs on Hive table handles using either table schema JSON or metadata columns.
- Expose identity partition values, spec IDs, sequence numbers, and row lineage info columns on Iceberg splits to support V2/V3 semantics.
- Support Iceberg write handles for CREATE TABLE, INSERT, MERGE, and distributed procedures with partition specs and correct storage formats, including ORC-as-DWRF mapping.
- Carry V3 column defaults and type attributes through Iceberg column handles so readers can materialize missing columns and interpret physical encodings correctly.

Bug Fixes:
- Treat Puffin-backed position delete files as deletion vectors and map all delete-file content types to the correct readers.
- Parse partition spec JSON using Iceberg’s hyphenated keys (e.g., spec-id) and accept specs without field-ids while rejecting malformed specs to avoid misclassification.
- Ensure identity partition substitution is limited to proven identity transforms and falls back to file reads when keys or specs are unusable.

Enhancements:
- Refine Iceberg split construction to attach data sequence numbers, optional first-row IDs, identity partition key maps, and accurate file formats (including DWRF and NIMBLE).
- Improve Iceberg table handle construction to carry index/table parameters, sampling, dbName, and data column field IDs, aligning with Velox Hive Iceberg expectations.

Build:
- Add a test-scoped dependency on org.apache.iceberg:iceberg-api to support Java-based schema evolution and scan assertions in native worker tests.

Tests:
- Add extensive connector tests covering table schema field IDs, identity partition handling across all transforms, info-column parsing, delete-file mapping, file format mapping, column defaults, and type attributes.
- Introduce an end-to-end Java schema-evolution test that validates partition evolution preserves row-level predicates across old and new specs using the Iceberg API and live table scans.

```
== NO RELEASE NOTE
```