### PR TITLE
fix(security): Reject special characters in the LDAP login username

### DIFF
--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/ldap/LdapAuthenticator.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/ldap/LdapAuthenticator.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.http.server.BasicPrincipal;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.spi.security.PasswordAuthenticator;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.VerifyException;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -55,6 +56,9 @@ public class LdapAuthenticator
 {
     private static final Logger log = Logger.get(LdapAuthenticator.class);
 
+    // Characters that carry meaning in an LDAP distinguished name (RFC 4514) or search filter (RFC 4515).
+    private static final CharMatcher SPECIAL_CHARACTERS = CharMatcher.anyOf(",=+<>#;*()\"\\\u0000");
+
     private final String userBindSearchPattern;
     private final Optional<String> groupAuthorizationSearchPattern;
     private final Optional<String> userBaseDistinguishedName;
@@ -85,6 +89,9 @@ public class LdapAuthenticator
     @Override
     public Principal createAuthenticatedPrincipal(String user, String password)
     {
+        if (containsSpecialCharacters(user)) {
+            throw new AccessDeniedException("Username contains a special LDAP character");
+        }
         try {
             return authenticationCache.getUnchecked(new Credentials(user, password));
         }
@@ -172,6 +179,11 @@ public class LdapAuthenticator
     private static String replaceUser(String pattern, String user)
     {
         return pattern.replaceAll("\\$\\{USER}", user);
+    }
+
+    private static boolean containsSpecialCharacters(String user)
+    {
+        return SPECIAL_CHARACTERS.matchesAnyOf(user);
     }
 
     private static void closeContext(DirContext context)

--- a/presto-password-authenticators/src/test/java/com/facebook/presto/password/ldap/TestLdapAuthenticator.java
+++ b/presto-password-authenticators/src/test/java/com/facebook/presto/password/ldap/TestLdapAuthenticator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.password.ldap;
+
+import com.facebook.presto.spi.security.AccessDeniedException;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestLdapAuthenticator
+{
+    private static LdapAuthenticator createAuthenticator()
+    {
+        LdapConfig config = new LdapConfig()
+                .setLdapUrl("ldaps://ldap.example.com:636")
+                .setUserBindSearchPattern("uid=${USER},ou=users,dc=example,dc=com")
+                .setUserBaseDistinguishedName("dc=example,dc=com")
+                .setGroupAuthorizationSearchPattern("(&(objectClass=inetOrgPerson)(memberOf=cn=presto,dc=example,dc=com)(uid=${USER}))");
+        return new LdapAuthenticator(config);
+    }
+
+    @Test
+    public void testRejectsUsernameWithLdapSpecialCharacters()
+    {
+        LdapAuthenticator authenticator = createAuthenticator();
+        // Metacharacters that would otherwise be interpolated into the bind DN and group search filter.
+        for (String user : new String[] {"*", "admin)(uid=*", "a\\29", "user,ou=admins", "a=b", "a(b)c"}) {
+            assertThatThrownBy(() -> authenticator.createAuthenticatedPrincipal(user, "password"))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessageContaining("special LDAP character");
+        }
+    }
+}


### PR DESCRIPTION
## Description

`LdapAuthenticator` interpolates the login username into the bind DN and the group-authorisation search filter through a plain replace:

    private static String replaceUser(String pattern, String user)
    {
        return pattern.replaceAll("\\$\\{USER}", user);
    }

`${USER}` is swapped for the raw username with no LDAP escaping. A value like `admin)(uid=*` therefore lands verbatim inside the RFC 4515 filter handed to `context.search(...)` in `checkForGroupMembership`, and inside the RFC 4514 bind DN built by `createPrincipal`. The metacharacters `* ( ) \` and the DN set `, = + < > # ; "` change the structure of the filter/DN instead of being read as literals, which is CWE-90 LDAP injection.

The username crosses a trust boundary (it is the Basic-auth credential supplied by the client), so the guard belongs in the authenticator rather than in each deployment's pattern. `createAuthenticatedPrincipal` now rejects a username containing an LDAP special character before any directory operation runs, matching the approach the sibling Trino codebase already takes. Ordinary usernames are untouched.

## Motivation and Context

Any deployment using the LDAP password authenticator with a `${USER}` group-auth pattern or bind pattern feeds unescaped client input straight into an LDAP filter/DN. Escaping at the single point of consumption removes the injection surface regardless of the configured pattern.

## Impact

LDAP password authentication only. Usernames containing `, = + < > # ; * ( ) " \` or NUL are rejected with `Username contains a special LDAP character`. No configuration change and no change to valid logins.

## Test Plan

`TestLdapAuthenticator` asserts each metacharacter username is rejected with `AccessDeniedException` before a connection is attempted. It fails on the unpatched tree, where the value flows into the LDAP path and surfaces a connection error instead, and passes with the guard in place.

    mvn -pl presto-password-authenticators test

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Security Changes
* Fix an LDAP injection in LDAP-based authentication by rejecting login usernames that contain LDAP special characters.
```

## Summary by Sourcery

Reject LDAP-special-character usernames to protect LDAP password authentication from injection attacks.

Bug Fixes:
- Prevent LDAP injection by rejecting login usernames containing LDAP distinguished-name or search-filter special characters before authentication proceeds.

Tests:
- Add coverage verifying LDAP-special-character usernames are denied before any directory connection is attempted.