### PR TITLE
fix: apply UUID byte-swap for nested columns in BinaryColumnReader

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/BinaryColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/BinaryColumnReader.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.parquet.RichColumnDescriptor;
 import io.airlift.slice.Slice;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
 
 import static com.facebook.presto.common.type.Chars.isCharType;
 import static com.facebook.presto.common.type.Chars.truncateToLengthAndTrimSpaces;
@@ -43,7 +44,7 @@ public class BinaryColumnReader
             Binary binary = valuesReader.readBytes();
             Slice value;
 
-            if (type instanceof UuidType) {
+            if (type instanceof UuidType || isUuidColumn()) {
                 byte[] src = binary.getBytes();
                 blockBuilder.writeLong(getLongBigEndian(src, 0));
                 blockBuilder.writeLong(getLongBigEndian(src, Long.BYTES));
@@ -68,6 +69,12 @@ public class BinaryColumnReader
         else if (isValueNull()) {
             blockBuilder.appendNull();
         }
+    }
+
+    private boolean isUuidColumn()
+    {
+        return columnDescriptor.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+                && columnDescriptor.getPrimitiveType().getTypeLength() == 16;
     }
 
     @Override


### PR DESCRIPTION
## Description

When reading UUID values from a **nested column** (e.g., `ARRAY<uuid>`), the `BinaryColumnReader.readValue()` method receives the column type as `varbinary` instead of `UuidType`. The existing `type instanceof UuidType` check at line 46 is therefore `false`, and the byte-swap reordering (`getLongBigEndian`) is **not applied**. The raw Parquet bytes are written directly without reordering, producing corrupted UUID values.

### Root cause

`BinaryColumnReader.readValue()` checks `if (type instanceof UuidType)` to decide whether to apply the byte-swap. For a top-level UUID column, `type` is `UuidType` and the byte-swap is applied correctly. For a UUID column nested inside a `ROW`, `ARRAY`, or `MAP`, `type` is `VarbinaryType` — the original UUID type information is lost in the `readValue()` call path.

### Fix

Add a fallback check: if the underlying Parquet column's `PrimitiveType` is `FIXED_LEN_BYTE_ARRAY` with length 16 (the physical representation of UUID in Parquet), apply the byte-swap reordering regardless of the `type` parameter.

### Verification

The `isUuidColumn()` helper uses the `RichColumnDescriptor` (available via `columnDescriptor`) to check the column's primitive type, which reliably identifies UUID columns regardless of whether `type` is `UuidType` or `VarbinaryType`.

### Related

Fixes #28313

## Summary by Sourcery

Bug Fixes:
- Apply UUID byte-swap logic for nested UUID columns represented as FIXED_LEN_BYTE_ARRAY in Parquet, preventing corrupted UUID values.