### PR TITLE
fix(build): Bump presto-spark-classloader-spark3 parent version to 0.300-SNAPSHOT

### DIFF
--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>presto-root</artifactId>
     <groupId>com.facebook.presto</groupId>
-    <version>0.299-SNAPSHOT</version>
+    <version>0.300-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Summary:
## Description

Bump the parent `<version>` in `presto-spark-classloader-spark3/pom.xml` from
`0.299-SNAPSHOT` to `0.300-SNAPSHOT` so it matches `presto-root` and the rest of
the reactor.

## Motivation and Context

The `maven-release-plugin` release cut for `0.299` bumped every module's parent
version to `0.300-SNAPSHOT`, but skipped `presto-spark-classloader-spark3`. That
module is declared inside the `spark3` profile, which is only active with
`-Dspark-version=3`, so it is not part of the release plugin's default reactor
and never gets rewritten.

The stale version breaks any Spark 3 build, because
`presto-spark-classloader-interface` requests
`presto-spark-classloader-spark3:jar:0.300-SNAPSHOT` while the reactor supplies
`0.299-SNAPSHOT`:

```
Could not resolve dependencies for project
com.facebook.presto:presto-spark-classloader-interface:jar:0.300-SNAPSHOT:
Could not find artifact
com.facebook.presto:presto-spark-classloader-spark3:jar:0.300-SNAPSHOT
```

This is a recurring miss on each release cut; the same fix was applied for
`0.298-SNAPSHOT` in #27747.

## Impact

Build-only. No public API or user-facing behavior changes.

## Test Plan

Built presto-trunk with the Spark 3 profile:

```
mvn -f presto-trunk clean install -Dspark-version=3 -DskipUI \
    -Dair.check.skip-all -DskipTests -pl '!presto-docs'
```

Fails on `presto-spark-classloader-interface` before this change; `BUILD SUCCESS`
across all 122 modules after.

## Contributor checklist

- [x] Please make sure your submission complies with our contributing guide, in particular code style and commit standards.
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the release notes guidelines.
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D115598274


