### PR TITLE
fix(native): Copy the OpenZL patch into the dependency images

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -36,6 +36,9 @@ COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /vel
 ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
 COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
 ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
+# from https://github.com/facebookincubator/velox/pull/18470
+COPY velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /velox
+ENV VELOX_OPENZL_CMAKE_PATCH=/velox/openzl-cxx-standard.patch
 COPY CMake/arrow/arrow-flight.patch /scripts
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
 RUN bash -c "mkdir build && \

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -41,6 +41,9 @@ COPY CMake/arrow/arrow-flight.patch /scripts
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
 COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
 ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
+# from https://github.com/facebookincubator/velox/pull/18470
+COPY velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /velox
+ENV VELOX_OPENZL_CMAKE_PATCH=/velox/openzl-cxx-standard.patch
 # install rpm needed for minio install.
 RUN mkdir build && \
     (cd build && export VELOX_BUILD_SHARED=ON && \


### PR DESCRIPTION
## Description
  Copy `velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch` into the
  native dependency images and point `VELOX_OPENZL_CMAKE_PATCH` at it, in both
  `centos-dependency.dockerfile` and `ubuntu-22.04-dependency.dockerfile`. This follows the
  pattern the same files already use for the arrow and fbthrift patches.

## Motivation and Context
  Velox facebookincubator/velox#18470 added `install_openzl`, which applies the OpenZL C++
  standard patch and defaults its location to `$SCRIPT_DIR/../CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch`.
  The dependency dockerfiles copy only `velox/scripts` plus a few named patches, so
  `/velox/CMake/...` does not exist in the image and the build fails as soon as the velox
  pointer includes OpenZL (#28340):

      + git apply /velox/scripts/../CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch
      error: can't open patch '/velox/scripts/../CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch': No such file or
  directory

  `install_openzl` honours `VELOX_OPENZL_CMAKE_PATCH` when set, which is what velox's own
  dockerfiles do; setting it here fixes the path for the Presto image layout.

  Note this is not visible in CI, because CI builds `presto_server` inside a pinned
  `presto-native-dependency` image rather than rebuilding these dockerfiles.

## Impact
  Build only. No functional or API change. Unblocks building the native dependency images
  from master.

## Test Plan
  - Built `centos-dependency.dockerfile` against master's velox pointer:
    before this change the build fails at `git apply` as above; with it, `install_openzl`
    completes and the dependency image builds through `install_clang15`, `install_cuda`
    and `install_ucx`.
  - Built the prestissimo runtime image on top of the resulting dependency image
    successfully.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure Velox’s OpenZL CMake patch is included in native execution dependency Docker images.

Build:
- Add copying and environment configuration for the OpenZL C++ standard patch in CentOS dependency Docker image.
- Add copying and environment configuration for the OpenZL C++ standard patch in Ubuntu 22.04 dependency Docker image.