### PR TITLE
fix: Contain StackOverflowError when filtering verifier source queries

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -80,6 +80,7 @@ import static com.facebook.presto.verifier.framework.SkippedReason.MISMATCHED_QU
 import static com.facebook.presto.verifier.framework.SkippedReason.NON_DETERMINISTIC;
 import static com.facebook.presto.verifier.framework.SkippedReason.SYNTAX_ERROR;
 import static com.facebook.presto.verifier.framework.SkippedReason.UNSUPPORTED_QUERY_TYPE;
+import static com.facebook.presto.verifier.framework.SkippedReason.VERIFIER_INTERNAL_ERROR;
 import static com.facebook.presto.verifier.framework.VerifierConfig.QUERY_BANK_MODE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -282,6 +283,19 @@ public class VerificationManager
             catch (ParsingException e) {
                 log.warn("Failed to parse query: %s", sourceQuery.getName());
                 postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, SYNTAX_ERROR, skipControl));
+            }
+            catch (StackOverflowError e) {
+                // Deeply nested ASTs, e.g. a WHERE clause with thousands of OR-ed predicates, overflow the
+                // recursive AST visitors. StackOverflowError is an Error, not an Exception, so it has to be
+                // caught explicitly or it escapes start() and aborts the entire run instead of one query.
+                log.warn(
+                        "Failed to analyze query, AST too deeply nested: %s, suite: %s, controlQueryId: %s, controlQueryLength: %s, testQueryLength: %s",
+                        sourceQuery.getName(),
+                        sourceQuery.getSuite(),
+                        sourceQuery.getQueryId(CONTROL).orElse("unknown"),
+                        sourceQuery.getQuery(CONTROL).length(),
+                        sourceQuery.getQuery(TEST).length());
+                postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, VERIFIER_INTERNAL_ERROR, skipControl));
             }
         }
         List<SourceQuery> selectQueries = selected.build();

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.event.client.AbstractEventClient;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -200,6 +201,37 @@ public class TestVerificationManager
         assertEquals(events.get(0).getErrorCode(), "VERIFIER_INTERNAL_ERROR");
     }
 
+    @Test
+    public void testStackOverflowWhileFilteringDoesNotAbortRun()
+    {
+        // A deeply nested AST, such as a WHERE clause with thousands of OR-ed predicates, overflows the
+        // stack in the recursive AST visitors used to filter source queries. The overflow is injected
+        // rather than built from SQL because the depth at which it happens shifts with the stack size
+        // and with how warm the JIT is, which would make the test flaky.
+        SqlParser overflowingParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON))
+        {
+            @Override
+            public Statement createStatement(String sql, ParsingOptions parsingOptions)
+            {
+                if (sql.contains("deeply_nested")) {
+                    throw new StackOverflowError();
+                }
+                return super.createStatement(sql, parsingOptions);
+            }
+        };
+
+        List<SourceQuery> queries = ImmutableList.of(
+                createSourceQuery("deep", "SELECT * FROM deeply_nested", "SELECT * FROM deeply_nested"),
+                createSourceQuery("shallow", "SELECT * FROM t1", "SELECT * FROM t1"));
+        VerificationManager manager = getVerificationManager(queries, new MockPrestoAction(GENERIC_INTERNAL_ERROR), VERIFIER_CONFIG, overflowingParser);
+        manager.start();
+
+        List<VerifierQueryEvent> events = eventClient.getEvents();
+        assertEquals(events.size(), 2);
+        assertSkippedEvent(events.get(0), "deep", VERIFIER_INTERNAL_ERROR);
+        assertEquals(manager.getQueriesSubmitted().get(), 1);
+    }
+
     private static SourceQuery createSourceQuery(String name, String controlQuery, String testQuery)
     {
         return new SourceQuery(SUITE, name, controlQuery, testQuery, Optional.empty(), Optional.empty(), QUERY_CONFIGURATION, QUERY_CONFIGURATION);
@@ -213,6 +245,11 @@ public class TestVerificationManager
     }
 
     private VerificationManager getVerificationManager(List<SourceQuery> sourceQueries, PrestoAction prestoAction, VerifierConfig verifierConfig)
+    {
+        return getVerificationManager(sourceQueries, prestoAction, verifierConfig, SQL_PARSER);
+    }
+
+    private VerificationManager getVerificationManager(List<SourceQuery> sourceQueries, PrestoAction prestoAction, VerifierConfig verifierConfig, SqlParser sqlParser)
     {
         return new VerificationManager(
                 () -> sourceQueries,
@@ -230,7 +267,7 @@ public class TestVerificationManager
                         verifierConfig,
                         createTestFunctionAndTypeManager(),
                         new DeterminismAnalyzerConfig()),
-                SQL_PARSER,
+                sqlParser,
                 ImmutableSet.of(eventClient),
                 ImmutableList.of(),
                 new QueryConfigurationOverridesConfig(),


### PR DESCRIPTION
Summary:
The verifier can abort before verifying a single query when one source query has a deeply nested AST:

```
ERROR  Bootstrap  Uncaught exception in thread main
  ... Exception in PostConstruct method VerificationManager::start()
Caused by: java.lang.StackOverflowError
  at ...LimitWithoutOrderByChecker.visitNode
  at ...AstVisitor.visitLogicalBinaryExpression
  at ...LogicalBinaryExpression.accept            <- repeats
```

The limit-without-order-by check recurses over the entire AST and consumes roughly 17 stack frames per `LogicalBinaryExpression` level, so a `WHERE` clause built from a few thousand OR-ed predicates exhausts the default 1MB stack.

That check is already wrapped in `catch (Exception e)`, carrying the comment *"We want to continue processing for the rest of the queries"*. But `StackOverflowError` is an `Error`, not an `Exception`, so it escapes `start()` and terminates the entire run instead of skipping the one query that triggered it. A single pathological query therefore costs the whole suite.

Catch it where source queries are filtered, alongside the existing `ParsingException` handling, and skip only that query, reporting it as `VERIFIER_INTERNAL_ERROR`. The log line records the query name, suite, control query id and query lengths so the offending query can be identified from the logs and from the results table. Today the run dies without naming the query at all, which makes this needlessly hard to diagnose.

Note that enlarging the JVM stack is not an equivalent fix. The depth the parser accepts and the depth this check survives both scale linearly with stack size, so there is always a range of queries that parse successfully and then overflow the check. A larger stack only shifts which queries fall into that range.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Handle stack overflows in verifier source query filtering so that a single pathological query is skipped instead of aborting the entire verification run.

Bug Fixes:
- Prevent StackOverflowError from escaping verifier startup by catching it during source query analysis and marking the query as a verifier internal error.

Enhancements:
- Extend VerificationManager test harness to accept a custom SqlParser for targeted error injection in tests.

Tests:
- Add a test ensuring that a StackOverflowError during source query filtering causes the offending query to be skipped and the remaining queries to proceed.