### PR TITLE
feat(native-pos): Enable RPC function planning on Presto-on-Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -25,6 +25,7 @@ import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.builtin.tools.WorkerFunctionRegistryTool;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.common.block.Block;
@@ -222,11 +223,14 @@ import com.facebook.presto.util.PrestoDataDefBindingHelper;
 import com.facebook.presto.version.EmbedVersion;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
-import com.google.inject.name.Names;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.testing.TestingMBeanServer;
@@ -482,14 +486,7 @@ public class PrestoSparkModule
 
         // planner
         binder.bind(PlanFragmenter.class).in(Scopes.SINGLETON);
-        // RPC functions are not supported in Presto-on-Spark; bind empty set.
-        binder.bind(new TypeLiteral<Supplier<Set<String>>>() {})
-                .annotatedWith(Names.named("rpcFunctionNames"))
-                .toInstance(ImmutableSet::of);
         binder.bind(PlanOptimizers.class).in(Scopes.SINGLETON);
-        // PlanOptimizers injects an RpcExecutionPolicy. Presto-on-Spark has no RPC functions
-        // (empty rpcFunctionNames above), so bind the no-op OSS default; AUTOMATIC resolves to
-        // PER_ROW and the policy is never consulted here.
         newOptionalBinder(binder, RpcExecutionPolicy.class).setDefault().to(DefaultRpcExecutionPolicy.class).in(Scopes.SINGLETON);
         binder.bind(AdaptivePlanOptimizers.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPlanOptimizerManager.class).in(Scopes.SINGLETON);
@@ -606,6 +603,35 @@ public class PrestoSparkModule
             ExecutorService executor)
     {
         return InMemoryTransactionManager.create(config, scheduledExecutor, catalogManager, executor);
+    }
+
+    /**
+     * Mirrors {@code ServerMainModule.provideRpcFunctionNames} for the Presto-on-Spark driver.
+     *
+     * <p>{@link WorkerFunctionRegistryTool} is bound by {@code DriverSidecarModule}, which is an
+     * optional deployment-supplied module, so it is looked up reflectively rather than injected —
+     * an OSS Presto-on-Spark build with no sidecar simply gets an empty set, matching the previous
+     * behaviour.
+     *
+     * <p>The lookup is deferred into the returned {@link Supplier} so that the metadata sidecar is
+     * never started on executors: {@code RpcFunctionOptimizer} only calls it during planning, which
+     * happens on the driver.
+     */
+    @Provides
+    @Singleton
+    @Named("rpcFunctionNames")
+    public static Supplier<Set<String>> provideRpcFunctionNames(FeaturesConfig featuresConfig, Injector injector)
+    {
+        if (!featuresConfig.isBuiltInSidecarFunctionsEnabled()) {
+            return ImmutableSet::of;
+        }
+        return () -> {
+            Binding<WorkerFunctionRegistryTool> binding = injector.getExistingBinding(Key.get(WorkerFunctionRegistryTool.class));
+            if (binding == null) {
+                return ImmutableSet.of();
+            }
+            return binding.getProvider().get().getRpcFunctionNames();
+        };
     }
 
     @Provides


### PR DESCRIPTION
Summary:
## Description

`PrestoSparkModule` bound the `rpcFunctionNames` supplier to
`ImmutableSet::of`, with the comment "RPC functions are not supported
in Presto-on-Spark". `RpcFunctionOptimizer.isRpcFunction()` reads that
supplier, so it always returned false: no `RPCNode` was ever planned on
Presto-on-Spark, and an RPC function instead reached the worker as an
ordinary scalar, where it was refused.

Replace the empty binding with a `Provides` method mirroring
`ServerMainModule.provideRpcFunctionNames`, which sources the names
from `WorkerFunctionRegistryTool` when
`built-in-sidecar-functions-enabled` is set.

`WorkerFunctionRegistryTool` is resolved through
`Injector.getExistingBinding` rather than injected directly, because
the module that binds it is optional and supplied by the deployment. A
build without that module gets an empty set, which is exactly the
previous behaviour. The lookup is deferred inside the returned
`Supplier` so that the metadata sidecar is only contacted on the
driver, where `RpcFunctionOptimizer` runs during planning, and never
from an executor.

## Motivation and Context

RPC functions are evaluated by the native worker through an `RPCNode`
plan node. Presto-on-Spark could not plan one, so the entire RPC
function surface was unreachable there even when the deployment had the
sidecar function registry enabled and the native executor was capable
of running those functions.

## Impact

- No new configuration properties. The behaviour is gated on the
  existing `built-in-sidecar-functions-enabled` feature config.
- With that config unset, which is the default, the supplier returns an
  empty set and planning is byte-for-byte unchanged.
- Deployments that do not install a module binding
  `WorkerFunctionRegistryTool` also get an empty set, so an
  Presto-on-Spark build without a sidecar is unaffected.
- Driver-only: the registry lookup happens inside the supplier and
  `RpcFunctionOptimizer` only runs during planning, so no executor ever
  contacts the metadata sidecar.
- `RpcExecutionPolicy` is deliberately untouched. Presto-on-Spark keeps
  the `DefaultRpcExecutionPolicy` default binding, so `AUTOMATIC`
  resolves to `PER_ROW`; batched RPC dispatch is out of scope here.

```
== NO RELEASE NOTE ==
```

Differential Revision: D115549057

## Summary by Sourcery

Enable planning of RPC functions on Presto-on-Spark when sidecar-based function registry is available and configured.

New Features:
- Expose RPC function names to the Presto-on-Spark planner via a supplier sourced from the worker function registry when built-in sidecar functions are enabled.

Enhancements:
- Preserve previous behaviour for deployments without sidecar support by returning an empty RPC function name set when the feature flag is disabled or no registry binding is present.
- Ensure RPC function registry lookup occurs only on the driver during planning, preventing executors from contacting the metadata sidecar.