### PR TITLE
feat(plugin-iceberg): Add support for retrying `DELETE`, `UPDATE`, and `MERGE` operations after an Iceberg commit conflict

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2414,15 +2414,36 @@ updates.
 
     Query 20250204_010445_00022_ymwi5 failed: Iceberg table updates require at least format version 2 and update mode must be merge-on-read
 
-Iceberg tables do not support running multiple :doc:`../sql/merge` statements on the same table in parallel. If two or more ``MERGE`` operations are executed concurrently on the same Iceberg table:
+Concurrent Iceberg table data modification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* The first operation to complete will succeed.
-* Subsequent operations will fail due to conflicting writes and will return the following error:
+When two statements concurrently update or delete rows in the same Iceberg table, Iceberg rejects the commit of the
+last statement to finish. That statement writes nothing, and Presto reports the failure with the following error:
 
 .. code-block:: text
 
-    Failed to commit Iceberg update to table: <table name>
-    Found conflicting files that can contain records matching true
+    Failed to commit changes to the Iceberg table <table name> because it was concurrently modified
+
+Presto supports query retries against the new state of the Iceberg table instead of failing it.
+Query retries are disabled by default. There are two ways to enable them:
+
+- Set the ``per-query-retry-limit`` configuration property in the coordinator's ``etc/config.properties`` file:
+
+.. code-block:: properties
+
+   # coordinator/etc/config.properties
+   coordinator=true
+   per-query-retry-limit=2
+
+- Set the ``query_retry_limit`` session property by executing the following statement:
+
+.. code-block:: sql
+
+    SET SESSION query_retry_limit = 2;
+
+The value configured in these properties determines how many times Presto will re-execute a failing query.
+Query retries apply only to statements running in autocommit mode. An Iceberg commit conflict raised by the
+:doc:`/sql/commit` statement is always reported to the client.
 
 Transaction support
 ^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommitFailures.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommitFailures.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ValidationException;
+
+import java.util.function.BooleanSupplier;
+
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_CONFLICT;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
+import static java.lang.String.format;
+
+public final class IcebergCommitFailures
+{
+    private static final String FAILED_COMMIT_ICEBERG_TABLE = "Failed to commit changes to the Iceberg table";
+    private IcebergCommitFailures() {}
+
+    /**
+     * Translates a failure raised while committing an Iceberg transaction into a {@link PrestoException}.
+     * <p>
+     * Commits that were rejected because another writer changed the table concurrently are reported with
+     * the retriable {@link IcebergErrorCode#ICEBERG_COMMIT_CONFLICT}, so that the engine can execute the
+     * statement again against the new state of the table. Everything else keeps the non-retriable
+     * {@link IcebergErrorCode#ICEBERG_COMMIT_ERROR}.
+     *
+     * @param tableChangedConcurrently tells whether the table moved to a snapshot written by somebody else
+     * while this transaction was open. It is only consulted for the exception types that a conflict can be
+     * reported with, so callers may implement it with a metadata refresh.
+     */
+    public static PrestoException toPrestoException(RuntimeException failure, SchemaTableName tableName,
+            BooleanSupplier tableChangedConcurrently)
+    {
+        if (isCommitConflict(failure, tableChangedConcurrently)) {
+            return new PrestoException(
+                    ICEBERG_COMMIT_CONFLICT,
+                    format("%s %s because it was concurrently modified", FAILED_COMMIT_ICEBERG_TABLE, tableName),
+                    failure);
+        }
+        return new PrestoException(ICEBERG_COMMIT_ERROR,
+                format("%s %s. %s", FAILED_COMMIT_ICEBERG_TABLE, tableName, failure.getMessage()), failure);
+    }
+
+    private static boolean isCommitConflict(RuntimeException failure, BooleanSupplier tableChangedConcurrently)
+    {
+        // The commit may or may not have been applied. Executing the statement again could apply it twice.
+        if (failure instanceof CommitStateUnknownException) {
+            return false;
+        }
+
+        // A CommitFailedException means Iceberg exhausted its own commit retries, and
+        // a ValidationException means one of the conflict validators of the operation rejected the new table state.
+        // In both cases nothing was written.
+        if (failure instanceof CommitFailedException || failure instanceof ValidationException) {
+            return tableChangedConcurrently.getAsBoolean();
+        }
+
+        return false;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergErrorCode.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergErrorCode.java
@@ -45,13 +45,22 @@ public enum IcebergErrorCode
     ICEBERG_TRANSACTION_CONFLICT_ERROR(20, EXTERNAL),
     ICEBERG_INCOMPATIBLE_COLUMN_TYPE(21, USER_ERROR),
     ICEBERG_INCOMPATIBLE_VERSION(21, EXTERNAL),
+
+    // The commit was rejected because another writer changed the table concurrently.
+    // Nothing was written, so the statement can be executed again against the new state of the table.
+    ICEBERG_COMMIT_CONFLICT(22, EXTERNAL, true),
     /**/;
 
     private final ErrorCode errorCode;
 
     IcebergErrorCode(int code, ErrorType type)
     {
-        errorCode = new ErrorCode(code + 0x0504_0000, name(), type);
+        this(code, type, false);
+    }
+
+    IcebergErrorCode(int code, ErrorType type, boolean retriable)
+    {
+        errorCode = new ErrorCode(code + 0x0504_0000, name(), type, retriable);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/transaction/IcebergTransactionContext.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.iceberg.transaction;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import jakarta.annotation.Nullable;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataTableScan;
@@ -29,7 +31,9 @@ import org.apache.iceberg.ReplaceSortOrder;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.RewriteManifests;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
@@ -42,10 +46,12 @@ import org.apache.iceberg.UpdateStatistics;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static com.facebook.presto.iceberg.IcebergCommitFailures.toPrestoException;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_TRANSACTION_CONFLICT_ERROR;
 import static com.facebook.presto.iceberg.IcebergUtil.opsFromTable;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -55,9 +61,11 @@ import static org.apache.iceberg.IcebergLibUtils.getScanContext;
 
 public class IcebergTransactionContext
 {
+    private static final Logger log = Logger.get(IcebergTransactionContext.class);
+
     private final IsolationLevel isolationLevel;
     private final boolean autoCommitContext;
-    private final Map<SchemaTableName, Transaction> txByTable;
+    private final Map<SchemaTableName, TableTransaction> txByTable;
     private final Map<SchemaTableName, Table> initiallyReadTables;
     private final AtomicReference<Runnable> callbacksOnCommit = new AtomicReference<>();
 
@@ -81,20 +89,12 @@ public class IcebergTransactionContext
 
     public Optional<Table> getTransactionTable(SchemaTableName tableName)
     {
-        if (txByTable.containsKey(tableName)) {
-            return Optional.ofNullable(txByTable.get(tableName).table());
-        }
-
-        return Optional.empty();
+        return getTransaction(tableName).map(Transaction::table);
     }
 
     public Optional<Transaction> getTransaction(SchemaTableName tableName)
     {
-        if (txByTable.containsKey(tableName)) {
-            return Optional.ofNullable(txByTable.get(tableName));
-        }
-
-        return Optional.empty();
+        return Optional.ofNullable(txByTable.get(tableName)).map(TableTransaction::getTransaction);
     }
 
     public Optional<Table> initiallyReadTable(SchemaTableName tableName)
@@ -109,7 +109,8 @@ public class IcebergTransactionContext
     public void registerTransaction(SchemaTableName tableName, Transaction transaction)
     {
         if (txByTable.isEmpty()) {
-            txByTable.put(tableName, transaction);
+            // the table this transaction creates does not exist yet, so there is no state to conflict with
+            txByTable.put(tableName, new TableTransaction(transaction, null));
         }
         else if (!txByTable.containsKey(tableName)) {
             throw new PrestoException(ICEBERG_TRANSACTION_CONFLICT_ERROR, "Not allowed to open write transactions on different tables");
@@ -137,7 +138,15 @@ public class IcebergTransactionContext
     public void commit()
     {
         if (!txByTable.isEmpty()) {
-            getOnlyElement(txByTable.values().iterator()).commitTransaction();
+            Map.Entry<SchemaTableName, TableTransaction> entry = getOnlyElement(txByTable.entrySet().iterator());
+            TableTransaction tableTransaction = entry.getValue();
+            Transaction transaction = tableTransaction.getTransaction();
+            try {
+                transaction.commitTransaction();
+            }
+            catch (RuntimeException e) {
+                throw toPrestoException(e, entry.getKey(), tableTransaction::isTableChangedConcurrently);
+            }
             if (callbacksOnCommit.get() != null) {
                 callbacksOnCommit.get().run();
             }
@@ -165,7 +174,60 @@ public class IcebergTransactionContext
 
         return txByTable.computeIfAbsent(
                 tableName,
-                k -> Transactions.newTransaction(table.name(), ((HasTableOperations) table).operations()));
+                k -> {
+                    TableOperations operations = ((HasTableOperations) table).operations();
+                    Transaction transaction = Transactions.newTransaction(table.name(), operations);
+                    return new TableTransaction(transaction, operations);
+                })
+                .getTransaction();
+    }
+
+    /**
+     * An Iceberg {@link Transaction} together with the state needed to tell, once its commit is
+     * rejected, whether the rejection was caused by another writer committing to the same table.
+     */
+    private static class TableTransaction
+    {
+        private final Transaction transaction;
+        @Nullable
+        private final TableOperations tableOperations;
+        private final OptionalLong tableBaseSnapshotId;
+
+        TableTransaction(Transaction transaction, @Nullable TableOperations tableOperations)
+        {
+            this.transaction = requireNonNull(transaction, "transaction is null");
+            this.tableOperations = tableOperations;
+            this.tableBaseSnapshotId = tableOperations == null ? OptionalLong.empty() : getCurrentSnapshotId(tableOperations.current());
+        }
+
+        Transaction getTransaction()
+        {
+            return transaction;
+        }
+
+        boolean isTableChangedConcurrently()
+        {
+            if (tableOperations == null) {
+                return false;
+            }
+
+            try {
+                return !getCurrentSnapshotId(tableOperations.refresh()).equals(tableBaseSnapshotId);
+            }
+            catch (RuntimeException e) {
+                // Without knowing the current state of the table, it’s impossible to distinguish a conflict from a deterministic failure.
+                // We assume the commit lost a race, so that the more common case stays retriable, a table that
+                // cannot be read will fail the retry right away anyway.
+                log.debug(e, "Could not refresh %s to tell whether its commit hit a concurrent modification", transaction.table().name());
+                return true;
+            }
+        }
+
+        private static OptionalLong getCurrentSnapshotId(TableMetadata metadata)
+        {
+            Snapshot snapshot = metadata.currentSnapshot();
+            return snapshot == null ? OptionalLong.empty() : OptionalLong.of(snapshot.snapshotId());
+        }
     }
 
     private class TransactionalTable

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergCommitFailures.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergCommitFailures.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.IcebergCommitFailures.toPrestoException;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_CONFLICT;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergCommitFailures
+{
+    private static final SchemaTableName TABLE_NAME = new SchemaTableName("test_schema", "test_table");
+
+    @Test
+    public void testConcurrentModificationIsRetriable()
+    {
+        ValidationException conflict = new ValidationException("Found new conflicting delete files that can apply to records matching true: [a.parquet]");
+        PrestoException failure = toPrestoException(conflict, TABLE_NAME, () -> true);
+
+        assertEquals(failure.getErrorCode(), ICEBERG_COMMIT_CONFLICT.toErrorCode());
+        assertTrue(failure.getErrorCode().isRetriable());
+        assertEquals(failure.getCause(), conflict);
+
+        String expectedMessage = String.format(
+                "Failed to commit changes to the Iceberg table %s because it was concurrently modified",
+                TABLE_NAME);
+        assertEquals(failure.getMessage(), expectedMessage);
+    }
+
+    @Test
+    public void testExhaustedIcebergCommitRetriesIsRetriable()
+    {
+        CommitFailedException commitFailedException = new CommitFailedException("Metadata location changed");
+        PrestoException failure = toPrestoException(commitFailedException, TABLE_NAME, () -> true);
+
+        assertEquals(failure.getErrorCode(), ICEBERG_COMMIT_CONFLICT.toErrorCode());
+        assertTrue(failure.getErrorCode().isRetriable());
+        assertEquals(failure.getCause(), commitFailedException);
+    }
+
+    @Test
+    public void testValidationFailureWithoutConcurrentChangeIsNotRetriable()
+    {
+        // e.g. HiveTableOperations reporting an invalid metastore object, which fails again on every attempt
+        PrestoException failure = toPrestoException(new ValidationException("Invalid Hive object for test_schema.test_table"), TABLE_NAME, () -> false);
+
+        assertEquals(failure.getErrorCode(), ICEBERG_COMMIT_ERROR.toErrorCode());
+        assertFalse(failure.getErrorCode().isRetriable());
+    }
+
+    @Test
+    public void testUnknownCommitStateIsNeverRetriable()
+    {
+        // the commit may have been applied, so running the statement again could apply it twice
+        PrestoException failure = toPrestoException(
+                new CommitStateUnknownException(new RuntimeException("connection reset")),
+                TABLE_NAME,
+                () -> {
+                    throw new AssertionError("the table state must not be consulted for an unknown commit state");
+                });
+
+        assertEquals(failure.getErrorCode(), ICEBERG_COMMIT_ERROR.toErrorCode());
+        assertFalse(failure.getErrorCode().isRetriable());
+    }
+
+    @Test
+    public void testUnrelatedFailureIsNotRetriable()
+    {
+        PrestoException failure = toPrestoException(new IllegalStateException("boom"), TABLE_NAME, () -> true);
+
+        assertEquals(failure.getErrorCode(), ICEBERG_COMMIT_ERROR.toErrorCode());
+        assertFalse(failure.getErrorCode().isRetriable());
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConcurrentUpdates.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConcurrentUpdates.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_RETRY_LIMIT;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * An UPDATE of an Iceberg table is a merge-on-read operation: it writes position delete files for
+ * the rows it changes together with their new versions, and stages both as a row delta on top of the
+ * snapshot the statement reads. Committing that row delta re-applies it to the latest table metadata and
+ * checks that no delete file has appeared since that snapshot, because another writer may have deleted rows
+ * this statement is rewriting. The check spans the whole table rather than the rows the statement touches,
+ * so two updates running at the same time conflict even when they change different rows: the first one
+ * commits a new snapshot, and the second one finds those delete files and has its commit rejected with an
+ * Iceberg {@code org.apache.iceberg.exceptions.ValidationException}. The loser of the race writes nothing,
+ * so the engine is expected to run the statement again against the new state of the table rather than fail it.
+ */
+public class TestIcebergConcurrentUpdates
+        extends AbstractTestQueryFramework
+{
+    private static final int WRITERS = 4; // Total number of different UPDATE statements executed over the same table.
+    private static final int ROUNDS = 5;  // Total number of rounds of concurrent updates.
+
+    private ExecutorService executor;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp()
+    {
+        executor = newFixedThreadPool(WRITERS);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        executor = null;
+    }
+
+    @Test
+    public void testConcurrentUpdatesAreRetried()
+            throws Exception
+    {
+        String tableName = "test_concurrent_updates";
+
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate(format("CREATE TABLE %s (id integer, value integer)", tableName));
+        assertUpdate(format("INSERT INTO %s SELECT CAST(id AS integer), 0 FROM UNNEST(sequence(1, %s)) AS t(id)", tableName, WRITERS), WRITERS);
+
+        // The "test_concurrent_updates" table contains the following data:
+        // 1, 0
+        // 2, 0
+        // 3, 0
+        // ...
+
+        Session session = Session.builder(getSession())
+                .setSystemProperty(QUERY_RETRY_LIMIT, String.valueOf(WRITERS * ROUNDS))
+                .build();
+
+        // Execute concurrent UPDATEs over the "test_concurrent_updates" table.
+        for (int round = 0; round < ROUNDS; round++) {
+            // each writer only touches its own row, so the statements only conflict when committing
+            CyclicBarrier startTogether = new CyclicBarrier(WRITERS);
+            List<Future<?>> updates = new ArrayList<>();
+            for (int writer = 1; writer <= WRITERS; writer++) {
+                String sql = format("UPDATE %s SET value = value + 1 WHERE id = %s", tableName, writer);
+                updates.add(executor.submit(() -> {
+                    startTogether.await(30, SECONDS);
+                    return getQueryRunner().execute(session, sql);
+                }));
+            }
+
+            for (Future<?> update : updates) {
+                // throws ICEBERG_COMMIT_CONFLICT if a rejected commit is not retried
+                update.get();
+            }
+        }
+
+        // After executing all UPDATE commands, the table must contain the following data:
+        // 1, 5
+        // 2, 5
+        // 3, 5
+        // ...
+
+        // Check the "test_concurrent_updates" table contains the expected data.
+        // It means concurrent UPDATE commands that failed were retried and succeeded,
+        // so the value of the "value" column for all rows is equal to the number of rounds.
+        assertEquals(computeScalar(format("SELECT count(*) FROM %s WHERE value = %s", tableName, ROUNDS)), (long) WRITERS);
+
+        // Check the list of executed queries and count the UPDATE commands that failed during the Iceberg commit and were re-executed.
+        String sql = format("UPDATE %s SET value = value \\+ 1 WHERE id = .*", tableName);
+        assertTrue(countRetriedQueries(sql) > 0, "expected concurrent updates to be retried");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testConcurrentUpdateAndMergeAreRetried()
+            throws Exception
+    {
+        String tableName = "test_concurrent_update_merge";
+
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate(format("CREATE TABLE %s (id integer, value integer)", tableName));
+        assertUpdate(format("INSERT INTO %s VALUES (1, 10), (2, 20)", tableName), 2);
+
+        // The "test_concurrent_update_merge" table contains the following data:
+        // 1, 10
+        // 2, 20
+
+        Session session = Session.builder(getSession())
+                .setSystemProperty(QUERY_RETRY_LIMIT, "10")
+                .build();
+
+        // Execute UPDATE and MERGE concurrently over the same table.
+        // Both statements modify different rows but will conflict when committing to Iceberg.
+        CyclicBarrier startTogether = new CyclicBarrier(2);
+        List<Future<?>> operations = new ArrayList<>();
+
+        // UPDATE modifies row with id = 1
+        String updateSql = format("UPDATE %s SET value = value + 1 WHERE id = 1", tableName);
+        operations.add(executor.submit(() -> {
+            startTogether.await(30, SECONDS);
+            return getQueryRunner().execute(session, updateSql);
+        }));
+
+        // MERGE modifies row with id = 2 and inserts row with id = 3
+        String mergeSql = format(
+                "MERGE INTO %s t USING (SELECT 2 AS id, 100 AS value UNION ALL SELECT 3 AS id, 300 AS value ) s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN " +
+                "  UPDATE SET value = s.value " +
+                "WHEN NOT MATCHED THEN" +
+                "  INSERT (id, value) VALUES(s.id, s.value)",
+                tableName);
+
+        operations.add(executor.submit(() -> {
+            startTogether.await(30, SECONDS);
+            return getQueryRunner().execute(session, mergeSql);
+        }));
+
+        for (Future<?> operation : operations) {
+            // throws ICEBERG_COMMIT_CONFLICT if a rejected commit is not retried
+            operation.get();
+        }
+
+        // After executing both UPDATE and MERGE commands, the table must contain the following data:
+        // 1, 11 (updated by UPDATE)
+        // 2, 100 (updated by MERGE)
+        // 3, 300 (inserted by MERGE)
+
+        // Check the "test_concurrent_update_merge" table contains the expected data.
+        assertQuery(session, format("SELECT id, value FROM %s ORDER BY id", tableName),
+                "VALUES (1, 11), (2, 100), (3, 300)");
+
+        // Check that at least one operation was retried due to commit conflict.
+        String updatePattern = format("UPDATE %s SET value = value \\+ 1 WHERE id = 1", tableName);
+        String mergePattern = format("MERGE INTO %s t USING .* ON t.id = s.id .*", tableName);
+        long retriedUpdates = countRetriedQueries(updatePattern);
+        long retriedMerges = countRetriedQueries(mergePattern);
+        assertTrue(retriedUpdates > 0 || retriedMerges > 0,
+                "expected at least one concurrent operation (UPDATE or MERGE) to be retried");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private long countRetriedQueries(String queryPattern)
+    {
+        Pattern retryPattern = Pattern.compile("-- retry query.*?; attempt:.*?" + queryPattern, Pattern.DOTALL);
+        return ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getQueryManager().getQueries().stream()
+                .filter(query -> retryPattern.matcher(query.getQuery()).matches())
+                .count();
+    }
+
+    @Test
+    public void testConflictingUpdateIsReportedAsRetriableError()
+    {
+        String tableName = "test_update_commit_conflict";
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate(format("CREATE TABLE %s (id integer, value integer)", tableName));
+        assertUpdate(format("INSERT INTO %s VALUES (1, 10), (2, 20)", tableName), 2);
+
+        // An explicit transaction is never retried, so the conflict is surfaced to the client.
+        Session session = getSession();
+        Session transactionSession = assertStartTransaction(session, "START TRANSACTION");
+        assertUpdate(transactionSession, format("UPDATE %s SET value = value + 1 WHERE id = 1", tableName), 1);
+
+        // Execute an UPDATE command outside the transaction.
+        // It commits while the transaction above still holds an uncommitted row delta for the same table.
+        assertUpdate(session, format("UPDATE %s SET value = value + 100 WHERE id = 2", tableName), 1);
+
+        // Commit the changes done by the UPDATE command executed in the transaction.
+        assertQueryFails(transactionSession, "COMMIT",
+                "Failed to commit changes to the Iceberg table tpch." + tableName + " because it was concurrently modified");
+
+        // Check that only the UPDATE command outside the transaction has modified the table data.
+        assertQuery(session, "SELECT id, value FROM " + tableName, "VALUES (1, 10), (2, 120)");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -633,7 +633,8 @@ public abstract class TestIcebergDistributedQueries
         session = assertEndTransaction(txnSession2, "commit");
 
         // Fail to commit transaction1 which includes the action for renaming column "b"
-        assertQueryFails(txnSession1, "commit", "Table metadata refresh is required");
+        assertQueryFails(txnSession1, "commit", "Failed to commit changes to the Iceberg table " +
+                "tpch.test_schema_conflict_between_transactions because it was concurrently modified");
 
         assertQuery(session, "select * from " + tableName, "values(1), (5)");
         assertQuery(getSession(), "select * from " + tableName, "values(1), (5)");

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -504,6 +504,7 @@ class Query
         // the pages will be lost.
         Iterable<List<Object>> data = null;
         List<String> binaryData = null;
+        boolean producedRows = false;
         try {
             long rows = 0;
             long bytes = 0;
@@ -549,7 +550,7 @@ class Query
                 }
             }
             if (rows > 0) {
-                hasProducedResult = true;
+                producedRows = true;
             }
         }
         catch (Exception e) {
@@ -562,9 +563,12 @@ class Query
         queryManager.recordHeartbeat(queryId);
 
         // TODO: figure out a better way to do this
+        // the only output of a data manipulation statement is a single row holding the update count
+        boolean isUpdateCountResult = (queryInfo.getUpdateInfo() != null) && (columns != null) &&
+                (columns.size() == 1) && (columns.get(0).getType().equals(StandardTypes.BIGINT));
+
         // grab the update count for non-queries
-        if ((data != null) && (queryInfo.getUpdateInfo() != null) && (updateCount == null) &&
-                (columns.size() == 1) && (columns.get(0).getType().equals(StandardTypes.BIGINT))) {
+        if ((data != null) && isUpdateCountResult && (updateCount == null)) {
             Iterator<List<Object>> iterator = data.iterator();
             if (iterator.hasNext()) {
                 Number number = (Number) iterator.next().get(0);
@@ -572,6 +576,14 @@ class Query
                     updateCount = number.longValue();
                 }
             }
+        }
+
+        // The update count is not a query result: it only becomes meaningful once the auto-commit
+        // transaction of the statement commits, and that happens after the count has been streamed
+        // out. Sending it therefore does not prevent the statement from being retried, unlike real
+        // rows, which the client cannot be asked to consume twice.
+        if (producedRows && !isUpdateCountResult) {
+            hasProducedResult = true;
         }
 
         closeExchangeClientIfNecessary(queryInfo);


### PR DESCRIPTION
## Description

Two concurrent modifications to Iceberg table data will lead to an Iceberg commit conflict.

The `DELETE`, `UPDATE`, and `MERGE` statements in Presto over Iceberg tables use the Merge-on-Read strategy to modify the table's data. This strategy writes position delete files for the rows it changes plus the new versions of those rows, and stages both as a row delta on top of the snapshot the statement read. To commit the changes made by these statements, Iceberg re-applies that row delta to the refreshed table metadata and validates that no delete files have appeared since the read snapshot, because another `DELETE`, `UPDATE`, or `MERGE` may have deleted rows this statement is rewriting. That validation uses a conflict-detection filter across the entire table, so two concurrent data modifications conflict even when they touch disjoint rows. The first one to commit creates a new snapshot; the second one sees the first one's delete files and rejects the commit with a `ValidationException: Found new conflicting delete files that can apply to records matching true`.  The `org.apache.iceberg.exceptions.ValidationException` reaches the `Failures.toFailure()` method and is converted into a Presto GENERIC_INTERNAL_ERROR, which is not retriable.

An Iceberg rejected commit writes nothing, so re-executing the  `DELETE`, `UPDATE`, or `MERGE` statement against the new snapshot is safe.

The goals of this enhancement are: 
- Add support to classify Iceberg commit failures as retriable errors.
- Add support to automatically retry the `DELETE`, `UPDATE`, and `MERGE` commands in case they execute concurrently in the same Iceberg table and produce Iceberg conflicts.
- When executing concurrent `DELETE`, `UPDATE`, or `MERGE` statements in Presto over the same Iceberg table and this enhancement is disabled, replace the following error message, which comes from the Iceberg library:
`Found new conflicting delete files that can apply to records matching true: [.../my_table/data/delete_file_4a09f495-5c09-4b2b-83ab-06eb944b6920.parquet]`
with the following Presto error message:
`Failed to commit changes to the Iceberg table iceberg.my_table because it was concurrently modified`.

This feature is disabled by default. To enable it, the user must set the "per-query-retry-limit" configuration property, or the "query_retry_limit" session property


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
When executing DML commands concurrently over the same Iceberg table, users will not have to manually reexecute the command that commits the changes in the last place. Presto will do it automatically for you if the "per-query-retry-limit" configuration property has a value higher than 0.

## Test Plan
- Add `TestIcebergCommitFailures` to verify classification of various Iceberg commit failure scenarios into retriable and non-retriable Presto exceptions.
- Add `TestIcebergConcurrentUpdates` to validate that:
    - concurrent Iceberg table updates are retried when this feature is enabled.
    - in explicit transactions, commit conflicts are surfaced to clients.
- Update expected error message for `TestIcebergDistributedQueries.testSingleTableSchemaConflictBetweenTransactions()` test.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for retrying `DELETE`, `UPDATE`, and `MERGE` operations after an Iceberg commit conflict.
```

## Summary by Sourcery

Classify Iceberg commit failures and surface concurrent commit conflicts as retriable errors, enabling automatic retries of DML statements that lose commit races while keeping other commit failures non-retriable.

New Features:
- Introduce ICEBERG_COMMIT_CONFLICT error code marked as retriable for concurrent Iceberg commit conflicts.
- Add logic to detect whether an Iceberg table was modified concurrently during a transaction using snapshot metadata.
- Allow UPDATE, DELETE, and MERGE statements on Iceberg tables to be retried when their commits are rejected due to concurrent writers, without treating successful update-count results as non-retriable output.

Enhancements:
- Refine query result handling so that update-count-only results do not mark a query as having produced non-retriable output.
- Extend Iceberg transaction context to track table state around transactions for better commit failure classification.

Tests:
- Add TestIcebergCommitFailures to verify classification of various Iceberg commit failure scenarios into retriable and non-retriable Presto exceptions.
- Add TestIcebergConcurrentUpdates to validate that concurrent Iceberg updates are retried when enabled and that explicit transactions see commit conflicts surfaced to clients.

## Summary by Sourcery

Classify Iceberg commit failures to distinguish concurrent commit conflicts from other errors and enable safe retries of conflicting DML statements, while ensuring non-idempotent results remain non-retriable.

New Features:
- Introduce a retriable ICEBERG_COMMIT_CONFLICT error code and helper to translate Iceberg commit failures into appropriate Presto exceptions.
- Track Iceberg table snapshot state in transaction context to detect concurrent table modifications during commit.
- Allow Iceberg UPDATE, DELETE, and MERGE statements to be retried when their commits are rejected due to concurrent writers by treating these conflicts as retriable.

Enhancements:
- Refine query result handling so that update-count-only outputs do not mark a query as having produced non-retriable results.

Tests:
- Add tests to verify classification of Iceberg commit failure scenarios into retriable and non-retriable errors.
- Add tests validating concurrent Iceberg updates and mixed UPDATE/MERGE operations are retried when enabled and that explicit transactions surface commit conflicts to clients.
- Adjust distributed Iceberg query tests to assert the new error message for schema conflicts between transactions.