### PR TITLE
fix(analyzer): Propagate runtime stats into view analysis sessions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
@@ -93,6 +93,7 @@ public class MetadataExtractor
                     Statement viewStatement = sqlParser.createStatement(view.getOriginalSql(), createParsingOptions(session, warningCollector));
                     Session.SessionBuilder viewSessionBuilder = Session.builder(metadata.getSessionPropertyManager())
                             .setQueryId(session.getQueryId())
+                            .setRuntimeStats(session.getRuntimeStats())
                             .setTransactionId(session.getTransactionId().orElse(null))
                             .setIdentity(session.getIdentity())
                             .setSource(session.getSource().orElse(null))

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -5232,6 +5232,7 @@ class StatementAnalyzer
         {
             Session.SessionBuilder viewSessionBuilder = Session.builder(metadata.getSessionPropertyManager())
                     .setQueryId(session.getQueryId())
+                    .setRuntimeStats(session.getRuntimeStats())
                     .setTransactionId(session.getTransactionId().orElse(null))
                     .setIdentity(identity)
                     .setSource(session.getSource().orElse(null))


### PR DESCRIPTION
Summary:
Runtime metrics recorded while analyzing a view body are silently dropped.

Reading a materialized view directly reports `materializedViewStatus`,
`materializedViewMissingPartitionsCount` and the metadata timers. Reading the
same materialized view through a regular view reports none of them.

Cause: `StatementAnalyzer.createViewSession` builds the view session with the non-copying `Session.builder` overload, which allocates a fresh `RuntimeStats` that is discarded when analysis returns.

```
== RELEASE NOTES ==

General Changes
* Fix query runtime metrics being dropped for tables and materialized views
  referenced through a view.
```

Differential Revision: D116370629

## Summary by Sourcery

Bug Fixes:
- Preserve runtime metrics when analyzing tables and materialized views referenced through regular views.