### PR TITLE
refactor(native): Rename ExchangeClient to InMemoryExchangeClient

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
@@ -51,7 +51,7 @@ MaterializedExchange::MaterializedExchange(
     DriverCtx* ctx,
     const std::shared_ptr<const MaterializedExchangeNode>&
         materializedExchangeNode,
-    std::shared_ptr<ExchangeClient> exchangeClient)
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient)
     : Exchange(
           operatorId,
           ctx,
@@ -199,7 +199,7 @@ std::unique_ptr<Operator> MaterializedExchangeTranslator::toOperator(
     DriverCtx* ctx,
     int32_t id,
     const core::PlanNodePtr& node,
-    std::shared_ptr<ExchangeClient> exchangeClient) {
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient) {
   if (auto materializedExchangeNode =
           std::dynamic_pointer_cast<const MaterializedExchangeNode>(node)) {
     return std::make_unique<MaterializedExchange>(

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.h
@@ -87,7 +87,7 @@ class MaterializedExchange : public velox::exec::Exchange {
       velox::exec::DriverCtx* ctx,
       const std::shared_ptr<const MaterializedExchangeNode>&
           materializedExchangeNode,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient);
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient);
 
   velox::RowVectorPtr getOutput() override;
 
@@ -135,7 +135,8 @@ class MaterializedExchangeTranslator
       velox::exec::DriverCtx* ctx,
       int32_t id,
       const velox::core::PlanNodePtr& node,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient) override;
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient)
+      override;
 };
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -28,7 +28,7 @@ ShuffleRead::ShuffleRead(
     int32_t operatorId,
     DriverCtx* ctx,
     const std::shared_ptr<const ShuffleReadNode>& shuffleReadNode,
-    std::shared_ptr<ExchangeClient> exchangeClient)
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient)
     : Exchange(
           operatorId,
           ctx,
@@ -172,7 +172,7 @@ std::unique_ptr<Operator> ShuffleReadTranslator::toOperator(
     DriverCtx* ctx,
     int32_t id,
     const core::PlanNodePtr& node,
-    std::shared_ptr<ExchangeClient> exchangeClient) {
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient) {
   if (auto shuffleReadNode =
           std::dynamic_pointer_cast<const ShuffleReadNode>(node)) {
     return std::make_unique<ShuffleRead>(

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
@@ -97,7 +97,7 @@ class ShuffleRead : public velox::exec::Exchange {
       int32_t operatorId,
       velox::exec::DriverCtx* ctx,
       const std::shared_ptr<const ShuffleReadNode>& shuffleReadNode,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient);
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient);
 
   velox::RowVectorPtr getOutput() override;
 
@@ -134,6 +134,7 @@ class ShuffleReadTranslator : public velox::exec::Operator::PlanNodeTranslator {
       velox::exec::DriverCtx* ctx,
       int32_t id,
       const velox::core::PlanNodePtr& node,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient) override;
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient)
+      override;
 };
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/operators/ShuffleWrite.h"
-#include "velox/exec/ExchangeClient.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox;

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -27,8 +27,8 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/ExchangeClient.h"
 #include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"

--- a/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
@@ -29,7 +29,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/ExchangeClient.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

Velox is being extended to support multiple exchange (receive-side) transports, which
requires the concrete exchange client to give up the generic `ExchangeClient` name to a
forthcoming abstract interface. This PR is the Prestissimo-side consequence of that
rename in facebookincubator/velox#18110.

## Velox change

facebookincubator/velox#18110 — `refactor(exec)!: Rename ExchangeClient to
InMemoryExchangeClient` renames the concrete class and moves
`velox/exec/ExchangeClient.{h,cpp}` to `velox/exec/InMemoryExchangeClient.{h,cpp}`. It is
the first of the receive-side stack (rename → node field → registry → MergeExchange).
`InMemory` follows the `InMemoryReadFile` precedent in `velox/common/file/File.h`.

The rename reaches Prestissimo through the public
`Operator::PlanNodeTranslator::toOperator` override, which now takes
`std::shared_ptr<velox::exec::InMemoryExchangeClient>` — so without this change
`MaterializedExchange` and `ShuffleRead` no longer override that virtual and fail to
compile. @kKPulla flagged the breakage on the Velox PR:
https://github.com/facebookincubator/velox/pull/18110#issuecomment-5085050509

## What changed

Mechanical — 11 sites in 7 files:

- Exchange-client type: `MaterializedExchange.{h,cpp}`, `ShuffleRead.{h,cpp}`
- Include of the moved header: `ShuffleWrite.cpp`,
  `tests/MaterializedExchangeTest.cpp`, `tests/ShuffleTest.cpp`

`MaterializedExchange.h` and `ShuffleRead.h` reach the type transitively via
`velox/exec/Exchange.h`, so they need no include change. Comments describing the
exchange-client *role* keep the `ExchangeClient` name, matching the upstream PR, since
the abstract interface reclaims that name in a follow-up.

## Landing order

Per @kKPulla on the Velox PR, a Velox change that breaks Presto lands as
expand / migrate / contract:

1. velox#18110 keeps `ExchangeClient` as an alias of `InMemoryExchangeClient` behind
   `#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY`, and merges. The alias also required
   `velox/exec/Exchange.h` to include the legacy header again: that is the path
   Prestissimo reaches the name through, so the alias on its own compiled but was
   unreachable.
2. This PR merges, moving the call sites to `InMemoryExchangeClient`.
3. A follow-up Velox PR removes the alias, the legacy header, and that include.

**The compat alias does not protect this repository's build.**
`VELOX_ENABLE_BACKWARD_COMPATIBILITY` is defined only by Meta's internal Prestissimo
Buck targets — it appears nowhere in this repo — so the github native build sees the new
name only. Whoever advances `presto-native-execution/velox` past velox#18110 therefore
needs this rename in the same change, as prestodb/presto#28130 did for the
`OutputBufferManager` → `DefaultOutputBufferManager` rename. Landing the advance without
it breaks master's native build.

This PR stays a draft until velox#18110 lands, and deliberately does not bump the
submodule yet.

## Test plan

- Built the native engine with velox#18110 in the submodule and ran queries through the
  native worker; no failures.
- All repo pre-commit hooks pass: clang-format, license-header, trailing-whitespace,
  end-of-file-fixer.

## Summary by Sourcery

Migrate native exchange client call sites to InMemoryExchangeClient to maintain compatibility with the updated Velox exchange API.

Enhancements:
- Update native exchange operators and related tests to use Velox's renamed InMemoryExchangeClient type.

Tests:
- Update exchange operator test includes for the renamed Velox client header.