### PR TITLE
feat(type): Support Hive type coercion from Double to Varchar

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -475,7 +475,7 @@ public class ParquetPageSourceFactory
             case FLOAT:
                 return prestoType.equals(REAL) || prestoType.equals(StandardTypes.DOUBLE);
             case DOUBLE:
-                return prestoType.equals(StandardTypes.DOUBLE);
+                return prestoType.equals(StandardTypes.DOUBLE) || prestoType.equals(VARCHAR) || prestoType.startsWith(CHAR);
             case BINARY:
                 return prestoType.equals(VARBINARY) || prestoType.equals(VARCHAR) || prestoType.startsWith(CHAR) || prestoType.equals(DECIMAL);
             case INT96:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeCoercion.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeCoercion.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.hive.parquet.ParquetTester;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.hive.HiveCommonSessionProperties.PARQUET_BATCH_READ_OPTIMIZATION_ENABLED;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Verifies that a Parquet DOUBLE column can be read through a Hive table whose column is declared
+ * as VARCHAR / VARCHAR(n) / CHAR(n). Exercises both the row-at-a-time reader
+ * ({@link com.facebook.presto.parquet.reader.DoubleColumnReader}) and the batch reader path
+ * (Int64FlatBatchReader + {@link com.facebook.presto.parquet.reader.ParquetReader#typeCoercion}).
+ */
+@Test
+public class TestHiveTypeCoercion
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "hive";
+    private static final String SCHEMA = "type_coercion_schema";
+    private static final List<Double> DOUBLE_VALUES = ImmutableList.of(
+            0.0d,
+            -1.5d,
+            4124.1324213412341241242134243d,
+            Double.MAX_VALUE,
+            Double.NaN,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY);
+
+    private DistributedQueryRunner queryRunner;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        this.queryRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+        this.queryRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = this.queryRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .put("hive.compression-codec", "GZIP")
+                .put("hive.storage-format", "PARQUET")
+                .build();
+        this.queryRunner.createCatalog(CATALOG, CATALOG, properties);
+        this.queryRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+        return this.queryRunner;
+    }
+
+    @DataProvider(name = "batchReadOptimizationEnabled")
+    public Object[][] batchReadOptimizationEnabled()
+    {
+        return new Object[][] {
+                {true},
+                {false},
+        };
+    }
+
+    @Test(dataProvider = "batchReadOptimizationEnabled")
+    public void testDoubleToUnboundedVarchar(boolean batchReadEnabled)
+            throws Exception
+    {
+        List<String> expected = DOUBLE_VALUES.stream().map(String::valueOf).collect(Collectors.toList());
+        runCoercionTest("double_to_varchar_" + batchReadEnabled, "VARCHAR", expected, batchReadEnabled);
+    }
+
+    @Test(dataProvider = "batchReadOptimizationEnabled")
+    public void testDoubleToBoundedVarchar(boolean batchReadEnabled)
+            throws Exception
+    {
+        int maxLength = 5;
+        List<String> expected = DOUBLE_VALUES.stream()
+                .map(value -> truncate(String.valueOf(value), maxLength))
+                .collect(Collectors.toList());
+        runCoercionTest("double_to_varchar5_" + batchReadEnabled, "VARCHAR(" + maxLength + ")", expected, batchReadEnabled);
+    }
+
+    @Test(dataProvider = "batchReadOptimizationEnabled")
+    public void testDoubleToChar(boolean batchReadEnabled)
+            throws Exception
+    {
+        int length = 6;
+        // CHAR(n) truncates to n characters, then trims trailing spaces before writing.
+        // Reading requires padding back to length n.
+        List<String> expected = DOUBLE_VALUES.stream()
+                .map(value -> padRight(truncate(String.valueOf(value), length), length))
+                .collect(Collectors.toList());
+        runCoercionTest("double_to_char" + length + "_" + batchReadEnabled, "CHAR(" + length + ")", expected, batchReadEnabled);
+    }
+
+    private void runCoercionTest(String tableName, String declaredType, List<String> expectedRows, boolean batchReadEnabled)
+            throws Exception
+    {
+        File resourcesLocation = generateMetadata(tableName);
+        try {
+            @Language("SQL") String createQuery = format(
+                    "CREATE TABLE %s.\"%s\".\"%s\" (field %s) WITH (external_location = '%s')",
+                    CATALOG, SCHEMA, tableName, declaredType, getResourceUrl(tableName));
+            this.queryRunner.execute(createQuery);
+
+            Session session = Session.builder(this.queryRunner.getDefaultSession())
+                    .setCatalogSessionProperty(CATALOG, PARQUET_BATCH_READ_OPTIMIZATION_ENABLED, String.valueOf(batchReadEnabled))
+                    .build();
+            @Language("SQL") String selectQuery = format("SELECT field FROM %s.\"%s\".\"%s\"", CATALOG,
+                SCHEMA, tableName);
+            MaterializedResult result = this.queryRunner.execute(session, selectQuery);
+            List<String> actualResults = result.getMaterializedRows().stream()
+                    .map(row -> (String) row.getField(0))
+                    .sorted()
+                    .collect(Collectors.toList());
+            List<String> sortedExpected = expectedRows.stream().sorted().collect(Collectors.toList());
+            assertEquals(actualResults, sortedExpected, "Rows read with batchReadEnabled=" + batchReadEnabled);
+        }
+        finally {
+            @Language("SQL") String dropQuery = format("DROP TABLE IF EXISTS %s.\"%s\".\"%s\"", CATALOG,
+                SCHEMA, tableName);
+            this.queryRunner.execute(dropQuery);
+            deleteMetadata(resourcesLocation);
+        }
+    }
+
+    private static File generateMetadata(String tableName)
+            throws Exception
+    {
+        URL url = TestHiveTypeCoercion.class.getClassLoader().getResource(".");
+        if (url == null) {
+            throw new RuntimeException("Could not obtain resource URL");
+        }
+        File temporaryDirectory = new File(url.getPath(), tableName);
+        if (!temporaryDirectory.mkdirs()) {
+            throw new RuntimeException("Could not create resource directory: " + temporaryDirectory.getPath());
+        }
+        File parquetFile = new File(temporaryDirectory, randomUUID().toString());
+        ParquetTester.writeParquetFileFromPresto(parquetFile,
+                ImmutableList.of(DoubleType.DOUBLE),
+                ImmutableList.of("field"),
+                new Iterable[] {DOUBLE_VALUES},
+                DOUBLE_VALUES.size(),
+                GZIP,
+                PARQUET_1_0);
+        return temporaryDirectory;
+    }
+
+    private static String getResourceUrl(String tableName)
+    {
+        URL resourceUrl = TestHiveTypeCoercion.class.getClassLoader().getResource(tableName);
+        if (resourceUrl == null) {
+            throw new RuntimeException("Cannot find resource path for table name: " + tableName);
+        }
+        return resourceUrl.toString();
+    }
+
+    private static void deleteMetadata(File file)
+    {
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                if (!Files.isSymbolicLink(child.toPath())) {
+                    deleteMetadata(child);
+                }
+            }
+        }
+        file.delete();
+    }
+
+    private static String truncate(String value, int maxLength)
+    {
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+
+    private static String padRight(String value, int length)
+    {
+        if (value.length() >= length) {
+            return value;
+        }
+        StringBuilder builder = new StringBuilder(length);
+        builder.append(value);
+        for (int i = value.length(); i < length; i++) {
+            builder.append(' ');
+        }
+        return builder.toString();
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -202,6 +202,10 @@ public class TupleDomainParquetPredicate
         }
 
         if (isVarcharType(type)) {
+            // Hive type coercion from Double to Varchar: Fall back to Domain.all to safely handle physical/logical type mismatches
+            if (column.getPrimitiveType().getPrimitiveTypeName() == PrimitiveTypeName.DOUBLE) {
+                return Domain.create(ValueSet.all(type), hasNullValue);
+            }
             for (int i = 0; i < minimums.size(); i++) {
                 Slice min = Slices.wrappedBuffer(((Binary) minimums.get(i)).toByteBuffer());
                 Slice max = Slices.wrappedBuffer(((Binary) maximums.get(i)).toByteBuffer());

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/DoubleColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/DoubleColumnReader.java
@@ -17,6 +17,12 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.parquet.RichColumnDescriptor;
 
+import static com.facebook.presto.common.type.Chars.isCharType;
+import static com.facebook.presto.common.type.Chars.truncateToLengthAndTrimSpaces;
+import static com.facebook.presto.common.type.Varchars.isVarcharType;
+import static com.facebook.presto.common.type.Varchars.truncateToLength;
+import static io.airlift.slice.Slices.utf8Slice;
+
 public class DoubleColumnReader
         extends AbstractColumnReader
 {
@@ -29,7 +35,16 @@ public class DoubleColumnReader
     protected void readValue(BlockBuilder blockBuilder, Type type)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
-            type.writeDouble(blockBuilder, valuesReader.readDouble());
+            double value = valuesReader.readDouble();
+            if (isVarcharType(type)) {
+                type.writeSlice(blockBuilder, truncateToLength(utf8Slice(String.valueOf(value)), type));
+                return;
+            }
+            if (isCharType(type)) {
+                type.writeSlice(blockBuilder, truncateToLengthAndTrimSpaces(utf8Slice(String.valueOf(value)), type));
+                return;
+            }
+            type.writeDouble(blockBuilder, value);
         }
         else if (isValueNull()) {
             blockBuilder.appendNull();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -80,6 +80,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.Chars.isCharType;
+import static com.facebook.presto.common.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
@@ -88,6 +90,8 @@ import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.Varchars.isVarcharType;
+import static com.facebook.presto.common.type.Varchars.truncateToLength;
 import static com.facebook.presto.parquet.ParquetValidationUtils.validateParquet;
 import static com.facebook.presto.parquet.reader.ListColumnReader.calculateCollectionOffsets;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -634,6 +638,11 @@ public class ParquetReader
                 newBlock = rewriteIntegerArrayBlock((IntArrayBlock) columnChunk.getBlock(), outputType);
             }
         }
+        else if (physicalDataType == PrimitiveTypeName.DOUBLE && (isVarcharType(outputType) || isCharType(outputType))) {
+            if (columnChunk.getBlock() instanceof LongArrayBlock) {
+                newBlock = rewriteDoubleArrayBlockToVarchar((LongArrayBlock) columnChunk.getBlock(), outputType);
+            }
+        }
 
         if (newBlock != null) {
             return new ColumnChunk(newBlock, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
@@ -668,6 +677,25 @@ public class ParquetReader
             }
             else {
                 targetType.writeLong(newBlockBuilder, longArrayBlock.getLong(position));
+            }
+        }
+
+        return newBlockBuilder.build();
+    }
+
+    private static Block rewriteDoubleArrayBlockToVarchar(LongArrayBlock longArrayBlock, Type targetType)
+    {
+        boolean varchar = isVarcharType(targetType);
+        int positionCount = longArrayBlock.getPositionCount();
+        BlockBuilder newBlockBuilder = targetType.createBlockBuilder(null, positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            if (longArrayBlock.isNull(position)) {
+                newBlockBuilder.appendNull();
+            }
+            else {
+                double value = Double.longBitsToDouble(longArrayBlock.getLong(position));
+                Slice slice = utf8Slice(String.valueOf(value));
+                targetType.writeSlice(newBlockBuilder, varchar ? truncateToLength(slice, targetType) : truncateToLengthAndTrimSpaces(slice, targetType));
             }
         }
 

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
@@ -257,6 +257,9 @@ public class TestTupleDomainParquetPredicate
 
         assertEquals(getDomain(columnDescriptor, DOUBLE, 10, doubleColumnStats(3.3, NaN, true), ID, Optional.of(collector)), Domain.all(DOUBLE));
 
+        // Hive type coercion from Double to Varchar
+        assertEquals(getDomain(columnDescriptor, createUnboundedVarcharType(), 10, doubleColumnStats(3.3, 42.24), ID, Optional.of(collector)),
+                Domain.notNull(createUnboundedVarcharType()));
         assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(NaN)), Domain.all(DOUBLE));
 
         assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(3.3, NaN)), Domain.all(DOUBLE));


### PR DESCRIPTION
## Description
Support for `DOUBLE` to `VARCHAR` type coercion in Hive tables backed by Parquet files in both row and batch readers.

Queries that implicitly or explicitly convert numeric DOUBLE values into VARCHAR strings in Hive tables are now supported seamlessly.


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add support for Hive type coercion from ``DOUBLE`` to ``VARCHAR``
```

## Summary by Sourcery

Add support for reading Parquet DOUBLE columns through Hive tables declared as VARCHAR/CHAR, enabling DOUBLE-to-string type coercion for Parquet-backed Hive tables.

New Features:
- Support coercing Parquet DOUBLE columns to Hive VARCHAR and CHAR types in both row-wise and batch readers.

Enhancements:
- Extend Parquet schema matching in the Hive connector to recognize VARCHAR and CHAR as valid targets for DOUBLE columns.

Tests:
- Add integration tests that verify DOUBLE-to-VARCHAR and DOUBLE-to-CHAR coercion for Parquet-backed Hive tables with and without batch read optimization enabled.