### PR TITLE
chore(deps): Upgrade openlineage to mitigate CVE-2026-40984, CVE-2026-40983

### DIFF
--- a/presto-openlineage-event-listener/pom.xml
+++ b/presto-openlineage-event-listener/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.openlineage</groupId>
             <artifactId>openlineage-java</artifactId>
-            <version>1.47.1</version>
+            <version>1.52.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
+++ b/presto-openlineage-event-listener/src/main/java/com/facebook/presto/plugin/openlineage/OpenLineageEventListener.java
@@ -286,7 +286,11 @@ public class OpenLineageEventListener
                 .namespace(this.jobNamespace)
                 .name(interpolator.interpolate(new OpenLineageJobContext(queryContext, queryMetadata)))
                 .facets(openLineage.newJobFacetsBuilder()
-                        .jobType(openLineage.newJobTypeJobFacet("BATCH", "PRESTO", "QUERY"))
+                        .jobType(openLineage.newJobTypeJobFacetBuilder()
+                                .processingType("BATCH")
+                                .integration("PRESTO")
+                                .jobType("QUERY")
+                                .build())
                         .sql(openLineage.newSQLJobFacet(queryMetadata.getQuery(), "presto"))
                         .build());
     }


### PR DESCRIPTION
## Description
Upgrade openlineage to 1.52.0v to mitigate CVE-2026-40984, CVE-2026-40983

## Motivation and Context

https://www.cve.org/CVERecord?id=CVE-2026-40984
https://www.cve.org/CVERecord?id=CVE-2026-40983

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade OpenLineage to 1.52.0 to mitigate `CVE-2026-40984 <https://www.cve.org/CVERecord?id=CVE-2026-40984>`_ and `CVE-2026-40983 <https://www.cve.org/CVERecord?id=CVE-2026-40983>`_.

```