### PR TITLE
fix(docs): Remove redundant labels

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/federation.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/federation.rst
@@ -35,8 +35,6 @@ Similar to the installation of Presto, this will hold the following configuratio
   The available catalog configuration properties for a connector are described
   in the respective connector documentation.
 
-.. _jvm_configuration:
-
 JVM Configuration
 ^^^^^^^^^^^^^^^^^
 
@@ -55,8 +53,6 @@ The following provides an example of ``etc/jvm.config``.
     -Xmx12G
     --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
 
-.. _configuration_properties:
-
 Configuration Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -72,8 +68,6 @@ The following provides an example of ``etc/flightshim.properties``.
     flight-shim.server-ssl-certificate-file=/path/to/server.crt
     flight-shim.server-ssl-key-file=/path/to/server.key
 
-.. _authentication:
-
 Authentication
 --------------
 
@@ -83,8 +77,6 @@ cert-key pair ``flight-shim.server-ssl-certificate-file`` and
 include the client cert file with ``client-ssl-certificate-file``. SSL is
 enabled by default, to disable SSL for an unsecure channel (for debugging
 purposes only) add the config ``flight-shim.server-ssl-enabled=false``.
-
-.. _worker_catalog_properties:
 
 Worker Catalog Properties
 -------------------------
@@ -128,8 +120,6 @@ To enable mTLS, the following properties must be configured:
 - ``arrow-flight.client-ssl-certificate``: Path to the client's SSL certificate. Sent to the server for client authentication.
 - ``arrow-flight.client-ssl-key``: Path to the client's SSL private key file. Used to establish the secure connection.
 - ``arrow-flight.server.verify``: When set to true, enables certificate verification.
-
-.. _running_flightshim:
 
 Running FlightShim
 ------------------

--- a/presto-docs/src/main/sphinx/router/deployment.rst
+++ b/presto-docs/src/main/sphinx/router/deployment.rst
@@ -24,15 +24,11 @@ Similar to the installation of Presto, this will hold the following configuratio
 * Config Properties: configuration for the Presto router
 * Router Properties: configuration and rules for running the router
 
-.. _router_node_properties:
-
 Node Properties
 ^^^^^^^^^^^^^^^
 
 The node properties file, ``etc/node.properties``, shares the same configuration
 as the main Presto server. Details can be found at :doc:`/installation/deployment`.
-
-.. _router_jvm_config:
 
 JVM Config
 ^^^^^^^^^^
@@ -50,8 +46,6 @@ The following provides an example of ``etc/jvm.config``.
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -Xmx12G
-
-.. _config_properties:
 
 Config Properties
 ^^^^^^^^^^^^^^^^^
@@ -77,8 +71,6 @@ If Kerberos authentication is required, adding the following configs:
     query-tracker.http-client.authentication.krb5.principal=presto@REMOTE.BIZ
     query-tracker.http-client.authentication.krb5.remote-service-name=HTTP/PRESTO@REMOTE.BIZ
     query-tracker.http-client.authentication.krb5.service-principal-pattern=PATTERN
-
-.. _router_properties:
 
 Router Properties
 ^^^^^^^^^^^^^^^^^
@@ -133,15 +125,11 @@ These properties requires some explanation:
   An optional parameter to specify to the router which credentials to use when communicating
   with Presto coordinator endpoints.
 
-.. _authentication:
-
 Authentication
 ------------------
 The router supports password file based authentication. This can be configured in the same
 way that it is with the regular Presto coordinator but within the router module (the ``etc`` folder
 within presto-router). See :ref:`Password File Authentication <password_file_auth>`.
-
-.. _running_router:
 
 Running Router
 --------------


### PR DESCRIPTION
## Description
The PR removes redundant labels (which are not used elsewhere across the documentation) from the Connector Federation and Deploying Presto Router pages. The change fixes the following warning:
```
./presto/presto-docs/src/main/sphinx/router/deployment.rst:139: WARNING: duplicate label authentication, other instance in ./presto/presto-docs/src/main/sphinx/presto_cpp/federation.rst
```
Relates to https://github.com/prestodb/presto/issues/28270 issue and needed to proceed with PR https://github.com/prestodb/presto/pull/28359.

## Motivation and Context
Reduce the number of warnings during the documentation build process.
The end goal to have zero warnings and enable zero warnings policy for documentation to prevent introducing new issues.

## Impact
_None_

## Test Plan
Build the documentation and check there is no mentioned warning and the number of warnings reduced.
```shell
make clean html SPHINXOPTS=""
```
Before changes: `build succeeded, 5 warnings.`
After changes: `build succeeded, 4 warnings.`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Clean up redundant labels in connector federation and router deployment documentation to reduce Sphinx build warnings.