### PR TITLE
DNR TEST

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.TypeWithName;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.TypeVariableConstraint;
@@ -40,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.type.TypeCalculation.calculateLiteralValue;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -570,15 +572,35 @@ public class SignatureBinder
         return builder.build();
     }
 
+    /**
+     * Whether the failure means the type signature cannot be instantiated at all, which makes the candidate
+     * unbindable rather than the query invalid. A literal parameter bound by one position of a signature can be
+     * out of range for the base of another position, e.g. char(x) once x has been bound to Integer.MAX_VALUE by
+     * an unbounded varchar. Different bases report that differently: char and decimal throw PrestoException with
+     * INVALID_FUNCTION_ARGUMENT, varchar throws IllegalArgumentException.
+     */
+    private static boolean isUninstantiableType(RuntimeException e)
+    {
+        if (e instanceof UnknownTypeException || e instanceof IllegalArgumentException) {
+            return true;
+        }
+        return e instanceof PrestoException && INVALID_FUNCTION_ARGUMENT.toErrorCode().equals(((PrestoException) e).getErrorCode());
+    }
+
     private boolean satisfiesCoercion(boolean allowCoercion, Type fromType, TypeSignature toTypeSignature)
     {
         if (allowCoercion) {
+            Type toType;
             try {
-                return functionAndTypeManager.canCoerce(fromType, functionAndTypeManager.getType(toTypeSignature));
+                toType = functionAndTypeManager.getType(toTypeSignature);
             }
-            catch (UnknownTypeException e) {
-                return false;
+            catch (RuntimeException e) {
+                if (isUninstantiableType(e)) {
+                    return false;
+                }
+                throw e;
             }
+            return functionAndTypeManager.canCoerce(fromType, toType);
         }
         else if (fromType.getTypeSignature().equals(toTypeSignature)) {
             return true;
@@ -732,9 +754,18 @@ public class SignatureBinder
                     originalTypeTypeParametersBuilder.add(typeSignatureParameter);
                 }
             }
+            Type originalType;
+            try {
+                originalType = functionAndTypeManager.getType(new TypeSignature(formalTypeSignature.getBase(), originalTypeTypeParametersBuilder.build()));
+            }
+            catch (RuntimeException e) {
+                if (isUninstantiableType(e)) {
+                    return SolverReturnStatus.UNSOLVABLE;
+                }
+                throw e;
+            }
             Optional<Type> commonSuperType;
             try {
-                Type originalType = functionAndTypeManager.getType(new TypeSignature(formalTypeSignature.getBase(), originalTypeTypeParametersBuilder.build()));
                 commonSuperType = functionAndTypeManager.getCommonSuperType(originalType, actualType);
                 if (!commonSuperType.isPresent()) {
                     return SolverReturnStatus.UNSOLVABLE;

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -512,7 +512,7 @@ public final class StringFunctions
     @Description("removes whitespace from the beginning of a string")
     @ScalarFunction("ltrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice)
     {
         return SliceUtf8.leftTrim(slice);
@@ -530,7 +530,7 @@ public final class StringFunctions
     @Description("removes whitespace from the end of a string")
     @ScalarFunction("rtrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice)
     {
         return rightTrim(slice);
@@ -548,7 +548,7 @@ public final class StringFunctions
     @Description("removes whitespace from the beginning and end of a string")
     @ScalarFunction("trim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice)
     {
         return trim(slice);
@@ -566,7 +566,7 @@ public final class StringFunctions
     @Description("remove the longest string containing only given characters from the beginning of a string")
     @ScalarFunction("ltrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return leftTrim(slice, codePointsToTrim);
@@ -584,7 +584,7 @@ public final class StringFunctions
     @Description("remove the longest string containing only given characters from the end of a string")
     @ScalarFunction("rtrim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return trimTrailingSpaces(rightTrim(slice, codePointsToTrim));
@@ -602,7 +602,7 @@ public final class StringFunctions
     @Description("remove the longest string containing only given characters from the beginning and end of a string")
     @ScalarFunction("trim")
     @LiteralParameters("x")
-    @SqlType("char(x)")
+    @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
     {
         return trimTrailingSpaces(trim(slice, codePointsToTrim));

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestScratchTrimCharBinding.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestScratchTrimCharBinding.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+
+public class TestScratchTrimCharBinding
+{
+    private final FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+
+    @Test
+    public void testCandidateOrderAndResolution()
+    {
+        for (String name : ImmutableList.of("trim", "ltrim", "rtrim")) {
+            System.out.println("=== registration order: " + name + " ===");
+            List<SqlFunction> candidates = candidates(name);
+            for (SqlFunction candidate : candidates) {
+                System.out.println("  " + candidate.getSignature());
+            }
+
+            // end-to-end: what the analyzer does for name(CAST(x AS varchar))
+            try {
+                FunctionHandle handle = functionAndTypeManager.lookupFunction(name, fromTypes(VARCHAR));
+                functionAndTypeManager.getFunctionMetadata(handle);
+                System.out.println("  -> analysis OK for " + name + "(varchar)");
+            }
+            catch (RuntimeException e) {
+                System.out.println("  -> ANALYSIS FAILED for " + name + "(varchar): " + e);
+            }
+
+            // same lookup, but with the char overloads examined first, which simulates a different
+            // registration order of the very same candidate set
+            List<SqlFunction> charFirst = new ArrayList<>();
+            for (SqlFunction candidate : candidates) {
+                if (candidate.getSignature().getArgumentTypes().get(0).getBase().equals("char")) {
+                    charFirst.add(candidate);
+                }
+            }
+            charFirst.addAll(candidates);
+            Signature resolved = new Signature(
+                    candidates.get(0).getSignature().getName(),
+                    candidates.get(0).getSignature().getKind(),
+                    VARCHAR.getTypeSignature(),
+                    VARCHAR.getTypeSignature());
+            try {
+                functionAndTypeManager.getSpecializedFunctionKey(resolved, charFirst);
+                System.out.println("  -> char-candidate-first lookup OK");
+            }
+            catch (RuntimeException e) {
+                System.out.println("  -> char-candidate-first lookup FAILED: " + e);
+            }
+        }
+    }
+
+    @Test
+    public void testWhichImplementationServesCharCallsites()
+    {
+        // With the char overloads returning varchar(x), a char(x) callsite and a varchar(x) callsite
+        // have the same return type, so check that a char argument still selects the char
+        // implementation rather than the varchar one.
+        for (String name : ImmutableList.of("trim", "ltrim", "rtrim")) {
+            for (List<com.facebook.presto.common.type.Type> arguments : ImmutableList.of(
+                    ImmutableList.<com.facebook.presto.common.type.Type>of(createCharType(10)),
+                    ImmutableList.<com.facebook.presto.common.type.Type>of(createCharType(10), VARCHAR))) {
+                FunctionHandle handle = functionAndTypeManager.lookupFunction(name, fromTypes(arguments));
+                Signature resolved = ((BuiltInFunctionHandle) handle).getSignature();
+                SqlFunction implementation = functionAndTypeManager
+                        .getSpecializedFunctionKey(resolved, candidates(name))
+                        .getFunction();
+                System.out.println(name + arguments + " resolved to " + resolved
+                        + "  implemented by " + implementation.getSignature());
+            }
+        }
+    }
+
+    @Test
+    public void testBindCharCandidateAgainstUnboundedVarchar()
+    {
+        Signature afterPr = trimSignature("varchar(x)");
+        System.out.println("binding " + afterPr + " against args=(varchar), return=varchar");
+        try {
+            System.out.println("  result: " + new SignatureBinder(functionAndTypeManager, afterPr, false)
+                    .bindVariables(fromTypes(VARCHAR), VARCHAR));
+        }
+        catch (RuntimeException e) {
+            System.out.println("  THREW: " + e);
+        }
+
+        Signature beforePr = trimSignature("char(x)");
+        System.out.println("binding " + beforePr + " against args=(varchar), return=varchar");
+        try {
+            System.out.println("  result: " + new SignatureBinder(functionAndTypeManager, beforePr, false)
+                    .bindVariables(fromTypes(VARCHAR), VARCHAR));
+        }
+        catch (RuntimeException e) {
+            System.out.println("  THREW: " + e);
+        }
+    }
+
+    private List<SqlFunction> candidates(String name)
+    {
+        Collection<SqlFunction> all = functionAndTypeManager.listBuiltInFunctions();
+        List<SqlFunction> candidates = new ArrayList<>();
+        for (SqlFunction candidate : all) {
+            if (candidate.getSignature().getName().getObjectName().equals(name)) {
+                candidates.add(candidate);
+            }
+        }
+        return candidates;
+    }
+
+    private static Signature trimSignature(String returnType)
+    {
+        return new Signature(
+                com.facebook.presto.common.QualifiedObjectName.valueOf("presto.default.trim"),
+                com.facebook.presto.spi.function.FunctionKind.SCALAR,
+                TypeSignature.parseTypeSignature(returnType, ImmutableSet.of("x")),
+                ImmutableList.of(TypeSignature.parseTypeSignature("char(x)", ImmutableSet.of("x"))));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestScratchTrimQuery.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestScratchTrimQuery.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestScratchTrimQuery
+{
+    @Test
+    public void testTrimOverUnboundedVarchar()
+    {
+        LocalQueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder().build());
+        for (String sql : ImmutableList.of(
+                "SELECT trim(CAST('  abc  ' AS varchar))",
+                "SELECT ltrim(CAST('  abc  ' AS varchar))",
+                "SELECT rtrim(CAST('  abc  ' AS varchar))",
+                "SELECT ltrim(CAST('  abc  ' AS varchar), ' ')",
+                "SELECT trim(LEADING ' ' FROM CAST('  abc  ' AS varchar))",
+                "SELECT ltrim(CAST('  abc  ' AS varchar(10)))")) {
+            try {
+                queryRunner.execute(sql);
+                System.out.println("OK    : " + sql);
+            }
+            catch (RuntimeException e) {
+                System.out.println("FAILED: " + sql + "\n        " + e);
+            }
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
@@ -504,6 +504,43 @@ public class TestSignatureBinder
     }
 
     @Test
+    public void testBindLiteralOutOfRangeForFormalTypeIsUnsolvable()
+    {
+        // The return type binds x to Integer.MAX_VALUE, which is out of range for char. The char(x)
+        // argument is then unbindable, but that must only make this candidate not match, rather than
+        // fail the query. See ltrim/rtrim(char(x)):varchar(x), which are examined as candidates while
+        // looking up the implementation of ltrim/rtrim over an unbounded varchar.
+        Signature charArgument = functionSignature()
+                .returnType(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
+                .argumentTypes(parseTypeSignature("char(x)", ImmutableSet.of("x")))
+                .build();
+
+        assertThat(charArgument)
+                .boundTo(ImmutableList.of("varchar"), "varchar")
+                .fails();
+
+        assertThat(charArgument)
+                .boundTo(ImmutableList.of("varchar"), "varchar")
+                .withCoercion()
+                .fails();
+
+        // decimal reports an out-of-range literal the same way char does
+        Signature decimalArgument = functionSignature()
+                .returnType(parseTypeSignature("varchar(x)", ImmutableSet.of("x")))
+                .argumentTypes(parseTypeSignature("decimal(x,2)", ImmutableSet.of("x")))
+                .build();
+
+        assertThat(decimalArgument)
+                .boundTo(ImmutableList.of("varchar"), "varchar")
+                .fails();
+
+        assertThat(decimalArgument)
+                .boundTo(ImmutableList.of("varchar"), "varchar")
+                .withCoercion()
+                .fails();
+    }
+
+    @Test
     public void testBasic()
     {
         Signature function = functionSignature()

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -684,16 +684,17 @@ public class TestStringFunctions
     @Test
     public void testCharLeftTrim()
     {
-        assertFunction("LTRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("hello", 9));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight("hello world", 13));
+        assertFunction("LTRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("LTRIM(CAST('   ' AS CHAR(3)))", createVarcharType(3), "");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
 
-        assertFunction("LTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("LTRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
+        assertFunction("LTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("LTRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -715,16 +716,16 @@ public class TestStringFunctions
     @Test
     public void testCharRightTrim()
     {
-        assertFunction("RTRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight(" hello world", 13));
+        assertFunction("RTRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), " hello world");
 
-        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
-        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("RTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight(" \u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("RTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("  \u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
+        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), " \u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("RTRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "  \u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -747,17 +748,17 @@ public class TestStringFunctions
     @Test
     public void testCharTrim()
     {
-        assertFunction("TRIM(CAST('' AS CHAR(20)))", createCharType(20), padRight("", 20));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createCharType(9), padRight("hello", 9));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createCharType(13), padRight("hello world", 13));
+        assertFunction("TRIM(CAST('' AS CHAR(20)))", createVarcharType(20), "");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)))", createVarcharType(9), "hello");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)))", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)))", createVarcharType(13), "hello world");
 
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
-        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createCharType(9), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 9));
-        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createCharType(10), padRight("\u4FE1\u5FF5 \u7231 \u5E0C\u671B", 10));
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST('\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST(' \u4FE1\u5FF5 \u7231 \u5E0C\u671B ' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST('  \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(9)))", createVarcharType(9), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
+        assertFunction("TRIM(CAST(' \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B' AS CHAR(10)))", createVarcharType(10), "\u4FE1\u5FF5 \u7231 \u5E0C\u671B");
     }
 
     @Test
@@ -807,21 +808,21 @@ public class TestStringFunctions
     @Test
     public void testCharLeftTrimParametrized()
     {
-        assertFunction("LTRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("LTRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("hello", 9));
-        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("llo", 9));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("llo", 7));
-        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight("hello world", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight("llo world", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight("hello world", 13));
+        assertFunction("LTRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("LTRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
+        assertFunction("LTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
+        assertFunction("LTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("LTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
 
         // non latin characters
-        assertFunction("LTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u00f3\u017a')", createCharType(4), padRight("\u0142\u0107", 4));
+        assertFunction("LTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u00f3\u017a')", createVarcharType(4), "\u0142\u0107");
     }
 
     private static SqlVarbinary varbinary(int... bytesAsInts)
@@ -848,7 +849,7 @@ public class TestStringFunctions
         assertFunction("RTRIM(' hello world ', ' ld')", createVarcharType(13), " hello wor");
         assertFunction("RTRIM(' hello world ', ' ehlowrd')", createVarcharType(13), "");
         assertFunction("RTRIM(' hello world ', ' x')", createVarcharType(13), " hello world");
-        assertFunction("RTRIM(CAST('abc def' AS CHAR(7)), 'def')", createCharType(7), padRight("abc", 7));
+        assertFunction("RTRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
 
         // non latin characters
         assertFunction("RTRIM('\u017a\u00f3\u0142\u0107', '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
@@ -865,21 +866,21 @@ public class TestStringFunctions
     @Test
     public void testCharRightTrimParametrized()
     {
-        assertFunction("RTRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("RTRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("  hello", 9));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("  hello", 7));
-        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight(" hello world", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight(" hello world", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight(" hello world", 13));
+        assertFunction("RTRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("RTRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "  hello");
+        assertFunction("RTRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), " hello world");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), " hello world");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("RTRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), " hello world");
 
         // non latin characters
-        assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createCharType(4), padRight("\u017a\u00f3", 4));
+        assertFunction("RTRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u0107\u0142')", createVarcharType(4), "\u017a\u00f3");
     }
 
     @Test
@@ -916,22 +917,22 @@ public class TestStringFunctions
     @Test
     public void testCharTrimParametrized()
     {
-        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createCharType(1), padRight("", 1));
-        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createCharType(3), padRight("", 3));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createCharType(9), padRight("  hello", 9));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createCharType(9), padRight("hello", 9));
-        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createCharType(9), padRight("llo", 9));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createCharType(7), padRight("llo", 7));
-        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createCharType(7), padRight("hello", 7));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createCharType(13), padRight("hello world", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createCharType(13), padRight("llo world", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createCharType(13), padRight("", 13));
-        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createCharType(13), padRight("hello world", 13));
-        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createCharType(7), padRight("abc", 7));
+        assertFunction("TRIM(CAST('' AS CHAR(1)), '')", createVarcharType(1), "");
+        assertFunction("TRIM(CAST('   ' AS CHAR(3)), '')", createVarcharType(3), "");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), '')", createVarcharType(9), "  hello");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), ' ')", createVarcharType(9), "hello");
+        assertFunction("TRIM(CAST('  hello  ' AS CHAR(9)), 'he ')", createVarcharType(9), "llo");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), ' ')", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST('  hello' AS CHAR(7)), 'e h')", createVarcharType(7), "llo");
+        assertFunction("TRIM(CAST('hello  ' AS CHAR(7)), 'l')", createVarcharType(7), "hello");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ')", createVarcharType(13), "hello world");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' eh')", createVarcharType(13), "llo world");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' ehlowrd')", createVarcharType(13), "");
+        assertFunction("TRIM(CAST(' hello world ' AS CHAR(13)), ' x')", createVarcharType(13), "hello world");
+        assertFunction("TRIM(CAST('abc def' AS CHAR(7)), 'def')", createVarcharType(7), "abc");
 
         // non latin characters
-        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createCharType(4), padRight("\u00f3", 4));
+        assertFunction("TRIM(CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4)), '\u017a\u0107\u0142')", createVarcharType(4), "\u00f3");
     }
 
     @Test

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleDistributedQueries.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleDistributedQueries.java
@@ -414,9 +414,9 @@ public class TestOracleDistributedQueries
         assertUpdate("INSERT INTO test_charn_filter SELECT shipmode FROM lineitem", 60175);
 
         assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = 'AIR'", "VALUES (8491)");
-        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = 'AIR    '", "VALUES (8491)");
-        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = 'AIR       '", "VALUES (8491)");
-        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = 'AIR            '", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = TRIM('AIR    ')", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = TRIM('AIR       ')", "VALUES (8491)");
+        assertQuery("SELECT count(*) FROM test_charn_filter WHERE TRIM(shipmode) = TRIM('AIR            ')", "VALUES (8491)");
         assertQuery("SELECT count(*) FROM test_charn_filter WHERE shipmode = 'NONEXIST'", "VALUES (0)");
 
         assertUpdate("CREATE TABLE test_varcharn_filter (shipmode VARCHAR(10))");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update string trimming functions and type binding to avoid failures when resolving trim/ltrim/rtrim over unbounded varchar and align char overloads to return varchar.

Bug Fixes:
- Treat literal parameters that are out of range for char/decimal as making a function signature unsolvable rather than causing query analysis to fail.
- Ensure trim/ltrim/rtrim over unbounded varchar no longer fail due to char(x) overload binding errors.
- Adjust Oracle connector string filter tests to compare trimmed values consistently.

Enhancements:
- Change trim/ltrim/rtrim scalar functions that accept char(x) to return varchar(x) instead of padded char results.

Tests:
- Update scalar string function tests to expect unpadded varchar results from char-based trim functions.
- Add SignatureBinder tests to verify that out-of-range literal arguments make candidate functions unsolvable rather than invalidating queries.
- Add scratch tests to inspect candidate ordering, resolution, and query behavior for trim/ltrim/rtrim, including calls over unbounded varchar.