### PR TITLE
chore(planner): Clean up HBO statistics recording

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -45,7 +45,6 @@ import com.facebook.presto.sql.planner.CanonicalPlan;
 import com.facebook.presto.sql.planner.PlanNodeCanonicalInfo;
 import com.facebook.presto.sql.planner.planPrinter.PlanNodeStats;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
@@ -133,29 +132,11 @@ public class HistoryBasedPlanStatisticsTracker
         // If track_history_stats_from_failed_queries is set to true, we do not require that the query is successful
         boolean trackStatsForFailedQueries = trackHistoryStatsFromFailedQuery(session);
         boolean querySucceed = queryInfo.getFailureInfo() == null;
-        if ((!querySucceed && !trackStatsForFailedQueries) || !queryInfo.getOutputStage().isPresent() || !queryInfo.getOutputStage().get().getPlan().isPresent()) {
+        if ((!querySucceed && !trackStatsForFailedQueries) || !isQueryEligibleForHistoryTracking(queryInfo, session)) {
             return ImmutableMap.of();
         }
 
-        // Only update statistics for SELECT/INSERT queries
-        List<QueryType> queryTypesEnabled = getQueryTypesEnabledForHBO(session);
-        if (!queryInfo.getQueryType().isPresent() || !queryTypesEnabled.contains(queryInfo.getQueryType().get())) {
-            return ImmutableMap.of();
-        }
-
-        if (!queryInfo.isFinalQueryInfo()) {
-            LOG.error("Expected final query info when updating history based statistics: %s", queryInfo);
-            return ImmutableMap.of();
-        }
-
-        StageInfo outputStage = queryInfo.getOutputStage().get();
-        List<StageInfo> allStages = ImmutableList.of();
-        if (querySucceed) {
-            allStages = outputStage.getAllStages();
-        }
-        else if (trackStatsForFailedQueries) {
-            allStages = outputStage.getAllStages().stream().filter(x -> x.getLatestAttemptExecutionInfo().getState().equals(StageExecutionState.FINISHED)).collect(toImmutableList());
-        }
+        List<StageInfo> allStages = getFinishedStages(queryInfo.getOutputStage().get());
 
         if (allStages.isEmpty()) {
             return ImmutableMap.of();
@@ -191,6 +172,11 @@ public class HistoryBasedPlanStatisticsTracker
                 }
 
                 double outputPositions = planNodeStats.getPlanNodeOutputPositions();
+                // A plan node which produced no rows is more often an aberration, for example a node whose driver was
+                // stopped before it produced output, than a property of the query itself
+                if (outputPositions == 0) {
+                    continue;
+                }
                 double outputBytes = adjustedOutputBytes(planNode, planNodeStats);
                 double nullJoinBuildKeyCount = planNodeStats.getPlanNodeNullJoinBuildKeyCount();
                 double joinBuildKeyCount = planNodeStats.getPlanNodeJoinBuildKeyCount();
@@ -255,6 +241,83 @@ public class HistoryBasedPlanStatisticsTracker
             }
         }
         return ImmutableMap.copyOf(planStatisticsMap);
+    }
+
+    private boolean isQueryEligibleForHistoryTracking(QueryInfo queryInfo, Session session)
+    {
+        if (!queryInfo.getOutputStage().isPresent() || !queryInfo.getOutputStage().get().getPlan().isPresent()) {
+            return false;
+        }
+
+        // Only update statistics for SELECT/INSERT queries
+        List<QueryType> queryTypesEnabled = getQueryTypesEnabledForHBO(session);
+        if (!queryInfo.getQueryType().isPresent() || !queryTypesEnabled.contains(queryInfo.getQueryType().get())) {
+            return false;
+        }
+
+        if (!queryInfo.isFinalQueryInfo()) {
+            LOG.error("Expected final query info when updating history based statistics: %s", queryInfo);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the stages whose runtime statistics are recorded as history, which are exactly the stages that reached
+     * {@link StageExecutionState#FINISHED}.
+     * <p>
+     * {@code CANCELED}, {@code ABORTED} and {@code FAILED} stages are all treated as partial executions and excluded:
+     * such a stage processed only part of its input, so its runtime statistics under count rows and bytes, and
+     * recording them would make future estimates for the same plan nodes too small. This is not limited to failed
+     * queries. A successful query cancels a stage as soon as its parent stage is done, which is what happens when a
+     * {@code LIMIT} above it is satisfied, and aborts any stage still running once the query completes.
+     */
+    @VisibleForTesting
+    static List<StageInfo> getFinishedStages(StageInfo outputStage)
+    {
+        return outputStage.getAllStages().stream()
+                .filter(stage -> stage.getLatestAttemptExecutionInfo().getState() == StageExecutionState.FINISHED)
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Returns the plan nodes of the stages which ended in a failure state. Statistics recorded for them by an earlier
+     * run described a run of the stage which completed, and the stage no longer completes, so they are no longer a
+     * good prediction of what the stage does.
+     */
+    private Set<PlanNodeWithHash> getPlanNodesOfFailedStages(QueryInfo queryInfo, Session session)
+    {
+        List<StageInfo> failedStages = queryInfo.getOutputStage().get().getAllStages().stream()
+                .filter(stage -> stage.getLatestAttemptExecutionInfo().getState().isFailure())
+                .collect(toImmutableList());
+        if (failedStages.isEmpty()) {
+            return ImmutableSet.of();
+        }
+
+        Map<CanonicalPlan, PlanNodeCanonicalInfo> canonicalInfoMap = new HashMap<>();
+        queryInfo.getPlanCanonicalInfo().forEach(canonicalPlanWithInfo ->
+                canonicalInfoMap.putIfAbsent(canonicalPlanWithInfo.getCanonicalPlan(), canonicalPlanWithInfo.getInfo()));
+
+        List<PlanCanonicalizationStrategy> canonicalizationStrategies = historyBasedPlanCanonicalizationStrategyList(session);
+        ImmutableSet.Builder<PlanNodeWithHash> planNodesWithHash = ImmutableSet.builder();
+        for (StageInfo stageInfo : failedStages) {
+            if (!stageInfo.getPlan().isPresent()) {
+                continue;
+            }
+            for (PlanNode planNode : forTree(PlanNode::getSources).depthFirstPreOrder(stageInfo.getPlan().get().getRoot())) {
+                if (!planNode.getStatsEquivalentPlanNode().isPresent()) {
+                    continue;
+                }
+                PlanNode statsEquivalentPlanNode = planNode.getStatsEquivalentPlanNode().get();
+                for (PlanCanonicalizationStrategy strategy : canonicalizationStrategies) {
+                    PlanNodeCanonicalInfo canonicalInfo = canonicalInfoMap.get(new CanonicalPlan(statsEquivalentPlanNode, strategy));
+                    if (canonicalInfo != null) {
+                        planNodesWithHash.add(new PlanNodeWithHash(statsEquivalentPlanNode, Optional.of(canonicalInfo.getHash())));
+                    }
+                }
+            }
+        }
+        return planNodesWithHash.build();
     }
 
     private static Set<PlanNodeId> getPlanNodeAppliedDynamicFilter(Map<PlanNodeId, PlanNodeStats> planNodeStatsMap, List<StageInfo> allStages)
@@ -407,10 +470,33 @@ public class HistoryBasedPlanStatisticsTracker
                                     historyBasedSourceInfo.getHistoricalPlanStatisticsEntryInfo().get());
                         }));
 
-        if (!newPlanStatistics.isEmpty()) {
-            historyBasedPlanStatisticsProvider.get().putStats(ImmutableMap.copyOf(newPlanStatistics));
+        Map<PlanNodeWithHash, HistoricalPlanStatistics> statisticsToStore = new HashMap<>(newPlanStatistics);
+        statisticsToStore.putAll(getInvalidatedStatistics(queryInfo, session, newPlanStatistics.keySet()));
+
+        if (!statisticsToStore.isEmpty()) {
+            historyBasedPlanStatisticsProvider.get().putStats(ImmutableMap.copyOf(statisticsToStore));
         }
         historyBasedStatisticsCacheManager.invalidate(queryInfo.getQueryId());
+    }
+
+    /**
+     * Returns empty statistics for every plan node of a failed stage which currently has recorded history, which
+     * overwrites and so drops that history. Plan nodes recorded by this query are left alone.
+     */
+    private Map<PlanNodeWithHash, HistoricalPlanStatistics> getInvalidatedStatistics(QueryInfo queryInfo, Session session, Set<PlanNodeWithHash> recordedPlanNodes)
+    {
+        if (!isQueryEligibleForHistoryTracking(queryInfo, session)) {
+            return ImmutableMap.of();
+        }
+        List<PlanNodeWithHash> planNodesOfFailedStages = getPlanNodesOfFailedStages(queryInfo, session).stream()
+                .filter(planNodeWithHash -> !recordedPlanNodes.contains(planNodeWithHash))
+                .collect(toImmutableList());
+        if (planNodesOfFailedStages.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        return historyBasedPlanStatisticsProvider.get().getStats(planNodesOfFailedStages, getHistoryBasedOptimizerTimeoutLimit(session).toMillis()).entrySet().stream()
+                .filter(entry -> !entry.getValue().getLastRunsStatistics().isEmpty())
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> HistoricalPlanStatistics.empty()));
     }
 
     private class FinalAggregationStatsInfo

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestHistoryBasedPlanStatisticsTracker.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestHistoryBasedPlanStatisticsTracker.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.execution.StageExecutionInfo;
+import com.facebook.presto.execution.StageExecutionState;
+import com.facebook.presto.execution.StageExecutionStats;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker.getFinishedStages;
+import static com.facebook.presto.execution.StageExecutionState.ABORTED;
+import static com.facebook.presto.execution.StageExecutionState.CANCELED;
+import static com.facebook.presto.execution.StageExecutionState.FAILED;
+import static com.facebook.presto.execution.StageExecutionState.FINISHED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHistoryBasedPlanStatisticsTracker
+{
+    private static final QueryId QUERY_ID = new QueryId("test_query");
+
+    @Test
+    public void testAllStagesFinished()
+    {
+        assertStageIds(getFinishedStages(stages(FINISHED, FINISHED, FINISHED)), 0, 1, 2);
+    }
+
+    @Test
+    public void testCanceledStagesAreNotTracked()
+    {
+        // A stage can be canceled while the query itself succeeds, for example when a limit above it is satisfied
+        assertStageIds(getFinishedStages(stages(FINISHED, CANCELED)), 0);
+        assertStageIds(getFinishedStages(stages(FINISHED, FINISHED, CANCELED)), 0, 1);
+        assertTrue(getFinishedStages(stages(CANCELED, CANCELED)).isEmpty());
+    }
+
+    @Test
+    public void testFailedAndAbortedStagesAreNotTracked()
+    {
+        assertStageIds(getFinishedStages(stages(ABORTED, FINISHED)), 1);
+        assertStageIds(getFinishedStages(stages(FAILED, FINISHED)), 1);
+        assertTrue(getFinishedStages(stages(FAILED, ABORTED)).isEmpty());
+    }
+
+    private static void assertStageIds(List<StageInfo> stages, int... expectedStageIds)
+    {
+        assertEquals(
+                stages.stream().map(stage -> stage.getStageId().getId()).collect(toImmutableList()),
+                Arrays.stream(expectedStageIds).boxed().collect(toImmutableList()));
+    }
+
+    /**
+     * Builds a chain of stages where the first state given belongs to the output stage, and every following stage is a
+     * source of the one before it.
+     */
+    private static StageInfo stages(StageExecutionState... states)
+    {
+        StageInfo stage = null;
+        for (int stageId = states.length - 1; stageId >= 0; stageId--) {
+            stage = new StageInfo(
+                    new StageId(QUERY_ID, stageId),
+                    URI.create("http://127.0.0.1"),
+                    Optional.empty(),
+                    new StageExecutionInfo(states[stageId], StageExecutionStats.zero(stageId), ImmutableList.of(), Optional.empty()),
+                    ImmutableList.of(),
+                    stage == null ? ImmutableList.of() : ImmutableList.of(stage),
+                    false);
+        }
+        return stage;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -285,6 +285,38 @@ public class TestHistoryBasedStatsTracking
     }
 
     @Test
+    public void testStatsOfZeroOutputRowsAreNotTracked()
+    {
+        String sql = "SELECT * FROM nation where substr(name, 1, 1) = 'Z'";
+
+        // Every node of this query produces no rows, which is more often an aberration than a property of the query,
+        // so no statistics are written at all
+        executeAndNoHistoryWritten(sql, createSession());
+        assertPlan(sql, anyTree(node(FilterNode.class, any()).withOutputRowCount(Double.NaN)));
+    }
+
+    @Test
+    public void testStatsOfFailedStagesAreInvalidated()
+    {
+        Session session = Session.builder(createSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, "NONE")
+                .build();
+        String sql = "SELECT o.orderstatus, count(*) FROM orders o JOIN lineitem l ON o.orderkey = l.orderkey WHERE length(o.comment) > 10 GROUP BY 1";
+        // Same aggregation over the same join, but the stage computing the aggregation fails
+        String failingSql = "SELECT o.orderstatus, if(count(*) = 0, 1, fail(1, 'failed')) FROM orders o JOIN lineitem l ON o.orderkey = l.orderkey WHERE length(o.comment) > 10 GROUP BY 1";
+
+        executeAndTrackHistory(sql, session);
+        assertPlan(session, sql, anyTree(node(AggregationNode.class, node(ExchangeNode.class, anyTree(any()))).with(validOutputRowCountMatcher())));
+
+        assertQueryFails(session, failingSql, ".*failed.*");
+        getHistoryProvider().waitProcessQueryEvents();
+
+        // History of the aggregation is dropped, since the stage computing it no longer completes
+        assertPlan(session, sql, anyTree(node(AggregationNode.class, node(ExchangeNode.class, anyTree(any()))).withOutputRowCount(Double.NaN)));
+    }
+
+    @Test
     public void testUnion()
     {
         assertPlan(

--- a/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoryBasedRedisStatisticsTracking.java
+++ b/redis-hbo-provider/src/test/java/com/facebook/presto/statistic/TestHistoryBasedRedisStatisticsTracking.java
@@ -203,17 +203,18 @@ public class TestHistoryBasedRedisStatisticsTracking
         checkCompletionService(completionService);
 
         // HBO Stats
-        Map<Character, Integer> rowCountMap = new HashMap<>();
-        rowCountMap.put('A', 2);
-        rowCountMap.put('B', 1);
-        rowCountMap.put('C', 2);
-        rowCountMap.put('D', 0);
-        rowCountMap.put('E', 2);
-        rowCountMap.put('F', 1);
-        rowCountMap.put('G', 1);
-        rowCountMap.put('H', 0);
-        rowCountMap.put('I', 4);
-        rowCountMap.put('J', 2);
+        Map<Character, Double> rowCountMap = new HashMap<>();
+        rowCountMap.put('A', 2D);
+        rowCountMap.put('B', 1D);
+        rowCountMap.put('C', 2D);
+        // No nation name starts with D or H, and statistics of a plan node which produced no rows are not recorded
+        rowCountMap.put('D', Double.NaN);
+        rowCountMap.put('E', 2D);
+        rowCountMap.put('F', 1D);
+        rowCountMap.put('G', 1D);
+        rowCountMap.put('H', Double.NaN);
+        rowCountMap.put('I', 4D);
+        rowCountMap.put('J', 2D);
 
         for (int i = 0; i < 10; i++) {
             char letter = (char) ('A' + i);


### PR DESCRIPTION
## Description

History based optimization recorded the runtime statistics of every stage of a successful query. A stage which did not reach `FINISHED` processed only part of its input, so its row and byte counts are too small, and recording them makes future estimates for the same plan nodes too low.

This is not limited to failed queries. On a successful query, a stage is canceled as soon as its parent stage reaches a terminal state (`SectionExecutionFactory` cancels child stages when a stage is done), which is what happens when a `LIMIT` above it is satisfied; and any stage still running when the query completes is aborted. `PlanNodeStatsSummarizer.aggregateStageStats` does not filter by stage state, and its own comment notes that "a LIMIT clause can cause a query to finish before stats are collected from the leaf stages".

This cleans up what gets recorded:

- Record only from stages which reached `FINISHED`, for successful queries too. This was already the behavior for failed queries, so the success and failure paths now share one code path.
- Skip plan nodes which produced no output rows, since an empty output is more often an aberration than a property of the query.
- Drop statistics already recorded for plan nodes of a stage which failed in this query. Those statistics described a run of the stage which completed, and the stage no longer completes, so they are no longer a good prediction. They are dropped by writing empty `HistoricalPlanStatistics` through the existing `putStats`, so no SPI change is needed. Only failure states (`FAILED`, `ABORTED`) invalidate history; `CANCELED` does not, since cancellation is routine for `LIMIT` queries.

Recording and invalidation now share a single `isQueryEligibleForHistoryTracking` precondition check, so invalidation cannot fire for query types that history based optimization does not track, or for non-final query info.

Failed queries still record statistics from the stages of theirs which did finish; that behavior is unchanged.

## Motivation and Context

Statistics from a partially executed stage are recorded as if they described a full run, which biases future history based estimates low for those plan nodes.

## Impact

No public API or configuration change. Fewer, more accurate history based statistics are recorded: plan nodes in a stage which did not finish, and plan nodes with no output rows, no longer contribute history, and history of plan nodes in a stage which failed is discarded.

## Test Plan

- New unit test `TestHistoryBasedPlanStatisticsTracker` covering stage selection for finished, canceled, aborted and failed stages.
- New end to end tests in `TestHistoryBasedStatsTracking`: `testStatsOfZeroOutputRowsAreNotTracked` and `testStatsOfFailedStagesAreInvalidated`.
- `mvn test -pl presto-tests -Dtest=TestHistoryBasedStatsTracking` passes, 28 tests.
- `TestHistoryBasedRetry` and `TestHiveHistoryBasedStatsTracking` pass.
- `mvn validate` and `mvn modernizer:modernizer` pass on `presto-main-base` and `presto-tests`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve accuracy of history based optimization statistics by recording them only from stages which finished, skipping plan nodes which produced no output rows, and removing statistics of plan nodes belonging to a stage which failed.
```

## Summary by Sourcery

Improve history-based optimization accuracy by recording statistics only from completed stages with meaningful output and removing history invalidated by stage failures.

Bug Fixes:
- Prevent inaccurate history-based optimizer statistics from being recorded for partially executed stages or plan nodes that produce no rows.
- Invalidate existing statistics for plan nodes belonging to failed or aborted stages while preserving routine cancellation behavior.

Enhancements:
- Unify query eligibility checks and apply finished-stage selection consistently for successful and failed queries.

Tests:
- Add unit coverage for selecting statistics from finished stages and excluding canceled, aborted, and failed stages.
- Add end-to-end coverage for zero-output statistics and invalidation after failed stages.
- Update Redis history-based statistics expectations for plan nodes with no output.