### PR TITLE
chore(deps): Bump jetty from 12.0.34 to 12.0.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.13.2</dep.antlr.version>
-        <dep.airlift.version>0.230</dep.airlift.version>
+        <dep.airlift.version>0.231</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
@@ -83,7 +83,7 @@
         <dep.avro.version>1.12.1</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
         <dep.protobuf-java.version>4.34.1</dep.protobuf-java.version>
-        <dep.jetty.version>12.0.34</dep.jetty.version>
+        <dep.jetty.version>12.0.38</dep.jetty.version>
         <dep.netty.version>4.2.16.Final</dep.netty.version>
         <dep.reactor-netty.version>1.3.6</dep.reactor-netty.version>
         <dep.snakeyaml.version>2.5</dep.snakeyaml.version>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Upgrade jetty from 12.0.34 to 12.0.38 to address CVE-2026-10050 , CVE-2026-10051 , CVE-2026-6790 and CVE-2026-8384

Bump airlift version from 0.230 to 0.231 for supporting this jetty upgarde.

Airlift PR - https://github.com/prestodb/airlift/pull/151

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade jetty to 12.0.38 to address `CVE-2026-10050 <https://github.com/advisories/GHSA-2fvj-hgj9-j2gr>`_ , `CVE-2026-10051 <https://github.com/advisories/GHSA-f4v5-65jj-pcr2>`_ , `CVE-2026-6790 <https://github.com/advisories/GHSA-7p3p-8qv8-m2vh>`_ ,  `CVE-2026-8384 <https://github.com/advisories/GHSA-w7x5-g22v-xqhr>`_.
```

