### PR TITLE
fix(native): Do not dereference null handles in error messages (#28341)

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
@@ -339,6 +339,8 @@ HivePrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) const {
+  VELOX_CHECK_NOT_NULL(
+      tableHandle.connectorTableLayout, "Missing table layout");
   auto hiveLayout =
       std::dynamic_pointer_cast<const protocol::hive::HiveTableLayoutHandle>(
           tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -452,6 +452,8 @@ IcebergPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) const {
+  VELOX_CHECK_NOT_NULL(
+      tableHandle.connectorTableLayout, "Missing table layout");
   auto icebergLayout = std::dynamic_pointer_cast<
       const protocol::iceberg::IcebergTableLayoutHandle>(
       tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -107,6 +107,8 @@ TpchPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) const {
+  VELOX_CHECK_NOT_NULL(
+      tableHandle.connectorTableLayout, "Missing table layout");
   auto tpchLayout =
       std::dynamic_pointer_cast<const protocol::tpch::TpchTableLayoutHandle>(
           tableHandle.connectorTableLayout);
@@ -158,6 +160,8 @@ TpcdsPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) const {
+  VELOX_CHECK_NOT_NULL(
+      tableHandle.connectorTableLayout, "Missing table layout");
   auto tpcdsLayout =
       std::dynamic_pointer_cast<const protocol::tpcds::TpcdsTableLayoutHandle>(
           tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationPrestoToVeloxConnector.cpp
@@ -49,6 +49,7 @@ ArrowFederationPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& /*exprConverter*/,
     const TypeParser& /*typeParser*/) const {
+  VELOX_CHECK_NOT_NULL(tableHandle.connectorHandle, "Missing table handle");
   auto arrowTable = std::dynamic_pointer_cast<
       const protocol::arrow_federation::ArrowFederationTableHandle>(
       tableHandle.connectorHandle);
@@ -57,6 +58,8 @@ ArrowFederationPrestoToVeloxConnector::toVeloxTableHandle(
       "Unexpected table handle type {}",
       tableHandle.connectorHandle->_type);
 
+  VELOX_CHECK_NOT_NULL(
+      tableHandle.connectorTableLayout, "Missing table layout");
   auto arrowLayout = std::dynamic_pointer_cast<
       const protocol::arrow_federation::ArrowFederationTableLayoutHandle>(
       tableHandle.connectorTableLayout);
@@ -65,6 +68,7 @@ ArrowFederationPrestoToVeloxConnector::toVeloxTableHandle(
       "Unexpected layout handle type {}",
       tableHandle.connectorTableLayout->_type);
 
+  VELOX_CHECK_NOT_NULL(tableHandle.transaction, "Missing transaction handle");
   auto arrowTransaction = std::dynamic_pointer_cast<
       const protocol::arrow_federation::ArrowFederationTransactionHandle>(
       tableHandle.transaction);

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -842,3 +842,37 @@ TEST_F(PrestoToVeloxConnectorTest, toVeloxSplitTranslatesDeletionVectorDelete) {
   EXPECT_EQ(deleteFile.contentLength, 64);
   EXPECT_EQ(deleteFile.referencedDataFile, "/path/to/data/file.dwrf");
 }
+
+TEST_F(PrestoToVeloxConnectorTest, hiveTableHandleWithMissingLayout) {
+  auto hiveHandle = std::make_shared<protocol::hive::HiveTableHandle>();
+  hiveHandle->schemaName = "test_schema";
+  hiveHandle->tableName = "test_table";
+
+  protocol::TableHandle tableHandle;
+  tableHandle.connectorId = "hive";
+  tableHandle.connectorHandle = hiveHandle;
+  // 'connectorTableLayout' is deliberately left unset.
+
+  const HivePrestoToVeloxConnector hiveConnector("hive");
+  VELOX_ASSERT_THROW(
+      hiveConnector.toVeloxTableHandle(
+          tableHandle, *exprConverter_, *typeParser_),
+      "Missing table layout");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, icebergTableHandleWithMissingLayout) {
+  auto icebergHandle =
+      std::make_shared<protocol::iceberg::IcebergTableHandle>();
+  icebergHandle->schemaName = "test_schema";
+
+  protocol::TableHandle tableHandle;
+  tableHandle.connectorId = "iceberg";
+  tableHandle.connectorHandle = icebergHandle;
+  // 'connectorTableLayout' is deliberately left unset.
+
+  const IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  VELOX_ASSERT_THROW(
+      icebergConnector.toVeloxTableHandle(
+          tableHandle, *exprConverter_, *typeParser_),
+      "Missing table layout");
+}


### PR DESCRIPTION
Summary:

Several `PrestoToVeloxConnector::toVeloxTableHandle` implementations pass
`tableHandle.<handle>->_type` as the failure message of the
`VELOX_CHECK_NOT_NULL` that guards the down-cast of that same handle.
`VELOX_CHECK` evaluates its format arguments lazily, inside the failure branch,
so when the handle is absent the check fails and the message then dereferences
the null `shared_ptr` it just rejected. The result is a SIGSEGV at address `0x8`
while reading `std::string _type`, instead of the intended `VeloxRuntimeError`.

The wrong-type case the message was written for is unaffected: a non-null handle
of an unexpected type still produces the intended error naming that type. Only
the absent-handle case crashes, and it takes down the whole worker process
rather than failing the single query.

Guard the pointer before the cast at each site, so the existing type check only
runs on a pointer that is safe to dereference. Sites fixed:

- `HivePrestoToVeloxConnector.cpp` - table layout
- `IcebergPrestoToVeloxConnector.cpp` - table layout
- `PrestoToVeloxConnector.cpp` - TPCH and TPCDS table layouts
- `ArrowFederationPrestoToVeloxConnector.cpp` - table handle, table layout and
  transaction handle

The Arrow Federation transaction handle is a distinct exposure: unlike
`connectorTableLayout`, nothing upstream dereferences `transaction`, so there is
no caller-side guarantee at all. Its `connectorHandle` check is currently
unreachable through `toConnectorTableHandle`, which dereferences that field
first, but `toVeloxTableHandle` is public and callable directly, so it is
guarded for consistency.

New tests `hiveTableHandleWithMissingLayout` and
`icebergTableHandleWithMissingLayout` cover the Hive and Iceberg paths; both
segfault without the corresponding guard and pass with it. TPCH, TPCDS and
Arrow Federation are the same mechanical change.

No behaviour change on any path that previously succeeded.

Differential Revision: D115679198


