### PR TITLE
fix(optimizer): Avoid NPE when a partitioning column is not a UNION output (#28345)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -1484,8 +1484,10 @@ public class AddExchanges
         {
             Optional<PreferredProperties.Global> parentPartitioningPreference = parentPreference.getGlobalProperties();
 
-            // case 1: parent provides preferred distributed partitioning
-            if (parentPartitioningPreference.isPresent() && parentPartitioningPreference.get().isDistributed() && parentPartitioningPreference.get().getPartitioningProperties().isPresent()) {
+            // case 1: parent provides preferred distributed partitioning that is expressible over this
+            // union's outputs. An untranslatable preference is treated as no preference and falls
+            // through to case 2 rather than failing to plan.
+            if (canTranslatePartitioningOntoBranches(node, parentPartitioningPreference)) {
                 PartitioningProperties parentPartitioningProperties = parentPartitioningPreference.get().getPartitioningProperties().get();
                 boolean nullsAndAnyReplicated = parentPartitioningProperties.isNullsAndAnyReplicated();
                 Partitioning desiredParentPartitioning = selectUnionPartitioning(node, parentPartitioningProperties);
@@ -1549,6 +1551,8 @@ public class AddExchanges
             //   * parentPartitioningPreference is Optional.empty()
             //   * parentPartitioningPreference is present, but is single node distribution
             //   * parentPartitioningPreference is present and is distributed, but does not have an explicit partitioning preference
+            //   * parentPartitioningPreference is present, distributed and explicit, but partitions on a
+            //     variable this union does not produce, so it cannot be translated onto the branches
 
             // first, classify children into single node and distributed
             List<PlanNode> singleNodeChildren = new ArrayList<>();
@@ -1885,6 +1889,19 @@ public class AddExchanges
         }
         // Optimizations can be applied if the first LocalProperty has been modified in the match in any way
         return !matchResult.get(0).equals(Optional.of(desiredLayout.get(0)));
+    }
+
+    // visitUnion case 1 translates the parent's preferred partitioning onto each union branch, so a
+    // column the union does not output cannot be translated. AssignUniqueId produces exactly that:
+    // it adds an output its own source lacks, and AddExchanges forwards the preference through it
+    // untranslated. See TestAddExchangesUnionPreferredPartitioning.
+    private static boolean canTranslatePartitioningOntoBranches(UnionNode node, Optional<PreferredProperties.Global> parentPartitioningPreference)
+    {
+        return parentPartitioningPreference
+                .filter(PreferredProperties.Global::isDistributed)
+                .flatMap(PreferredProperties.Global::getPartitioningProperties)
+                .map(partitioning -> node.getOutputVariables().containsAll(partitioning.getPartitioningColumns()))
+                .orElse(false);
     }
 
     private static boolean meetsPartitioningRequirements(PreferredProperties preferred, ActualProperties actual)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -146,6 +146,20 @@ public class TestAddExchangesPlans
                                                         tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
     }
 
+    @Test
+    public void testUnionWithUntranslatablePreferredPartitioning()
+    {
+        Session session = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(SIMPLIFY_PLAN_WITH_EMPTY_INPUT, "true")
+                .build();
+        String sql = "SELECT (SELECT orders.orderkey " +
+                "FROM orders JOIN (SELECT nationkey FROM nation WHERE false) empty_relation ON true " +
+                "WHERE orders.orderkey = outer_relation.key) " +
+                "FROM (SELECT nationkey AS key FROM nation UNION ALL SELECT regionkey AS key FROM region) outer_relation";
+
+        assertPlanValidatorWithSession(sql, session, false, ignored -> {});
+    }
+
     private void assertPlanWithMergePartitionStrategy(
             String sql,
             String partitionMergingStrategy,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesUnionPreferredPartitioning.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesUnionPreferredPartitioning.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Regression tests for {@code AddExchanges.visitUnion} case 1, which translates the parent's
+ * preferred partitioning onto each union branch and therefore only works when every preferred
+ * partitioning column is an output of the union.
+ * <p>
+ * See {@code AddExchanges.canTranslatePartitioningOntoBranches} for why a column need not be.
+ * <p>
+ * These tests isolate the mixed and fully unmapped boundary cases. The SQL plan test in
+ * {@link TestAddExchangesPlans#testUnionWithUntranslatablePreferredPartitioning()} covers the
+ * end-to-end optimizer path, asserting only that planning completes. It deliberately makes no
+ * claim about node adjacency, because earlier optimizers may legally rewrite that shape.
+ */
+public class TestAddExchangesUnionPreferredPartitioning
+        extends BaseRuleTest
+{
+    /**
+     * Some preferred partitioning columns are union outputs and some are not.
+     * Before the guard this threw {@link NullPointerException} from
+     * {@code outputToInputTranslator}, because {@code getVariableMapping()} is a plain
+     * {@code Map} and a missing key yields null.
+     */
+    @Test
+    public void testUnionWithPartlyUnmappedPreferredPartitioning()
+    {
+        assertPlansWithUnionPreserved(true);
+    }
+
+    /**
+     * Boundary case: no preferred partitioning column is a union output, failing at the same site
+     * as the case above. It also pins that a null-safe {@code outputToInputTranslator} is not on
+     * its own sufficient, since every column would then fail to translate,
+     * {@code PartitioningProperties.translateVariable} would return {@code Optional.empty()}, and
+     * the {@code get()} in {@code selectUnionPartitioning} would throw
+     * {@link java.util.NoSuchElementException}.
+     */
+    @Test
+    public void testUnionWithFullyUnmappedPreferredPartitioning()
+    {
+        assertPlansWithUnionPreserved(false);
+    }
+
+    private void assertPlansWithUnionPreserved(boolean includeUnionOutputInPartitioning)
+    {
+        tester().assertThat(new AddExchanges(tester().getMetadata(), new PartitioningProviderManager(), false))
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a");
+                    VariableReferenceExpression a1 = p.variable("a1");
+                    VariableReferenceExpression a2 = p.variable("a2");
+                    VariableReferenceExpression unique = p.variable("unique");
+                    ImmutableList.Builder<VariableReferenceExpression> distinctVariables = ImmutableList.builder();
+                    if (includeUnionOutputInPartitioning) {
+                        distinctVariables.add(a);
+                    }
+                    // `unique` is produced by the AssignUniqueId, never by the union
+                    distinctVariables.add(unique);
+                    PlanNode union = p.union(
+                            ImmutableListMultimap.<VariableReferenceExpression, VariableReferenceExpression>builder()
+                                    .putAll(a, a1, a2)
+                                    .build(),
+                            ImmutableList.of(p.values(a1), p.values(a2)));
+                    return p.markDistinct(
+                            p.variable("is_distinct", BOOLEAN),
+                            distinctVariables.build(),
+                            p.assignUniqueId(unique, union));
+                })
+                // The regression is that planning threw, so completing at all is the assertion.
+                // The union check only rules out the node being rewritten away; it does not
+                // distinguish case 1 from case 2, since both emit a UnionNode.
+                .validates(plan -> assertTrue(
+                        PlanNodeSearcher.searchFrom(plan.getRoot()).where(UnionNode.class::isInstance).matches(),
+                        "expected the UnionNode to survive planning"));
+    }
+}


### PR DESCRIPTION
Summary:

`AddExchanges.visitUnion` assumes every column in the parent's preferred partitioning is an
output of the union. When one is not, planning fails with a `NullPointerException`. This adds a
guard so the preference is used only when it is expressible over the union's outputs.

## The bug

Case 1 of `visitUnion` takes the parent's preferred partitioning and translates it onto each
union branch. Two helpers assume every partitioning column has a corresponding branch column:

- `outputToInputTranslator` does `Optional.of(getVariableMapping().get(variable).get(i))`.
  `getVariableMapping()` is a plain `Map`, so a missing key yields null and this throws
  `NullPointerException`. This is the observed crash.
- `createDirectTranslator` does `inputToOutput.get(input).iterator().next()`. On a `SetMultimap`
  a missing key yields an empty set, so this throws `NoSuchElementException`.

The failure happens during optimization, so it is deterministic and no retry succeeds.
Presto on Spark is affected too, since it shares the planner.

## How a non-output column reaches the union

`AssignUniqueId` emits an id variable that its own source does not produce, and `AddExchanges`
has no `visitAssignUniqueId` override, so `visitPlan` forwards the parent preference to the
child untranslated.

`TransformCorrelatedScalarSubquery` builds a `MarkDistinct` over a lateral join whose input is
an `AssignUniqueId`, passing the join input's outputs, which include the id variable, as
`distinctVariables`. `visitMarkDistinct` turns those into a distributed partitioning preference.
The join does not forward that preference, so the crashing shape is the one left after the join
is eliminated, for example by `SimplifyPlanWithEmptyInput` when the subquery side is provably
empty:

```
MarkDistinct(distinctVariables = [a, unique])
  AssignUniqueId(unique)
    Union(a -> [a1, a2])
```

`unique` is not a union output, so translating the preference onto the branches is impossible.

A second route exists in deployments that still enable preferred write partitioning, where an
`INSERT` into a partitioned table pushes the target's partition columns down as a preference and
a partition column projected as a constant above the union is not a union output. That session
property was removed in 0.291, so it is not the trigger here, but both routes converge on the
same entry point and one guard covers both.

## The fix

Enter case 1 only when the union's outputs contain every column of the preferred partitioning.
Otherwise treat the preference as absent and fall through to case 2, which already handles
"distributed, but no explicit partitioning preference" by planning each branch with
`PreferredProperties.any()`.

The guard sits at the entry point rather than at the two crash sites because both unsafe helpers
are reachable only from there: `outputToInputTranslator` is called only by
`selectUnionPartitioning`, which is called only by case 1.

This cannot regress a query that plans today. When `getPartitioning()` is present,
`PartitioningProperties` keeps `partitioningColumns` equal to the partitioning's variable
references, so any plan the guard newly diverts would have reached `createDirectTranslator` and
thrown. An empty column set still satisfies `containsAll`, so single-partition preferences are
untouched. The only cost is a lost optimization in the mixed case, where some partitioning
columns are translatable and some are not, and that case previously crashed.

The guard tests `getOutputVariables()`. Case 1 dereferences the union two ways, through
`getVariableMapping()` in the translator and through `getOutputVariables()` in the two
`createMapping` calls, and `SetOperationNode` does not enforce that the two agree. Keying on the
outputs covers all three sites, and it cannot be weaker in practice because `sourceOutputLayout()`
would itself throw if the outputs were not contained in the mapping's key set.

## Why not a null-safe translator

Making `outputToInputTranslator` return `Optional.ofNullable(...)` and skipping untranslatable
branches is not sufficient. The fall-through at the end of `selectUnionPartitioning` returns
`createPartitioning(parentPreference.getPartitioningColumns())`, which still contains the
untranslatable column, and case 1 then hands it to `createDirectTranslator`.

The result is the
same failure at a different line, `NoSuchElementException` instead of `NullPointerException`.
The second test case pins that, so the partial fix cannot be reintroduced silently.

## Review-driven refactors

The guard's behaviour is unchanged since the first version. Its shape changed across three rounds
of review comments:

1. The condition moved out of the `if` into a named predicate,
   `canTranslatePartitioningOntoBranches`, leaving no `Optional.get()` call in the `if`.
2. The predicate moved from the inner `Rewriter` class to `AddExchanges` as a `private static`,
   beside `meetsPartitioningRequirements`, matching every other private static helper in the file.
3. The predicate body became an `Optional` filter/flatMap/map chain, mirroring an existing chain
   in this file.

Round 2 asked for `ImmutableSet.copyOf(node.getOutputVariables())` in place of the list scan, and
round 3 asked for that copy to be removed, so the membership test is back to `List.containsAll`.
That is the correct end state. `SetOperationNode` stores `outputVariables` and `outputToInputs` as
independent constructor parameters with no invariant tying them, so the allocation-free
`getVariableMapping().keySet()` is not a safe substitute for `getOutputVariables()`, and both
operands are small enough that hashing the outputs on each call buys nothing.

An earlier run of `test / test (17, :presto-hive)` failed in
`TestSingleNodeCteExecution.testComplexQuery3` with `UnsupportedOperationException: not yet
implemented` thrown from `LocalExecutionPlanner`. That shard passes on this revision, rebased onto
`remote/master` at `5dd6d2bf4c95`, so the failure is intermittent and unrelated to this change:

- The query is CTEs and joins with no `UNION`, so `visitUnion` never runs and this guard is
  unreachable for it.
- `LocalExecutionPlanner` contains no `MergeJoin` handling at all, so any `MergeJoinNode` reaching
  it throws. That is a pre-existing engine gap, not something this diff can introduce.
- `AddExchanges.java` has had no upstream commit since 2026-07-07, so the rebase crossed no change
  relevant to this file.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix ``NullPointerException`` during planning when a preferred partitioning column is not an output of a ``UNION``.
```

Differential Revision: D115744811


