### PR TITLE
feat(native): Expose GPU memory and utilization in /v1/status

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -139,6 +139,18 @@ Worker Properties
 
 The configuration properties of Presto C++ workers are described here, in alphabetical order.
 
+``gpu.status-update-interval-ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``integer``
+* **Default value:** ``1000``
+
+  Period, in milliseconds, of the background task that samples the GPU memory
+  and utilization values reported by the worker status endpoint. Sampling runs
+  on this task rather than on the status path so that a stalled CUDA or NVML
+  call cannot delay the resource manager heartbeat. Set to ``0`` to disable
+  sampling, leaving the GPU fields at ``-1``. Only effective on cuDF-enabled
+  builds with cuDF enabled at run time.
+
 ``runtime-metrics-collection-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * **Type:** ``boolean``

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -51,6 +51,10 @@ public class NodeStatus
     // (reported separately in asyncDataCacheBytes) but may include memory that
     // is spillable under pressure.
     private final long queryMemoryBytes;
+    private final long gpuMemoryUsedBytes;
+    private final long gpuMemoryCapacityBytes;
+    private final long gpuUtilizationPercent;
+    private final long gpuMemoryBandwidthPercent;
 
     @ThriftConstructor
     @JsonCreator
@@ -70,7 +74,11 @@ public class NodeStatus
             @JsonProperty("heapAvailable") long heapAvailable,
             @JsonProperty("nonHeapUsed") long nonHeapUsed,
             @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
-            @JsonProperty("queryMemoryBytes") long queryMemoryBytes)
+            @JsonProperty("queryMemoryBytes") long queryMemoryBytes,
+            @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
+            @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
+            @JsonProperty("gpuUtilizationPercent") long gpuUtilizationPercent,
+            @JsonProperty("gpuMemoryBandwidthPercent") long gpuMemoryBandwidthPercent)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -88,6 +96,10 @@ public class NodeStatus
         this.nonHeapUsed = nonHeapUsed;
         this.asyncDataCacheBytes = asyncDataCacheBytes;
         this.queryMemoryBytes = queryMemoryBytes;
+        this.gpuMemoryUsedBytes = gpuMemoryUsedBytes;
+        this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
+        this.gpuUtilizationPercent = gpuUtilizationPercent;
+        this.gpuMemoryBandwidthPercent = gpuMemoryBandwidthPercent;
     }
 
     @ThriftField(1)
@@ -200,5 +212,33 @@ public class NodeStatus
     public long getQueryMemoryBytes()
     {
         return queryMemoryBytes;
+    }
+
+    @ThriftField(17)
+    @JsonProperty
+    public long getGpuMemoryUsedBytes()
+    {
+        return gpuMemoryUsedBytes;
+    }
+
+    @ThriftField(18)
+    @JsonProperty
+    public long getGpuMemoryCapacityBytes()
+    {
+        return gpuMemoryCapacityBytes;
+    }
+
+    @ThriftField(19)
+    @JsonProperty
+    public long getGpuUtilizationPercent()
+    {
+        return gpuUtilizationPercent;
+    }
+
+    @ThriftField(20)
+    @JsonProperty
+    public long getGpuMemoryBandwidthPercent()
+    {
+        return gpuMemoryBandwidthPercent;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -629,6 +629,10 @@ public class TestResourceManagerClusterStateProvider
                 2,
                 3,
                 0,
+                0,
+                0,
+                0,
+                0,
                 0);
     }
 
@@ -649,6 +653,10 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
+                0,
+                0,
+                0,
                 0,
                 0);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
@@ -30,7 +30,14 @@ public class TestNodeStatus
 {
     private static final JsonCodec<NodeStatus> CODEC = jsonCodec(NodeStatus.class);
 
-    private static NodeStatus nodeStatus(long nonHeapUsed, long asyncDataCacheBytes, long queryMemoryBytes)
+    private static NodeStatus nodeStatus(
+            long nonHeapUsed,
+            long asyncDataCacheBytes,
+            long queryMemoryBytes,
+            long gpuMemoryUsedBytes,
+            long gpuMemoryCapacityBytes,
+            long gpuUtilizationPercent,
+            long gpuMemoryBandwidthPercent)
     {
         return new NodeStatus(
                 "test-node",
@@ -48,22 +55,29 @@ public class TestNodeStatus
                 8192,
                 nonHeapUsed,
                 asyncDataCacheBytes,
-                queryMemoryBytes);
+                queryMemoryBytes,
+                gpuMemoryUsedBytes,
+                gpuMemoryCapacityBytes,
+                gpuUtilizationPercent,
+                gpuMemoryBandwidthPercent);
     }
 
     @Test
     public void testJsonRoundTrip()
     {
-        // Distinct values for the three long fields, including a negative one,
-        // so the round-trip would catch a swapped, dropped, or sign-mangled
-        // field.
-        NodeStatus expected = nodeStatus(-1L, 111L, 222L);
+        // Distinct values for every long field, including a negative one, so the
+        // round-trip would catch a swapped, dropped, or sign-mangled field.
+        NodeStatus expected = nodeStatus(-1L, 111L, 222L, 333L, 444L, 55L, 66L);
 
         NodeStatus actual = CODEC.fromJson(CODEC.toJson(expected));
 
         assertEquals(actual.getNonHeapUsed(), -1L);
         assertEquals(actual.getAsyncDataCacheBytes(), 111L);
         assertEquals(actual.getQueryMemoryBytes(), 222L);
+        assertEquals(actual.getGpuMemoryUsedBytes(), 333L);
+        assertEquals(actual.getGpuMemoryCapacityBytes(), 444L);
+        assertEquals(actual.getGpuUtilizationPercent(), 55L);
+        assertEquals(actual.getGpuMemoryBandwidthPercent(), 66L);
         assertEquals(actual.getHeapUsed(), expected.getHeapUsed());
         assertEquals(actual.getHeapAvailable(), expected.getHeapAvailable());
         assertEquals(actual.getNodeId(), expected.getNodeId());

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -92,6 +92,10 @@ public class StatusResource
                 memoryMXBean.getHeapMemoryUsage().getMax(),
                 memoryMXBean.getNonHeapMemoryUsage().getUsed(),
                 0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
-                0L); // queryMemoryBytes: native-only; JVM query memory is on-heap
+                0L, // queryMemoryBytes: native-only; JVM query memory is on-heap
+                -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L); // gpuMemoryBandwidthPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -315,6 +315,10 @@ public class TestHttpResourceManagerClient
                 1,
                 1,
                 0,
+                0,
+                0,
+                0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -59,6 +59,10 @@ public class TestResourceManagerClusterStatusSender
             2,
             3,
             0,
+            0,
+            0,
+            0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -79,6 +79,21 @@ if(PRESTO_ENABLE_CUDF)
   # The symbols from velox_cudf_exec are not included in the Velox mono library
   # and need to be linked separately.
   target_link_libraries(presto_server_lib velox_cudf_exec)
+  # NVML (libnvidia-ml) for GPU utilization in /v1/status. CUDA::nvml provides
+  # the nvml.h include dir and links the driver stub (real lib comes from the
+  # NVIDIA runtime at run time).
+  find_package(CUDAToolkit REQUIRED)
+  # CUDAToolkit can be found (nvcc, cuda_runtime.h) yet NOT create the CUDA::nvml target when the
+  # NVML stub (libnvidia-ml.so from cuda-nvml-dev) is missing from the build image. Without this
+  # guard, linking would silently no-op and produce a presto_server with zero NVML symbols
+  # (gpuUtilizationPercent stays -1 at runtime). Fail the build loudly instead.
+  if(NOT TARGET CUDA::nvml)
+    message(
+      FATAL_ERROR
+      "CUDA::nvml target not found. Install cuda-nvml-dev (or ensure libnvidia-ml.so is in the CUDA toolkit lib/stubs directory) in the build image."
+    )
+  endif()
+  target_link_libraries(presto_server_lib CUDA::nvml)
 endif()
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -89,6 +89,8 @@
 #include "velox/serializers/UnsafeRowSerializer.h"
 
 #ifdef PRESTO_ENABLE_CUDF
+#include <cuda_runtime.h>
+#include <nvml.h>
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
@@ -1318,6 +1320,21 @@ void PrestoServer::addServerPeriodicTasks() {
       1'000'000, // 1 second
       "populate_mem_cpu_info");
 
+#ifdef PRESTO_ENABLE_CUDF
+  // Sample GPU metrics off the serving path so fetchNodeStatus() (RM heartbeat)
+  // only reads cached atomics — never runs synchronous CUDA/NVML probes.
+  // updateGpuStatusCache() is a no-op unless cuDF is enabled at runtime, so
+  // scheduling it unconditionally here is safe regardless of init ordering.
+  const uint64_t gpuStatusIntervalMs =
+      SystemConfig::instance()->gpuStatusUpdateIntervalMs();
+  if (gpuStatusIntervalMs > 0) {
+    periodicTaskManager_->addTask(
+        [server = this]() { server->updateGpuStatusCache(); },
+        gpuStatusIntervalMs * 1'000, // ms -> micros
+        "update_gpu_status");
+  }
+#endif
+
   periodicTaskManager_->addTask(
       [start = start_]() {
         const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
@@ -2014,6 +2031,23 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
     queryMemoryBytes += pool.second.reservedBytes;
   }
 
+  // GPU metrics. cuDF/RMM allocations do not flow through Velox MemoryPools, so
+  // these are sampled directly from the device/NVML. To keep the synchronous
+  // CUDA/NVML probes off this path (fetchNodeStatus feeds the RM heartbeat — a
+  // stalled probe here can get the worker declared dead), sampling runs on the
+  // periodic 'update_gpu_status' task and we only read the cached atomics here.
+  // -1 sentinel when cuDF is disabled/not registered or a probe has not
+  // succeeded yet (same convention as 'nonHeapUsed'). Semantics of each value
+  // are documented on updateGpuStatusCache().
+  const int64_t gpuMemoryUsedBytes =
+      gpuMemoryUsedBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryCapacityBytes =
+      gpuMemoryCapacityBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuUtilizationPercent =
+      gpuUtilizationPercent_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryBandwidthPercent =
+      gpuMemoryBandwidthPercent_.load(std::memory_order_relaxed);
+
   protocol::NodeStatus nodeStatus{
       nodeId_,
       {nodeVersion_},
@@ -2030,9 +2064,54 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed,
       asyncDataCacheBytes,
-      queryMemoryBytes};
+      queryMemoryBytes,
+      gpuMemoryUsedBytes,
+      gpuMemoryCapacityBytes,
+      gpuUtilizationPercent,
+      gpuMemoryBandwidthPercent};
 
   return nodeStatus;
+}
+
+void PrestoServer::updateGpuStatusCache() {
+#ifdef PRESTO_ENABLE_CUDF
+  if (!velox::cudf_velox::CudfConfig::getInstance().enabled) {
+    return;
+  }
+  // cudaMemGetInfo reports the whole device: 'used' reflects the retained RMM
+  // pool reservation (high-water mark) — the right notion for "how full is the
+  // GPU". Stored into gpuMemory{Used,Capacity}Bytes_.
+  size_t gpuFree = 0;
+  size_t gpuTotal = 0;
+  if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
+    gpuMemoryCapacityBytes_.store(
+        static_cast<int64_t>(gpuTotal), std::memory_order_relaxed);
+    gpuMemoryUsedBytes_.store(
+        static_cast<int64_t>(gpuTotal - gpuFree), std::memory_order_relaxed);
+  }
+
+  // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
+  // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM
+  // is. NOTE: NVML reports the whole physical device; under fractional/shared
+  // GPU (time-slicing/MPS) this reflects the shared GPU, not just this worker
+  // (see plan Annex A3).
+  // NVML init once for the server lifetime (process exit reclaims it).
+  static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
+  if (nvmlReady) {
+    nvmlDevice_t nvmlDevice;
+    nvmlUtilization_t util;
+    // Index 0: inside the container NVML sees only the GPU(s) exposed to this
+    // pod, so device 0 is this worker's GPU. Multi-GPU-visible containers
+    // would need PCI-bus-id mapping to the active CUDA device.
+    if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
+        nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
+      gpuUtilizationPercent_.store(
+          static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
+      gpuMemoryBandwidthPercent_.store(
+          static_cast<int64_t>(util.memory), std::memory_order_relaxed);
+    }
+  }
+#endif
 }
 
 void PrestoServer::registerDynamicFunctions() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -2036,9 +2036,10 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // CUDA/NVML probes off this path (fetchNodeStatus feeds the RM heartbeat — a
   // stalled probe here can get the worker declared dead), sampling runs on the
   // periodic 'update_gpu_status' task and we only read the cached atomics here.
-  // -1 sentinel when cuDF is disabled/not registered or a probe has not
-  // succeeded yet (same convention as 'nonHeapUsed'). Semantics of each value
-  // are documented on updateGpuStatusCache().
+  // -1 sentinel when cuDF is disabled/not registered, when no probe has run
+  // yet, or when the most recent probe failed (same convention as
+  // 'nonHeapUsed'). Semantics of each value are documented on
+  // updateGpuStatusCache().
   const int64_t gpuMemoryUsedBytes =
       gpuMemoryUsedBytes_.load(std::memory_order_relaxed);
   const int64_t gpuMemoryCapacityBytes =
@@ -2078,23 +2079,33 @@ void PrestoServer::updateGpuStatusCache() {
   if (!velox::cudf_velox::CudfConfig::getInstance().enabled) {
     return;
   }
+  // Every probe stores unconditionally, writing the -1 sentinel when it fails.
+  // Leaving the previous sample in place would be worse than reporting nothing:
+  // a stale value is indistinguishable from a fresh one, so a GPU that stopped
+  // responding would keep reporting healthy numbers indefinitely.
+
   // cudaMemGetInfo reports the whole device: 'used' reflects the retained RMM
   // pool reservation (high-water mark) — the right notion for "how full is the
   // GPU". Stored into gpuMemory{Used,Capacity}Bytes_.
+  int64_t gpuMemoryUsedBytes = -1;
+  int64_t gpuMemoryCapacityBytes = -1;
   size_t gpuFree = 0;
   size_t gpuTotal = 0;
   if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
-    gpuMemoryCapacityBytes_.store(
-        static_cast<int64_t>(gpuTotal), std::memory_order_relaxed);
-    gpuMemoryUsedBytes_.store(
-        static_cast<int64_t>(gpuTotal - gpuFree), std::memory_order_relaxed);
+    gpuMemoryCapacityBytes = static_cast<int64_t>(gpuTotal);
+    gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
   }
+  gpuMemoryCapacityBytes_.store(
+      gpuMemoryCapacityBytes, std::memory_order_relaxed);
+  gpuMemoryUsedBytes_.store(gpuMemoryUsedBytes, std::memory_order_relaxed);
 
   // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
   // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM
   // is. NOTE: NVML reports the whole physical device; under fractional/shared
   // GPU (time-slicing/MPS) this reflects the shared GPU, not just this worker
   // (see plan Annex A3).
+  int64_t gpuUtilizationPercent = -1;
+  int64_t gpuMemoryBandwidthPercent = -1;
   // NVML init once for the server lifetime (process exit reclaims it).
   static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
   if (nvmlReady) {
@@ -2105,12 +2116,14 @@ void PrestoServer::updateGpuStatusCache() {
     // would need PCI-bus-id mapping to the active CUDA device.
     if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
         nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
-      gpuUtilizationPercent_.store(
-          static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
-      gpuMemoryBandwidthPercent_.store(
-          static_cast<int64_t>(util.memory), std::memory_order_relaxed);
+      gpuUtilizationPercent = static_cast<int64_t>(util.gpu);
+      gpuMemoryBandwidthPercent = static_cast<int64_t>(util.memory);
     }
   }
+  gpuUtilizationPercent_.store(
+      gpuUtilizationPercent, std::memory_order_relaxed);
+  gpuMemoryBandwidthPercent_.store(
+      gpuMemoryBandwidthPercent, std::memory_order_relaxed);
 #endif
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -261,6 +261,11 @@ class PrestoServer {
 
   void populateMemAndCPUInfo();
 
+  // Samples GPU device/pool/utilization metrics and stores them into the
+  // gpu*_ atomics. Runs on the periodic-task executor (never on the heartbeat
+  // path). No-op unless built with cuDF and enabled at runtime.
+  void updateGpuStatusCache();
+
   // Periodically yield tasks if there are tasks queued.
   void yieldTasks();
 
@@ -360,6 +365,16 @@ class PrestoServer {
   // the first sample and when no cache instance exists (classic JVM behaviour).
   std::atomic<int64_t> asyncDataCacheBytes_{0};
   CPUMon cpuMon_;
+
+  // Cached GPU metrics. Sampled off the serving path by the periodic
+  // 'update_gpu_status' task (updateGpuStatusCache) and read by
+  // fetchNodeStatus(). This keeps the synchronous CUDA/NVML probes off the
+  // heartbeat path: fetchNodeStatus() feeds the RM heartbeat, and a stalled
+  // probe there can get the worker declared dead. -1 = unavailable.
+  std::atomic<int64_t> gpuMemoryUsedBytes_{-1};
+  std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
+  std::atomic<int64_t> gpuUtilizationPercent_{-1};
+  std::atomic<int64_t> gpuMemoryBandwidthPercent_{-1};
 
   std::string environment_;
   std::string nodeVersion_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -370,7 +370,8 @@ class PrestoServer {
   // 'update_gpu_status' task (updateGpuStatusCache) and read by
   // fetchNodeStatus(). This keeps the synchronous CUDA/NVML probes off the
   // heartbeat path: fetchNodeStatus() feeds the RM heartbeat, and a stalled
-  // probe there can get the worker declared dead. -1 = unavailable.
+  // probe there can get the worker declared dead. -1 = unavailable, which each
+  // sampling pass rewrites on probe failure rather than leaving a stale value.
   std::atomic<int64_t> gpuMemoryUsedBytes_{-1};
   std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
   std::atomic<int64_t> gpuUtilizationPercent_{-1};

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -264,6 +264,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLogNumZombieTasks, 20),
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 30s
           NUM_PROP(kHeartbeatFrequencyMs, 0),
+          NUM_PROP(kGpuStatusUpdateIntervalMs, 1'000), // 1s
           BOOL_PROP(kHttpClientHttp2Enabled, false),
           NUM_PROP(kHttpClientHttp2MaxStreamsPerConnection, 8),
           NUM_PROP(kHttpClientHttp2InitialStreamWindow, 1 << 23 /*8MB*/),
@@ -1065,6 +1066,10 @@ uint64_t SystemConfig::announcementMaxFrequencyMs() const {
 
 uint64_t SystemConfig::heartbeatFrequencyMs() const {
   return optionalProperty<uint64_t>(kHeartbeatFrequencyMs).value();
+}
+
+uint64_t SystemConfig::gpuStatusUpdateIntervalMs() const {
+  return optionalProperty<uint64_t>(kGpuStatusUpdateIntervalMs).value();
 }
 
 bool SystemConfig::httpClientHttp2Enabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -790,6 +790,14 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHeartbeatFrequencyMs{
       "heartbeat-frequency-ms"};
 
+  /// Period (ms) of the background task that samples GPU memory/utilization
+  /// metrics into the cache read by /v1/status (see PrestoServer::
+  /// updateGpuStatusCache). Keeps CUDA/NVML probes off the heartbeat path.
+  /// 0 disables sampling (GPU fields stay at the -1 sentinel). Only effective
+  /// on cuDF-enabled builds/workers.
+  static constexpr std::string_view kGpuStatusUpdateIntervalMs{
+      "gpu.status-update-interval-ms"};
+
   /// Whether HTTP/2 is enabled for HTTP client connections.
   static constexpr std::string_view kHttpClientHttp2Enabled{
       "http-client.http2-enabled"};
@@ -1294,6 +1302,8 @@ class SystemConfig : public ConfigBase {
   uint64_t announcementMaxFrequencyMs() const;
 
   uint64_t heartbeatFrequencyMs() const;
+
+  uint64_t gpuStatusUpdateIntervalMs() const;
 
   bool httpClientHttp2Enabled() const;
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -247,6 +247,22 @@ TEST_F(ConfigTest, asyncCacheNumShards) {
   ASSERT_EQ(config.asyncCacheNumShards(), 8);
 }
 
+TEST_F(ConfigTest, gpuStatusUpdateIntervalMs) {
+  SystemConfig config;
+  init(config, {});
+  // Default is 1s.
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 1'000);
+
+  // Custom value (e.g. faster sampling).
+  init(
+      config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "250"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 250);
+
+  // 0 disables the GPU sampling task.
+  init(config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "0"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 0);
+}
+
 TEST_F(ConfigTest, asyncCacheSsdFlushThresholdBytes) {
   SystemConfig config;
   init(config, {});

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8316,6 +8316,34 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "queryMemoryBytes");
+  to_json_key(
+      j,
+      "gpuMemoryUsedBytes",
+      p.gpuMemoryUsedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryUsedBytes");
+  to_json_key(
+      j,
+      "gpuMemoryCapacityBytes",
+      p.gpuMemoryCapacityBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryCapacityBytes");
+  to_json_key(
+      j,
+      "gpuUtilizationPercent",
+      p.gpuUtilizationPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuUtilizationPercent");
+  to_json_key(
+      j,
+      "gpuMemoryBandwidthPercent",
+      p.gpuMemoryBandwidthPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryBandwidthPercent");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8391,6 +8419,44 @@ void from_json(const json& j, NodeStatus& p) {
         "NodeStatus",
         "int64_t",
         "queryMemoryBytes");
+  }
+  if (j.count("gpuMemoryUsedBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryUsedBytes",
+        p.gpuMemoryUsedBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryUsedBytes");
+  }
+  if (j.count("gpuMemoryCapacityBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryCapacityBytes",
+        p.gpuMemoryCapacityBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryCapacityBytes");
+  }
+  // Backward compatible: guard with j.count() so payloads from older workers
+  // that lack this field still deserialize (defaults to 0 via the struct).
+  if (j.count("gpuUtilizationPercent")) {
+    from_json_key(
+        j,
+        "gpuUtilizationPercent",
+        p.gpuUtilizationPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuUtilizationPercent");
+  }
+  if (j.count("gpuMemoryBandwidthPercent")) {
+    from_json_key(
+        j,
+        "gpuMemoryBandwidthPercent",
+        p.gpuMemoryBandwidthPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryBandwidthPercent");
   }
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2014,6 +2014,10 @@ struct NodeStatus {
   int64_t nonHeapUsed = {};
   int64_t asyncDataCacheBytes = {};
   int64_t queryMemoryBytes = {};
+  int64_t gpuMemoryUsedBytes = {};
+  int64_t gpuMemoryCapacityBytes = {};
+  int64_t gpuUtilizationPercent = {};
+  int64_t gpuMemoryBandwidthPercent = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found" | grep -v "libnvidia-ml") && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 
 #/////////////////////////////////////////////


### PR DESCRIPTION
### Description

Adds four fields to `NodeStatus` (Thrift ids 17-20), populated by Prestissimo
workers and exposed through `/v1/status`:

- `gpuMemoryUsedBytes` — device memory in use, from `cudaMemGetInfo`. With an RMM
  pool this is the pool's retained reservation, which is the right notion for
  "how full is the GPU".
- `gpuMemoryCapacityBytes` — total device memory.
- `gpuUtilizationPercent` — GPU compute utilization from NVML (nvidia-smi's
  "GPU-Util").
- `gpuMemoryBandwidthPercent` — NVML memory-bandwidth utilization: the fraction
  of time device memory was being read or written.

All four report `-1` when cuDF is not compiled in, not enabled at run time, or
when no probe has succeeded yet. The Java coordinator reports `-1`
unconditionally, since it has no GPU.

The probes are synchronous, so they run on a periodic background task that stores
atomics, and `fetchNodeStatus()` only reads those. That path feeds the resource
manager heartbeat, where a stalled CUDA or NVML call could get the worker
declared dead. The period is controlled by the new
`gpu.status-update-interval-ms` property (default 1000 ms; `0` disables
sampling).

The build commit links `CUDA::nvml` for cuDF-enabled builds and fails configure
with an explicit message if the target is absent, rather than silently producing
a `presto_server` with no NVML symbols where `gpuUtilizationPercent` would stay
`-1` forever. It also excludes `libnvidia-ml` from the runtime image's
missing-library check, since that library comes from the NVIDIA driver on a GPU
host rather than from the CUDA toolkit.

### Motivation

A GPU-enabled worker exposes no GPU signal at all today, so a scheduler or
autoscaler has no way to tell a saturated GPU worker from an idle one — the host
memory fields say nothing about device memory. These four fields give the same
kind of visibility for the GPU that `heapUsed`/`asyncDataCacheBytes` give for the
host.

cuDF allocates device memory through RMM, outside the `MemoryPool` accounting
behind the existing memory fields, so the values have to be sampled from the
device rather than derived from Velox memory statistics.

Memory alone is not enough to distinguish idle from busy: an RMM pool holds its
reservation between queries, so `gpuMemoryUsedBytes` stays high on an idle
worker. The two NVML percentages are what separate "GPU is reserved" from "GPU is
working".

### Impact

- Four added `NodeStatus` fields. Thrift skips unknown field ids and the JSON
  deserializer ignores unknown properties, so a new worker reporting them to an
  older coordinator, or an older worker omitting them, both keep working. When the
  fields are absent, they deserialize to `0` rather than `-1`, matching how
  `asyncDataCacheBytes`/`queryMemoryBytes` behave; a consumer should treat
  `gpuMemoryCapacityBytes == 0` as "no GPU data" since a real GPU always reports a
  non-zero capacity.
- `presto_protocol_core.{h,cpp}` are generated, and the `j.count()` guards on the
  new fields in `from_json` are hand-added, consistent with what #27783 did for the
  host-memory fields. Happy to move these behind a `special/NodeStatus.cpp.inc`
  override instead if that is the preferred convention.
- No behavior change for non-GPU builds: the sampling code is inside
  `#ifdef PRESTO_ENABLE_CUDF` and the fields stay at `-1`.
- One new configuration property, `gpu.status-update-interval-ms`, documented in
  `presto_cpp/properties.rst`.
- cuDF-enabled builds now require `CUDA::nvml`. The CI dependency image
  (`prestodb/presto-native-dependency:0.299-202606161331-03dfaf88`) already
  carries `cuda-nvml-devel-12-9` and the `libnvidia-ml.so` stub, so no image
  change is needed.
- No new third-party dependencies; NVML ships with the CUDA toolkit.

### Test plan

- `TestNodeStatus` extended so the JSON round-trip covers all four new fields
  with distinct values, which catches a dropped, swapped or sign-mangled field.
- `ConfigTest` covers `gpu.status-update-interval-ms`, including `0`.
- Java build and the five affected test classes run locally against current
  master: 27 tests, no failures.
- CI compiles the cuDF path (`prestocpp-linux-build` builds with
  `PRESTO_OPTIONAL_FEATURES="cudf,..."`), so the `#ifdef PRESTO_ENABLE_CUDF`
  code is covered there.
- Not yet exercised on GPU hardware: no GPU host was available, so the `> 0`
  readings under a cuDF workload have not been observed. On a non-GPU worker the
  fields correctly report `-1`. Happy to follow up with numbers from a GPU worker
  if that is wanted before merge.

### Release notes

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add ``gpuMemoryUsedBytes``, ``gpuMemoryCapacityBytes``, ``gpuUtilizationPercent`` and ``gpuMemoryBandwidthPercent`` to the worker status endpoint, reporting GPU device memory and utilization. The values are ``-1`` unless the worker is a cuDF-enabled build with cuDF enabled at run time.
* Add configuration property ``gpu.status-update-interval-ms`` to control how often GPU memory and utilization are sampled. Set to ``0`` to disable sampling.
```

## Summary by Sourcery

Expose asynchronously sampled GPU memory and utilization metrics in /v1/status for cuDF-enabled Prestissimo workers.

New Features:
- Expose GPU memory usage, capacity, compute utilization, and memory-bandwidth utilization through worker status responses.

Enhancements:
- Sample GPU metrics asynchronously and cache them for status and resource-manager heartbeat requests, with unavailable values represented by -1.
- Add configurable GPU status sampling through gpu.status-update-interval-ms, including an option to disable sampling.
- Require and link NVML for cuDF-enabled builds while keeping non-GPU and Java coordinator behavior unchanged.

Build:
- Update cuDF-enabled build and runtime checks to support the NVML dependency supplied by GPU hosts.

Documentation:
- Document the GPU status sampling configuration property and newly exposed status metrics.

Tests:
- Extend node status serialization and configuration tests for GPU fields and sampling settings.