### PR TITLE
feat(native-pos): Add MaterializedOutputBuffer backpressure counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutput.cpp
@@ -497,7 +497,7 @@ void MaterializedOutput::noMoreInput() {
 
 BlockingReason MaterializedOutput::isBlocked(ContinueFuture* future) {
   // Drain at the high watermark or park until below the low watermark.
-  return buffer_->backpressure(future);
+  return buffer_->isBlocked(future);
 }
 
 bool MaterializedOutput::isFinished() {

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -132,8 +132,10 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::tryDrainPartition(
     int64_t targetBytes) {
   if (!tryAcquireFlushing()) {
     // Another driver is already draining and it will pick up our data.
+    buffer_->concurrentAppendCount_ += 1;
     return 0;
   }
+  buffer_->flushAcquireCount_ += 1;
 
   int64_t totalDrainedBytes = 0;
   do {
@@ -337,6 +339,7 @@ void MaterializedOutputBuffer::addBlockedPromise(
     velox::ContinueFuture* future) {
   velox::ContinuePromise promise{"MaterializedOutputBuffer::addBlockedPromise"};
   *future = promise.getSemiFuture();
+  backpressureBlockCount_ += 1;
   blockedPromises_.withWLock(
       [&](auto& promises) { promises.push_back(std::move(promise)); });
   // Avoid missing a concurrent low-watermark crossing during registration.
@@ -347,6 +350,7 @@ void MaterializedOutputBuffer::tryDrainPartitions() {
   while (bufferedBytes_ >= lowWatermarkBytes_) {
     // Flush the fullest partitions this thread can acquire.
     const uint64_t drainedBytes = tryDrainPartitionsInternal();
+    backpressureDrainedBytes_ += static_cast<int64_t>(drainedBytes);
     if (drainedBytes == 0) {
       // Nothing left this thread can drain (others are flushing the rest).
       break;
@@ -354,7 +358,7 @@ void MaterializedOutputBuffer::tryDrainPartitions() {
   }
 }
 
-velox::exec::BlockingReason MaterializedOutputBuffer::backpressure(
+velox::exec::BlockingReason MaterializedOutputBuffer::isBlocked(
     velox::ContinueFuture* future) {
   if (!isBufferFull()) {
     return velox::exec::BlockingReason::kNotBlocked;
@@ -395,6 +399,9 @@ void MaterializedOutputBuffer::maybeWakeBlockedDrivers() {
   }
   std::vector<velox::ContinuePromise> toFulfill;
   blockedPromises_.withWLock([&](auto& promises) { toFulfill.swap(promises); });
+  if (!toFulfill.empty()) {
+    backpressureWakeCount_ += static_cast<int64_t>(toFulfill.size());
+  }
   for (auto& promise : toFulfill) {
     promise.setValue();
   }
@@ -579,6 +586,16 @@ MaterializedOutputBuffer::stats() const {
   result[std::string(kReclaimCount)] = velox::RuntimeMetric(reclaimCount_);
   result[std::string(kReclaimedBytes)] =
       velox::RuntimeMetric(reclaimedBytes_, Unit::kBytes);
+  result[std::string(kConcurrentAppendCount)] =
+      velox::RuntimeMetric(concurrentAppendCount_);
+  result[std::string(kFlushAcquireCount)] =
+      velox::RuntimeMetric(flushAcquireCount_);
+  result[std::string(kBackpressureBlockCount)] =
+      velox::RuntimeMetric(backpressureBlockCount_);
+  result[std::string(kBackpressureWakeCount)] =
+      velox::RuntimeMetric(backpressureWakeCount_);
+  result[std::string(kBackpressureDrainedBytes)] =
+      velox::RuntimeMetric(backpressureDrainedBytes_, Unit::kBytes);
   return result;
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -79,6 +79,17 @@ class MaterializedOutputBuffer {
       "materializedOutputBuffer.reclaimCount";
   static constexpr std::string_view kReclaimedBytes =
       "materializedOutputBuffer.reclaimedBytes";
+  // Lock-free append / backpressure effectiveness counters.
+  static constexpr std::string_view kConcurrentAppendCount =
+      "materializedOutputBuffer.concurrentAppendCount";
+  static constexpr std::string_view kFlushAcquireCount =
+      "materializedOutputBuffer.flushAcquireCount";
+  static constexpr std::string_view kBackpressureBlockCount =
+      "materializedOutputBuffer.backpressureBlockCount";
+  static constexpr std::string_view kBackpressureWakeCount =
+      "materializedOutputBuffer.backpressureWakeCount";
+  static constexpr std::string_view kBackpressureDrainedBytes =
+      "materializedOutputBuffer.backpressureDrainedBytes";
 
   /// Reclaims partition buffers, then waits for writer network drain. The
   /// nested lifetime keeps the raw back-pointer valid. Priority -1 runs before
@@ -183,7 +194,7 @@ class MaterializedOutputBuffer {
   folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const;
 
   /// Drains at the high watermark, then parks until below the low watermark.
-  velox::exec::BlockingReason backpressure(velox::ContinueFuture* future);
+  velox::exec::BlockingReason isBlocked(velox::ContinueFuture* future);
 
   /// Best-effort reservation for coalesce and compression during one drain.
   void ensureDrainMemoryHeadroom();
@@ -218,39 +229,39 @@ class MaterializedOutputBuffer {
           writer_(writer),
           buffer_(buffer) {}
 
-    // Lock-free append; if over 'drainThreshold_', tries to become flusher and
-    // drain. Returns bytes drained (0 if not the flusher).
+    /// Lock-free append; if over 'drainThreshold_', tries to become flusher and
+    /// drain. Returns bytes drained (0 if not the flusher).
     int64_t enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
 
    private:
     friend class MaterializedOutputBuffer;
 
-    // A successful sole-flusher CAS must be paired with releaseFlushing().
+    /// A successful sole-flusher CAS must be paired with releaseFlushing().
     bool tryAcquireFlushing() {
       bool expected = false;
       return flushing_.compare_exchange_strong(expected, true);
     }
 
-    // Release the flusher flag (seq_cst store). Only the current flusher calls
-    // this.
+    /// Release the flusher flag (seq_cst store). Only the current flusher calls
+    /// this.
     void releaseFlushing() {
       flushing_ = false;
     }
 
-    // Pop all currently-available RowGroups into 'out' (caller must hold
-    // 'flushing_'). Returns total bytes popped.
+    /// Pop all currently-available RowGroups into 'out' (caller must hold
+    /// 'flushing_'). Returns total bytes popped.
     int64_t drainAvailable(std::deque<std::unique_ptr<folly::IOBuf>>& out);
 
-    // Flushes bounded chunks; an oversized RowGroup is sent alone. Caller
-    // holds 'flushing_'. Returns total bytes flushed.
+    /// Flushes bounded chunks; an oversized RowGroup is sent alone. Caller
+    /// holds 'flushing_'. Returns total bytes flushed.
     int64_t drainAndFlush();
 
-    // Release, recheck, and reacquire until below target so a concurrent append
-    // cannot leave an over-threshold partition without a flusher.
+    /// Release, recheck, and reacquire until below target so a concurrent
+    /// append cannot leave an over-threshold partition without a flusher.
     int64_t tryDrainPartition(int64_t targetBytes);
 
-    // Closes once and flushes all remaining data. Teardown is quiescent, but
-    // still uses the flusher gate to preserve writer ordering.
+    /// Closes once and flushes all remaining data. Teardown is quiescent, but
+    /// still uses the flusher gate to preserve writer ordering.
     int64_t noMoreData();
 
     folly::UMPMCQueue<std::unique_ptr<folly::IOBuf>, /*MayBlock=*/false>
@@ -301,17 +312,17 @@ class MaterializedOutputBuffer {
   /// Update drain stats and subtract from buffered bytes counter.
   void updateDrainStats(int64_t drainedBytes);
 
-  // Coalesce data into a contiguous buffer and send to the ShuffleWriter.
+  /// Coalesce data into a contiguous buffer and send to the ShuffleWriter.
   void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
 
-  // Wake parked producers after crossing the low watermark.
+  /// Wake parked producers after crossing the low watermark.
   void maybeWakeBlockedDrivers();
 
-  // Merge a deque of RowGroup IOBufs into a single contiguous IOBuf.
+  /// Merge a deque of RowGroup IOBufs into a single contiguous IOBuf.
   std::unique_ptr<folly::IOBuf> coalesceRowGroups(
       std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups);
 
-  // Free callback for pool-tracked IOBufs.
+  /// Free callback for pool-tracked IOBufs.
   static void freeTrackedIOBuf(void* buf, void* userData);
 
   // Immutable config.
@@ -345,6 +356,13 @@ class MaterializedOutputBuffer {
   std::atomic_int64_t peakBufferedBytes_{0};
   std::atomic_int64_t reclaimCount_{0};
   std::atomic_int64_t reclaimedBytes_{0};
+
+  // Effectiveness counters.
+  std::atomic_int64_t concurrentAppendCount_{0};
+  std::atomic_int64_t flushAcquireCount_{0};
+  std::atomic_int64_t backpressureBlockCount_{0};
+  std::atomic_int64_t backpressureWakeCount_{0};
+  std::atomic_int64_t backpressureDrainedBytes_{0};
 
   std::atomic_int64_t lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -1057,7 +1057,7 @@ TEST_F(MaterializedExchangeTest, backpressureParksAndWakesProducer) {
 
   // The flusher gate prevents this producer from draining, so it parks.
   velox::ContinueFuture future = velox::ContinueFuture::makeEmpty();
-  auto reason = buffer->backpressure(&future);
+  auto reason = buffer->isBlocked(&future);
   EXPECT_EQ(reason, velox::exec::BlockingReason::kWaitForConsumer);
   ASSERT_TRUE(future.valid());
   EXPECT_FALSE(future.isReady());


### PR DESCRIPTION
Summary:
Effectiveness counters from the lock-free diff MOB PR (https://github.com/prestodb/presto/pull/28172) into this follow-up so the base stays focused on behavior. These are diagnostic-only RuntimeMetrics (relaxed atomics, read once in `stats()`); they have no effect on runtime behavior.

- `concurrentAppendCount` — CAS-losers on the per-partition `flushing_` flag; proves the lock-free append path is exercised.
- `flushAcquireCount` — CAS-winners; number of flush sessions.
- `backpressureBlockCount` — producers parked at the high watermark.
- `backpressureWakeCount` — producers woken at the low watermark.
- `backpressureDrainedBytes` — bytes a producer self-drained before parking.

```
== NO RELEASE NOTE ==
```

