### PR TITLE
fix: Include dynamic filter variables in PruneUnreferencedOutputs rightInputs

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -225,6 +225,7 @@ public class PruneUnreferencedOutputs
                 rightInputsBuilder.add(node.getRightHashVariable().get());
             }
             rightInputsBuilder.addAll(expectedFilterInputs);
+            rightInputsBuilder.addAll(node.getDynamicFilters().values());
             Set<VariableReferenceExpression> rightInputs = rightInputsBuilder.build();
 
             PlanNode left = context.rewrite(node.getLeft(), leftInputs);


### PR DESCRIPTION
## Description

When the `IcebergAggregationOptimizer` (introduced in #27085) pushes down min/max/count aggregations to Iceberg file stats, the aggregation node is replaced with a constant ProjectNode. Subsequently, the `PruneUnreferencedOutputs` optimizer prunes the right side's output variables because `visitJoin` does not include dynamic filter variables in the `rightInputs` set. This causes the `JoinNode` constructor validation to fail.

## Root Cause

In `PruneUnreferencedOutputs.Rewriter.visitJoin`, the `rightInputsBuilder` collects all variables that the right side should retain, but omits the dynamic filter values (`node.getDynamicFilters().values()`). When the right side is a ProjectNode (created by the IcebergAggregationOptimizer's constant folding), the `visitProject` method prunes any output variable not in the expected inputs, and the `count` variable (referenced by the dynamic filter) is removed.

## Fix

Add `node.getDynamicFilters().values()` to the `rightInputsBuilder` so that the right side preserves all variables referenced by dynamic filters.

Closes #28364

## Summary by Sourcery

Bug Fixes:
- Preserve variables referenced by dynamic filters when pruning unreferenced join outputs, preventing invalid join plans after aggregation pushdown and constant folding.