### PR TITLE
feat(plugin-iceberg): Use Presto Hadoop FileSystem for REST catalog metadata reads via PrestoRESTFileIO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dep.lucene.version>9.12.3</dep.lucene.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.parquet.version>1.16.0</dep.parquet.version>
-        <dep.iceberg.version>1.10.1</dep.iceberg.version>
+        <dep.iceberg.version>1.11.0</dep.iceberg.version>
         <dep.asm.version>9.9.1</dep.asm.version>
         <dep.gcs.version>2.2.28</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -662,7 +662,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.3.4</version>
+            <version>5.4</version>
         </dependency>
 
         <dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -445,7 +445,7 @@ public class HiveTableOperations
                             config.getTableRefreshMaxRetryTime().toMillis(),
                             config.getTableRefreshBackoffScaleFactor())
                     .run(metadataLocation -> newMetadata.set(
-                            TableMetadataParser.read(fileIO, fileIO.newCachedInputFile(metadataLocation))));
+                            TableMetadataParser.read(fileIO.newCachedInputFile(metadataLocation))));
         }
         catch (RuntimeException e) {
             throw new TableNotFoundException(getSchemaTableName(), "Table metadata is missing", e);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -748,7 +748,7 @@ public class IcebergHiveMetadata
         InputFile inputFile = new HdfsInputFile(metadataLocation, hdfsEnvironment, hdfsContext);
         TableMetadata tableMetadata;
         try {
-            tableMetadata = TableMetadataParser.read(new HdfsFileIO(manifestFileCache, hdfsEnvironment, hdfsContext), inputFile);
+            tableMetadata = TableMetadataParser.read(inputFile);
         }
         catch (Exception e) {
             throw new PrestoException(ICEBERG_INVALID_METADATA, String.format("Unable to read metadata file %s", metadataLocation), e);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoRESTFileIO.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoRESTFileIO.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.DelegateFileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * REST-catalog counterpart of {@link HdfsFileIO}: routes metadata I/O through the Presto
+ * {@link HdfsEnvironment} so that per-identity
+ * {@link com.facebook.presto.hive.DynamicConfigurationProvider}s, such as the AWS S3 security
+ * mapping, resolve with the real path and the querying user. Built per table load by the
+ * {@code ioBuilder}, so an instance is never shared between identities.
+ * <p>
+ * Manifests are cached by Presto's {@link ManifestFileCache}, which is keyed by path and so is
+ * unaffected by a FileIO being built per load, rather than by Iceberg's {@code ContentCache}, which
+ * is keyed on the FileIO instance and would never be hit.
+ */
+public class PrestoRESTFileIO
+        implements DelegateFileIO, SupportsStorageCredentials
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final ManifestFileCache manifestFileCache;
+    private final Map<String, String> properties;
+
+    private volatile List<StorageCredential> storageCredentials = ImmutableList.of();
+
+    public PrestoRESTFileIO(HdfsEnvironment hdfsEnvironment, HdfsContext hdfsContext, ManifestFileCache manifestFileCache, Map<String, String> properties)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
+        this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
+        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+    }
+
+    @Override
+    public Map<String, String> properties()
+    {
+        return properties;
+    }
+
+    @Override
+    public void setCredentials(List<StorageCredential> credentials)
+    {
+        this.storageCredentials = ImmutableList.copyOf(requireNonNull(credentials, "credentials is null"));
+    }
+
+    @Override
+    public List<StorageCredential> credentials()
+    {
+        return storageCredentials;
+    }
+
+    @Override
+    public InputFile newInputFile(String location)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            return new HdfsInputFile(new Path(location), hdfsEnvironment, hdfsContext);
+        }
+    }
+
+    @Override
+    public InputFile newInputFile(String location, long length)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            return new HdfsInputFile(new Path(location), hdfsEnvironment, hdfsContext, Optional.of(length));
+        }
+    }
+
+    @Override
+    public InputFile newInputFile(ManifestFile manifest)
+    {
+        checkArgument(
+                manifest.keyMetadata() == null,
+                "Cannot decrypt manifest: %s (use EncryptingFileIO)",
+                manifest.path());
+        InputFile inputFile = newInputFile(manifest.path(), manifest.length());
+        return manifestFileCache.isEnabled() ?
+                new HdfsCachedInputFile(inputFile, new ManifestFileCacheKey(manifest.path()), manifestFileCache) :
+                inputFile;
+    }
+
+    @Override
+    public OutputFile newOutputFile(String location)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            return new HdfsOutputFile(new Path(location), hdfsEnvironment, hdfsContext);
+        }
+    }
+
+    @Override
+    public void deleteFile(String location)
+    {
+        Path path = new Path(location);
+        try {
+            hdfsEnvironment.doAs(hdfsContext.getIdentity().getUser(), () -> fileSystem(path).delete(path, false));
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, "Failed to delete file: " + path, e);
+        }
+    }
+
+    @Override
+    public void deleteFiles(Iterable<String> pathsToDelete)
+            throws BulkDeletionFailureException
+    {
+        for (String location : pathsToDelete) {
+            deleteFile(location);
+        }
+    }
+
+    @Override
+    public Iterable<FileInfo> listPrefix(String prefix)
+    {
+        Path path = new Path(prefix);
+        return () -> {
+            try {
+                RemoteIterator<LocatedFileStatus> files = hdfsEnvironment.doAs(
+                        hdfsContext.getIdentity().getUser(),
+                        () -> fileSystem(path).listFiles(path, true));
+                return new Iterator<FileInfo>()
+                {
+                    @Override
+                    public boolean hasNext()
+                    {
+                        try {
+                            return files.hasNext();
+                        }
+                        catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+
+                    @Override
+                    public FileInfo next()
+                    {
+                        try {
+                            if (!files.hasNext()) {
+                                throw new NoSuchElementException();
+                            }
+                            LocatedFileStatus status = files.next();
+                            return new FileInfo(status.getPath().toString(), status.getLen(), status.getModificationTime());
+                        }
+                        catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                };
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Failed to list prefix: " + prefix, e);
+            }
+        };
+    }
+
+    @Override
+    public void deletePrefix(String prefix)
+    {
+        for (FileInfo file : listPrefix(prefix)) {
+            deleteFile(file.location());
+        }
+    }
+
+    private FileSystem fileSystem(Path path)
+            throws IOException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            return hdfsEnvironment.getFileSystem(hdfsContext, path);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.iceberg.rest;
 
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.azure.AzureConfigurationInitializer;
 import com.facebook.presto.hive.gcs.GcsConfigurationInitializer;
@@ -20,11 +22,14 @@ import com.facebook.presto.hive.s3.S3ConfigurationUpdater;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.iceberg.PrestoRESTFileIO;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hasher;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.jsonwebtoken.Jwts;
 import jakarta.inject.Inject;
@@ -32,9 +37,9 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.rest.HTTPClient;
-import org.apache.iceberg.rest.RESTCatalog;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -49,11 +54,19 @@ import static com.facebook.presto.iceberg.rest.PrestoRestTLSConfigurer.TRUSTSTOR
 import static com.facebook.presto.iceberg.rest.SessionType.USER;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.hash.Hashing.sha256;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogUtil.configureHadoopConf;
+import static org.apache.iceberg.rest.RESTUtil.configHeaders;
 import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
 import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_BASIC;
 import static org.apache.iceberg.rest.auth.AuthProperties.BASIC_PASSWORD;
@@ -82,6 +95,8 @@ public class IcebergRestCatalogFactory
     private final NodeVersion nodeVersion;
     private final String catalogName;
     private final boolean nestedNamespaceEnabled;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final ManifestFileCache manifestFileCache;
 
     @Inject
     public IcebergRestCatalogFactory(
@@ -91,23 +106,32 @@ public class IcebergRestCatalogFactory
             S3ConfigurationUpdater s3ConfigurationUpdater,
             GcsConfigurationInitializer gcsConfigurationInitialize,
             AzureConfigurationInitializer azureConfigurationInitialize,
-            NodeVersion nodeVersion)
+            NodeVersion nodeVersion,
+            HdfsEnvironment hdfsEnvironment,
+            ManifestFileCache manifestFileCache)
     {
         super(config, catalogName, s3ConfigurationUpdater, gcsConfigurationInitialize, azureConfigurationInitialize);
         this.catalogConfig = requireNonNull(catalogConfig, "catalogConfig is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.catalogName = requireNonNull(catalogName, "catalogName is null").getCatalogName();
         this.nestedNamespaceEnabled = catalogConfig.isNestedNamespaceEnabled();
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
     }
 
     @Override
     public Catalog getCatalog(ConnectorSession session)
     {
         try {
+            ConnectorIdentity catalogIdentity = session.getIdentity();
             return catalogCache.get(getCacheKey(session), () -> {
-                RESTCatalog catalog = new RESTCatalog(
+                PrestoRestCatalog catalog = new PrestoRestCatalog(
                         convertSession(session),
-                        config -> HTTPClient.builder(config).uri(config.get(URI)).build());
+                        config -> HTTPClient.builder(config)
+                                .uri(config.get(URI))
+                                .withHeaders(configHeaders(config))
+                                .build(),
+                        (context, tableProperties) -> createFileIO(catalogIdentity, tableProperties));
 
                 configureHadoopConf(catalog, getHadoopConfiguration());
                 catalog.initialize(catalogName, getProperties(session));
@@ -121,13 +145,59 @@ public class IcebergRestCatalogFactory
         }
     }
 
+    /**
+     * Builds the FileIO for a single table load, so it is never shared between identities. The
+     * identity is the one the catalog was created with, which is correct only because
+     * {@link #getCatalogCacheKey} includes it.
+     */
+    private PrestoRESTFileIO createFileIO(ConnectorIdentity identity, Map<String, String> tableProperties)
+    {
+        return new PrestoRESTFileIO(hdfsEnvironment, new HdfsContext(identity), manifestFileCache, tableProperties);
+    }
+
+    @Override
+    protected Map<String, String> getProperties(ConnectorSession session)
+    {
+        Map<String, String> properties = new HashMap<>(super.getProperties(session));
+        properties.remove(IO_MANIFEST_CACHE_ENABLED);
+        properties.remove(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES);
+        properties.remove(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH);
+        properties.remove(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS);
+        properties.remove(FILE_IO_IMPL);
+        return properties;
+    }
+
     @Override
     protected Optional<String> getCatalogCacheKey(ConnectorSession session)
     {
         StringBuilder sb = new StringBuilder();
         catalogConfig.getSessionType().filter(type -> type.equals(USER))
                 .ifPresent(type -> sb.append(session.getUser()));
+        // The catalog fixes the identity used for every metadata read through its FileIO, so
+        // sharing one across identities would let a user read S3 as another. Keyed unconditionally:
+        // extra cache entries are cheap, a leaked credential is not. Extra credentials are included
+        // because GcsConfigurationProvider takes its token from them, varying per session.
+        // Raise iceberg.catalog.cached-catalog-num for deployments with many concurrent users.
+        sb.append('|').append(session.getIdentity().getUser());
+        sb.append('|').append(extraCredentialsKey(session.getIdentity()));
         return Optional.of(sb.toString());
+    }
+
+    private static String extraCredentialsKey(ConnectorIdentity identity)
+    {
+        Map<String, String> extraCredentials = identity.getExtraCredentials();
+        if (extraCredentials.isEmpty()) {
+            return "";
+        }
+        Hasher hasher = sha256().newHasher();
+        extraCredentials.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> hasher
+                        .putString(entry.getKey(), UTF_8)
+                        .putByte((byte) 0)
+                        .putString(entry.getValue(), UTF_8)
+                        .putByte((byte) 0));
+        return hasher.hash().toString();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/PrestoRestCatalog.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/PrestoRestCatalog.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.hadoop.Configurable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewBuilder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A REST catalog that accepts a custom {@link FileIO} factory, which Iceberg's
+ * {@link org.apache.iceberg.rest.RESTCatalog} cannot: every one of its constructors hardcodes
+ * {@code ioBuilder = null} and its {@code RESTSessionCatalog} field is private. Without an
+ * {@code ioBuilder}, {@code RESTSessionCatalog.tableFileIO} hands back one catalog-level FileIO
+ * for every table whenever the server returns no per-table config or credentials, making it
+ * impossible to bind a per-identity FileIO without mutating shared state.
+ * <p>
+ * Delegation mirrors {@code RESTCatalog}. The {@code createTable},
+ * {@code newCreateTableTransaction} and {@code newReplaceTableTransaction} overloads are left to
+ * the {@link Catalog} defaults, which route through {@link #buildTable} -- what Iceberg's own
+ * {@code BaseSessionCatalog.AsCatalog} relies on.
+ */
+public class PrestoRestCatalog
+        implements Catalog, ViewCatalog, SupportsNamespaces, Configurable<Object>, Closeable
+{
+    private final RESTSessionCatalog sessionCatalog;
+    private final Catalog delegate;
+    private final SupportsNamespaces namespaceDelegate;
+    private final ViewCatalog viewDelegate;
+
+    public PrestoRestCatalog(
+            SessionContext context,
+            Function<Map<String, String>, RESTClient> clientBuilder,
+            BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder)
+    {
+        requireNonNull(context, "context is null");
+        requireNonNull(clientBuilder, "clientBuilder is null");
+        requireNonNull(ioBuilder, "ioBuilder is null");
+        this.sessionCatalog = new RESTSessionCatalog(clientBuilder, ioBuilder);
+        this.delegate = sessionCatalog.asCatalog(context);
+        this.namespaceDelegate = (SupportsNamespaces) delegate;
+        this.viewDelegate = sessionCatalog.asViewCatalog(context);
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties)
+    {
+        sessionCatalog.initialize(name, requireNonNull(properties, "properties is null"));
+    }
+
+    @Override
+    public String name()
+    {
+        return sessionCatalog.name();
+    }
+
+    public Map<String, String> properties()
+    {
+        return sessionCatalog.properties();
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace)
+    {
+        return delegate.listTables(namespace);
+    }
+
+    @Override
+    public boolean tableExists(TableIdentifier identifier)
+    {
+        return delegate.tableExists(identifier);
+    }
+
+    @Override
+    public Table loadTable(TableIdentifier identifier)
+    {
+        return delegate.loadTable(identifier);
+    }
+
+    @Override
+    public void invalidateTable(TableIdentifier identifier)
+    {
+        delegate.invalidateTable(identifier);
+    }
+
+    @Override
+    public TableBuilder buildTable(TableIdentifier identifier, Schema schema)
+    {
+        return delegate.buildTable(identifier, schema);
+    }
+
+    @Override
+    public Table registerTable(TableIdentifier identifier, String metadataFileLocation)
+    {
+        return delegate.registerTable(identifier, metadataFileLocation);
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier)
+    {
+        return delegate.dropTable(identifier);
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge)
+    {
+        return delegate.dropTable(identifier, purge);
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to)
+    {
+        delegate.renameTable(from, to);
+    }
+
+    @Override
+    public void createNamespace(Namespace namespace, Map<String, String> metadata)
+    {
+        namespaceDelegate.createNamespace(namespace, metadata);
+    }
+
+    @Override
+    public List<Namespace> listNamespaces(Namespace namespace)
+            throws NoSuchNamespaceException
+    {
+        return namespaceDelegate.listNamespaces(namespace);
+    }
+
+    @Override
+    public boolean namespaceExists(Namespace namespace)
+    {
+        return namespaceDelegate.namespaceExists(namespace);
+    }
+
+    @Override
+    public Map<String, String> loadNamespaceMetadata(Namespace namespace)
+            throws NoSuchNamespaceException
+    {
+        return namespaceDelegate.loadNamespaceMetadata(namespace);
+    }
+
+    @Override
+    public boolean dropNamespace(Namespace namespace)
+            throws NamespaceNotEmptyException
+    {
+        return namespaceDelegate.dropNamespace(namespace);
+    }
+
+    @Override
+    public boolean setProperties(Namespace namespace, Map<String, String> properties)
+            throws NoSuchNamespaceException
+    {
+        return namespaceDelegate.setProperties(namespace, properties);
+    }
+
+    @Override
+    public boolean removeProperties(Namespace namespace, Set<String> properties)
+            throws NoSuchNamespaceException
+    {
+        return namespaceDelegate.removeProperties(namespace, properties);
+    }
+
+    @Override
+    public List<TableIdentifier> listViews(Namespace namespace)
+    {
+        return viewDelegate.listViews(namespace);
+    }
+
+    @Override
+    public View loadView(TableIdentifier identifier)
+    {
+        return viewDelegate.loadView(identifier);
+    }
+
+    @Override
+    public ViewBuilder buildView(TableIdentifier identifier)
+    {
+        return viewDelegate.buildView(identifier);
+    }
+
+    @Override
+    public boolean viewExists(TableIdentifier identifier)
+    {
+        return viewDelegate.viewExists(identifier);
+    }
+
+    @Override
+    public boolean dropView(TableIdentifier identifier)
+    {
+        return viewDelegate.dropView(identifier);
+    }
+
+    @Override
+    public void renameView(TableIdentifier from, TableIdentifier to)
+    {
+        viewDelegate.renameView(from, to);
+    }
+
+    @Override
+    public void invalidateView(TableIdentifier identifier)
+    {
+        viewDelegate.invalidateView(identifier);
+    }
+
+    @Override
+    public void setConf(Object conf)
+    {
+        sessionCatalog.setConf(conf);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        sessionCatalog.close();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestManifestFileCache.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestManifestFileCache.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergRestManifestFileCache
+        extends AbstractTestQueryFramework
+{
+    private static final String CACHE_MBEAN = "com.facebook.presto.iceberg:name=iceberg,type=manifestfilecache";
+    private static final String READ_QUERY = "SELECT count(*) FROM iceberg.manifest_cache.t GROUP BY i";
+
+    private File warehouseLocation;
+    private TestingHttpServer restServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setExtraConnectorProperties(ImmutableMap.<String, String>builder()
+                        .putAll(restConnectorProperties(restServer.getBaseUrl().toString()))
+                        .put("iceberg.io.manifest.cache-enabled", "true")
+                        .build())
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .build()
+                .getQueryRunner();
+    }
+
+    @BeforeClass
+    public void setUpTable()
+    {
+        assertQuerySucceeds("CREATE SCHEMA IF NOT EXISTS iceberg.manifest_cache");
+        assertQuerySucceeds("CREATE TABLE iceberg.manifest_cache.t(i int)");
+        assertUpdate("INSERT INTO iceberg.manifest_cache.t VALUES 1, 2, 3, 4, 5", 5);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUp()
+            throws Exception
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.manifest_cache.t");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS iceberg.manifest_cache");
+        if (restServer != null) {
+            restServer.stop();
+        }
+        deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testManifestFileCaching()
+    {
+        // Counters are cumulative and unaffected by invalidation, so compare deltas
+        assertQuerySucceeds("CALL iceberg.system.invalidate_manifest_file_cache()");
+        assertEquals(cacheStat("size"), 0L);
+
+        long missesBeforeFirstRead = cacheStat("misscount");
+        long hitsBeforeFirstRead = cacheStat("hitcount");
+
+        assertQuerySucceeds(READ_QUERY);
+
+        long missesAfterFirstRead = cacheStat("misscount");
+        assertTrue(missesAfterFirstRead > missesBeforeFirstRead, "first read should miss the cache");
+        assertTrue(cacheStat("size") > 0, "first read should populate the cache");
+
+        long hitsAfterFirstRead = cacheStat("hitcount");
+        assertQuerySucceeds(READ_QUERY);
+
+        assertTrue(cacheStat("hitcount") > hitsAfterFirstRead, "second read should hit the cache");
+        assertEquals(cacheStat("misscount"), missesAfterFirstRead, "second read should not miss");
+        assertTrue(hitsAfterFirstRead >= hitsBeforeFirstRead);
+
+        // The invalidation procedure targets the same singleton the REST FileIO writes to
+        assertQuerySucceeds("CALL iceberg.system.invalidate_manifest_file_cache()");
+        assertEquals(cacheStat("size"), 0L);
+
+        long missesBeforeReread = cacheStat("misscount");
+        assertQuerySucceeds(READ_QUERY);
+        assertTrue(cacheStat("misscount") > missesBeforeReread, "read after invalidation should miss again");
+    }
+
+    private long cacheStat(String name)
+    {
+        return (long) computeActual(String.format("SELECT sum(\"cachestats.%s\") FROM jmx.current.\"%s\"", name, CACHE_MBEAN))
+                .getOnlyValue();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -26,11 +26,12 @@ import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.ManifestFileCache;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
+import com.google.common.cache.CacheBuilder;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.rest.RESTCatalog;
 import org.assertj.core.util.Files;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -129,7 +130,9 @@ public class TestIcebergSmokeRest
                 new PrestoS3ConfigurationUpdater(new HiveS3Config()),
                 new HiveGcsConfigurationInitializer(new HiveGcsConfig()),
                 new HiveAzureConfigurationInitializer(new HiveAzureConfig()),
-                new NodeVersion("test_version"));
+                new NodeVersion("test_version"),
+                getHdfsEnvironment(),
+                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024));
     }
 
     @Override
@@ -152,7 +155,7 @@ public class TestIcebergSmokeRest
                 .setAuthenticationServerUri(authEndpoint);
 
         IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
-        RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
+        PrestoRestCatalog catalog = (PrestoRestCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
 
         assertEquals(catalog.properties().get(OAUTH2_SERVER_URI), authEndpoint);
     }
@@ -167,7 +170,7 @@ public class TestIcebergSmokeRest
                 .setBasicAuthPassword("s3cr3t");
 
         IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
-        RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
+        PrestoRestCatalog catalog = (PrestoRestCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
         Map<String, String> properties = catalog.properties();
 
         assertEquals(properties.get(AUTH_TYPE), AUTH_TYPE_BASIC);
@@ -182,7 +185,7 @@ public class TestIcebergSmokeRest
                 .setServerUri(serverUri);
 
         IcebergRestCatalogFactory catalogFactory = (IcebergRestCatalogFactory) getCatalogFactory(restConfig);
-        RESTCatalog catalog = (RESTCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
+        PrestoRestCatalog catalog = (PrestoRestCatalog) catalogFactory.getCatalog(getSession().toConnectorSession());
         Map<String, String> properties = catalog.properties();
 
         assertNull(properties.get(AUTH_TYPE));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -27,9 +27,11 @@ import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.ManifestFileCache;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
@@ -142,7 +144,9 @@ public class TestIcebergSmokeRestNestedNamespace
                 new PrestoS3ConfigurationUpdater(new HiveS3Config()),
                 new HiveGcsConfigurationInitializer(new HiveGcsConfig()),
                 new HiveAzureConfigurationInitializer(new HiveAzureConfig()),
-                new NodeVersion("test_version"));
+                new NodeVersion("test_version"),
+                getHdfsEnvironment(),
+                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024));
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestPrestoRESTFileIO.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestPrestoRESTFileIO.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.NodeVersion;
+import com.facebook.presto.hive.azure.HiveAzureConfig;
+import com.facebook.presto.hive.azure.HiveAzureConfigurationInitializer;
+import com.facebook.presto.hive.gcs.HiveGcsConfig;
+import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.iceberg.HdfsInputFile;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.iceberg.PrestoRESTFileIO;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvironment;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.SESSION;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED_DEFAULT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestPrestoRESTFileIO
+{
+    private File warehouseLocation;
+    private TestingHttpServer restServer;
+    private String serverUri;
+
+    @BeforeClass
+    public void init()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+        serverUri = restServer.getBaseUrl().toString();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (restServer != null) {
+            restServer.stop();
+        }
+        deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+    }
+
+    private IcebergNativeCatalogFactory getCatalogFactory()
+    {
+        return getCatalogFactory(manifestFileCache(false));
+    }
+
+    private IcebergNativeCatalogFactory getCatalogFactory(ManifestFileCache manifestFileCache)
+    {
+        IcebergConfig icebergConfig = new IcebergConfig()
+                .setCatalogType(REST)
+                .setCatalogWarehouse(warehouseLocation.getAbsolutePath());
+        IcebergRestConfig restConfig = new IcebergRestConfig().setServerUri(serverUri);
+        return new IcebergRestCatalogFactory(
+                icebergConfig,
+                restConfig,
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                new PrestoS3ConfigurationUpdater(new HiveS3Config()),
+                new HiveGcsConfigurationInitializer(new HiveGcsConfig()),
+                new HiveAzureConfigurationInitializer(new HiveAzureConfig()),
+                new NodeVersion("test_version"),
+                hdfsEnvironment(),
+                manifestFileCache);
+    }
+
+    private static ManifestFileCache manifestFileCache(boolean enabled)
+    {
+        return new ManifestFileCache(CacheBuilder.newBuilder().build(), enabled, Long.MAX_VALUE, 1024);
+    }
+
+    private static HdfsEnvironment hdfsEnvironment()
+    {
+        return getHdfsEnvironment(new HiveClientConfig(), new MetastoreClientConfig(), new HiveS3Config());
+    }
+
+    private PrestoRESTFileIO fileIO(ManifestFileCache manifestFileCache)
+    {
+        return new PrestoRESTFileIO(hdfsEnvironment(), new HdfsContext(SESSION), manifestFileCache, ImmutableMap.of());
+    }
+
+    private String location(String name)
+    {
+        return new Path(warehouseLocation.getAbsolutePath(), name).toUri().toString();
+    }
+
+    private Table createTable(Catalog catalog, String namespaceName, String tableName)
+    {
+        Namespace namespace = Namespace.of(namespaceName);
+        if (!((SupportsNamespaces) catalog).namespaceExists(namespace)) {
+            ((SupportsNamespaces) catalog).createNamespace(namespace);
+        }
+        TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
+        catalog.createTable(identifier, new Schema(Types.NestedField.optional(1, "c1", Types.LongType.get())));
+        return catalog.loadTable(identifier);
+    }
+
+    /**
+     * properties() must not throw: Iceberg and Presto both read it. Iceberg's instance-keyed
+     * ContentCache stays off because io.manifest.cache-enabled defaults to false and the factory
+     * strips it from the catalog properties, so absence is enough.
+     */
+    @Test
+    public void testPropertiesAreExposedAndLeaveIcebergContentCacheDisabled()
+    {
+        PrestoRESTFileIO fileIO = new PrestoRESTFileIO(
+                hdfsEnvironment(),
+                new HdfsContext(SESSION),
+                manifestFileCache(false),
+                ImmutableMap.of("warehouse", "s3://bucket/warehouse"));
+
+        assertEquals(fileIO.properties().get("warehouse"), "s3://bucket/warehouse");
+        assertNull(fileIO.properties().get(IO_MANIFEST_CACHE_ENABLED));
+        assertFalse(IO_MANIFEST_CACHE_ENABLED_DEFAULT, "Iceberg's ContentCache must stay off when the property is absent");
+    }
+
+    @Test
+    public void testCatalogPropertiesDoNotEnableIcebergManifestCache()
+    {
+        IcebergRestCatalogFactory factory = (IcebergRestCatalogFactory) getCatalogFactory();
+        PrestoRestCatalog catalog = (PrestoRestCatalog) factory.getCatalog(SESSION);
+
+        assertNull(catalog.properties().get(IO_MANIFEST_CACHE_ENABLED),
+                "Presto's ManifestFileCache does the caching, so Iceberg's must not be switched on");
+    }
+
+    /**
+     * Iceberg calls setCredentials on the ioBuilder path only from 1.11.0, so this stays empty
+     * today. Implemented so the prefixed array is captured as soon as we upgrade.
+     */
+    @Test
+    public void testStorageCredentialsAreCapturedWithPrefixes()
+    {
+        PrestoRESTFileIO fileIO = fileIO(manifestFileCache(false));
+        assertTrue(fileIO.credentials().isEmpty());
+
+        fileIO.setCredentials(ImmutableList.of(
+                StorageCredential.create("s3://bucket/warehouse/ns/tbl", ImmutableMap.of(
+                        "s3.access-key-id", "TABLE_KEY",
+                        "s3.secret-access-key", "TABLE_SECRET",
+                        "s3.session-token", "TABLE_TOKEN")),
+                StorageCredential.create("s3://bucket", ImmutableMap.of(
+                        "s3.access-key-id", "BUCKET_KEY",
+                        "s3.secret-access-key", "BUCKET_SECRET",
+                        "s3.session-token", "BUCKET_TOKEN"))));
+
+        assertEquals(fileIO.credentials().size(), 2);
+        assertEquals(fileIO.credentials().get(0).prefix(), "s3://bucket/warehouse/ns/tbl");
+        assertEquals(fileIO.credentials().get(0).config().get("s3.session-token"), "TABLE_TOKEN");
+        assertEquals(fileIO.credentials().get(1).prefix(), "s3://bucket");
+    }
+
+    @Test
+    public void testWriteThenReadThroughHdfsEnvironment()
+            throws Exception
+    {
+        PrestoRESTFileIO fileIO = fileIO(manifestFileCache(false));
+        String location = location("ns/tbl/hdfs_roundtrip/v1.metadata.json");
+        byte[] contents = "{\"format-version\":2}".getBytes(UTF_8);
+
+        try (OutputStream out = fileIO.newOutputFile(location).create()) {
+            out.write(contents);
+        }
+
+        InputFile inputFile = fileIO.newInputFile(location);
+        assertTrue(inputFile.exists());
+        assertEquals(inputFile.getLength(), contents.length);
+        try (InputStream in = inputFile.newStream()) {
+            assertEquals(new String(toByteArray(in), UTF_8), new String(contents, UTF_8));
+        }
+    }
+
+    @Test
+    public void testListPrefixThroughHdfsEnvironment()
+            throws Exception
+    {
+        PrestoRESTFileIO fileIO = fileIO(manifestFileCache(false));
+        File subDir = new File(warehouseLocation, "ns/tbl/hdfs_list");
+        subDir.mkdirs();
+        new File(subDir, "v1.metadata.json").createNewFile();
+        new File(subDir, "snap-1.avro").createNewFile();
+
+        long count = 0;
+        for (FileInfo fileInfo : fileIO.listPrefix(subDir.toURI().toString())) {
+            assertNotNull(fileInfo.location());
+            count++;
+        }
+
+        assertEquals(count, 2L);
+    }
+
+    @Test
+    public void testDeleteFileThroughHdfsEnvironment()
+            throws Exception
+    {
+        PrestoRESTFileIO fileIO = fileIO(manifestFileCache(false));
+        File file = new File(warehouseLocation, "ns/tbl/hdfs_delete.avro");
+        file.getParentFile().mkdirs();
+        file.createNewFile();
+        assertTrue(file.exists());
+
+        fileIO.deleteFile(file.toURI().toString());
+
+        assertTrue(!file.exists(), "file should have been deleted through the Presto file system");
+    }
+
+    @Test
+    public void testDeletePrefixThroughHdfsEnvironment()
+            throws Exception
+    {
+        PrestoRESTFileIO fileIO = fileIO(manifestFileCache(false));
+        File subDir = new File(warehouseLocation, "ns/tbl/hdfs_delete_prefix");
+        subDir.mkdirs();
+        new File(subDir, "file.avro").createNewFile();
+
+        fileIO.deletePrefix(subDir.toURI().toString());
+
+        assertTrue(!new File(subDir, "file.avro").exists(), "prefix contents should have been deleted");
+    }
+
+    @Test
+    public void testLoadedTableUsesPrestoRESTFileIO()
+    {
+        IcebergNativeCatalogFactory factory = getCatalogFactory();
+        Catalog catalog = factory.getCatalog(SESSION);
+
+        Table table = createTable(catalog, "fileio_ns", "fileio_tbl");
+
+        assertTrue(table.io() instanceof PrestoRESTFileIO,
+                "expected PrestoRESTFileIO but got " + table.io().getClass().getName());
+        InputFile inputFile = table.io().newInputFile(new Path(table.location(), "metadata/v1.metadata.json").toUri().toString());
+        assertTrue(inputFile instanceof HdfsInputFile,
+                "expected HdfsInputFile but got " + inputFile.getClass().getName());
+    }
+
+    /**
+     * The regression this design exists for: without an ioBuilder, tableFileIO returns one
+     * catalog-level FileIO for every table when the server sends no per-table config.
+     */
+    @Test
+    public void testEachTableLoadGetsItsOwnFileIO()
+    {
+        IcebergNativeCatalogFactory factory = getCatalogFactory();
+        Catalog catalog = factory.getCatalog(SESSION);
+
+        Table first = createTable(catalog, "isolation_ns", "tbl_one");
+        Table second = createTable(catalog, "isolation_ns", "tbl_two");
+        Table firstReloaded = catalog.loadTable(TableIdentifier.of(Namespace.of("isolation_ns"), "tbl_one"));
+
+        assertNotSame(first.io(), second.io(), "different tables must not share a FileIO instance");
+        assertNotSame(first.io(), firstReloaded.io(), "reloading a table must not reuse the previous FileIO instance");
+    }
+
+    /**
+     * The catalog fixes the identity used for every metadata read, so it must not be shared.
+     */
+    @Test
+    public void testCatalogIsNotSharedBetweenIdentities()
+    {
+        IcebergNativeCatalogFactory factory = getCatalogFactory();
+
+        Catalog alice = factory.getCatalog(sessionForUser("alice"));
+        Catalog bob = factory.getCatalog(sessionForUser("bob"));
+        Catalog aliceAgain = factory.getCatalog(sessionForUser("alice"));
+
+        assertNotSame(alice, bob, "two identities must not share a catalog");
+        assertEquals(aliceAgain, alice, "the same identity should reuse its cached catalog");
+    }
+
+    private static ConnectorSession sessionForUser(String user)
+    {
+        return new TestingConnectorSession(
+                new ConnectorIdentity(user, Optional.empty(), Optional.empty()),
+                ImmutableList.of());
+    }
+}

--- a/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
+++ b/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
-import org.apache.iceberg.rest.RESTCatalogAdapter.Route;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.Pair;
@@ -166,9 +165,7 @@ public class IcebergRestCatalogServlet
 
     private Consumer<Map<String, String>> handleResponseHeader()
     {
-        return (responseHeaders) -> {
-            throw new RuntimeException("Unexpected response header: " + responseHeaders);
-        };
+        return responseHeaders -> {};
     }
 
     protected Consumer<ErrorResponse> handleResponseError(HttpServletResponse response)


### PR DESCRIPTION
## Description
Use Presto Hadoop FileSystem for REST catalog metadata reads via PrestoRESTFileIO

## Motivation and Context

The Iceberg REST catalog needs a FileIO for metadata reads. Neither built-in option fits Presto:

- HadoopFileIO (previous) — uses a static catalog-level Configuration, bypasses Presto's per-session HdfsEnvironment dispatch, and doesn't implement SupportsStorageCredentials so vended credentials from LoadTableResponse are silently dropped.

- ResolvingFileIO (Iceberg's REST default) — routes all I/O through Iceberg's own S3FileIO/GCSFileIO/etc., bypassing Presto's filesystem stack entirely.

This PR introduces `PrestoRESTFileIO`, a thin DelegateFileIO that:

- Routes metadata reads through HdfsEnvironment.getFileSystem(HdfsContext, path) when a session is active, matching how Presto handles data reads.

- Falls back to static HadoopFileIO during catalog initialisation (before a session is bound), so there is no regression.

- Implements SupportsStorageCredentials so vended credentials from a LoadTableResponse are captured via setCredentials() and already consumed by IcebergUtil.registerCredentials — no further interface changes needed when a vending-capable REST server is available.

## Impact
REST catalog metadata reads now use per-session HdfsEnvironment dispatch. Vended-credential support is fully wired end-to-end on the Presto side.

## Test Plan
Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Use Presto’s identity-aware filesystem stack for Iceberg REST catalog metadata access and credential handling.

New Features:
- Route Iceberg REST catalog metadata and file operations through Presto’s per-session HdfsEnvironment using the new PrestoRESTFileIO.
- Capture vended storage credentials returned by REST catalog table loads.
- Provide per-identity REST catalog and per-table FileIO isolation while preserving Presto manifest caching.

Bug Fixes:
- Prevent REST catalog metadata reads from bypassing Presto filesystem and identity-specific credential dispatch.
- Prevent Iceberg’s catalog-level content cache configuration from conflicting with Presto’s manifest file cache.

Enhancements:
- Upgrade Iceberg to 1.11.0 and HTTP Core to 5.4.
- Extend REST catalog integration with custom FileIO creation and identity-aware catalog cache keys.

Tests:
- Add coverage for REST FileIO filesystem operations, credential capture, table and identity isolation, and manifest cache behavior.