### PR TITLE
fix(function): Stop key_sampling_percent from returning NaN (#28368)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst
+++ b/presto-docs/src/main/sphinx/functions/plugin-loaded-functions.rst
@@ -259,3 +259,42 @@ String Functions
     Generates a double value between 0.0 and 1.0 based on the hash of the given ``varchar``.
     This function is useful for deterministic sampling of data.
 
+    .. warning::
+
+        The result is **not** uniformly distributed. The implementation reinterprets the
+        64 bits of an XXH64 hash as an IEEE-754 double, so the random bits land in the
+        exponent rather than in the mantissa. Measured over 200,000 keys, the output is a
+        mixture of two components:
+
+        * **47.4% of keys return a value below 1e-30**, of which 1.97% return exactly
+          ``0.0``. That 1.97% includes the ~0.05% of keys whose hash decodes to a
+          non-finite double; those return ``0.0`` rather than ``NaN``. These values are
+          nearly all distinct, so their relative *order* is still uniformly random, but
+          as *numbers* they are indistinguishable from zero.
+        * **47.5% of keys collapse onto just 25 distinct values** -- the multiples of
+          ``0.04`` -- because ``fmod()`` of a large double lands on a coarse lattice.
+          Each of those 25 values is shared by roughly 3,800 keys.
+
+        The remaining ~5% are spread finely in between. In total, 47.6% of keys share
+        their value with at least one other key.
+
+        The practical effect is that ``P(result < p)`` is roughly ``0.51 + 0.49 * p``
+        instead of ``p``. Measured over the same 200,000 keys:
+
+        =========  ==========  ========
+        ``p``      uniform     actual
+        =========  ==========  ========
+        0.00001    0.001%      51.4%
+        0.05       5%          54.0%
+        0.10       10%         56.2%
+        0.50       50%         76.2%
+        0.90       90%         96.0%
+        =========  ==========  ========
+
+        So the function is unusable as a small-fraction sampler: a threshold predicate
+        selects roughly half the population however small ``p`` is, and only approaches
+        its nominal rate as ``p`` approaches 1. Ranking with ``ORDER BY`` is much less
+        affected, because ranks over distinct values are uniformly random regardless of
+        how those values are spread. The exceptions there are the ``0.0`` tie and the
+        25-value lattice, which make ties common.
+

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/SimpleSamplingPercent.java
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/SimpleSamplingPercent.java
@@ -18,16 +18,29 @@ import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
 import com.facebook.presto.spi.function.SqlParameter;
 import com.facebook.presto.spi.function.SqlType;
 
+import static java.lang.String.format;
+
 public class SimpleSamplingPercent
 {
+    // The body of key_sampling_percent, kept in one place because the guard below has to evaluate
+    // it twice: a SQL-invoked function body is a single expression, so there is no way to bind an
+    // intermediate name. The planner eliminates the common subexpression.
+    private static final String SAMPLING_PERCENT_EXPRESSION =
+            "(abs(from_ieee754_64(xxhash64(cast(input as varbinary)))) % 100) / 100.";
+
     private SimpleSamplingPercent() {}
 
+    // from_ieee754_64 of a hash decodes to NaN or +/-infinity whenever the exponent bits are all
+    // ones, and `mod(infinity(), 100)` is itself NaN, so ~0.05% of keys used to leave this
+    // function as NaN -- outside the documented [0, 1] range. The guard tests the final result
+    // rather than the decoded double, because is_nan on the decoded value would miss the
+    // infinity case.
     @SqlInvokedScalarFunction(value = "key_sampling_percent", deterministic = true, calledOnNullInput = false)
     @Description("Returns a value between 0.0 and 1.0 using the hash of the given input string")
     @SqlParameter(name = "input", type = "varchar")
     @SqlType("double")
     public static String keySamplingPercent()
     {
-        return "return (abs(from_ieee754_64(xxhash64(cast(input as varbinary)))) % 100) / 100. ";
+        return format("return if(is_nan(%s), 0.0, %s) ", SAMPLING_PERCENT_EXPRESSION, SAMPLING_PERCENT_EXPRESSION);
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
@@ -126,6 +126,43 @@ public abstract class AbstractTestSqlInvokedFunctions
     public void testDefaultSamplingPercent()
     {
         assertQuery("select key_sampling_percent('abc')", "select 0.56");
+
+        // All three of these keys hash to bit patterns that from_ieee754_64 decodes to NaN, which
+        // used to fall straight out of the function. An all-ones exponent with a zero mantissa
+        // would decode to +/-infinity instead, and mod(infinity, 100) is also NaN, but that is
+        // roughly 2^-52 of the key space so there is no practical fixture for it. That is exactly
+        // why the guard tests the final result instead of is_finite of the decoded double.
+        assertQuery("select key_sampling_percent('1000000033568641')", "select 0.0");
+        assertQuery("select key_sampling_percent('1000000044599808')", "select 0.0");
+        assertQuery("select is_nan(key_sampling_percent('1000000045201652'))", "select false");
+    }
+
+    @Test
+    public void testKeySamplingPercentIsAlwaysInRange()
+    {
+        // The general invariant, over a diverse key set that includes the three NaN-decoding keys.
+        assertQuery(
+                "select bool_and(v between 0.0 and 1.0) from (" +
+                        "  select key_sampling_percent(k) v from (" +
+                        "    select cast(1000000000000000 + x * 7919 as varchar) k from unnest(sequence(1, 2000)) t(x)" +
+                        "    union all select * from (values ('1000000033568641'), ('1000000044599808'), ('1000000045201652'))))",
+                "select true");
+    }
+
+    @Test
+    public void testKeySamplingPercentCallerBehavior()
+    {
+        // The two caller shapes that NaN actually broke, end to end. '1000000033568641' decodes to
+        // NaN; the other three are ordinary keys (0.56, 2.39e-93 and 0.48 respectively).
+        String keys = "(values ('1000000033568641'), ('abc'), ('001yxzuj'), ('56wfythjhdhvgewuikwemn')) t(k)";
+
+        // ORDER BY ... DESC. Presto sorts NaN above every other value, so the NaN key used to be
+        // force-picked at rank 1. It now scores 0.0, and 'abc' (0.56) legitimately wins.
+        assertQuery("select k from " + keys + " order by key_sampling_percent(k) desc limit 1", "select 'abc'");
+
+        // AVG. A single NaN used to poison the whole aggregate.
+        assertQuery("select is_nan(avg(key_sampling_percent(k))) from " + keys, "select false");
+        assertQuery("select avg(key_sampling_percent(k)) from " + keys, "select 0.26");
     }
 
     @Test


### PR DESCRIPTION
Summary:

`key_sampling_percent` is documented as returning "a value between 0.0 and 1.0",
and for ~0.05% of keys it returns `NaN` instead. This diff makes those keys
return `0.0`, and documents what the distribution actually looks like.

The cause: the body decodes an XXH64 hash as an IEEE-754 double via
`from_ieee754_64`. When the hash's exponent bits are all ones the decoded value
is `NaN` or +/-infinity, and `mod(infinity(), 100)` is itself `NaN` (verified in
production Presto), so both cases fall out of the function as `NaN`.

`NaN` is not merely out of contract, it is actively harmful in the two places
this function is used:

- `ORDER BY key_sampling_percent(k) DESC` -- Presto sorts `NaN` as greater than
  everything, so a key hashing to `NaN` is deterministically force-picked at
  rank 1. At 0.048% that is about one forced pick per 2,083 keys in a partition,
  and it is the same key every day.
- `AVG(key_sampling_percent(k))` -- a single `NaN` poisons the aggregate.

The docs are also updated to describe the real shape of the output, which is a
two-component mixture rather than anything uniform: 47.4% of keys land below
`1e-30` (1.97% exactly `0.0`), and 47.5% collapse onto just 25 values -- the
multiples of `0.04` -- because `fmod()` of a large double lands on a coarse
lattice. Net effect is `P(result < p)` ~= `0.51 + 0.49 * p`, so the function is
unusable as a small-fraction sampler and only approaches its nominal rate as `p`
approaches 1. Ranking is much less affected, because ranks over distinct values
are uniform however the values are spread.

This is deliberately the narrow fix. It moves 0.048% of keys and leaves the
distribution defects alone, because those cannot be repaired without re-rolling
essentially every existing sample. The next diffs in this stack add
`hash_to_uniform` for callers who want a correct sampler.

Not a no-op for threshold callers: `NaN < p` is false today and `0.0 < p` is
true, so those 0.048% of keys move into `WHERE key_sampling_percent(k) < p`
samples rather than being silently dropped. That is the correct direction -- they
should never have been excluded -- but it is a change, not a pure repair.

The guard tests the final result rather than the decoded double on purpose:
`is_nan` on the intermediate would miss +/-infinity, which only becomes `NaN`
after the `mod`. The expression is repeated because a SQL-invoked function body
is a single expression with no way to bind a name; the planner eliminates the
common subexpression.

Differential Revision: D116231465

## Summary by Sourcery

Ensure key_sampling_percent always returns a valid finite value while documenting its observed distribution and validating affected caller behavior.

Bug Fixes:
- Ensure key_sampling_percent returns 0.0 instead of NaN for hash inputs that decode to non-finite values.
- Prevent NaN results from causing incorrect ranking and poisoning aggregate calculations for key_sampling_percent callers.

Enhancements:
- Document the observed output distribution and sampling limitations of key_sampling_percent.

Documentation:
- Update key_sampling_percent documentation to describe its actual output distribution and behavior.

Tests:
- Add coverage verifying key_sampling_percent remains within its documented range and behaves correctly in ordering and aggregate queries.