### PR TITLE
feat(planner): Enable segmented aggregation for partial aggregations

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSegmentedAggregation.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSegmentedAggregation.java
@@ -18,10 +18,13 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.SEGMENTED_AGGREGATION_ENABLED;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.ORDER_BASED_EXECUTION_ENABLED;
@@ -35,6 +38,9 @@ import static io.airlift.tpch.TpchTable.CUSTOMER;
 import static io.airlift.tpch.TpchTable.LINE_ITEM;
 import static io.airlift.tpch.TpchTable.NATION;
 import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestSegmentedAggregation
         extends AbstractTestQueryFramework
@@ -169,11 +175,94 @@ public class TestSegmentedAggregation
         }
     }
 
+    /**
+     * SELECT agg FROM t1 JOIN t2 ON t1.k = t2.k GROUP BY t1.g1, t2.g2, where t1 and t2 are both bucketed
+     * by k and t1 is sorted by g1.
+     * <p>
+     * The join is colocated, so no exchange sits under it and the join output keeps the probe side's sort
+     * on g1. The grouping keys do not contain the bucket key, so the aggregation is repartitioned and split
+     * into a final over a partial, and the partial is pushed below that exchange onto the join output where
+     * g1 is still a pre-grouped prefix. Only the partial can be segmented: the exchange above it does not
+     * preserve the sort order, which is why {@link com.facebook.presto.sql.planner.optimizations.AddLocalExchanges}
+     * cannot compute this prefix.
+     */
+    @Test
+    public void testPartialAggregationBelowExchangeIsSegmented()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        try {
+            queryRunner.execute("CREATE TABLE test_segmented_partial_agg_t1 WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey'], \n" +
+                    "  sorted_by = ARRAY['name'], partitioned_by=array['ds'], \n" +
+                    "  format = 'DWRF' ) AS \n" +
+                    // Selecting the needed columns rather than *: orders has a date column and DWRF
+                    // does not support the date type.
+                    "SELECT custkey, name, nationkey, '2021-07-11' as ds FROM customer\n");
+            queryRunner.execute("CREATE TABLE test_segmented_partial_agg_t2 WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey'], \n" +
+                    "  partitioned_by=array['ds'], \n" +
+                    "  format = 'DWRF' ) AS \n" +
+                    "SELECT custkey, orderkey, orderstatus, '2021-07-11' as ds FROM orders\n");
+
+            @Language("SQL") String sql = "SELECT t1.name, t2.orderstatus, COUNT(*) \n" +
+                    "FROM test_segmented_partial_agg_t1 t1 JOIN test_segmented_partial_agg_t2 t2 ON t1.custkey = t2.custkey \n" +
+                    "WHERE t1.ds = '2021-07-11' AND t2.ds = '2021-07-11' \n" +
+                    "GROUP BY 1, 2";
+
+            assertPlanText(segmentedAggregationEnabled(), sql, "Aggregate(PARTIAL)(SEGMENTED, [name])");
+            assertNoPlanText(segmentedAggregationDisabled(), sql, "SEGMENTED");
+
+            // Segmenting the partial aggregation must not change the result.
+            assertQueryWithSameQueryRunner(segmentedAggregationEnabled(), sql, segmentedAggregationDisabled());
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS test_segmented_partial_agg_t1");
+            queryRunner.execute("DROP TABLE IF EXISTS test_segmented_partial_agg_t2");
+        }
+    }
+
+    private void assertPlanText(Session session, @Language("SQL") String sql, String expected)
+    {
+        String plan = (String) computeActual(session, "EXPLAIN (TYPE DISTRIBUTED) " + sql).getOnlyValue();
+        assertTrue(plan.contains(expected), format("Expected the plan to contain [%s] but it was:%n%s", expected, plan));
+    }
+
+    private void assertNoPlanText(Session session, @Language("SQL") String sql, String unexpected)
+    {
+        String plan = (String) computeActual(session, "EXPLAIN (TYPE DISTRIBUTED) " + sql).getOnlyValue();
+        assertFalse(plan.contains(unexpected), format("Did not expect the plan to contain [%s] but it was:%n%s", unexpected, plan));
+    }
+
     private Session orderBasedExecutionEnabled()
     {
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setCatalogSessionProperty(HIVE_CATALOG, ORDER_BASED_EXECUTION_ENABLED, "true")
                 .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, "true")
                 .build();
+    }
+
+    /**
+     * Pins the join so the sorted table is the probe: the join output only carries the probe side's
+     * local properties.
+     */
+    private Session segmentedAggregation(boolean enabled)
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, ORDER_BASED_EXECUTION_ENABLED, "true")
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, enabled ? "true" : "false")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "NONE")
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .build();
+    }
+
+    private Session segmentedAggregationEnabled()
+    {
+        return segmentedAggregation(true);
+    }
+
+    private Session segmentedAggregationDisabled()
+    {
+        return segmentedAggregation(false);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -1174,7 +1174,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.of(
                                 new PushPartialAggregationThroughJoin(),
-                                new PushPartialAggregationThroughExchange(metadata.getFunctionAndTypeManager(), featuresConfig.isNativeExecutionEnabled()))),
+                                new PushPartialAggregationThroughExchange(metadata, metadata.getFunctionAndTypeManager(), featuresConfig.isNativeExecutionEnabled()))),
                 // MergePartialAggregationsWithFilter should immediately follow PushPartialAggregationThroughExchange
                 new MergePartialAggregationsWithFilter(metadata.getFunctionAndTypeManager()),
                 new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -21,6 +21,8 @@ import com.facebook.presto.matching.Capture;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.function.AggregationFunctionImplementation;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
@@ -35,6 +37,8 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.planner.PlannerUtils;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.ActualProperties;
+import com.facebook.presto.sql.planner.optimizations.LocalProperties;
 import com.facebook.presto.sql.planner.optimizations.SymbolMapper;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.google.common.collect.ImmutableList;
@@ -45,10 +49,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getPartialAggregationByteReductionThreshold;
 import static com.facebook.presto.SystemSessionProperties.getPartialAggregationStrategy;
+import static com.facebook.presto.SystemSessionProperties.isSegmentedAggregationEnabled;
 import static com.facebook.presto.SystemSessionProperties.isStreamingForPartialAggregationEnabled;
 import static com.facebook.presto.SystemSessionProperties.usePartialAggregationHistory;
 import static com.facebook.presto.cost.PartialAggregationStatsEstimate.isUnknown;
@@ -61,6 +67,8 @@ import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel;
 import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy.AUTOMATIC;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy.NEVER;
+import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
+import static com.facebook.presto.sql.planner.optimizations.PropertyDerivations.derivePropertiesRecursively;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
@@ -69,17 +77,20 @@ import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public class PushPartialAggregationThroughExchange
         implements Rule<AggregationNode>
 {
+    private final Metadata metadata;
     private final FunctionAndTypeManager functionAndTypeManager;
     private final boolean nativeExecution;
     private String statsSource;
 
-    public PushPartialAggregationThroughExchange(FunctionAndTypeManager functionAndTypeManager, boolean nativeExecution)
+    public PushPartialAggregationThroughExchange(Metadata metadata, FunctionAndTypeManager functionAndTypeManager, boolean nativeExecution)
     {
+        this.metadata = requireNonNull(metadata, "metadata is null");
         this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionManager is null");
         this.nativeExecution = nativeExecution;
     }
@@ -200,6 +211,97 @@ public class PushPartialAggregationThroughExchange
         }
     }
 
+    /**
+     * Marks a partial aggregation as segmented when its input is already grouped on a prefix of the
+     * grouping keys, so that the operator can flush a group as soon as the prefix changes instead of
+     * holding every group until the memory cap is hit. Controlled by {@code segmented_aggregation_enabled},
+     * the same session property that enables segmented aggregation elsewhere.
+     * <p>
+     * {@link com.facebook.presto.sql.planner.optimizations.AddLocalExchanges} already applies that
+     * property, but only to a SINGLE aggregation, and it runs before this rule. Whenever the grouping keys
+     * require a repartition, that aggregation sits above the exchange and its source is a remote source
+     * with no local properties, so the prefix it computes is always empty. The partial aggregation is the
+     * only one that ends up on the ordered input: this rule matches exchanges with no ordering scheme, so
+     * nothing above the exchange can be grouped on the input's order. It is also the aggregation that
+     * benefits, because it is the one holding every group until it reaches its memory limit.
+     * <p>
+     * A stale prefix would only cost an extra flush, never a wrong answer: a partial aggregation is
+     * allowed to emit a group at any point and the final aggregation merges the pieces. The pre-grouped
+     * variables are still dropped on the final aggregation, where the guarantee would be load bearing.
+     */
+    private AggregationNode withSegmentedPreGroupedVariables(AggregationNode partial, PlanNode source, Context context)
+    {
+        // Only ever a partial: looking through a local exchange, and tolerating a prefix that turns out not
+        // to hold, are both only safe because a partial aggregation may flush a group early. On a final
+        // aggregation the same prefix would produce a wrong answer, and a final does normally sit directly
+        // above a local exchange.
+        checkState(partial.getStep() == PARTIAL, "expected a partial aggregation, found %s", partial.getStep());
+        if (!isSegmentedAggregationEnabled(context.getSession()) || partial.getGroupingKeys().isEmpty()) {
+            return partial;
+        }
+        if (!partial.getPreGroupedVariables().isEmpty()) {
+            // Something already decided how this aggregation is grouped, currently only
+            // streaming_for_partial_aggregation_enabled, which marks every grouping key. Deriving a prefix
+            // here would narrow that decision rather than add to it, so leave it alone.
+            return partial;
+        }
+
+        List<VariableReferenceExpression> groupingKeys = partial.getGroupingKeys();
+        // PropertyDerivations does not understand a GroupReference, so the memo subtree is materialized first.
+        ActualProperties properties = derivePropertiesRecursively(resolveGroupReferences(source, context.getLookup()), metadata, context.getSession());
+        List<LocalProperty<VariableReferenceExpression>> inputOrder = properties.getLocalProperties();
+        if (inputOrder.isEmpty()) {
+            return partial;
+        }
+        // match() returns the grouping keys that are NOT covered by the input's local properties;
+        // an empty result means every key is pre-grouped. See AddLocalExchanges#visitAggregation.
+        // match() returns one element per desired property, and a single GroupingProperty was requested.
+        List<Optional<LocalProperty<VariableReferenceExpression>>> match = LocalProperties.match(inputOrder, LocalProperties.grouped(groupingKeys));
+        checkState(match.size() == 1, "expected a single match result, found %s", match.size());
+        List<VariableReferenceExpression> preGroupedVariables;
+        if (!match.get(0).isPresent()) {
+            // An empty match means the input is already grouped on every grouping key, so the aggregation
+            // can stream. Note this is only claimed because the input actually reports the property, unlike
+            // streaming_for_partial_aggregation_enabled, which marks every key regardless of the input.
+            preGroupedVariables = groupingKeys;
+        }
+        else if (match.get(0).get().getColumns().size() < groupingKeys.size()) {
+            // Some, but not all, of the grouping keys are pre-grouped: the match holds the ones that are not.
+            // Only the leading one is claimed. The operator flushes whenever any pre-grouped variable
+            // changes, so the shortest prefix flushes the least, at the cost of holding the remaining keys
+            // in the hash table for longer, and a shorter prefix is always weaker than what the input
+            // reports. Leading is taken in the order of the input's properties, not of the grouping keys,
+            // so it is the column the input changes on least often.
+            Set<VariableReferenceExpression> preGrouped = groupingKeys.stream()
+                    .filter(groupingKey -> !match.get(0).get().getColumns().contains(groupingKey))
+                    .collect(toImmutableSet());
+            preGroupedVariables = inputOrder.stream()
+                    .flatMap(property -> property.getColumns().stream())
+                    .filter(preGrouped::contains)
+                    .findFirst()
+                    .map(ImmutableList::of)
+                    .orElse(ImmutableList.of());
+            if (preGroupedVariables.isEmpty()) {
+                return partial;
+            }
+        }
+        else {
+            // Nothing is pre-grouped.
+            return partial;
+        }
+        return new AggregationNode(
+                partial.getSourceLocation(),
+                partial.getId(),
+                partial.getSource(),
+                partial.getAggregations(),
+                partial.getGroupingSets(),
+                preGroupedVariables,
+                partial.getStep(),
+                partial.getHashVariable(),
+                partial.getGroupIdVariable(),
+                partial.getAggregationId());
+    }
+
     private PlanNode pushPartial(AggregationNode aggregation, ExchangeNode exchange, Context context)
     {
         List<PlanNode> partials = new ArrayList<>();
@@ -216,7 +318,7 @@ public class PushPartialAggregationThroughExchange
             }
 
             SymbolMapper symbolMapper = mappingsBuilder.build();
-            AggregationNode mappedPartial = symbolMapper.map(aggregation, source, context.getIdAllocator());
+            AggregationNode mappedPartial = withSegmentedPreGroupedVariables(symbolMapper.map(aggregation, source, context.getIdAllocator()), source, context);
 
             Assignments.Builder assignments = Assignments.builder();
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -109,6 +109,7 @@ import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Glo
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.partitionedOnCoalesce;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.streamPartitionedOn;
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -518,11 +519,14 @@ public class PropertyDerivations
                     constants.putAll(buildProperties.getConstants());
 
                     if (node.isCrossJoin()) {
-                        // Cross join preserves only constants from probe and build sides.
-                        // Cross join doesn't preserve sorting or grouping local properties on either side.
+                        // A cross join emits the probe once per build row, so a run of equal probe values
+                        // is repeated and the probe's local properties no longer hold. The exception is a
+                        // build side that produces at most one row: the probe then passes through with the
+                        // build's columns appended, keeping its order. Only constants survive from the
+                        // build side either way.
                         return ActualProperties.builder()
                                 .global(probeProperties)
-                                .local(ImmutableList.of())
+                                .local(isScalar(node.getRight()) ? probeProperties.getLocalProperties() : ImmutableList.of())
                                 .constants(constants)
                                 .build();
                     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
@@ -32,6 +32,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.derivePropertiesRecursively;
 import static com.facebook.presto.util.Failures.checkArgument;
 
@@ -79,6 +81,14 @@ public class ValidateStreamingAggregations
         public Void visitAggregation(AggregationNode node, Void context)
         {
             if (node.getPreGroupedVariables().isEmpty()) {
+                return null;
+            }
+
+            // A partial or intermediate aggregation may emit a group at any point, and the final
+            // aggregation merges whatever it emits, so its pre-grouped variables are a hint about where
+            // the input is likely to change rather than a guarantee about how it is grouped. Requiring the
+            // input to actually be grouped only makes sense where flushing early would change the result.
+            if (node.getStep() != FINAL && node.getStep() != SINGLE) {
                 return null;
             }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchange.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchange.java
@@ -45,7 +45,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testPartialAggregationAdded()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
@@ -70,7 +70,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testNoPartialAggregationWhenDisabled()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "NEVER")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
@@ -90,7 +90,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testNoPartialAggregationWhenReductionBelowThreshold()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);
@@ -116,7 +116,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testNoPartialAggregationWhenReductionBelowThresholdUsingPartialAggregationStats()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .setSystemProperty(USE_PARTIAL_AGGREGATION_HISTORY, "true")
                 .on(p -> constructAggregation(p))
@@ -132,7 +132,7 @@ public class TestPushPartialAggregationThroughExchange
     public void testNoPartialAggregationWhenReductionAboveThresholdUsingPartialAggregationStats()
     {
         // when use_partial_aggregation_history=true, we use row count reduction (instead of bytes) to decide if partial aggregation is useful
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .setSystemProperty(USE_PARTIAL_AGGREGATION_HISTORY, "true")
                 .on(p -> constructAggregation(p))
@@ -147,7 +147,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testNoPartialAggregationWhenRowReductionBelowThreshold()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .setSystemProperty(USE_PARTIAL_AGGREGATION_HISTORY, "true")
                 .on(p -> constructAggregation(p))
@@ -162,7 +162,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testPartialAggregationWhenRowReductionAboveThreshold()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .setSystemProperty(USE_PARTIAL_AGGREGATION_HISTORY, "true")
                 .on(p -> constructAggregation(p))
@@ -181,7 +181,7 @@ public class TestPushPartialAggregationThroughExchange
     @Test
     public void testPartialAggregationEnabledWhenNotConfident()
     {
-        tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .setSystemProperty(PARTIAL_AGGREGATION_STRATEGY, "AUTOMATIC")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchangeOrdering.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchangeOrdering.java
@@ -39,7 +39,7 @@ public class TestPushPartialAggregationThroughExchangeOrdering
         // preserves aggregation output variable ordering when creating PARTIAL and FINAL
         // AggregationNodes. HashMap would scramble "sum_x" and "min_y" causing
         // BIGINT vs VARCHAR type mismatch at PartitionedOutput in Velox.
-        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BIGINT);
                     VariableReferenceExpression x = p.variable("x", BIGINT);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSegmentedPartialAggregation.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSegmentedPartialAggregation.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.SystemSessionProperties.SEGMENTED_AGGREGATION_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.roundRobinExchange;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests {@code segmented_aggregation_enabled} for a partial aggregation pushed below an exchange, which is
+ * the only aggregation that ends up on the ordered input.
+ */
+public class TestSegmentedPartialAggregation
+        extends BaseRuleTest
+{
+    /**
+     * Sorted on {@code a} and grouped by {@code (a, b)}: the partial can flush whenever {@code a} changes.
+     */
+    @Test
+    public void testPrefixOfGroupingKeysIsSegmented()
+    {
+        PlanNode result = applyRule(true, (p, variables) -> p.sort(ImmutableList.of(variables.get(0)), values(p, variables)));
+        assertEquals(preGroupedNames(result), ImmutableList.of("a"));
+    }
+
+    /**
+     * Sorted on both grouping keys, so the partial aggregation can stream and needs no hash table.
+     */
+    @Test
+    public void testAllGroupingKeysPreGroupedStreams()
+    {
+        PlanNode result = applyRule(true, (p, variables) -> p.sort(ImmutableList.of(variables.get(0), variables.get(1)), values(p, variables)));
+        assertEquals(preGroupedNames(result), ImmutableList.of("a", "b"));
+    }
+
+    /**
+     * Sorted on {@code (a, b)} and grouped by {@code (a, b, c)}: only {@code a} is claimed. The operator
+     * flushes whenever any pre-grouped variable changes, so claiming the shortest prefix flushes the least,
+     * at the cost of holding {@code (b, c)} in the hash table for longer.
+     */
+    @Test
+    public void testOnlyTheLeadingSortedColumnIsClaimed()
+    {
+        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, "true")
+                .setSystemProperty(STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED, "false")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression c = p.variable("c", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    return p.aggregation(agg -> agg
+                            .addAggregation(p.variable("sum_x", BIGINT), p.rowExpression("sum(x)"))
+                            .singleGroupingSet(a, b, c)
+                            .step(PARTIAL)
+                            .source(p.gatheringExchange(
+                                    ExchangeNode.Scope.REMOTE_STREAMING,
+                                    p.sort(ImmutableList.of(a, b), p.values(a, b, c, x)))));
+                })
+                .get();
+        assertEquals(preGroupedNames(result), ImmutableList.of("a"), "Only the leading sorted column should be claimed");
+    }
+
+    /**
+     * A cross join against a single row keeps the probe's order: the nested loop join emits the probe
+     * unchanged with the build's columns appended, so the input is still grouped for the aggregation above
+     * it. This is the shape of a broadcast scalar, such as a total joined onto every row.
+     */
+    @Test
+    public void testOrderSurvivesCrossJoinWithScalarBuild()
+    {
+        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, "true")
+                .setSystemProperty(STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED, "false")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression total = p.variable("total", BIGINT);
+                    PlanNode scalarBuild = p.aggregation(agg -> agg
+                            .addAggregation(total, p.rowExpression("count()"))
+                            .globalGrouping()
+                            .source(p.values(p.variable("ignored", BIGINT))));
+                    return p.aggregation(agg -> agg
+                            .addAggregation(p.variable("sum_x", BIGINT), p.rowExpression("sum(x)"))
+                            .singleGroupingSet(a, b)
+                            .step(PARTIAL)
+                            .source(p.gatheringExchange(
+                                    ExchangeNode.Scope.REMOTE_STREAMING,
+                                    p.join(
+                                            JoinType.INNER,
+                                            p.sort(ImmutableList.of(a), p.values(a, b, x)),
+                                            scalarBuild))));
+                })
+                .get();
+        assertEquals(preGroupedNames(result), ImmutableList.of("a"), "A scalar cross join must not hide the input's order");
+    }
+
+    /**
+     * The order is not claimed across a local exchange. A local exchange splits the input into streams, and
+     * a source with several drivers feeds it pages from different splits, so the runs an aggregation would
+     * flush on are interleaved rather than merely shortened. Property derivation reports no local
+     * properties for one, and this rule does not second guess it.
+     */
+    @Test
+    public void testOrderIsNotClaimedAcrossLocalExchange()
+    {
+        PlanNode result = applyRule(true, (p, variables) -> roundRobinExchange(
+                p.getIdAllocator().getNextId(),
+                ExchangeNode.Scope.LOCAL,
+                p.sort(ImmutableList.of(variables.get(0)), values(p, variables))));
+        assertTrue(preGroupedNames(result).isEmpty(), "A local exchange does not preserve the input's order");
+    }
+
+    /**
+     * streaming_for_partial_aggregation_enabled marks every grouping key, and segmenting must not narrow
+     * that to a prefix when both properties are on.
+     */
+    @Test
+    public void testStreamingForPartialAggregationIsNotNarrowed()
+    {
+        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, "true")
+                .setSystemProperty(STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    return p.aggregation(agg -> agg
+                            .addAggregation(p.variable("sum_x", BIGINT), p.rowExpression("sum(x)"))
+                            .singleGroupingSet(a, b)
+                            .preGroupedVariables(a, b)
+                            .step(PARTIAL)
+                            .source(p.gatheringExchange(
+                                    ExchangeNode.Scope.REMOTE_STREAMING,
+                                    p.sort(ImmutableList.of(a), p.values(a, b, x)))));
+                })
+                .get();
+        assertEquals(preGroupedNames(result), ImmutableList.of("a", "b"), "An existing pre-grouped decision must be left alone");
+    }
+
+    @Test
+    public void testUnsortedSourceIsNotSegmented()
+    {
+        PlanNode result = applyRule(true, (p, variables) -> values(p, variables));
+        assertTrue(preGroupedNames(result).isEmpty(), "An unsorted input has no pre-grouped prefix");
+    }
+
+    @Test
+    public void testDisabledByDefault()
+    {
+        PlanNode result = applyRule(false, (p, variables) -> p.sort(ImmutableList.of(variables.get(0)), values(p, variables)));
+        assertTrue(preGroupedNames(result).isEmpty(), "No pre-grouped variables expected when the session property is off");
+    }
+
+    private static PlanNode values(PlanBuilder planBuilder, List<VariableReferenceExpression> variables)
+    {
+        return planBuilder.values(variables.get(0), variables.get(1), variables.get(2));
+    }
+
+    /**
+     * Builds {@code PARTIAL aggregation on (a, b) -> remote exchange -> source} and applies the rule, which
+     * pushes the aggregation below the exchange.
+     */
+    private PlanNode applyRule(boolean enabled, BiFunction<PlanBuilder, List<VariableReferenceExpression>, PlanNode> source)
+    {
+        return tester().assertThat(new PushPartialAggregationThroughExchange(tester().getMetadata(), getFunctionManager(), false))
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, enabled ? "true" : "false")
+                .setSystemProperty(STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED, "false")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    return p.aggregation(agg -> agg
+                            .addAggregation(p.variable("sum_x", BIGINT), p.rowExpression("sum(x)"))
+                            .singleGroupingSet(a, b)
+                            .step(PARTIAL)
+                            .source(p.gatheringExchange(
+                                    ExchangeNode.Scope.REMOTE_STREAMING,
+                                    source.apply(p, ImmutableList.of(a, b, x)))));
+                })
+                .get();
+    }
+
+    /**
+     * The rule rewrites the exchange so that every branch is {@code Project(PARTIAL aggregation)}. Walk the
+     * result structurally: the untouched parts of the plan are still group references, which cannot be
+     * traversed.
+     */
+    private static List<String> preGroupedNames(PlanNode plan)
+    {
+        assertEquals(plan.getSources().size(), 1, "Expected a single exchange branch");
+        ProjectNode project = (ProjectNode) plan.getSources().get(0);
+        AggregationNode partial = (AggregationNode) project.getSource();
+        assertEquals(partial.getStep(), PARTIAL);
+        return partial.getPreGroupedVariables().stream()
+                .map(VariableReferenceExpression::getName)
+                .collect(toImmutableList());
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
 
 public class TestValidateStreamingAggregations
@@ -86,6 +87,27 @@ public class TestValidateStreamingAggregations
                                                         nationTableHandle,
                                                         ImmutableList.of(p.variable("nationkey", BIGINT)),
                                                         ImmutableMap.of(p.variable("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)))))));
+    }
+
+    /**
+     * The same plan that fails for a SINGLE aggregation is accepted for a partial one. A partial
+     * aggregation may emit a group at any point and the final aggregation merges the pieces, so its
+     * pre-grouped variables say where the input is expected to change rather than guaranteeing how it is
+     * grouped.
+     */
+    @Test
+    public void testPartialAggregationIsNotValidated()
+    {
+        validatePlan(
+                p -> p.aggregation(
+                        a -> a.step(PARTIAL)
+                                .singleGroupingSet(p.variable("nationkey"))
+                                .preGroupedVariables(p.variable("nationkey"))
+                                .source(
+                                        p.tableScan(
+                                                nationTableHandle,
+                                                ImmutableList.of(p.variable("nationkey", BIGINT)),
+                                                ImmutableMap.of(p.variable("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT))))));
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Streaming aggregation with input not grouped on the grouping keys")


### PR DESCRIPTION
## Description

`segmented_aggregation_enabled` lets an aggregation flush a group as soon as the pre-grouped prefix of its grouping keys changes, instead of holding every group until it reaches its memory limit. This makes it apply to a partial aggregation that has been pushed below an exchange.

Three changes:

1. `PushPartialAggregationThroughExchange` derives the input's local properties at the position the partial aggregation actually lands, and marks it segmented there. Only the leading pre-grouped column is claimed: the operator flushes whenever any pre-grouped variable changes, so the shortest prefix flushes the least, at the cost of holding the remaining keys in the hash table for longer. A shorter prefix is always weaker than what the input reports, so it stays valid.

2. `PropertyDerivations` keeps the probe side's local properties across a cross join whose build side produces at most one row. They were dropped for every cross join, but the nested loop join keeps the page with more rows whole and repeats the smaller one, so a single row build leaves the probe's order intact. This is the shape of a broadcast scalar, such as a total joined onto every row.

3. `ValidateStreamingAggregations` is scoped to final and single aggregations.

## Motivation and Context

The pre-grouped prefix is only ever computed by `AddLocalExchanges`, which requires the aggregation to still be `SINGLE` and runs before it is split. Whenever the grouping keys need a repartition, that aggregation sits above the remote exchange and its source is a remote source with no local properties, so the prefix is always empty. Segmented aggregation therefore cannot engage in exactly the distributed plans where it would pay.

The partial aggregation is the one that ends up on the ordered input, since this rule pushes it below the exchange, and it is also the aggregation that benefits, because it is the side that accumulates every group. The final aggregation cannot be segmented at all: the rule only matches exchanges with no ordering scheme, so nothing above the exchange is grouped on the input's order.

Scoping the validator is required by the above and is correct on its own terms. It verifies that the input of an aggregation with pre-grouped variables really is grouped on them, which is the right check where flushing a group early would change the result. A partial or intermediate aggregation may emit a group at any point regardless, and the final merges the pieces, so for those the pre-grouped variables describe where the input is expected to change rather than guaranteeing how it is grouped, and validating them as a guarantee rejects plans that are correct.

## Impact

Gated by the existing `segmented_aggregation_enabled` session property, which is disabled by default. No new configuration.

With it enabled, a partial aggregation over an input that is grouped on a prefix of its grouping keys, such as a scan of a bucketed table declared `sorted_by` those columns, is marked segmented and bounds the number of groups it holds between flushes. Plans are unchanged when the property is off, and unchanged when the input reports no usable order.

The cross join derivation change applies regardless of the property. It only ever adds local properties that were previously discarded, so it can remove a redundant local exchange or sort above such a join.

## Test Plan

- `TestSegmentedPartialAggregation`: a sorted prefix is segmented; only the leading sorted column is claimed when several are available; all grouping keys pre-grouped streams instead; the order is not claimed across a local exchange; an unsorted input is not segmented; nothing happens when the property is off; and the order survives a cross join with a scalar build.
- `TestValidateStreamingAggregations`: a partial aggregation whose pre-grouped variables the input does not corroborate is accepted, where the same plan is still rejected for a single aggregation.
- `TestSegmentedAggregation` (Hive): end to end on a bucketed table declared `sorted_by`, joined on its bucket key, asserting the `Aggregate(PARTIAL)(SEGMENTED, [...])` marker appears with the property on, does not appear with it off, and that results are identical either way.
- Existing suites that depend on derived properties pass unchanged: `TestAddExchanges`, `TestAddExchangesPlans`, `TestAddLocalExchanges`, `TestEliminateSorts`, `TestPushPartialAggregationThroughExchange`, `TestPushPartialAggregationThroughExchangeOrdering`, `TestMergePartialAggregationsWithFilter`, `TestPushPartialAggregationThroughJoin`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve ``segmented_aggregation_enabled`` so that it also applies to a partial aggregation pushed below an exchange, when the input of that exchange is grouped on a prefix of the grouping keys. Previously the property had no effect whenever the grouping keys required a repartition.
* Improve local property derivation to keep the probe side's properties across a cross join whose build side produces at most one row, instead of discarding them.
```

## Summary by Sourcery

Enable segmented aggregation for partial aggregations pushed below exchanges and relax streaming aggregation validation to apply only where early flushing can affect correctness.

New Features:
- Support segmented aggregation for partial aggregations that are pushed below exchanges when the input is locally grouped on a prefix of the grouping keys.

Bug Fixes:
- Preserve probe-side local properties across cross joins with scalar build sides so downstream operators can rely on input ordering.

Enhancements:
- Scope streaming aggregation validation to final and single aggregations, treating pre-grouped variables on partial aggregations as hints rather than guarantees.
- Update plan optimizer wiring to pass metadata into partial-aggregation pushdown and derive local properties for segmented partial aggregations.

Tests:
- Add planner unit tests covering segmented partial aggregation behavior under various input orders, cross joins, local exchanges, and session property settings.
- Extend streaming aggregation sanity tests to verify that partial aggregations with unsupported pre-grouped variables are accepted.
- Add an end-to-end Hive test ensuring segmented partial aggregations appear in plans only when enabled and produce identical query results.