### PR TITLE
fix(planner): Keep probe local properties across a cross join with a scalar build

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -109,6 +109,7 @@ import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Glo
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.partitionedOnCoalesce;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.singleStreamPartition;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.streamPartitionedOn;
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -518,11 +519,14 @@ public class PropertyDerivations
                     constants.putAll(buildProperties.getConstants());
 
                     if (node.isCrossJoin()) {
-                        // Cross join preserves only constants from probe and build sides.
-                        // Cross join doesn't preserve sorting or grouping local properties on either side.
+                        // A cross join emits the probe once per build row, so a run of equal probe values
+                        // is repeated and the probe's local properties no longer hold. The exception is a
+                        // build side that produces at most one row: the probe then passes through with the
+                        // build's columns appended, keeping its order. Only constants survive from the
+                        // build side either way.
                         return ActualProperties.builder()
                                 .global(probeProperties)
-                                .local(ImmutableList.of())
+                                .local(isScalar(node.getRight()) ? probeProperties.getLocalProperties() : ImmutableList.of())
                                 .constants(constants)
                                 .build();
                     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPropertyDerivations.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPropertyDerivations.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.SortingProperty;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.function.Function;
+
+import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.optimizations.PropertyDerivations.derivePropertiesRecursively;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestPropertyDerivations
+        extends BaseRuleTest
+{
+    /**
+     * A build side producing exactly one row leaves the probe's order intact: the nested loop join keeps
+     * the page with more rows whole and appends the build's columns to it. This is the shape of a
+     * broadcast scalar, such as a total joined onto every row.
+     */
+    @Test
+    public void testCrossJoinWithScalarBuildKeepsProbeLocalProperties()
+    {
+        ActualProperties properties = deriveCrossJoin(p -> p.aggregation(agg -> agg
+                .addAggregation(p.variable("total", BIGINT), p.rowExpression("count()"))
+                .globalGrouping()
+                .source(p.values(p.variable("ignored", BIGINT)))));
+        assertEquals(sortedColumnNames(properties), ImmutableList.of("a"));
+    }
+
+    /**
+     * A build side that may produce several rows repeats each probe row, so a run of equal probe values is
+     * interleaved with the other runs and the probe's order no longer holds.
+     */
+    @Test
+    public void testCrossJoinWithNonScalarBuildDiscardsProbeLocalProperties()
+    {
+        ActualProperties properties = deriveCrossJoin(p -> p.values(2, p.variable("total", BIGINT)));
+        assertTrue(properties.getLocalProperties().isEmpty(), "A build side of more than one row must not keep the probe's order");
+    }
+
+    /**
+     * Builds {@code cross join(sort(values) , build)} and derives its properties. The probe is sorted on
+     * {@code a}, so the join's local properties are the question under test.
+     */
+    private ActualProperties deriveCrossJoin(Function<PlanBuilder, PlanNode> build)
+    {
+        PlanBuilder planBuilder = new PlanBuilder(tester().getSession(), new PlanNodeIdAllocator(), tester().getMetadata());
+        VariableReferenceExpression a = planBuilder.variable("a", BIGINT);
+        VariableReferenceExpression b = planBuilder.variable("b", BIGINT);
+        PlanNode join = planBuilder.join(
+                JoinType.INNER,
+                planBuilder.sort(ImmutableList.of(a), planBuilder.values(a, b)),
+                build.apply(planBuilder));
+        return derivePropertiesRecursively(join, tester().getMetadata(), tester().getSession());
+    }
+
+    private static ImmutableList<String> sortedColumnNames(ActualProperties properties)
+    {
+        return properties.getLocalProperties().stream()
+                .map(property -> (SortingProperty<VariableReferenceExpression>) property)
+                .peek(property -> assertEquals(property.getOrder(), ASC_NULLS_FIRST))
+                .map(property -> property.getColumn().getName())
+                .collect(toImmutableList());
+    }
+}


### PR DESCRIPTION
Property derivation discarded every local property on both sides of a cross
join. That is right in general, because a cross join emits each probe row once
per build row, so a run of equal probe values is repeated and the run structure
the properties describe no longer holds.

It is wrong when the build side produces at most one row. The nested loop join
keeps the page with more rows whole and appends the columns of the smaller one,
so the probe passes through in its original order with the build's columns
attached. That is the shape of a broadcast scalar, such as a total or a
threshold joined onto every row, and it appears often enough between a sorted
source and the operators that consume order to matter: a window function or a
streaming aggregation above such a join was told its input was unordered and
had to sort or hash again.

Keep the probe's local properties when the build side is scalar, and keep
discarding them otherwise. Constants already survived from both sides and are
unchanged.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve property derivation to keep the probe side's local properties across a cross join whose build side produces at most one row, instead of discarding them. Operators above such a join, such as window functions and streaming aggregations, can now use the order of the probe input.
```

## Summary by Sourcery

Preserve probe input ordering information through cross joins with scalar build sides so downstream operators can continue to exploit it.

Bug Fixes:
- Preserve probe-side local properties across cross joins when the build side produces at most one row, while continuing to discard them for non-scalar builds.

Tests:
- Add property derivation coverage for scalar and non-scalar cross joins.