### PR TITLE
fix: Skip foreign-dialect views in REST catalog to prevent Invalid view JSON crash

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.TableAlreadyExistsException;
@@ -53,6 +54,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 
@@ -77,6 +79,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getColumnsForWrite;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergView;
 import static com.facebook.presto.iceberg.IcebergUtil.getViewComment;
+import static com.facebook.presto.iceberg.IcebergUtil.isPrestoView;
 import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.validateViewDefinitionForBranches;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
@@ -103,6 +106,7 @@ import static org.apache.iceberg.NullOrder.NULLS_LAST;
 public class IcebergNativeMetadata
         extends IcebergAbstractMetadata
 {
+    private static final Logger log = Logger.get(IcebergNativeMetadata.class);
     private static final String VIEW_DIALECT = "presto";
 
     private final Optional<String> warehouseDataDir;
@@ -348,7 +352,19 @@ public class IcebergNativeMetadata
                         if (view.properties().containsKey(PRESTO_MATERIALIZED_VIEW_FORMAT_VERSION)) {
                             continue;
                         }
-                        verifyAndPopulateViews(view, schemaTableName, view.sqlFor(VIEW_DIALECT).sql(), views);
+                        // Skip views that have no genuine Presto SQL representation. Views created by
+                        // other engines (e.g. Netezza, Spark, Trino) store raw SQL under their own
+                        // dialect; sqlFor() falls back to the closest (or first) representation when
+                        // the "presto" dialect is absent, which later causes MetadataManager to fail
+                        // trying to JSON-deserialise plain SQL as a ViewDefinition.
+                        SQLViewRepresentation sqlRepresentation = view.sqlFor(VIEW_DIALECT);
+                        boolean hasPrestoDialect = sqlRepresentation != null && VIEW_DIALECT.equalsIgnoreCase(sqlRepresentation.dialect());
+                        if (!hasPrestoDialect || !isPrestoView(view)) {
+                            log.debug("Skipping view '%s': not a Presto view (dialect=%s, prestoViewFlag=%s)",
+                                    schemaTableName, sqlRepresentation == null ? "<none>" : sqlRepresentation.dialect(), isPrestoView(view));
+                            continue;
+                        }
+                        verifyAndPopulateViews(view, schemaTableName, sqlRepresentation.sql(), views);
                     }
                 }
                 catch (IllegalArgumentException e) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -680,6 +680,11 @@ public final class IcebergUtil
                 .build();
     }
 
+    public static boolean isPrestoView(View view)
+    {
+        return "true".equalsIgnoreCase(view.properties().get(PRESTO_VIEW_FLAG));
+    }
+
     public static Optional<Map<String, String>> tryGetProperties(Table table)
     {
         try {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestForeignDialectView.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestForeignDialectView.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+
+/**
+ * Regression tests for views present in an Iceberg REST catalog that were not created by Presto
+ * (e.g. by Netezza, Spark or Trino directly against the catalog), covering:
+ * <a href="https://github.com/prestodb/presto/issues/28318">Presto Iceberg Rest Catalog - fails to read view representation</a>
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestForeignDialectView
+        extends AbstractTestQueryFramework
+{
+    private File warehouseLocation;
+    private TestingHttpServer restServer;
+    private String serverUri;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+
+        serverUri = restServer.getBaseUrl().toString();
+        super.init();
+
+        getQueryRunner().execute("CREATE SCHEMA IF NOT EXISTS test_schema");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (restServer != null) {
+            restServer.stop();
+        }
+        deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setExtraConnectorProperties(restConnectorProperties(serverUri))
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setSchemaName("test_schema")
+                .setCreateTpchTables(false)
+                .build().getQueryRunner();
+    }
+
+    private RESTCatalog getRestCatalog()
+    {
+        RESTCatalog catalog = new RESTCatalog();
+        Map<String, String> catalogProps = new HashMap<>();
+        catalogProps.put("uri", serverUri);
+        catalogProps.put("warehouse", warehouseLocation.getAbsolutePath());
+        catalog.initialize("test_catalog", catalogProps);
+        return catalog;
+    }
+
+    /**
+     * Creates an Iceberg view directly through the REST catalog (bypassing Presto's CREATE VIEW),
+     * simulating a view authored by a foreign engine (e.g. Netezza) with a non-"presto" SQL dialect
+     * and without the "presto_view" property Presto sets on views it creates.
+     */
+    private void createForeignDialectView(RESTCatalog catalog, String viewName, String sql)
+    {
+        TableIdentifier viewId = TableIdentifier.of(Namespace.of("test_schema"), viewName);
+        Schema schema = new Schema(Types.NestedField.optional(1, "id", Types.LongType.get()));
+        catalog.buildView(viewId)
+                .withSchema(schema)
+                .withQuery("netezza", sql)
+                .withDefaultNamespace(Namespace.of("test_schema"))
+                .create();
+    }
+
+    @Test
+    public void testListViewsExcludesForeignDialectView()
+            throws Exception
+    {
+        RESTCatalog catalog = getRestCatalog();
+        try {
+            assertUpdate("CREATE TABLE test_show_views_base (id BIGINT)");
+            assertUpdate("CREATE VIEW test_show_views_presto AS SELECT id FROM test_show_views_base");
+            createForeignDialectView(catalog, "test_show_views_foreign", "select * from \"test_show_views_base\"");
+
+            // Listing views (via information_schema.views, which is backed by getViews()) should
+            // include the Presto-authored view but silently skip the foreign-dialect one, rather
+            // than crashing with "Invalid view JSON".
+            assertQuery("SELECT table_name FROM information_schema.views " +
+                            "WHERE table_schema = 'test_schema' AND table_name LIKE 'test_show_views%'",
+                    "VALUES 'test_show_views_presto'");
+        }
+        finally {
+            catalog.dropView(TableIdentifier.of(Namespace.of("test_schema"), "test_show_views_foreign"));
+            catalog.close();
+            assertUpdate("DROP VIEW IF EXISTS test_show_views_presto");
+            assertUpdate("DROP TABLE IF EXISTS test_show_views_base");
+        }
+    }
+
+    @Test
+    public void testSelectFromForeignDialectViewDoesNotCrash()
+            throws Exception
+    {
+        RESTCatalog catalog = getRestCatalog();
+        try {
+            assertUpdate("CREATE TABLE test_select_foreign_base (id BIGINT)");
+            createForeignDialectView(catalog, "test_select_foreign_view", "select * from \"test_select_foreign_base\"");
+
+            // Querying the foreign-dialect view directly must not crash with "Invalid view JSON".
+            // Since the view is not surfaced by getViews(), Presto falls through to the table lookup
+            // path and reports the view as a missing table/view, rather than crashing.
+            assertQueryFails("SELECT * FROM test_schema.test_select_foreign_view",
+                    ".*(does not exist|Table .* not found).*");
+        }
+        finally {
+            catalog.dropView(TableIdentifier.of(Namespace.of("test_schema"), "test_select_foreign_view"));
+            catalog.close();
+            assertUpdate("DROP TABLE IF EXISTS test_select_foreign_base");
+        }
+    }
+
+    @Test
+    public void testSelectFromPrestoViewStillWorksAlongsideForeignDialectView()
+            throws Exception
+    {
+        RESTCatalog catalog = getRestCatalog();
+        try {
+            assertUpdate("CREATE TABLE test_mixed_base (id BIGINT)");
+            assertUpdate("INSERT INTO test_mixed_base VALUES (1), (2), (3)", 3);
+            assertUpdate("CREATE VIEW test_mixed_presto_view AS SELECT id FROM test_mixed_base");
+            createForeignDialectView(catalog, "test_mixed_foreign_view", "select * from \"test_mixed_base\"");
+
+            // A Presto-authored view in the same schema as a foreign-dialect view must still be
+            // queryable normally, whether looked up individually or via a bulk listing operation.
+            assertQuery("SELECT * FROM test_mixed_presto_view", "VALUES 1, 2, 3");
+            assertQuery("SELECT COUNT(*) FROM information_schema.views WHERE table_schema = 'test_schema' AND table_name = 'test_mixed_presto_view'", "VALUES 1");
+        }
+        finally {
+            catalog.dropView(TableIdentifier.of(Namespace.of("test_schema"), "test_mixed_foreign_view"));
+            catalog.close();
+            assertUpdate("DROP VIEW IF EXISTS test_mixed_presto_view");
+            assertUpdate("DROP TABLE IF EXISTS test_mixed_base");
+        }
+    }
+
+    @Test
+    public void testForeignEngineLabelledPrestoDialectStillRejected()
+            throws Exception
+    {
+        RESTCatalog catalog = getRestCatalog();
+        try {
+            assertUpdate("CREATE TABLE test_spoofed_base (id BIGINT)");
+
+            // A foreign engine could label its representation's dialect as "presto" without the SQL
+            // actually being a serialized Presto ViewDefinition. The "presto_view" property (set only
+            // by Presto's own CREATE VIEW path) must still be required to accept the view, even when
+            // the dialect alone claims to be "presto".
+            TableIdentifier viewId = TableIdentifier.of(Namespace.of("test_schema"), "test_spoofed_view");
+            catalog.buildView(viewId)
+                    .withSchema(new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())))
+                    .withQuery("presto", "select * from \"test_spoofed_base\"")
+                    .withDefaultNamespace(Namespace.of("test_schema"))
+                    .create();
+
+            assertQueryFails("SELECT * FROM test_schema.test_spoofed_view",
+                    ".*(does not exist|Table .* not found).*");
+            assertQuery("SELECT COUNT(*) FROM information_schema.views " +
+                    "WHERE table_schema = 'test_schema' AND table_name = 'test_spoofed_view'", "VALUES 0");
+        }
+        finally {
+            catalog.dropView(TableIdentifier.of(Namespace.of("test_schema"), "test_spoofed_view"));
+            catalog.close();
+            assertUpdate("DROP TABLE IF EXISTS test_spoofed_base");
+        }
+    }
+
+    @Test
+    public void testInformationSchemaColumnsForForeignDialectView()
+            throws Exception
+    {
+        RESTCatalog catalog = getRestCatalog();
+        try {
+            assertUpdate("CREATE TABLE test_view_foreign_base (id BIGINT)");
+            createForeignDialectView(catalog, "test_view_foreign", "select * from \"test_view_foreign_base\"");
+
+            // information_schema.columns filtered by an exact table_name (a query pattern commonly
+            // issued by BI tools) resolves candidate names via InformationSchemaMetadata's
+            // calculatePrefixesWithTableName(), which uses the same existence check as SHOW COLUMNS /
+            // DESCRIBE (MetadataResolver.getView().isPresent() || getTableHandle().isPresent()). Since
+            // the foreign-dialect view is not surfaced by getViews(), it is excluded from this
+            // existence check and yields no rows here, rather than crashing on the underlying SQL
+            // representation.
+            assertQueryReturnsEmptyResult("SELECT column_name FROM information_schema.columns " +
+                    "WHERE table_schema = 'test_schema' AND table_name = 'test_view_foreign'");
+        }
+        finally {
+            catalog.dropView(TableIdentifier.of(Namespace.of("test_schema"), "test_view_foreign"));
+            catalog.close();
+            assertUpdate("DROP TABLE IF EXISTS test_view_foreign_base");
+        }
+    }
+}


### PR DESCRIPTION
## Description

Presto crashes with Invalid view JSON when querying any view in an Iceberg REST catalog pointing to Netezza IRC .

## Motivation and Context

Fix the issue https://github.com/prestodb/presto/issues/28318

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

When querying views created from presto
<img width="1675" height="743" alt="Screenshot 2026-08-11 at 8 31 21 PM" src="https://github.com/user-attachments/assets/e9d28a44-3f34-4797-ac1b-00edf25dc73c" />

When querying views created by other engines

<img width="3246" height="1416" alt="image" src="https://github.com/user-attachments/assets/08646d94-6ae0-4ded-bba0-b77862c2b847" />





## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix Invalid view JSON error when listing or querying views in an Iceberg REST catalog that were created by a non-Presto engine (e.g. Netezza, Spark, Trino).
```

## Summary by Sourcery

Skip non-Presto-dialect views returned by Iceberg REST catalogs to avoid crashes when listing or querying views created by other engines.

Bug Fixes:
- Prevent Invalid view JSON errors when accessing Iceberg REST catalog views that lack a Presto SQL dialect representation.

Enhancements:
- Add debug logging when Iceberg REST catalog views are skipped due to missing Presto-dialect SQL representation.

## Summary by Sourcery

Skip Iceberg REST catalog views that lack a Presto SQL dialect representation to avoid crashes when loading view definitions.

Bug Fixes:
- Prevent Invalid view JSON errors when listing or querying views in Iceberg REST catalogs for views created by non-Presto engines.

Enhancements:
- Add debug logging to report when Iceberg REST catalog views are skipped due to missing Presto-dialect SQL representations.