### PR TITLE
feat(native-pos): Add khyperloglog_agg_java_compat alias

### DIFF
--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -29,6 +29,20 @@ Functions
     columns ``x`` and ``y``. The MinHash structure summarizes ``x`` and the HyperLogLog
     sketches represent ``y`` values linked to ``x`` values.
 
+.. function:: khyperloglog_agg_java_compat(x, y) -> KHyperLogLog
+
+    Alias of :func:`khyperloglog_agg`, provided for cross-engine portability.
+
+    The native (C++) engine's ``khyperloglog_agg`` hashes its inputs differently
+    from the Java implementation, so sketches built by the two engines are not
+    byte compatible and cannot be merged with each other. The native engine
+    registers ``khyperloglog_agg_java_compat`` as a separate aggregate that
+    reproduces the Java hashing exactly, leaving its own ``khyperloglog_agg``
+    unchanged so existing sketches stay reproducible.
+
+    Use this name when a sketch must be built by either engine and later merged
+    or compared. On Java it behaves identically to :func:`khyperloglog_agg`.
+
 .. function:: cardinality(khll) -> bigint
     :noindex:
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -1046,6 +1046,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         if (functionsConfig.getLimitNumberOfGroupsForKHyperLogLogAggregations()) {
             builder.function(new MergeKHyperLogLogWithLimitAggregationFunction(functionsConfig.getKHyperLogLogAggregationGroupNumberLimit()));
             builder.function(new KHyperLogLogWithLimitAggregationFunction(functionsConfig.getKHyperLogLogAggregationGroupNumberLimit()));
+            builder.function(new KHyperLogLogWithLimitAggregationFunction(KHyperLogLogWithLimitAggregationFunction.JAVA_COMPAT_NAME, functionsConfig.getKHyperLogLogAggregationGroupNumberLimit()));
         }
         else {
             builder.aggregates(MergeKHyperLogLogAggregationFunction.class);

--- a/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogAggregationFunction.java
@@ -29,7 +29,21 @@ import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
 import static com.facebook.presto.common.type.StandardTypes.K_HYPER_LOG_LOG;
 
-@AggregationFunction("khyperloglog_agg")
+/**
+ * The {@code khyperloglog_agg_java_compat} alias exists for cross-engine
+ * portability. Velox's {@code khyperloglog_agg} hashes its inputs differently
+ * from this implementation, so sketches built by the two engines are not byte
+ * compatible. Velox therefore registers a second aggregate,
+ * {@code khyperloglog_agg_java_compat}, that reproduces this implementation's
+ * hashing exactly.
+ *
+ * <p>Registering the same name here lets a single query resolve and produce
+ * identical sketches on both engines. On a native cluster the coordinator still
+ * resolves the name against this registry before dispatching execution to the
+ * worker, so the alias is required there too, not only when the query runs on
+ * Java. It is deliberately an alias rather than a second implementation.
+ */
+@AggregationFunction(value = "khyperloglog_agg", alias = "khyperloglog_agg_java_compat")
 public final class KHyperLogLogAggregationFunction
 {
     private static final KHyperLogLogStateSerializer SERIALIZER = new KHyperLogLogStateSerializer();

--- a/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogWithLimitAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogWithLimitAggregationFunction.java
@@ -48,6 +48,12 @@ public final class KHyperLogLogWithLimitAggregationFunction
         extends SqlAggregationFunction
 {
     private static final String NAME = "khyperloglog_agg";
+    /**
+     * Alias of {@link #NAME}, registered so that a query can resolve on both
+     * the Java and native engines. See {@link KHyperLogLogAggregationFunction}
+     * for why the native engine needs a separate name.
+     */
+    public static final String JAVA_COMPAT_NAME = "khyperloglog_agg_java_compat";
     private static final KHyperLogLogStateSerializer SERIALIZER = new KHyperLogLogStateSerializer();
     private static final MethodHandle LONG_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, long.class, long.class);
     private static final MethodHandle SLICE_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class, long.class);
@@ -58,10 +64,17 @@ public final class KHyperLogLogWithLimitAggregationFunction
     private static final MethodHandle OUTPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "output", KHyperLogLogState.class, BlockBuilder.class);
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "combine", KHyperLogLogState.class, KHyperLogLogState.class);
     private final long groupLimit;
+    private final String name;
 
     public KHyperLogLogWithLimitAggregationFunction(long groupLimit)
     {
-        super(NAME, ImmutableList.of(typeVariable("E"), typeVariable("T")), ImmutableList.of(), K_HYPER_LOG_LOG.getTypeSignature(), ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("T")));
+        this(NAME, groupLimit);
+    }
+
+    public KHyperLogLogWithLimitAggregationFunction(String name, long groupLimit)
+    {
+        super(name, ImmutableList.of(typeVariable("E"), typeVariable("T")), ImmutableList.of(), K_HYPER_LOG_LOG.getTypeSignature(), ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("T")));
+        this.name = name;
         this.groupLimit = groupLimit;
     }
 
@@ -87,7 +100,7 @@ public final class KHyperLogLogWithLimitAggregationFunction
         MethodHandle inputFunction = getMethodHandle(firstInputType, secondInputType);
 
         AggregationMetadata metadata = new AggregationMetadata(
-                generateAggregationName(NAME, K_HYPER_LOG_LOG.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                generateAggregationName(name, K_HYPER_LOG_LOG.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, firstInputType), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, secondInputType)),
                 inputFunction,
                 COMBINE_FUNCTION,
@@ -108,7 +121,7 @@ public final class KHyperLogLogWithLimitAggregationFunction
                 GroupedAccumulator.class,
                 metadata,
                 classLoader);
-        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), K_HYPER_LOG_LOG,
+        return new BuiltInAggregationFunctionImplementation(name, inputTypes, ImmutableList.of(intermediateType), K_HYPER_LOG_LOG,
                 true, false, metadata, accumulatorClass, groupedAccumulatorClass);
     }
 


### PR DESCRIPTION
Summary:
## Description

Registers `khyperloglog_agg_java_compat` as an alias of `khyperloglog_agg`, and
documents it. No behaviour change on Java: the alias resolves to the same
implementation.

## Motivation and Context

The native (C++) engine's `khyperloglog_agg` hashes its inputs differently from
the Java implementation, in two places: the MinHash key hash sign-extends tail
bytes `>= 0x80`, and a `varchar` uii is added to the HLL as raw bytes rather
than being pre-hashed with `XxHash64` first. Sketches built by the two engines
are therefore not byte compatible and cannot be merged with each other.

Correcting the native `khyperloglog_agg` in place is not viable: it would move
the bytes of sketches that have already been persisted by native workers. So
the native engine instead registers a second aggregate,
`khyperloglog_agg_java_compat`, which reproduces the Java hashing exactly and
leaves `khyperloglog_agg` untouched.

For a single query to resolve on both engines, that name must exist here too.
Note this is required even for queries that run entirely on a native cluster:
the coordinator resolves the function name against this registry before
dispatching execution to the worker, so without the alias the query fails at
planning with "Function khyperloglog_agg_java_compat not registered".

It is deliberately an alias rather than a second implementation, so the two
cannot drift apart.

## Impact

Additive. One new function name, resolving to the existing
`KHyperLogLogAggregationFunction`. No existing name, signature or output
changes.

## Test Plan

`khyperloglog_agg_java_compat` is a pure alias, so it is covered by the existing
`khyperloglog_agg` tests; `AggregationFromAnnotationsParser.getNames()` builds
the registered-name list from `value()` plus `alias()`, which is the same
mechanism already used by `merge_qtree`.

```
mvn compile -pl presto-main-base
  BUILD SUCCESS (2235 source files)
```

Cross-engine behaviour was verified against a native cluster: before this
change, `SELECT khyperloglog_agg_java_compat(...)` fails at planning with
"Function khyperloglog_agg_java_compat not registered", while
`khyperloglog_agg` resolves and executes on the native worker, confirming that
the coordinator gates name resolution.

## Contributor checklist

- [x] Please make sure your submission complies with our contributing guide
- [x] PR description addresses the issue accurately and concisely
- [x] Documentation update included
- [x] No new dependencies added

## Release Notes

```
== NO RELEASE NOTE ==

```

Differential Revision: D115735407

