### PR TITLE
feat: Add FIRST/AFTER clause to ALTER TABLE ADD COLUMN

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2028,6 +2028,10 @@ Alter table operations are supported in the Iceberg connector::
 
      ALTER TABLE iceberg.web.page_views ADD COLUMN zipcode VARCHAR;
 
+     ALTER TABLE iceberg.web.page_views ADD COLUMN region VARCHAR FIRST;
+
+     ALTER TABLE iceberg.web.page_views ADD COLUMN city VARCHAR AFTER country;
+
      ALTER TABLE iceberg.web.page_views RENAME COLUMN zipcode TO location;
 
      ALTER TABLE iceberg.web.page_views DROP COLUMN location;

--- a/presto-docs/src/main/sphinx/sql/alter-table.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-table.rst
@@ -8,7 +8,7 @@ Synopsis
 .. code-block:: none
 
     ALTER TABLE [ IF EXISTS ] name RENAME TO new_name
-    ALTER TABLE [ IF EXISTS ] name ADD COLUMN [ IF NOT EXISTS ] column_name data_type [ DEFAULT default_expression ] [ COMMENT comment ] [ WITH ( property_name = expression [, ...] ) ]
+    ALTER TABLE [ IF EXISTS ] name ADD COLUMN [ IF NOT EXISTS ] column_name data_type [ DEFAULT default_expression ] [ COMMENT comment ] [ WITH ( property_name = expression [, ...] ) ] [ FIRST | AFTER existing_column_name ]
     ALTER TABLE [ IF EXISTS ] name DROP COLUMN column_name
     ALTER TABLE [ IF EXISTS ] name RENAME COLUMN [ IF EXISTS ] column_name TO new_column_name
     ALTER TABLE [ IF EXISTS ] name ADD [ CONSTRAINT constraint_name ] { PRIMARY KEY | UNIQUE } ( { column_name [, ...] } ) [ { ENABLED | DISABLED } ] [ [ NOT ] RELY ] [ [ NOT ] ENFORCED } ]
@@ -40,6 +40,11 @@ The optional ``IF EXISTS`` (when used before the column name) clause causes the 
 
 The optional ``IF NOT EXISTS`` clause causes the error to be suppressed if the column already exists.
 
+For ``ADD COLUMN`` statements, the optional ``FIRST`` and ``AFTER`` clauses control where the new
+column is placed in the table's column order. When neither clause is given, the column is appended at the
+end. ``FIRST`` and ``AFTER`` require support from the connector; connectors that do not support them
+report an error. ``AFTER`` requires the named column to already exist.
+
 For ``CREATE BRANCH`` statements:
 
 * The optional ``OR REPLACE`` clause causes the branch to be replaced if it already exists.
@@ -70,6 +75,14 @@ Add column ``zip`` to the ``users`` table::
 Add column ``zip`` to the ``users`` table if table ``users`` exists and column ``zip`` not already exists::
 
     ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS zip varchar;
+
+Add column ``zip`` as the first column of the ``users`` table::
+
+    ALTER TABLE users ADD COLUMN zip varchar FIRST;
+
+Add column ``zip`` immediately after the ``city`` column of the ``users`` table::
+
+    ALTER TABLE users ADD COLUMN zip varchar AFTER city;
 
 Drop column ``zip`` from the ``users`` table::
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -3327,7 +3327,13 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate("ALTER TABLE test_add_column ADD COLUMN b bigint COMMENT 'test comment BBB'");
         assertQueryFails("ALTER TABLE test_add_column ADD COLUMN a varchar", ".* Column 'a' already exists");
         assertQueryFails("ALTER TABLE test_add_column ADD COLUMN c bad_type", ".* Unknown type 'bad_type' for column 'c'");
-        assertQuery("SHOW COLUMNS FROM test_add_column", "VALUES ('a', 'bigint', '', 'test comment AAA', 19, NULL, NULL), ('b', 'bigint', '', 'test comment BBB', 19, NULL, NULL)");
+        // Hive does not implement the position-aware addColumn, so a position clause must be rejected outright
+        // rather than silently appending the column somewhere the user did not ask for
+        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN c bigint FIRST", ".*This connector does not support adding columns with FIRST clause");
+        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN c bigint AFTER a", ".*This connector does not support adding columns with AFTER clause");
+        // Omitting the clause appends, which is the connector's existing behavior
+        assertUpdate("ALTER TABLE test_add_column ADD COLUMN c bigint COMMENT 'test comment CCC'");
+        assertQuery("SHOW COLUMNS FROM test_add_column", "VALUES ('a', 'bigint', '', 'test comment AAA', 19, NULL, NULL), ('b', 'bigint', '', 'test comment BBB', 19, NULL, NULL), ('c', 'bigint', '', 'test comment CCC', 19, NULL, NULL)");
         assertUpdate("DROP TABLE test_add_column");
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -70,6 +70,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
@@ -1250,8 +1251,22 @@ public abstract class IcebergAbstractMetadata
         }
     }
 
+    /**
+     * All the logic lives in the position-aware overload below, which this delegates to with
+     * {@link ColumnPosition.Last}. The engine only ever calls that overload, so a subclass that needs to
+     * customize {@code addColumn} must override it; overriding only this three-argument form would leave the
+     * subclass bypassed for every {@code ADD COLUMN} statement, positioned or not. Note that the
+     * {@code ConnectorMetadata} default for the position-aware overload delegates back to this
+     * three-argument form for {@code Last}, so a subclass must not reintroduce that direction of delegation.
+     */
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        addColumn(session, tableHandle, column, new ColumnPosition.Last());
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
     {
         if (!column.isNullable() && !column.getDefaultValue().isPresent()) {
             throw new PrestoException(NOT_SUPPORTED, "This connector does not support add column with non null");
@@ -1269,11 +1284,14 @@ public abstract class IcebergAbstractMetadata
                     "Table '%s' is currently at format version %d. ", handle.getSchemaTableName(), opsFromTable(icebergTable).current().formatVersion(), handle.getSchemaTableName()));
             Object defaultValue = column.getDefaultValue().get();
             Literal<?> defaultLiteral = convertToIcebergLiteral(defaultValue, columnType);
-            updateSchema.addColumn(column.getName(), columnType, column.getComment().orElse(null), defaultLiteral).commit();
+            updateSchema.addColumn(column.getName(), columnType, column.getComment().orElse(null), defaultLiteral);
         }
         else {
-            updateSchema.addColumn(column.getName(), columnType, column.getComment().orElse(null)).commit();
+            updateSchema.addColumn(column.getName(), columnType, column.getComment().orElse(null));
         }
+        // The move is staged on the same UpdateSchema as the add, so the column is added and positioned in a single commit
+        applyColumnPosition(updateSchema, icebergTable.schema(), column.getName(), position);
+        updateSchema.commit();
         if (column.getProperties().containsKey(PARTITIONING_PROPERTY)) {
             List<String> partitioningTransform = (List<String>) column.getProperties().get(PARTITIONING_PROPERTY);
             UpdatePartitionSpec updatePartitionSpec = icebergTable.updateSpec();
@@ -1283,6 +1301,68 @@ public abstract class IcebergAbstractMetadata
             }
             updatePartitionSpec.commit();
         }
+    }
+
+    /**
+     * Stages the {@code FIRST | AFTER <column>} move for a newly added column on the given
+     * {@link UpdateSchema}. {@link ColumnPosition.Last}, which is what an omitted clause resolves to,
+     * is a no-op, because Iceberg appends by default.
+     * {@code schema} is the table schema before the add, which is where an {@code AFTER} target must exist.
+     */
+    private static void applyColumnPosition(UpdateSchema updateSchema, Schema schema, String columnName, ColumnPosition position)
+    {
+        if (position instanceof ColumnPosition.Last) {
+            return;
+        }
+        if (position instanceof ColumnPosition.First) {
+            updateSchema.moveFirst(columnName);
+            return;
+        }
+        if (position instanceof ColumnPosition.After) {
+            String afterColumnName = ((ColumnPosition.After) position).getColumnName();
+            // The engine lowercases the target name, while an Iceberg field keeps whatever case the table was
+            // created with, so the lookup has to be case-insensitive to match the name SHOW COLUMNS reports.
+            // Only the top-level columns are scanned, rather than using Schema.caseInsensitiveFindField: that
+            // builds a lower-case index over the whole schema, which resolves dotted paths to nested fields
+            // whose leaf name would be wrong here, and throws outright if any two fields anywhere in the table
+            // differ only by case.
+            //
+            // A name that does not resolve is rejected here rather than passed to moveAfter, which would raise
+            // an IllegalArgumentException for a name it cannot find. The engine already rejects a target that
+            // is not a real column, so this is the guard for a caller that goes through the SPI directly.
+            //
+            // A dotted name (e.g. "struct_col.nested") is a valid nested-field path in Iceberg but not a valid
+            // AFTER target: the AFTER clause positions a column among its siblings at the same nesting level,
+            // so only a top-level column name is accepted here.
+            if (afterColumnName.contains(".")) {
+                throw new PrestoException(COLUMN_NOT_FOUND, format(
+                        "Column '%s' does not exist as a top-level column. The AFTER clause requires a top-level column name, not a nested field path.",
+                        afterColumnName));
+            }
+            NestedField afterColumn = findTopLevelColumn(schema, afterColumnName)
+                    .orElseThrow(() -> new PrestoException(COLUMN_NOT_FOUND, format("Column '%s' does not exist", afterColumnName)));
+            updateSchema.moveAfter(columnName, afterColumn.name());
+            return;
+        }
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported column position: " + position);
+    }
+
+    /**
+     * Finds a top-level column of {@code schema} by name, preferring an exact match over a case-insensitive
+     * one, so that a table whose top-level columns differ only by case resolves deterministically rather than
+     * by whatever order the fields happen to be in.
+     */
+    private static Optional<NestedField> findTopLevelColumn(Schema schema, String columnName)
+    {
+        Optional<NestedField> exactMatch = schema.columns().stream()
+                .filter(field -> field.name().equals(columnName))
+                .findFirst();
+        if (exactMatch.isPresent()) {
+            return exactMatch;
+        }
+        return schema.columns().stream()
+                .filter(field -> field.name().equalsIgnoreCase(columnName))
+                .findFirst();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -80,6 +80,7 @@ import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.resol
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.nio.file.Files.createTempDirectory;
@@ -769,6 +770,79 @@ public abstract class IcebergDistributedSmokeTestBase
         assertQuery("SELECT * FROM test_commuted_not_null_table", "VALUES (NULL, 2)");
         assertQueryFails("INSERT INTO test_commuted_not_null_table (b, a) VALUES (NULL, 3),(4, NULL),(NULL, NULL)", "NULL value not allowed for NOT NULL column: b");
         assertUpdate("DROP TABLE IF EXISTS test_commuted_not_null_table");
+    }
+
+    @Test
+    public void testAddColumnWithPosition()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_position (second INTEGER, fourth INTEGER)");
+        assertEquals(columnNames("test_add_column_position"), ImmutableList.of("second", "fourth"));
+
+        assertUpdate(session, "ALTER TABLE test_add_column_position ADD COLUMN first INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_position"), ImmutableList.of("first", "second", "fourth"));
+
+        assertUpdate(session, "ALTER TABLE test_add_column_position ADD COLUMN third INTEGER AFTER second");
+        assertEquals(columnNames("test_add_column_position"), ImmutableList.of("first", "second", "third", "fourth"));
+
+        // AFTER the last column is equivalent to appending
+        assertUpdate(session, "ALTER TABLE test_add_column_position ADD COLUMN fifth INTEGER AFTER fourth");
+        assertEquals(columnNames("test_add_column_position"), ImmutableList.of("first", "second", "third", "fourth", "fifth"));
+
+        // An omitted clause appends the column
+        assertUpdate(session, "ALTER TABLE test_add_column_position ADD COLUMN sixth INTEGER");
+        assertUpdate(session, "ALTER TABLE test_add_column_position ADD COLUMN seventh INTEGER");
+        assertEquals(columnNames("test_add_column_position"), ImmutableList.of("first", "second", "third", "fourth", "fifth", "sixth", "seventh"));
+
+        // Every column gets a distinct value, so a positional mix-up between two columns cannot pass. The
+        // by-name projection is what pins the order: SELECT * expands in whatever order the columns are in
+        // and therefore matches the positional INSERT either way, while the projection below is compared
+        // against the same tuple and fails unless each name holds the value written at its position
+        assertUpdate(session, "INSERT INTO test_add_column_position VALUES (1, 2, 3, 4, 5, 6, 7)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_position", "VALUES (1, 2, 3, 4, 5, 6, 7)");
+        assertQuery(session, "SELECT first, second, third, fourth, fifth, sixth, seventh FROM test_add_column_position", "VALUES (1, 2, 3, 4, 5, 6, 7)");
+
+        dropTable(session, "test_add_column_position");
+    }
+
+    @Test
+    public void testAddColumnPositionErrors()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_position_errors (a INTEGER, b INTEGER)");
+        assertUpdate(session, "INSERT INTO test_add_column_position_errors VALUES (1, 2)", 1);
+
+        assertQueryFails(
+                "ALTER TABLE test_add_column_position_errors ADD COLUMN c INTEGER AFTER does_not_exist",
+                ".*Column 'does_not_exist' does not exist");
+        // The failed statement must not have added the column
+        assertEquals(columnNames("test_add_column_position_errors"), ImmutableList.of("a", "b"));
+
+        // A column may not be positioned after itself either, because it does not exist yet
+        assertQueryFails(
+                "ALTER TABLE test_add_column_position_errors ADD COLUMN c INTEGER AFTER c",
+                ".*Column 'c' does not exist");
+        assertEquals(columnNames("test_add_column_position_errors"), ImmutableList.of("a", "b"));
+
+        // An existing column is an error with a position clause just as it is without one, and must not move
+        assertQueryFails(
+                "ALTER TABLE test_add_column_position_errors ADD COLUMN b INTEGER FIRST",
+                ".*Column 'b' already exists");
+        assertEquals(columnNames("test_add_column_position_errors"), ImmutableList.of("a", "b"));
+
+        // A synthesized column is exposed by getColumnHandles but is hidden and is not a field of the Iceberg
+        // schema, so it is not a usable target; the engine rejects it before the connector is reached
+        assertQueryFails(
+                "ALTER TABLE test_add_column_position_errors ADD COLUMN c INTEGER AFTER \"$path\"",
+                ".*Cannot add a column after hidden column '\\$path'");
+        assertEquals(columnNames("test_add_column_position_errors"), ImmutableList.of("a", "b"));
+
+        // IF NOT EXISTS makes the same statement a no-op, which must not reorder the existing column either
+        assertUpdate(session, "ALTER TABLE test_add_column_position_errors ADD COLUMN IF NOT EXISTS b INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_position_errors"), ImmutableList.of("a", "b"));
+        assertQuery(session, "SELECT * FROM test_add_column_position_errors", "VALUES (1, 2)");
+
+        dropTable(session, "test_add_column_position_errors");
     }
 
     @Test
@@ -2980,5 +3054,17 @@ public abstract class IcebergDistributedSmokeTestBase
         finally {
             queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
         }
+    }
+
+    /**
+     * Returns the table's column names in table order, resolved against the default session's schema.
+     * {@code assertQuery} compares results as an unordered multiset, so asserting order requires
+     * comparing the materialized rows directly.
+     */
+    protected List<String> columnNames(String tableName)
+    {
+        return computeActual("SHOW COLUMNS FROM " + tableName).getMaterializedRows().stream()
+                .map(row -> (String) row.getField(0))
+                .collect(toImmutableList());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -503,6 +503,40 @@ public class TestIcebergV3
     }
 
     @Test
+    public void testAddColumnWithDefaultAndPosition()
+    {
+        String tableName = "test_add_column_default_position";
+        String columnOrderQuery = "SELECT column_name FROM information_schema.columns" +
+                " WHERE table_schema = '" + TEST_SCHEMA + "' AND table_name = '" + tableName + "' ORDER BY ordinal_position";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+
+            // The default literal and the move are staged on a single UpdateSchema, so both have to survive one commit
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN country VARCHAR DEFAULT 'IN' FIRST");
+            // Asserted with assertQueryOrdered, because assertQuery compares results as an unordered multiset
+            // and would pass for any column order
+            assertQueryOrdered(columnOrderQuery, "VALUES ('country'), ('id'), ('name')");
+            Table table = loadTable(tableName);
+            assertEquals(table.schema().findField("country").initialDefault(), "IN");
+            assertEquals(table.schema().findField("country").writeDefault(), "IN");
+
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN region VARCHAR DEFAULT 'APAC' AFTER id");
+            assertQueryOrdered(columnOrderQuery, "VALUES ('country'), ('id'), ('region'), ('name')");
+            table = loadTable(tableName);
+            assertEquals(table.schema().findField("region").initialDefault(), "APAC");
+            assertEquals(table.schema().findField("region").writeDefault(), "APAC");
+
+            // A row written without the defaulted columns reads them back in their requested positions
+            assertUpdate("INSERT INTO " + tableName + " (id, name) VALUES (1, 'Alice')", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES ('IN', 1, 'APAC', 'Alice')");
+            assertQuery("SELECT country, region FROM " + tableName, "VALUES ('IN', 'APAC')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testSetColumnDefaultRequiresV3()
     {
         String tableName = "test_set_column_default_v2";

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.hive;
 
 import com.facebook.presto.FullConnectorSession;
+import com.facebook.presto.Session;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
@@ -21,12 +22,18 @@ import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types.IntegerType;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -34,10 +41,12 @@ import java.nio.file.Path;
 
 import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 
 public class TestIcebergSmokeHive
         extends IcebergDistributedSmokeTestBase
@@ -93,5 +102,295 @@ public class TestIcebergSmokeHive
         assertQueryFails(format("SHOW CREATE SCHEMA %s.%s.%s", getSession().getCatalog().get(), "show_create_iceberg_schema", "tabletest"), ".*Too many parts in schema name: iceberg.show_create_iceberg_schema.tabletest");
         assertQueryFails(format("SHOW CREATE SCHEMA %s", "schema_not_exist"), ".*Schema 'iceberg.schema_not_exist' does not exist");
         assertUpdate("DROP SCHEMA show_create_iceberg_schema");
+    }
+
+    /**
+     * {@code ADD COLUMN ... FIRST|AFTER} is resolved in the engine and applied by
+     * {@code IcebergAbstractMetadata} through {@code UpdateSchema}, so it behaves identically for every
+     * Iceberg catalog. The catalog-independent schema-evolution and complex-type cases therefore live
+     * here rather than in {@link IcebergDistributedSmokeTestBase}, which runs against every catalog.
+     */
+    @Test
+    public void testAddColumnWithPositionAndComplexTypes()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_complex (second INTEGER)");
+
+        assertUpdate(session, "ALTER TABLE test_add_column_complex ADD COLUMN r ROW(x INTEGER, y VARCHAR) FIRST");
+        assertUpdate(session, "ALTER TABLE test_add_column_complex ADD COLUMN a ARRAY(INTEGER) AFTER second");
+        assertUpdate(session, "ALTER TABLE test_add_column_complex ADD COLUMN m MAP(VARCHAR, INTEGER) AFTER a");
+
+        assertEquals(columnNames("test_add_column_complex"), ImmutableList.of("r", "second", "a", "m"));
+
+        assertUpdate(
+                session,
+                "INSERT INTO test_add_column_complex VALUES (CAST(ROW(7, 'seven') AS ROW(x INTEGER, y VARCHAR)), 2, ARRAY[8, 9], MAP(ARRAY['ten'], ARRAY[10]))",
+                1);
+
+        // Asserted against the materialized row rather than with assertQuery, because the expected side of
+        // assertQuery runs on H2, which cannot represent map, array or row types
+        MaterializedRow row = getOnlyElement(computeActual(session, "SELECT * FROM test_add_column_complex").getMaterializedRows());
+        assertEquals(row.getField(0), ImmutableList.of(7, "seven"));
+        assertEquals(row.getField(1), 2);
+        assertEquals(row.getField(2), ImmutableList.of(8, 9));
+        assertEquals(row.getField(3), ImmutableMap.of("ten", 10));
+
+        // Reading the complex columns by name must agree with the positional read above
+        assertQuery(session, "SELECT r.x, r.y, second, a[1], a[2], m['ten'] FROM test_add_column_complex", "VALUES (7, 'seven', 2, 8, 9, 10)");
+
+        dropTable(session, "test_add_column_complex");
+    }
+
+    @Test
+    public void testAddColumnWithPositionOnPartitionedTable()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_partitioned (a INTEGER, part VARCHAR) WITH (partitioning = ARRAY['part'])");
+
+        assertUpdate(session, "ALTER TABLE test_add_column_partitioned ADD COLUMN first INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_partitioned"), ImmutableList.of("first", "a", "part"));
+
+        // Partitioning still works after the reposition, and each partition holds distinct values
+        assertUpdate(session, "INSERT INTO test_add_column_partitioned VALUES (1, 2, 'p1'), (10, 20, 'p2')", 2);
+        assertQuery(session, "SELECT * FROM test_add_column_partitioned WHERE part = 'p1'", "VALUES (1, 2, 'p1')");
+        assertQuery(session, "SELECT first, a FROM test_add_column_partitioned WHERE part = 'p2'", "VALUES (10, 20)");
+        assertQueryOrdered(session, "SELECT * FROM test_add_column_partitioned ORDER BY part", "VALUES (1, 2, 'p1'), (10, 20, 'p2')");
+
+        dropTable(session, "test_add_column_partitioned");
+    }
+
+    @Test
+    public void testAddColumnWithPositionToTableWithExistingRows()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_existing_rows AS SELECT 2 AS second, 4 AS fourth", 1);
+
+        assertUpdate(session, "ALTER TABLE test_add_column_existing_rows ADD COLUMN first INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_existing_rows"), ImmutableList.of("first", "second", "fourth"));
+
+        // The pre-existing row has no value for the new column; the other two columns keep their own values,
+        // asserted by name so the absent value cannot be confused with a shifted column
+        assertQuery(session, "SELECT second, fourth FROM test_add_column_existing_rows WHERE first IS NULL", "VALUES (2, 4)");
+        assertQuery(session, "SELECT count(*) FROM test_add_column_existing_rows", "VALUES 1");
+
+        // A row written after the reposition round-trips completely
+        assertUpdate(session, "INSERT INTO test_add_column_existing_rows VALUES (1, 20, 40)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_existing_rows WHERE first = 1", "VALUES (1, 20, 40)");
+
+        dropTable(session, "test_add_column_existing_rows");
+    }
+
+    @Test
+    public void testAddColumnInMiddleThenDropIt()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_then_drop (a INTEGER, c INTEGER)");
+
+        assertUpdate(session, "ALTER TABLE test_add_column_then_drop ADD COLUMN b INTEGER AFTER a");
+        assertEquals(columnNames("test_add_column_then_drop"), ImmutableList.of("a", "b", "c"));
+        assertUpdate(session, "INSERT INTO test_add_column_then_drop VALUES (1, 2, 3)", 1);
+
+        assertUpdate(session, "ALTER TABLE test_add_column_then_drop DROP COLUMN b");
+        assertEquals(columnNames("test_add_column_then_drop"), ImmutableList.of("a", "c"));
+
+        // The row written while the middle column existed is still readable, and the surviving columns
+        // did not shift into the hole left by the dropped one
+        assertQuery(session, "SELECT * FROM test_add_column_then_drop", "VALUES (1, 3)");
+        assertQuery(session, "SELECT a, c FROM test_add_column_then_drop", "VALUES (1, 3)");
+        assertQueryFails("SELECT b FROM test_add_column_then_drop", ".*Column 'b' cannot be resolved");
+
+        // And the table still accepts writes with the narrowed schema
+        assertUpdate(session, "INSERT INTO test_add_column_then_drop VALUES (10, 30)", 1);
+        assertQueryOrdered(session, "SELECT * FROM test_add_column_then_drop ORDER BY a", "VALUES (1, 3), (10, 30)");
+
+        dropTable(session, "test_add_column_then_drop");
+    }
+
+    @Test
+    public void testAddColumnInMiddleAfterDroppingColumn()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_after_drop (a INTEGER, b INTEGER, c INTEGER)");
+        assertUpdate(session, "INSERT INTO test_add_column_after_drop VALUES (1, 2, 3)", 1);
+
+        assertUpdate(session, "ALTER TABLE test_add_column_after_drop DROP COLUMN b");
+        assertEquals(columnNames("test_add_column_after_drop"), ImmutableList.of("a", "c"));
+
+        // The dropped name is no longer a valid position target
+        assertQueryFails(
+                "ALTER TABLE test_add_column_after_drop ADD COLUMN d INTEGER AFTER b",
+                ".*Column 'b' does not exist");
+
+        // Adding a differently named column in the vacated middle position, and writing to it, still works
+        assertUpdate(session, "ALTER TABLE test_add_column_after_drop ADD COLUMN b2 INTEGER AFTER a");
+        assertEquals(columnNames("test_add_column_after_drop"), ImmutableList.of("a", "b2", "c"));
+        assertUpdate(session, "INSERT INTO test_add_column_after_drop VALUES (10, 20, 30)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_after_drop WHERE a = 10", "VALUES (10, 20, 30)");
+        assertQuery(session, "SELECT a, c FROM test_add_column_after_drop WHERE b2 IS NULL", "VALUES (1, 3)");
+
+        // Reusing the dropped name is allowed, because Iceberg assigns the new column a fresh field id
+        assertUpdate(session, "ALTER TABLE test_add_column_after_drop ADD COLUMN b INTEGER AFTER b2");
+        assertEquals(columnNames("test_add_column_after_drop"), ImmutableList.of("a", "b2", "b", "c"));
+        assertUpdate(session, "INSERT INTO test_add_column_after_drop VALUES (100, 200, 250, 300)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_after_drop WHERE a = 100", "VALUES (100, 200, 250, 300)");
+        // The re-added column reads as absent for the rows written before it existed, rather than
+        // picking up the old column's values
+        assertQueryOrdered(session, "SELECT a FROM test_add_column_after_drop WHERE b IS NULL ORDER BY a", "VALUES 1, 10");
+
+        dropTable(session, "test_add_column_after_drop");
+    }
+
+    @Test
+    public void testAddColumnAfterNewlyAddedColumn()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_chain (a INTEGER, e INTEGER)");
+
+        // Each added column becomes a valid AFTER target for the next statement
+        assertUpdate(session, "ALTER TABLE test_add_column_chain ADD COLUMN b INTEGER AFTER a");
+        assertUpdate(session, "ALTER TABLE test_add_column_chain ADD COLUMN c INTEGER AFTER b");
+        assertUpdate(session, "ALTER TABLE test_add_column_chain ADD COLUMN d INTEGER AFTER c");
+
+        assertEquals(columnNames("test_add_column_chain"), ImmutableList.of("a", "b", "c", "d", "e"));
+
+        assertUpdate(session, "INSERT INTO test_add_column_chain VALUES (1, 2, 3, 4, 5)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_chain", "VALUES (1, 2, 3, 4, 5)");
+        assertQuery(session, "SELECT a, b, c, d, e FROM test_add_column_chain", "VALUES (1, 2, 3, 4, 5)");
+
+        dropTable(session, "test_add_column_chain");
+    }
+
+    @Test
+    public void testAddColumnFirstRepeatedly()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_repeat_first (c INTEGER)");
+
+        // The second FIRST must land ahead of the column added by the first one
+        assertUpdate(session, "ALTER TABLE test_add_column_repeat_first ADD COLUMN b INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_repeat_first"), ImmutableList.of("b", "c"));
+
+        assertUpdate(session, "ALTER TABLE test_add_column_repeat_first ADD COLUMN a INTEGER FIRST");
+        assertEquals(columnNames("test_add_column_repeat_first"), ImmutableList.of("a", "b", "c"));
+
+        assertUpdate(session, "INSERT INTO test_add_column_repeat_first VALUES (1, 2, 3)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_repeat_first", "VALUES (1, 2, 3)");
+        // The by-name projection is what pins the order: it is compared against the same tuple the
+        // positional INSERT used, so it fails unless each name holds the value written at its position
+        assertQuery(session, "SELECT a, b, c FROM test_add_column_repeat_first", "VALUES (1, 2, 3)");
+
+        dropTable(session, "test_add_column_repeat_first");
+    }
+
+    @Test
+    public void testAddColumnPositionTargetIsCaseInsensitive()
+    {
+        Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_add_column_target_case (a INTEGER, c INTEGER)");
+
+        // The AFTER target is normalized the same way any other column reference is
+        assertUpdate(session, "ALTER TABLE test_add_column_target_case ADD COLUMN b INTEGER AFTER A");
+        assertEquals(columnNames("test_add_column_target_case"), ImmutableList.of("a", "b", "c"));
+
+        assertUpdate(session, "ALTER TABLE test_add_column_target_case ADD COLUMN b2 INTEGER AFTER \"b\"");
+        assertEquals(columnNames("test_add_column_target_case"), ImmutableList.of("a", "b", "b2", "c"));
+
+        assertUpdate(session, "INSERT INTO test_add_column_target_case VALUES (1, 2, 3, 4)", 1);
+        assertQuery(session, "SELECT * FROM test_add_column_target_case", "VALUES (1, 2, 3, 4)");
+        assertQuery(session, "SELECT a, b, b2, c FROM test_add_column_target_case", "VALUES (1, 2, 3, 4)");
+
+        dropTable(session, "test_add_column_target_case");
+    }
+
+    /**
+     * A table created by another engine can hold a column whose Iceberg name is not lowercase. The engine
+     * lowercases the {@code AFTER} target before handing it to the connector, so the connector has to resolve
+     * it against the Iceberg schema case-insensitively; a case-sensitive lookup would reject every spelling
+     * the user could type and make the clause unusable on such a table.
+     */
+    @Test
+    public void testAddColumnAfterCasePreservedColumn()
+    {
+        Session session = getSession();
+        String tableName = "test_add_column_after_mixed_case";
+        assertUpdate(session, "CREATE TABLE " + tableName + " (a INTEGER, c INTEGER)");
+
+        // Renaming through the Iceberg API preserves the case, which CREATE TABLE through Presto cannot do
+        getIcebergTable(session, tableName).updateSchema().renameColumn("a", "MixedCase").commit();
+        assertEquals(columnNames(tableName), ImmutableList.of("mixedcase", "c"));
+
+        // Every spelling of the target normalizes to the same name, and all of them have to resolve
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN b INTEGER AFTER \"MixedCase\"");
+        assertEquals(columnNames(tableName), ImmutableList.of("mixedcase", "b", "c"));
+
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN b2 INTEGER AFTER mixedcase");
+        assertEquals(columnNames(tableName), ImmutableList.of("mixedcase", "b2", "b", "c"));
+
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, 2, 3, 4)", 1);
+        assertQuery(session, "SELECT * FROM " + tableName, "VALUES (1, 2, 3, 4)");
+        assertQuery(session, "SELECT mixedcase, b2, b, c FROM " + tableName, "VALUES (1, 2, 3, 4)");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testAddColumnWithPositionAndPartitioning()
+    {
+        Session session = getSession();
+        String tableName = "test_add_column_position_partitioning";
+        assertUpdate(session, "CREATE TABLE " + tableName + " (a INTEGER, c INTEGER)");
+
+        // The connector commits the schema, including the move, before committing the new partition field, so
+        // the two have to agree on which column was added
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN b INTEGER WITH (partitioning = 'identity') AFTER a");
+        assertEquals(columnNames(tableName), ImmutableList.of("a", "b", "c"));
+
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, 2, 3), (10, 20, 30)", 2);
+        assertQuery(session, "SELECT * FROM " + tableName + " WHERE b = 2", "VALUES (1, 2, 3)");
+        assertQueryOrdered(session, "SELECT * FROM " + tableName + " ORDER BY a", "VALUES (1, 2, 3), (10, 20, 30)");
+
+        // The new column is the partition field, which confirms the partition spec followed the repositioned column
+        assertQueryOrdered(session, "SELECT b FROM \"" + tableName + "$partitions\" ORDER BY b", "VALUES 2, 20");
+
+        dropTable(session, tableName);
+    }
+
+    /**
+     * A struct can legitimately hold two sibling fields whose names differ only by case, which is not a
+     * collision for Iceberg because they have distinct field ids. Resolving the {@code AFTER} target through
+     * {@link org.apache.iceberg.Schema#caseInsensitiveFindField} would build a lower-case index over every
+     * field in the table and reject such a schema outright, so only the top-level columns are scanned.
+     */
+    @Test
+    public void testAddColumnAfterOnTableWithNestedCaseCollision()
+    {
+        Session session = getSession();
+        String tableName = "test_add_column_nested_case_collision";
+        assertUpdate(session, "CREATE TABLE " + tableName + " (a INTEGER, s ROW(x INTEGER), c INTEGER)");
+
+        // Presto lowercases field names, so the colliding sibling has to be added through the Iceberg API
+        getIcebergTable(session, tableName).updateSchema().addColumn("s", "X", IntegerType.get()).commit();
+
+        assertUpdate(session, "ALTER TABLE " + tableName + " ADD COLUMN b INTEGER AFTER a");
+        assertEquals(columnNames(tableName), ImmutableList.of("a", "b", "s", "c"));
+
+        // A nested field is not a valid target: the engine validates the target against the table's columns,
+        // so the connector never sees a dotted name and cannot move the column after a nested leaf
+        assertQueryFails(session, "ALTER TABLE " + tableName + " ADD COLUMN d INTEGER AFTER \"s.x\"", ".*Column 's.x' does not exist");
+        assertEquals(columnNames(tableName), ImmutableList.of("a", "b", "s", "c"));
+
+        // Writing is not asserted here: an INSERT into a table with such a struct fails with
+        // "Duplicate field: x", which was confirmed to happen with no ADD COLUMN involved at all and so is
+        // unrelated to this feature
+        assertQuery(session, "SELECT count(*) FROM " + tableName, "VALUES 0");
+
+        dropTable(session, tableName);
+    }
+
+    private Table getIcebergTable(Session session, String tableName)
+    {
+        CatalogManager catalogManager = getDistributedQueryRunner().getCoordinator().getCatalogManager();
+        ConnectorId connectorId = catalogManager.getCatalog(ICEBERG_CATALOG).get().getConnectorId();
+        return getIcebergTable(session.toConnectorSession(connectorId), session.getSchema().get(), tableName);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -23,12 +23,15 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.type.UnknownTypeException;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.tree.AddColumn;
 import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition.After;
+import com.facebook.presto.sql.tree.ColumnPosition.First;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.transaction.TransactionManager;
@@ -47,6 +50,7 @@ import static com.facebook.presto.spi.ColumnMetadata.DEFAULT_VALUE_PROPERTY;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_EXISTS;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_COLUMN;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
@@ -138,8 +142,51 @@ public class AddColumnTask
                 .setProperties(columnProperties)
                 .build();
 
-        metadata.addColumn(session, tableHandle.get(), column);
+        ColumnPosition position = toConnectorColumnPosition(statement, metadata, session, tableName.getCatalogName(), tableHandle.get(), columnHandles);
+
+        metadata.addColumn(session, tableHandle.get(), column, position);
 
         return immediateFuture(null);
+    }
+
+    /**
+     * Converts the optional {@code FIRST | AFTER <column>} clause of the statement into the connector
+     * representation. An absent clause becomes {@link ColumnPosition.Last}, so the column is appended,
+     * which is the pre-existing behavior.
+     * <p>
+     * The two {@code ColumnPosition} types in scope here are distinct: the unqualified {@code First} and
+     * {@code After} are {@link com.facebook.presto.sql.tree.ColumnPosition} from the statement, while
+     * {@code ColumnPosition.First} and the like are the {@link ColumnPosition} handed to the connector.
+     */
+    private static ColumnPosition toConnectorColumnPosition(
+            AddColumn statement,
+            Metadata metadata,
+            Session session,
+            String catalogName,
+            TableHandle tableHandle,
+            Map<String, ColumnHandle> columnHandles)
+    {
+        return statement.getPosition()
+                .<ColumnPosition>map(position -> {
+                    if (position instanceof First) {
+                        return new ColumnPosition.First();
+                    }
+                    if (position instanceof After) {
+                        Identifier afterIdentifier = ((After) position).getColumn();
+                        String afterColumn = metadata.normalizeIdentifier(session, catalogName, afterIdentifier.getValue());
+                        ColumnHandle afterColumnHandle = columnHandles.get(afterColumn);
+                        if (afterColumnHandle == null) {
+                            throw new SemanticException(MISSING_COLUMN, statement, "Column '%s' does not exist", afterIdentifier.getValue());
+                        }
+                        // A hidden column, such as a connector's synthesized "$path", has no place in the table's
+                        // column order, so it cannot be positioned after even though getColumnHandles exposes it
+                        if (metadata.getColumnMetadata(session, tableHandle, afterColumnHandle).isHidden()) {
+                            throw new SemanticException(NOT_SUPPORTED, statement, "Cannot add a column after hidden column '%s'", afterIdentifier.getValue());
+                        }
+                        return new ColumnPosition.After(afterColumn);
+                    }
+                    throw new SemanticException(NOT_SUPPORTED, statement, "Unsupported column position: %s", position);
+                })
+                .orElseGet(ColumnPosition.Last::new);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
@@ -267,9 +268,9 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
     {
-        delegate.addColumn(session, tableHandle, column);
+        delegate.addColumn(session, tableHandle, column, position);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -40,6 +40,7 @@ import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.api.Experimental;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
@@ -244,9 +245,9 @@ public interface Metadata
     void setColumnDefault(Session session, TableHandle tableHandle, String columnName, Object defaultValue);
 
     /**
-     * Add the specified column to the table.
+     * Add the specified column to the table at the specified position.
      */
-    void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column);
+    void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position);
 
     /**
      * Set the specified type to the column.

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -57,6 +57,7 @@ import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
@@ -811,11 +812,11 @@ public class MetadataManager
     }
 
     @Override
-    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadataForWrite(session, connectorId);
-        metadata.addColumn(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), column);
+        metadata.addColumn(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), column, position);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
@@ -1147,11 +1148,11 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
-    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
     {
         long startTime = System.nanoTime();
         try {
-            delegate.addColumn(session, tableHandle, column);
+            delegate.addColumn(session, tableHandle, column, position);
         }
         finally {
             stats.recordAddColumnCall(System.nanoTime() - startTime);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestAddColumnTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestAddColumnTask.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.metadata.AbstractMockMetadata;
+import com.facebook.presto.metadata.Catalog;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ColumnPosition;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.tree.AddColumn;
+import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition.After;
+import com.facebook.presto.sql.tree.ColumnPosition.First;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.testing.TestingWarningCollector;
+import com.facebook.presto.testing.TestingWarningCollectorConfig;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.sql.QueryUtil.identifier;
+import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestAddColumnTask
+{
+    private static final String CATALOG_NAME = "catalog";
+    private static final String TABLE_NAME = "test_table";
+
+    private TransactionManager transactionManager;
+    private Session testSession;
+    private MockMetadata metadata;
+    private final TestingWarningCollector warningCollector = new TestingWarningCollector(new WarningCollectorConfig(), new TestingWarningCollectorConfig().setAddWarnings(true));
+
+    @BeforeMethod
+    public void setUp()
+    {
+        CatalogManager catalogManager = new CatalogManager();
+        transactionManager = createTestTransactionManager(catalogManager);
+        Catalog testCatalog = createBogusTestingCatalog(CATALOG_NAME);
+        catalogManager.registerCatalog(testCatalog);
+        ColumnPropertyManager columnPropertyManager = new ColumnPropertyManager();
+        columnPropertyManager.addProperties(testCatalog.getConnectorId(), emptyList());
+        testSession = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema("schema")
+                .setTransactionId(transactionManager.beginTransaction(false))
+                .build();
+        metadata = new MockMetadata(createTestFunctionAndTypeManager(), columnPropertyManager, testCatalog.getConnectorId());
+    }
+
+    @Test
+    public void testAddColumnWithoutPositionAppends()
+    {
+        execute(addColumn());
+        assertEquals(metadata.getReceivedPosition(), new ColumnPosition.Last());
+    }
+
+    @Test
+    public void testAddColumnFirst()
+    {
+        execute(addColumn(new First()));
+        assertEquals(metadata.getReceivedPosition(), new ColumnPosition.First());
+    }
+
+    @Test
+    public void testAddColumnAfter()
+    {
+        execute(addColumn(new After(identifier("x"))));
+        assertEquals(metadata.getReceivedPosition(), new ColumnPosition.After("x"));
+    }
+
+    @Test
+    public void testAddColumnAfterIsNormalized()
+    {
+        // The connector receives the normalized name, so it can look the target up in its own column map
+        execute(addColumn(new After(new Identifier("X", true))));
+        assertEquals(metadata.getReceivedPosition(), new ColumnPosition.After("x"));
+
+        // An unquoted identifier is normalized the same way
+        execute(addColumn(new After(new Identifier("X", false))));
+        assertEquals(metadata.getReceivedPosition(), new ColumnPosition.After("x"));
+    }
+
+    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = ".*Column 'missing' does not exist")
+    public void testAddColumnAfterMissingColumn()
+    {
+        execute(addColumn(new After(identifier("missing"))));
+    }
+
+    /**
+     * A hidden column is in getColumnHandles but is not part of the table's column order, so it is rejected
+     * here rather than being pushed down for every connector to reject on its own. The error says the column
+     * is hidden rather than that it does not exist, matching how DROP COLUMN and RENAME COLUMN report it.
+     */
+    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = ".*Cannot add a column after hidden column 'hidden'")
+    public void testAddColumnAfterHiddenColumn()
+    {
+        execute(addColumn(new After(identifier("hidden"))));
+    }
+
+    private static AddColumn addColumn()
+    {
+        return new AddColumn(
+                QualifiedName.of(TABLE_NAME),
+                columnDefinition(),
+                false,
+                false);
+    }
+
+    private static AddColumn addColumn(com.facebook.presto.sql.tree.ColumnPosition position)
+    {
+        return new AddColumn(
+                QualifiedName.of(TABLE_NAME),
+                columnDefinition(),
+                Optional.of(position),
+                false,
+                false);
+    }
+
+    private static ColumnDefinition columnDefinition()
+    {
+        return new ColumnDefinition(identifier("c"), "BIGINT", true, emptyList(), Optional.empty());
+    }
+
+    private void execute(AddColumn statement)
+    {
+        getFutureValue(new AddColumnTask().execute(statement, transactionManager, metadata, new AllowAllAccessControl(), testSession, emptyList(), warningCollector, ""));
+    }
+
+    private static class MockMetadata
+            extends AbstractMockMetadata
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final ColumnPropertyManager columnPropertyManager;
+        private final ConnectorId catalogHandle;
+        private final TableHandle tableHandle;
+        private ColumnPosition receivedPosition;
+
+        public MockMetadata(FunctionAndTypeManager functionAndTypeManager, ColumnPropertyManager columnPropertyManager, ConnectorId catalogHandle)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
+            this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+            this.tableHandle = new TableHandle(catalogHandle, new TestingTableHandle(), TestingTransactionHandle.create(), Optional.empty());
+        }
+
+        @Override
+        public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
+        {
+            this.receivedPosition = position;
+        }
+
+        public ColumnPosition getReceivedPosition()
+        {
+            return receivedPosition;
+        }
+
+        @Override
+        public MetadataResolver getMetadataResolver(Session session)
+        {
+            return new MetadataResolver()
+            {
+                @Override
+                public boolean catalogExists(String catalogName)
+                {
+                    return catalogHandle.getCatalogName().equals(catalogName);
+                }
+
+                @Override
+                public boolean schemaExists(CatalogSchemaName schemaName)
+                {
+                    return true;
+                }
+
+                @Override
+                public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
+                {
+                    return Optional.of(tableHandle);
+                }
+
+                @Override
+                public List<ColumnMetadata> getColumns(TableHandle tableHandle)
+                {
+                    return emptyList();
+                }
+
+                @Override
+                public Map<String, ColumnHandle> getColumnHandles(TableHandle tableHandle)
+                {
+                    return ImmutableMap.of();
+                }
+
+                @Override
+                public Optional<ViewDefinition> getView(QualifiedObjectName viewName)
+                {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName viewName)
+                {
+                    return Optional.empty();
+                }
+            };
+        }
+
+        @Override
+        public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+        {
+            // "x" is the only real column, so AFTER x resolves and AFTER missing does not. "hidden" stands for a
+            // synthesized column, which a connector exposes here even though it is not part of the column order
+            return ImmutableMap.of(
+                    "x", new TestingColumnHandle("x"),
+                    "hidden", new TestingColumnHandle("hidden"));
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            String columnName = ((TestingColumnHandle) columnHandle).getName();
+            return ColumnMetadata.builder()
+                    .setName(columnName)
+                    .setType(BIGINT)
+                    .setHidden(columnName.equals("hidden"))
+                    .build();
+        }
+
+        @Override
+        public ColumnPropertyManager getColumnPropertyManager()
+        {
+            return columnPropertyManager;
+        }
+
+        @Override
+        public Type getType(TypeSignature signature)
+        {
+            return functionAndTypeManager.getType(signature);
+        }
+
+        @Override
+        public Optional<ConnectorId> getCatalogHandle(Session session, String catalogName)
+        {
+            if (catalogHandle.getCatalogName().equals(catalogName)) {
+                return Optional.of(catalogHandle);
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
@@ -321,7 +322,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
@@ -45,6 +45,15 @@ public class TestSqlFormatter
         assertQuery("ALTER TABLE sales.orders DROP COLUMN \"Customer\"");
     }
 
+    @Test
+    public void testAddColumnPosition()
+    {
+        assertQuery("ALTER TABLE sales.orders ADD COLUMN customer VARCHAR FIRST");
+        assertQuery("ALTER TABLE sales.orders ADD COLUMN customer VARCHAR AFTER order_id");
+        assertQuery("ALTER TABLE IF EXISTS sales.orders ADD COLUMN IF NOT EXISTS customer VARCHAR AFTER order_id");
+        assertQuery("ALTER TABLE sales.orders ADD COLUMN customer VARCHAR AFTER \"OrderId\"");
+    }
+
     private void assertQuery(String query)
     {
         SqlParser parser = new SqlParser();

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
@@ -30,13 +30,14 @@ import static java.lang.String.format;
  * Concrete subclasses bind the storage format (PARQUET) so the same matrix
  * runs against every reader and proves parity.
  *
- * Two velox-level scenarios are intentionally absent because they are not
- * expressible as Presto Iceberg SQL DDL and are covered by the velox unit/e2e
+ * One velox-level scenario is intentionally absent because it is not
+ * expressible as Presto Iceberg SQL DDL and is covered by the velox unit/e2e
  * tests instead:
- * - column reorder (no ALTER ... FIRST/AFTER; only SELECT projection order, which
- *   {@link #testRenameReorderDropAdd} exercises),
  * - nested struct field add/drop/reorder (the connector only evolves top-level
  *   columns).
+ *
+ * Top-level column reordering via {@code ALTER TABLE … ADD COLUMN … FIRST|AFTER}
+ * is tested by {@link #testAddColumnFirst} and {@link #testAddColumnAfter}.
  */
 public abstract class AbstractTestSchemaEvolution
         extends AbstractTestQueryFramework
@@ -185,6 +186,72 @@ public abstract class AbstractTestSchemaEvolution
             // resolve by field id to their original data; d is null-filled.
             assertQuery(format("SELECT c2, a, d FROM %s ORDER BY a", table),
                     "VALUES ('x', BIGINT '1', NULL), ('y', BIGINT '2', NULL), ('z', BIGINT '3', NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // ADD COLUMN … FIRST positions the new column at ordinal 0. Old files do not
+    // contain it, so the native reader must null-fill by field id, not by position.
+    // New files written after the DDL carry the value at the new field id.
+    @Test
+    public void testAddColumnFirst()
+    {
+        String table = "schema_evolution_add_first";
+        try {
+            assertUpdate(format("CREATE TABLE %s (a INTEGER, b VARCHAR) WITH (format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'x'), (2, 'y')", table), 2);
+
+            assertUpdate(format("ALTER TABLE %s ADD COLUMN z INTEGER FIRST", table));
+
+            // Old rows must read NULL for the new leading column.
+            assertQuery(format("SELECT z, a, b FROM %s ORDER BY a", table),
+                    "VALUES (NULL, 1, 'x'), (NULL, 2, 'y')");
+
+            // New rows have a real value for z; pre-existing rows keep their field-id
+            // bindings unchanged (a and b must not shift by one position).
+            assertUpdate(format("INSERT INTO %s VALUES (99, 3, 'new')", table), 1);
+            assertQuery(format("SELECT z, a, b FROM %s ORDER BY a", table),
+                    "VALUES (NULL, 1, 'x'), (NULL, 2, 'y'), (99, 3, 'new')");
+            assertQuery(format("SELECT b, z, a FROM %s ORDER BY a", table),
+                    "VALUES ('x', NULL, 1), ('y', NULL, 2), ('new', 99, 3)");
+            // SELECT * must return columns in schema order: z (FIRST), a, b.
+            assertQuery(format("SELECT * FROM %s ORDER BY a", table),
+                    "VALUES (NULL, 1, 'x'), (NULL, 2, 'y'), (99, 3, 'new')");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // ADD COLUMN … AFTER <col> inserts the new column between two existing ones.
+    // The native reader must correctly null-fill for old files and bind the value
+    // for new files, in both cases using field id rather than physical position.
+    @Test
+    public void testAddColumnAfter()
+    {
+        String table = "schema_evolution_add_after";
+        try {
+            assertUpdate(format("CREATE TABLE %s (a INTEGER, c VARCHAR) WITH (format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'x'), (2, 'y')", table), 2);
+
+            // Insert column b between a and c.
+            assertUpdate(format("ALTER TABLE %s ADD COLUMN b INTEGER AFTER a", table));
+
+            // Old files do not have b; it must null-fill without disturbing c.
+            assertQuery(format("SELECT a, b, c FROM %s ORDER BY a", table),
+                    "VALUES (1, NULL, 'x'), (2, NULL, 'y')");
+
+            // New rows carry a value for b; a and c keep their field-id bindings.
+            assertUpdate(format("INSERT INTO %s VALUES (3, 10, 'z')", table), 1);
+            assertQuery(format("SELECT a, b, c FROM %s ORDER BY a", table),
+                    "VALUES (1, NULL, 'x'), (2, NULL, 'y'), (3, 10, 'z')");
+            assertQuery(format("SELECT b, a, c FROM %s ORDER BY a", table),
+                    "VALUES (NULL, 1, 'x'), (NULL, 2, 'y'), (10, 3, 'z')");
+            // SELECT * must return columns in schema order: a, b (AFTER a), c.
+            assertQuery(format("SELECT * FROM %s ORDER BY a", table),
+                    "VALUES (1, NULL, 'x'), (2, NULL, 'y'), (3, 10, 'z')");
         }
         finally {
             assertUpdate(format("DROP TABLE IF EXISTS %s", table));

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -57,7 +57,8 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
-        ADD COLUMN (IF NOT EXISTS)? column=columnDefinition            #addColumn
+        ADD COLUMN (IF NOT EXISTS)? column=columnDefinition
+        (FIRST | AFTER after=identifier)?                              #addColumn
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         ADD constraintSpecification                                    #addConstraint
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
@@ -711,7 +712,7 @@ constraintEnforced
 
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
-    : ADD | ADMIN | ALL | ANALYZE | ANY | ARRAY | ASC | AT
+    : ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT
     | BEFORE | BERNOULLI | BRANCH
     | CALL | CALLED | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | COPARTITION | CURRENT | CURRENT_ROLE
     | DATA | DATE | DAY | DEFAULT | DEFINER | DESC | DESCRIPTOR | DETERMINISTIC | DISABLED | DISTRIBUTED | DAYS
@@ -740,6 +741,7 @@ nonReserved
 
 ADD: 'ADD';
 ADMIN: 'ADMIN';
+AFTER: 'AFTER';
 ALL: 'ALL';
 ALTER: 'ALTER';
 ANALYZE: 'ANALYZE';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Call;
 import com.facebook.presto.sql.tree.CallArgument;
 import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.ConstraintSpecification;
 import com.facebook.presto.sql.tree.CreateBranch;
@@ -1549,6 +1550,18 @@ public final class SqlFormatter
                 builder.append("IF NOT EXISTS ");
             }
             builder.append(formatColumnDefinition(node.getColumn()));
+            node.getPosition().ifPresent(position -> {
+                if (position instanceof ColumnPosition.First) {
+                    builder.append(" FIRST");
+                }
+                else if (position instanceof ColumnPosition.After) {
+                    builder.append(" AFTER ")
+                            .append(formatName(((ColumnPosition.After) position).getColumn()));
+                }
+                else {
+                    throw new UnsupportedOperationException("Unsupported column position: " + position);
+                }
+            });
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -36,6 +36,7 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CharLiteral;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ConstraintSpecification;
@@ -639,8 +640,20 @@ class AstBuilder
         return new AddColumn(getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (ColumnDefinition) visit(context.columnDefinition()),
+                getColumnPosition(context),
                 context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() < context.COLUMN().getSymbol().getTokenIndex()),
                 context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() > context.COLUMN().getSymbol().getTokenIndex()));
+    }
+
+    private Optional<ColumnPosition> getColumnPosition(SqlBaseParser.AddColumnContext context)
+    {
+        if (context.FIRST() != null) {
+            return Optional.of(new ColumnPosition.First());
+        }
+        if (context.AFTER() != null) {
+            return Optional.of(new ColumnPosition.After((Identifier) visit(context.after)));
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
@@ -28,25 +28,37 @@ public class AddColumn
 {
     private final QualifiedName name;
     private final ColumnDefinition column;
+    private final Optional<ColumnPosition> position;
     private final boolean tableExists;
     private final boolean columnNotExists;
 
     public AddColumn(QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
 
     {
-        this(Optional.empty(), name, column, tableExists, columnNotExists);
+        this(Optional.empty(), name, column, Optional.empty(), tableExists, columnNotExists);
     }
 
     public AddColumn(NodeLocation location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
     {
-        this(Optional.of(location), name, column, tableExists, columnNotExists);
+        this(Optional.of(location), name, column, Optional.empty(), tableExists, columnNotExists);
     }
 
-    private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
+    public AddColumn(QualifiedName name, ColumnDefinition column, Optional<ColumnPosition> position, boolean tableExists, boolean columnNotExists)
+    {
+        this(Optional.empty(), name, column, position, tableExists, columnNotExists);
+    }
+
+    public AddColumn(NodeLocation location, QualifiedName name, ColumnDefinition column, Optional<ColumnPosition> position, boolean tableExists, boolean columnNotExists)
+    {
+        this(Optional.of(location), name, column, position, tableExists, columnNotExists);
+    }
+
+    private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column, Optional<ColumnPosition> position, boolean tableExists, boolean columnNotExists)
     {
         super(location);
         this.name = requireNonNull(name, "table is null");
         this.column = requireNonNull(column, "column is null");
+        this.position = requireNonNull(position, "position is null");
         this.tableExists = tableExists;
         this.columnNotExists = columnNotExists;
     }
@@ -59,6 +71,11 @@ public class AddColumn
     public ColumnDefinition getColumn()
     {
         return column;
+    }
+
+    public Optional<ColumnPosition> getPosition()
+    {
+        return position;
     }
 
     public boolean isTableExists()
@@ -80,7 +97,12 @@ public class AddColumn
     @Override
     public List<Node> getChildren()
     {
-        return ImmutableList.of(column);
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.add(column);
+        if (position.isPresent() && (position.get() instanceof ColumnPosition.After)) {
+            nodes.add(((ColumnPosition.After) position.get()).getColumn());
+        }
+        return nodes.build();
     }
 
     @Override
@@ -92,7 +114,7 @@ public class AddColumn
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, column, tableExists, columnNotExists);
+        return Objects.hash(name, column, position, tableExists, columnNotExists);
     }
 
     @Override
@@ -107,6 +129,7 @@ public class AddColumn
         AddColumn o = (AddColumn) obj;
         return Objects.equals(name, o.name) &&
                 Objects.equals(column, o.column) &&
+                Objects.equals(position, o.position) &&
                 Objects.equals(tableExists, o.tableExists) &&
                 Objects.equals(columnNotExists, o.columnNotExists);
     }
@@ -117,6 +140,7 @@ public class AddColumn
         return toStringHelper(this)
                 .add("name", name)
                 .add("column", column)
+                .add("position", position)
                 .add("tableExists", tableExists)
                 .add("columnNotExists", columnNotExists)
                 .toString();

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnPosition.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnPosition.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Position of a new column within a table, from the optional
+ * {@code FIRST | AFTER <column>} clause of {@code ALTER TABLE ... ADD COLUMN}. An absent
+ * clause appends the column, so there is no variant for it here.
+ * <p>
+ * The only implementations are the nested {@link First} and {@link After} classes. This
+ * would be a sealed interface, but the checkstyle version in use cannot parse the
+ * {@code sealed} and {@code permits} modifiers.
+ */
+public interface ColumnPosition
+{
+    final class First
+            implements ColumnPosition
+    {
+        @Override
+        public int hashCode()
+        {
+            return First.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return (obj != null) && (getClass() == obj.getClass());
+        }
+
+        @Override
+        public String toString()
+        {
+            return "FIRST";
+        }
+    }
+
+    final class After
+            implements ColumnPosition
+    {
+        private final Identifier column;
+
+        public After(Identifier column)
+        {
+            this.column = requireNonNull(column, "column is null");
+        }
+
+        public Identifier getColumn()
+        {
+            return column;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(column);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+            After o = (After) obj;
+            return Objects.equals(column, o.column);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "AFTER " + column;
+        }
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -603,6 +603,9 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitAddColumn(AddColumn node, C context)
     {
         process(node.getColumn(), context);
+        node.getPosition()
+                .filter(position -> position instanceof ColumnPosition.After)
+                .ifPresent(position -> process(((ColumnPosition.After) position).getColumn(), context));
 
         return null;
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CharLiteral;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ConstraintSpecification;
@@ -2131,6 +2132,42 @@ public class TestSqlParser
     }
 
     @Test
+    public void testAddColumnWithPosition()
+    {
+        // No clause at all leaves the position absent, so connectors keep the pre-existing append behavior
+        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty()), Optional.empty(), false, false));
+
+        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint FIRST", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty()), Optional.of(new ColumnPosition.First()), false, false));
+
+        assertInvalidStatement("ALTER TABLE foo.t ADD COLUMN c bigint LAST", ".*mismatched input 'LAST'.*");
+
+        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint AFTER b", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty()), Optional.of(new ColumnPosition.After(identifier("b"))), false, false));
+
+        // The clause composes with every other modifier of ADD COLUMN
+        assertStatement("ALTER TABLE IF EXISTS foo.t ADD COLUMN IF NOT EXISTS c bigint NOT NULL AFTER b",
+                new AddColumn(QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(identifier("c"), "bigint", false, emptyList(), Optional.empty()), Optional.of(new ColumnPosition.After(identifier("b"))), true, true));
+
+        assertStatement("ALTER TABLE foo.t ADD COLUMN country varchar DEFAULT 'IN' FIRST",
+                new AddColumn(QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(identifier("country"), "varchar", true, emptyList(), Optional.empty(), Optional.of(new StringLiteral("IN"))),
+                        Optional.of(new ColumnPosition.First()), false, false));
+
+        // AFTER remains usable as an identifier, both as the new column name and as the target
+        assertStatement("ALTER TABLE foo.t ADD COLUMN after bigint AFTER after", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("after"), "bigint", true, emptyList(), Optional.empty()),
+                Optional.of(new ColumnPosition.After(identifier("after"))), false, false));
+
+        // A delimited target keeps its case
+        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint AFTER \"MixedCase\"", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty()),
+                Optional.of(new ColumnPosition.After(new Identifier("MixedCase", true))), false, false));
+    }
+
+    @Test
     public void testAlterColumnSetDataType()
     {
         assertStatement("ALTER TABLE foo.t ALTER COLUMN c SET DATA TYPE BIGINT", new SetColumnType(
@@ -2788,12 +2825,19 @@ public class TestSqlParser
                                 new DereferenceExpression(new Identifier("t"), new Identifier("current_role"))),
                         table(QualifiedName.of("t"))));
 
+        // AFTER is a keyword only inside the ADD COLUMN position clause
+        assertStatement("SELECT after FROM t",
+                simpleQuery(
+                        selectList(new Identifier("after")),
+                        table(QualifiedName.of("t"))));
+
         assertExpression("stats", new Identifier("stats"));
         assertExpression("nfd", new Identifier("nfd"));
         assertExpression("nfc", new Identifier("nfc"));
         assertExpression("nfkd", new Identifier("nfkd"));
         assertExpression("nfkc", new Identifier("nfkc"));
         assertExpression("current_role", new Identifier("current_role"));
+        assertExpression("after", new Identifier("after"));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestDefaultTraversalVisitorAddColumn.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestDefaultTraversalVisitorAddColumn.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * {@link DefaultTraversalVisitor} enumerates the children of {@link AddColumn} explicitly rather than
+ * iterating {@link Node#getChildren()}, so the identifier of an {@code AFTER <column>} position has to
+ * be visited deliberately. An analysis pass built on the visitor that collects column references
+ * would otherwise silently skip the position target.
+ */
+public class TestDefaultTraversalVisitorAddColumn
+{
+    @Test
+    public void testAfterIdentifierIsVisited()
+    {
+        Identifier afterColumn = new Identifier("existing_column");
+
+        assertEquals(
+                visitedIdentifiers(addColumn(Optional.of(new ColumnPosition.After(afterColumn)))),
+                ImmutableList.of("existing_column"));
+    }
+
+    @Test
+    public void testPositionsWithoutIdentifierVisitNothing()
+    {
+        // The visitor does not descend into a ColumnDefinition, so the AFTER target is the only
+        // identifier reachable from an AddColumn node
+        assertEquals(visitedIdentifiers(addColumn(Optional.empty())), ImmutableList.of());
+        assertEquals(visitedIdentifiers(addColumn(Optional.of(new ColumnPosition.First()))), ImmutableList.of());
+    }
+
+    private static AddColumn addColumn(Optional<ColumnPosition> position)
+    {
+        ColumnDefinition column = new ColumnDefinition(new Identifier("new_column"), "INTEGER", true, emptyList(), Optional.empty());
+        return new AddColumn(QualifiedName.of("test_table"), column, position, false, false);
+    }
+
+    private static List<String> visitedIdentifiers(AddColumn node)
+    {
+        IdentifierCollector collector = new IdentifierCollector();
+        collector.process(node, null);
+        return collector.getIdentifiers().stream()
+                .map(Identifier::getValue)
+                .collect(toImmutableList());
+    }
+
+    private static class IdentifierCollector
+            extends DefaultTraversalVisitor<Void, Void>
+    {
+        private final ImmutableList.Builder<Identifier> identifiers = ImmutableList.builder();
+
+        @Override
+        protected Void visitIdentifier(Identifier node, Void context)
+        {
+            identifiers.add(node);
+            return null;
+        }
+
+        public List<Identifier> getIdentifiers()
+        {
+            return identifiers.build();
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ColumnPosition.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ColumnPosition.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Position at which a new column should be added to a table.
+ * <p>
+ * The only implementations are the nested {@link First}, {@link Last} and {@link After}
+ * classes. This would be a sealed interface, but the checkstyle version in use cannot
+ * parse the {@code sealed} and {@code permits} modifiers.
+ */
+public interface ColumnPosition
+{
+    final class First
+            implements ColumnPosition
+    {
+        @Override
+        public int hashCode()
+        {
+            return First.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return (obj != null) && (getClass() == obj.getClass());
+        }
+
+        @Override
+        public String toString()
+        {
+            return "FIRST";
+        }
+    }
+
+    final class Last
+            implements ColumnPosition
+    {
+        @Override
+        public int hashCode()
+        {
+            return Last.class.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return (obj != null) && (getClass() == obj.getClass());
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LAST";
+        }
+    }
+
+    final class After
+            implements ColumnPosition
+    {
+        private final String columnName;
+
+        public After(String columnName)
+        {
+            this.columnName = requireNonNull(columnName, "columnName is null");
+        }
+
+        public String getColumnName()
+        {
+            return columnName;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(columnName);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+            After o = (After) obj;
+            return Objects.equals(columnName, o.columnName);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "AFTER " + columnName;
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_APPLICABLE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public interface ConnectorMetadata
@@ -401,11 +402,49 @@ public interface ConnectorMetadata
     }
 
     /**
-     * Add the specified column
+     * Add the specified column, appended to the end of the table's columns.
+     * <p>
+     * Implementing this method is enough to support {@code ADD COLUMN} without a position clause.
+     * To also support {@code FIRST} and {@code AFTER}, override
+     * {@link #addColumn(ConnectorSession, ConnectorTableHandle, ColumnMetadata, ColumnPosition)}.
      */
     default void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support adding columns");
+    }
+
+    /**
+     * Add the specified column at the specified position.
+     * <p>
+     * The default implementation delegates to
+     * {@link #addColumn(ConnectorSession, ConnectorTableHandle, ColumnMetadata)} for
+     * {@link ColumnPosition.Last}, so connectors that do not support positioning keep working
+     * unchanged, and rejects every other position rather than appending in the wrong place.
+     * Connectors add support by overriding this method. An implementation that wraps another
+     * {@link ConnectorMetadata} must forward this method as well as the three-argument form, or the
+     * wrapped connector's positioning support is lost behind this default.
+     * <p>
+     * The engine validates a {@link ColumnPosition.After} target against
+     * {@link #getColumnHandles(ConnectorSession, ConnectorTableHandle)} and rejects a hidden column, so the
+     * target is a visible column of the table. An implementation should still reject a target it cannot
+     * resolve, rather than passing it on to an underlying API that cannot find it, since nothing stops a
+     * caller from using this interface directly.
+     */
+    default void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
+    {
+        requireNonNull(position, "position is null");
+        if (position instanceof ColumnPosition.Last) {
+            addColumn(session, tableHandle, column);
+            return;
+        }
+        if (position instanceof ColumnPosition.First) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support adding columns with FIRST clause");
+        }
+        if (position instanceof ColumnPosition.After) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support adding columns with AFTER clause");
+        }
+        // Never silently append for a position this method does not understand, or the column would land in the wrong place
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support adding columns at position: " + position);
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.ColumnPosition;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
@@ -344,6 +345,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             delegate.addColumn(session, tableHandle, column);
+        }
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column, ColumnPosition position)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.addColumn(session, tableHandle, column, position);
         }
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/connector/TestConnectorMetadataAddColumn.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/connector/TestConnectorMetadataAddColumn.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * The position-aware {@code addColumn} overload has a default implementation that keeps connectors
+ * which only implement the older three-argument form working unchanged.
+ */
+public class TestConnectorMetadataAddColumn
+{
+    private static final ColumnMetadata COLUMN = ColumnMetadata.builder().setName("c").setType(BIGINT).build();
+
+    @Test
+    public void testLastDelegatesToLegacyOverload()
+    {
+        LegacyMetadata metadata = new LegacyMetadata();
+        metadata.addColumn(null, null, COLUMN, new ColumnPosition.Last());
+        assertEquals(metadata.getLegacyCallCount(), 1);
+    }
+
+    @Test
+    public void testFirstIsRejected()
+    {
+        LegacyMetadata metadata = new LegacyMetadata();
+        assertNotSupported(metadata, new ColumnPosition.First(), "This connector does not support adding columns with FIRST clause");
+        // The legacy overload must not be reached, or the column would be appended in the wrong place
+        assertEquals(metadata.getLegacyCallCount(), 0);
+    }
+
+    @Test
+    public void testAfterIsRejected()
+    {
+        LegacyMetadata metadata = new LegacyMetadata();
+        assertNotSupported(metadata, new ColumnPosition.After("x"), "This connector does not support adding columns with AFTER clause");
+        assertEquals(metadata.getLegacyCallCount(), 0);
+    }
+
+    @Test
+    public void testConnectorWithoutAddColumnSupport()
+    {
+        // A connector that implements neither overload still reports the pre-existing message for LAST
+        LegacyMetadata metadata = LegacyMetadata.unsupported();
+        assertNotSupported(metadata, new ColumnPosition.Last(), "This connector does not support adding columns");
+        // LAST still routes through the legacy overload, which is where that pre-existing rejection comes from
+        assertEquals(metadata.getLegacyCallCount(), 1);
+    }
+
+    @Test
+    public void testUnrecognizedPositionIsRejected()
+    {
+        // A position this default does not understand must not silently append, or the column lands in the wrong place
+        LegacyMetadata metadata = new LegacyMetadata();
+        assertNotSupported(metadata, new UnknownPosition(), "This connector does not support adding columns at position");
+        assertEquals(metadata.getLegacyCallCount(), 0);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullPositionIsRejected()
+    {
+        new LegacyMetadata().addColumn(null, null, COLUMN, null);
+    }
+
+    private static void assertNotSupported(ConnectorMetadata metadata, ColumnPosition position, String message)
+    {
+        try {
+            metadata.addColumn(null, null, COLUMN, position);
+            fail("expected exception");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), NOT_SUPPORTED.toErrorCode());
+            assertTrue(e.getMessage().contains(message), "unexpected message: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Stands in for a position type added to the SPI after this default was written.
+     */
+    private static class UnknownPosition
+            implements ColumnPosition
+    {
+    }
+
+    /**
+     * A connector that implements only the older three-argument {@code addColumn}, counting the calls
+     * it receives. {@link #unsupported()} instead stands in for a connector that implements neither
+     * overload, by falling back to the interface default. Beyond {@code addColumn}, only the methods
+     * {@link ConnectorMetadata} leaves abstract are stubbed out.
+     */
+    private static class LegacyMetadata
+            implements ConnectorMetadata
+    {
+        private final boolean supported;
+        private int legacyCallCount;
+
+        LegacyMetadata()
+        {
+            this(true);
+        }
+
+        private LegacyMetadata(boolean supported)
+        {
+            this.supported = supported;
+        }
+
+        static LegacyMetadata unsupported()
+        {
+            return new LegacyMetadata(false);
+        }
+
+        @Override
+        public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+        {
+            // Counted before the delegation below, so the count records that this overload was entered even
+            // when the unsupported case throws out of it
+            legacyCallCount++;
+            if (!supported) {
+                ConnectorMetadata.super.addColumn(session, tableHandle, column);
+            }
+        }
+
+        public int getLegacyCallCount()
+        {
+            return legacyCallCount;
+        }
+
+        @Override
+        public List<String> listSchemaNames(ConnectorSession session)
+        {
+            return emptyList();
+        }
+
+        @Override
+        public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+        {
+            return emptyMap();
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+        {
+            return emptyMap();
+        }
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Call;
 import com.facebook.presto.sql.tree.CallArgument;
 import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition;
 import com.facebook.presto.sql.tree.CreateMaterializedView;
 import com.facebook.presto.sql.tree.CreateSchema;
 import com.facebook.presto.sql.tree.CreateTable;
@@ -104,11 +105,12 @@ public class DefaultTreeRewriter<C>
     protected Node visitAddColumn(AddColumn node, C context)
     {
         Node column = process(node.getColumn(), context);
-        if (node.getColumn() == column) {
+        Optional<ColumnPosition> position = processColumnPosition(node.getPosition(), context);
+        if (node.getColumn() == column && sameElement(node.getPosition(), position)) {
             return node;
         }
 
-        return new AddColumn(node.getName(), (ColumnDefinition) column, node.isTableExists(), node.isColumnNotExists());
+        return new AddColumn(node.getName(), (ColumnDefinition) column, position, node.isTableExists(), node.isColumnNotExists());
     }
 
     @Override
@@ -689,6 +691,22 @@ public class DefaultTreeRewriter<C>
         }
         Optional<T> result = element.map(e -> (T) process(e, context));
         return sameElement(element, result) ? element : result;
+    }
+
+    /**
+     * Rewrites the identifier of an {@code AFTER <column>} position, so a subclass that rewrites column
+     * references reaches the position target as well. {@code FIRST} carries no identifier.
+     * {@link ColumnPosition} is not a {@link Node}, so the {@code process} overloads above do not apply to it.
+     * Returns the argument itself when nothing changed, so the caller can detect that by identity.
+     */
+    private Optional<ColumnPosition> processColumnPosition(Optional<ColumnPosition> position, C context)
+    {
+        if (position == null || !position.isPresent() || !(position.get() instanceof ColumnPosition.After)) {
+            return position;
+        }
+        Identifier afterColumn = ((ColumnPosition.After) position.get()).getColumn();
+        Node rewritten = process(afterColumn, context);
+        return afterColumn == rewritten ? position : Optional.of(new ColumnPosition.After((Identifier) rewritten));
     }
 
     private static <T> boolean sameElement(Optional<T> a, Optional<T> b)

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestDefaultTreeRewriterAddColumn.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestDefaultTreeRewriterAddColumn.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.rewrite;
+
+import com.facebook.presto.sql.tree.AddColumn;
+import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.ColumnPosition;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * A rewriter that renames column references has to reach the identifier of an {@code AFTER <column>}
+ * position too, otherwise the rewritten statement positions the new column against a name that no
+ * longer exists in the rewritten context.
+ */
+public class TestDefaultTreeRewriterAddColumn
+{
+    @Test
+    public void testAfterIdentifierIsRewritten()
+    {
+        AddColumn rewritten = (AddColumn) new ColumnRenamer()
+                .process(addColumn(Optional.of(new ColumnPosition.After(new Identifier("old_name")))), null);
+
+        Optional<ColumnPosition> position = rewritten.getPosition();
+        assertTrue(position.isPresent() && position.get() instanceof ColumnPosition.After);
+        assertEquals(((ColumnPosition.After) position.get()).getColumn(), new Identifier("new_name"));
+    }
+
+    @Test
+    public void testUnchangedNodeIsReturnedAsIs()
+    {
+        // The early return must not fire when only the position needs rewriting, and must still fire
+        // when nothing does
+        AddColumn unaffected = addColumn(Optional.of(new ColumnPosition.After(new Identifier("untouched"))));
+        assertSame(new ColumnRenamer().process(unaffected, null), unaffected);
+
+        AddColumn noPosition = addColumn(Optional.empty());
+        assertSame(new ColumnRenamer().process(noPosition, null), noPosition);
+    }
+
+    @Test
+    public void testPositionsWithoutIdentifierArePreserved()
+    {
+        assertEquals(rewrittenPosition(new ColumnPosition.First()), Optional.of(new ColumnPosition.First()));
+    }
+
+    private static Optional<ColumnPosition> rewrittenPosition(ColumnPosition position)
+    {
+        return ((AddColumn) new ColumnRenamer().process(addColumn(Optional.of(position)), null)).getPosition();
+    }
+
+    private static AddColumn addColumn(Optional<ColumnPosition> position)
+    {
+        ColumnDefinition column = new ColumnDefinition(new Identifier("new_column"), "INTEGER", true, emptyList(), Optional.empty());
+        return new AddColumn(QualifiedName.of("test_table"), column, position, false, false);
+    }
+
+    /**
+     * Renames the single column {@code old_name} to {@code new_name}, standing in for any subclass that
+     * rewrites column references. Expression reconstruction is left to subclasses, so this supplies the
+     * {@code visitExpression} implementation the base class requires.
+     */
+    private static class ColumnRenamer
+            extends DefaultTreeRewriter<Void>
+    {
+        @Override
+        protected Node visitExpression(Expression node, Void context)
+        {
+            if ((node instanceof Identifier) && ((Identifier) node).getValue().equals("old_name")) {
+                return new Identifier("new_name");
+            }
+            return node;
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Adds an optional `FIRST | AFTER <column>` clause to `ALTER TABLE ... ADD COLUMN`, so a new column can be placed in the table's column order instead of always being appended, and implements it for the Iceberg connector.

```sql
ALTER TABLE users ADD COLUMN zip varchar FIRST;
ALTER TABLE users ADD COLUMN zip varchar AFTER city;
```

There is deliberately no `LAST` keyword, because Spark does not support one and an omitted clause already appends. The append position is still modeled in the SPI as `ColumnPosition.Last`, which is what an omitted clause resolves to, so today's behavior is preserved exactly.

Design inspired by trinodb/trino#20914

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Today a new column is always appended. Rewriting the whole table is the only way to place a column where it belongs, even though formats such as Iceberg reorder columns natively as a metadata-only operation.

Column order is user-visible — it drives `SELECT *` output and positional `INSERT` — so being unable to control it is a real gap for schema evolution, and one that Trino, Hive, and Spark all address with the same syntax.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- `ALTER TABLE ... ADD COLUMN` accepts an optional `FIRST | AFTER <column>` clause. Omitting the clause behaves exactly as before (append).
- `FIRST` and `AFTER` require connector support. Connectors that do not implement positioning reject them with `This connector does not support adding columns with FIRST clause` / `... with AFTER clause` rather than appending in the wrong place.
- `AFTER` requires the named column to already exist and to be visible. A missing target fails with `Column '<name>' does not exist`; a hidden column, such as a connector's synthesized `$path`, fails with `Cannot add a column after hidden column '<name>'`, matching how `DROP COLUMN` and `RENAME COLUMN` report a hidden column.
- Supported by the Iceberg connector. Not supported by Hive or any other connector in this PR.
- `AFTER` is non-reserved, so existing queries that use `after` as an identifier keep working.
- SPI: `ConnectorMetadata` gains a `ColumnPosition` overload of `addColumn` with a default implementation, so existing connectors compile and behave unchanged with no modification. The default delegates to the existing three-argument `addColumn` for `Last` and rejects any other position. The three-argument form is not deprecated, since it remains the right method to implement for connectors that cannot position columns. A decorating implementation has to forward the new overload as well, or the wrapped connector's support is lost behind the default; `ClassLoaderSafeConnectorMetadata` forwards both.

## Test Plan
<!---Please fill in how you tested your change-->
- **Parser** (`TestSqlParser`, `TestSqlFormatter`) — every combination of the clause with the other `ADD COLUMN` modifiers (`IF EXISTS`, `IF NOT EXISTS`, `DEFAULT`, `COMMENT`, `WITH`), an absent clause, a delimited target that keeps its case, and `AFTER` used as an identifier both as the new column name and as the target. Round-tripping through `SqlFormatter` is covered.
- **AST visitors** (`TestDefaultTraversalVisitorAddColumn`, `TestDefaultTreeRewriterAddColumn`) — the `AFTER` identifier is reached by traversal and rewritten by the verifier's rewriter, and the rewriter's early return fires only when nothing changed.
- **Engine** (`TestAddColumnTask`) — an omitted clause reaches the connector as `Last`, `FIRST` as `First`, and `AFTER` as a normalized `After`; a missing target fails as `MISSING_COLUMN`; a hidden target fails as `NOT_SUPPORTED` rather than being pushed down for every connector to reject on its own.
- **SPI** (`TestConnectorMetadataAddColumn`) — a connector implementing only the three-argument `addColumn` gets `Last` routed to it unchanged and every other position rejected; the legacy overload is asserted not to be reached for `FIRST`/`AFTER`, which is what proves the column cannot be silently appended.
- **Hive** (`TestHiveIntegrationSmokeTest#testAddColumn`) — the same invariant end to end: `FIRST` and `AFTER` are rejected outright, and an omitted clause still appends.
- **Iceberg** — query-level tests for the position semantics and their interaction with schema evolution: `FIRST`, `AFTER` a middle column, `AFTER` the last column, and an omitted clause (`IcebergDistributedSmokeTestBase#testAddColumnWithPosition`); plus, in `TestIcebergSmokeHive` so they run once rather than per catalog, adding in the middle and dropping it, adding in the middle after a drop (including reusing the dropped name), repeated `FIRST`, chaining `AFTER` onto a just-added column, a case-insensitive target, a case-preserved target, a target on a table whose nested struct fields differ only by case, complex types, partitioned tables, pre-existing rows, and the clause combined with `WITH (partitioning = ...)`. `TestIcebergV3#testAddColumnWithDefaultAndPosition` covers the clause combined with `DEFAULT <literal>`, where the default and the move are staged on a single `UpdateSchema` and both have to survive one commit.
  - Every column gets a distinct non-null value so a positional mix-up cannot pass; the column order is asserted after every statement and the rows are read back both positionally and by name, so the engine and connector must agree on the order.
  - Error paths (`IcebergDistributedSmokeTestBase#testAddColumnPositionErrors`) cover a missing target, a column positioned after itself, an existing column name, a synthesized column as target, and `IF NOT EXISTS` as a no-op — each asserting the failed statement neither added nor moved a column.
- **Native** (Prestissimo) (TestSchemaEvolutionParquet) — end-to-end tests with a live C++ worker against Parquet/Iceberg files: testAddColumnFirst writes rows with [a, b], adds z FIRST, and verifies pre-existing rows read z as NULL while new rows carry the value; testAddColumnAfter does the same for a column inserted mid-schema. Both tests assert the shifted columns (a, b, c) are not null-filled — directly exercising the Velox kParquetFieldId mapping fix without which shifted output-schema channels were incorrectly treated as missing.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an optional ``FIRST`` or ``AFTER <column>`` clause to ``ALTER TABLE ... ADD COLUMN`` to control where the new column is placed. Omitting the clause appends the column, which is the previous behavior. ``FIRST`` and ``AFTER`` require connector support.

SPI Changes
* Add an ``addColumn`` overload to ``ConnectorMetadata`` that takes a ``ColumnPosition``. The default implementation delegates to the existing three-argument ``addColumn`` when the column is appended, so connectors need no changes; override it to support the ``FIRST`` and ``AFTER`` clauses.

Iceberg Connector Changes
* Add support for the ``FIRST`` and ``AFTER <column>`` clauses of ``ALTER TABLE ... ADD COLUMN``, which control where the new column is placed in the table's column order.
```



## Summary by Sourcery

Add support for positioning new columns with FIRST and AFTER clauses in ALTER TABLE ADD COLUMN, wiring the engine, SPI, and Iceberg connector to honor column order while keeping existing connectors backward compatible.

New Features:
- Support FIRST and AFTER <column> positioning clauses in ALTER TABLE ... ADD COLUMN syntax and AST.
- Expose column position information to connectors via a new ColumnPosition SPI type and an addColumn overload that accepts it.
- Implement column positioning for the Iceberg connector, including interactions with defaults, partitioning, complex types, and case-insensitive column resolution.

Enhancements:
- Extend metadata and execution APIs to propagate column position from parsed SQL through AddColumnTask into connector metadata.
- Ensure AFTER remains a non-reserved keyword outside the ADD COLUMN position clause, and update SQL formatter and traversal/rewriter utilities to handle the new position structure.
- Add comprehensive tests for parser, formatter, verifier, metadata plumbing, and Iceberg behavior, plus helper utilities for asserting column order.

Tests:
- Add unit and integration tests covering column positioning semantics, error cases, default values, partitioning, and complex types in Iceberg tables.
- Add tests validating SPI default behavior for connectors that only implement legacy addColumn, including rejection of unsupported positions.
- Add parser, formatter, and verifier tests ensuring correct handling and traversal of the new position clause and AST nodes.