### PR TITLE
fix(plugin-oracle): Honor user-credential-name/password-credential-name

### DIFF
--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -49,15 +49,10 @@ public class OracleClientModule
     public static ConnectionFactory connectionFactory(BaseJdbcConfig config, OracleConfig oracleConfig)
             throws SQLException
     {
-        Properties connectionProperties = new Properties();
-
         requireNonNull(oracleConfig, "oracle config is null");
         requireNonNull(config, "BaseJdbc config is null");
 
-        if (config.getConnectionUser() != null && config.getConnectionPassword() != null) {
-            connectionProperties.setProperty("user", config.getConnectionUser());
-            connectionProperties.setProperty("password", config.getConnectionPassword());
-        }
+        Properties connectionProperties = DriverConnectionFactory.basicConnectionProperties(config);
 
         if (oracleConfig.isTlsEnabled()) {
             requireNonNull(oracleConfig.getTrustStorePath(), "oracle.tls.truststore-path is null");

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -70,8 +70,8 @@ public class OracleClientModule
         return new DriverConnectionFactory(
                 new OracleDriver(),
                 config.getConnectionUrl(),
-                Optional.empty(),
-                Optional.empty(),
+                Optional.ofNullable(config.getUserCredentialName()),
+                Optional.ofNullable(config.getPasswordCredentialName()),
                 connectionProperties);
     }
 }

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
@@ -56,7 +56,7 @@ public class TestCredentialPassthrough
     @Test
     public void testCredentialPassthrough()
     {
-        oracleQueryRunner.execute(getSession(), "SELECT 1 FROM dual");
+        oracleQueryRunner.execute(getSession(), "CREATE TABLE test_create (a bigint)");
     }
 
     private static QueryRunner createQueryRunner(OracleServerTester oracleServer)

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
@@ -65,7 +65,12 @@ public class TestCredentialPassthrough
     @Test(expectedExceptions = RuntimeException.class)
     public void testCredentialPassthroughFailsWithoutExtraCredentials()
     {
-        oracleQueryRunner.execute(getSession(false), "CREATE TABLE test_create_negative (a bigint)");
+        // Uses a separate catalog (registered fresh here, never previously authenticated) rather
+        // than the "oracle" catalog the positive test already used, so this can't accidentally pass
+        // by reusing an already-authenticated pooled connection instead of actually requiring
+        // extraCredentials.
+        oracleQueryRunner.createCatalog("oracle_negative", "oracle", catalogProperties(oracleServer));
+        oracleQueryRunner.execute(getSession("oracle_negative", false), "CREATE TABLE test_create_negative (a bigint)");
     }
 
     private static QueryRunner createQueryRunner(OracleServerTester oracleServer)
@@ -75,12 +80,7 @@ public class TestCredentialPassthrough
         try {
             queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
             queryRunner.installPlugin(new OraclePlugin());
-            Map<String, String> properties = ImmutableMap.<String, String>builder()
-                    .put("connection-url", oracleServer.getJdbcUrl())
-                    .put("user-credential-name", "oracle.user")
-                    .put("password-credential-name", "oracle.password")
-                    .build();
-            queryRunner.createCatalog("oracle", "oracle", properties);
+            queryRunner.createCatalog("oracle", "oracle", catalogProperties(oracleServer));
 
             return queryRunner;
         }
@@ -90,13 +90,28 @@ public class TestCredentialPassthrough
         }
     }
 
+    private static Map<String, String> catalogProperties(OracleServerTester oracleServer)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("connection-url", oracleServer.getJdbcUrl())
+                .put("user-credential-name", "oracle.user")
+                .put("password-credential-name", "oracle.password")
+                .put("allow-drop-table", "true")
+                .build();
+    }
+
     private static Session getSession(boolean withExtraCredentials)
+    {
+        return getSession("oracle", withExtraCredentials);
+    }
+
+    private static Session getSession(String catalog, boolean withExtraCredentials)
     {
         Map<String, String> extraCredentials = withExtraCredentials
                 ? ImmutableMap.of("oracle.user", OracleServerTester.TEST_USER, "oracle.password", OracleServerTester.TEST_PASS)
                 : ImmutableMap.of();
         return testSessionBuilder()
-                .setCatalog("oracle")
+                .setCatalog(catalog)
                 .setSchema(OracleServerTester.TEST_SCHEMA)
                 .setIdentity(new Identity(
                         OracleServerTester.TEST_USER,

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.oracle;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+/**
+ * Regression test for the Oracle connector's connection factory: per-session extraCredentials
+ * (user-credential-name / password-credential-name) must be honored, not silently ignored.
+ * connection-user / connection-password are deliberately left unset in the catalog properties, so
+ * the query below can only succeed via the session's extraCredentials.
+ */
+public class TestCredentialPassthrough
+{
+    private final OracleServerTester oracleServer;
+    private final QueryRunner oracleQueryRunner;
+
+    public TestCredentialPassthrough()
+            throws Exception
+    {
+        oracleServer = new OracleServerTester();
+        oracleQueryRunner = createQueryRunner(oracleServer);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        if (oracleServer != null) {
+            oracleServer.close();
+        }
+    }
+
+    @Test
+    public void testCredentialPassthrough()
+    {
+        oracleQueryRunner.execute(getSession(), "SELECT 1 FROM dual");
+    }
+
+    private static QueryRunner createQueryRunner(OracleServerTester oracleServer)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+            queryRunner.installPlugin(new OraclePlugin());
+            Map<String, String> properties = ImmutableMap.<String, String>builder()
+                    .put("connection-url", oracleServer.getJdbcUrl())
+                    .put("user-credential-name", "oracle.user")
+                    .put("password-credential-name", "oracle.password")
+                    .build();
+            queryRunner.createCatalog("oracle", "oracle", properties);
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    private static Session getSession()
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of(
+                "oracle.user", OracleServerTester.TEST_USER,
+                "oracle.password", OracleServerTester.TEST_PASS);
+        return testSessionBuilder()
+                .setCatalog("oracle")
+                .setSchema(OracleServerTester.TEST_SCHEMA)
+                .setIdentity(new Identity(
+                        OracleServerTester.TEST_USER,
+                        Optional.empty(),
+                        ImmutableMap.of(),
+                        extraCredentials,
+                        ImmutableMap.of(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .build();
+    }
+}

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
@@ -19,11 +19,13 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
@@ -31,14 +33,15 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
  * Regression test for the Oracle connector's connection factory: per-session extraCredentials
  * (user-credential-name / password-credential-name) must be honored, not silently ignored.
  * connection-user / connection-password are deliberately left unset in the catalog properties, so
- * the query below can only succeed via the session's extraCredentials.
+ * the positive-path query below can only succeed via the session's extraCredentials.
  */
 public class TestCredentialPassthrough
 {
-    private final OracleServerTester oracleServer;
-    private final QueryRunner oracleQueryRunner;
+    private OracleServerTester oracleServer;
+    private QueryRunner oracleQueryRunner;
 
-    public TestCredentialPassthrough()
+    @BeforeClass
+    public void createQueryRunner()
             throws Exception
     {
         oracleServer = new OracleServerTester();
@@ -48,15 +51,21 @@ public class TestCredentialPassthrough
     @AfterClass(alwaysRun = true)
     public void destroy()
     {
-        if (oracleServer != null) {
-            oracleServer.close();
-        }
+        closeAllRuntimeException(oracleQueryRunner, oracleServer);
     }
 
     @Test
     public void testCredentialPassthrough()
     {
-        oracleQueryRunner.execute(getSession(), "CREATE TABLE test_create (a bigint)");
+        Session session = getSession(true);
+        oracleQueryRunner.execute(session, "CREATE TABLE test_create (a bigint)");
+        oracleQueryRunner.execute(session, "DROP TABLE test_create");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testCredentialPassthroughFailsWithoutExtraCredentials()
+    {
+        oracleQueryRunner.execute(getSession(false), "CREATE TABLE test_create_negative (a bigint)");
     }
 
     private static QueryRunner createQueryRunner(OracleServerTester oracleServer)
@@ -81,11 +90,11 @@ public class TestCredentialPassthrough
         }
     }
 
-    private static Session getSession()
+    private static Session getSession(boolean withExtraCredentials)
     {
-        Map<String, String> extraCredentials = ImmutableMap.of(
-                "oracle.user", OracleServerTester.TEST_USER,
-                "oracle.password", OracleServerTester.TEST_PASS);
+        Map<String, String> extraCredentials = withExtraCredentials
+                ? ImmutableMap.of("oracle.user", OracleServerTester.TEST_USER, "oracle.password", OracleServerTester.TEST_PASS)
+                : ImmutableMap.of();
         return testSessionBuilder()
                 .setCatalog("oracle")
                 .setSchema(OracleServerTester.TEST_SCHEMA)

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestCredentialPassthrough.java
@@ -57,20 +57,24 @@ public class TestCredentialPassthrough
     @Test
     public void testCredentialPassthrough()
     {
-        Session session = getSession(true);
+        Map<String, String> correctCredentials =
+                ImmutableMap.of("oracle.user", OracleServerTester.TEST_USER, "oracle.password", OracleServerTester.TEST_PASS);
+        Session session = getSession(correctCredentials);
         oracleQueryRunner.execute(session, "CREATE TABLE test_create (a bigint)");
         oracleQueryRunner.execute(session, "DROP TABLE test_create");
     }
 
     @Test(expectedExceptions = RuntimeException.class)
-    public void testCredentialPassthroughFailsWithoutExtraCredentials()
+    public void testCredentialPassthroughFailsWithWrongExtraCredentials()
     {
-        // Uses a separate catalog (registered fresh here, never previously authenticated) rather
-        // than the "oracle" catalog the positive test already used, so this can't accidentally pass
-        // by reusing an already-authenticated pooled connection instead of actually requiring
-        // extraCredentials.
-        oracleQueryRunner.createCatalog("oracle_negative", "oracle", catalogProperties(oracleServer));
-        oracleQueryRunner.execute(getSession("oracle_negative", false), "CREATE TABLE test_create_negative (a bigint)");
+        // Supplies a definitely-wrong password via extraCredentials, rather than omitting
+        // extraCredentials entirely: this directly proves the value actually passed through
+        // extraCredentials is what Oracle authenticates against (the mechanism the original bug
+        // broke), and must fail regardless of any connection reuse/caching, unlike an
+        // omitted-credentials case which could in principle succeed via some other fallback.
+        Map<String, String> wrongCredentials =
+                ImmutableMap.of("oracle.user", OracleServerTester.TEST_USER, "oracle.password", "definitely-wrong-password");
+        oracleQueryRunner.execute(getSession(wrongCredentials), "CREATE TABLE test_create_negative (a bigint)");
     }
 
     private static QueryRunner createQueryRunner(OracleServerTester oracleServer)
@@ -100,18 +104,10 @@ public class TestCredentialPassthrough
                 .build();
     }
 
-    private static Session getSession(boolean withExtraCredentials)
+    private static Session getSession(Map<String, String> extraCredentials)
     {
-        return getSession("oracle", withExtraCredentials);
-    }
-
-    private static Session getSession(String catalog, boolean withExtraCredentials)
-    {
-        Map<String, String> extraCredentials = withExtraCredentials
-                ? ImmutableMap.of("oracle.user", OracleServerTester.TEST_USER, "oracle.password", OracleServerTester.TEST_PASS)
-                : ImmutableMap.of();
         return testSessionBuilder()
-                .setCatalog(catalog)
+                .setCatalog("oracle")
                 .setSchema(OracleServerTester.TEST_SCHEMA)
                 .setIdentity(new Identity(
                         OracleServerTester.TEST_USER,


### PR DESCRIPTION
## Description

Fixes #28350.

`OracleClientModule.connectionFactory()` builds its own `DriverConnectionFactory`
to add Oracle-specific connection properties (TLS truststore,
`oracle.jdbc.includeSynonyms`), so it bypasses the
`DriverConnectionFactory(Driver, BaseJdbcConfig)` convenience constructor that
every other JDBC connector relies on for per-session credential passthrough.
In doing so it hardcoded the `userCredentialName`/`passwordCredentialName`
constructor arguments to `Optional.empty()`, silently dropping support for
the standard `user-credential-name`/`password-credential-name` config
properties. Oracle is the only Presto JDBC connector where session
`extraCredentials` are ignored - confirmed by comparing against
`presto-mysql`, which relies on the default wiring and works correctly.

This passes `config.getUserCredentialName()`/`getPasswordCredentialName()`
through instead, matching that default pattern.

## Testing

Added `TestCredentialPassthrough`, modeled directly on `presto-mysql`'s test
of the same name. `connection-user`/`connection-password` are deliberately
left unset in the catalog properties, so the test query can only succeed if
the session's `extraCredentials` are actually used - this would fail before
this change and pass after.

I wasn't able to complete a full local reactor build/test run in my
environment (a Windows machine without Docker) - the TestContainers-based
Oracle test itself needs Docker to run, and a full `-am` reactor build here
also hits unrelated pre-existing Windows-generated-code/checkstyle issues in
modules I didn't touch (`presto-parser`, `presto-thrift-api`, generated
ANTLR/Thrift sources). I did verify `presto-oracle`'s own source changes
compile correctly in isolation and match the working `presto-mysql` pattern
exactly. I'd appreciate a CI run / maintainer review to confirm the test
itself passes.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Fix the Oracle connector ignoring per-session extraCredentials
  (user-credential-name/password-credential-name), always using the
  static connection-user/connection-password instead.
```

## Summary by Sourcery

Fix Oracle credential passthrough so session-provided credentials are used for JDBC authentication.

Bug Fixes:
- Honor per-session extra credentials configured through user-credential-name and password-credential-name in the Oracle connector instead of silently falling back to static connection credentials.

Tests:
- Add Oracle connector regression tests covering successful and failed authentication through session extra credentials.