### PR TITLE
feat(native): Expose cuDF live-allocated GPU bytes in /v1/status

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -139,6 +139,18 @@ Worker Properties
 
 The configuration properties of Presto C++ workers are described here, in alphabetical order.
 
+``gpu.status-update-interval-ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``integer``
+* **Default value:** ``1000``
+
+  Period, in milliseconds, of the background task that samples the GPU memory
+  and utilization values reported by the worker status endpoint. Sampling runs
+  on this task rather than on the status path so that a stalled CUDA or NVML
+  call cannot delay the resource manager heartbeat. Set to ``0`` to disable
+  sampling, leaving the GPU fields at ``-1``. Only effective on cuDF-enabled
+  builds with cuDF enabled at run time.
+
 ``runtime-metrics-collection-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * **Type:** ``boolean``

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -55,6 +55,7 @@ public class NodeStatus
     private final long gpuMemoryCapacityBytes;
     private final long gpuUtilizationPercent;
     private final long gpuMemoryBandwidthPercent;
+    private final long gpuPoolAllocatedBytes;
 
     @ThriftConstructor
     @JsonCreator
@@ -78,7 +79,8 @@ public class NodeStatus
             @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
             @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
             @JsonProperty("gpuUtilizationPercent") long gpuUtilizationPercent,
-            @JsonProperty("gpuMemoryBandwidthPercent") long gpuMemoryBandwidthPercent)
+            @JsonProperty("gpuMemoryBandwidthPercent") long gpuMemoryBandwidthPercent,
+            @JsonProperty("gpuPoolAllocatedBytes") long gpuPoolAllocatedBytes)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -100,6 +102,7 @@ public class NodeStatus
         this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
         this.gpuUtilizationPercent = gpuUtilizationPercent;
         this.gpuMemoryBandwidthPercent = gpuMemoryBandwidthPercent;
+        this.gpuPoolAllocatedBytes = gpuPoolAllocatedBytes;
     }
 
     @ThriftField(1)
@@ -240,5 +243,12 @@ public class NodeStatus
     public long getGpuMemoryBandwidthPercent()
     {
         return gpuMemoryBandwidthPercent;
+    }
+
+    @ThriftField(21)
+    @JsonProperty
+    public long getGpuPoolAllocatedBytes()
+    {
+        return gpuPoolAllocatedBytes;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NodeStatus.java
@@ -51,6 +51,10 @@ public class NodeStatus
     // (reported separately in asyncDataCacheBytes) but may include memory that
     // is spillable under pressure.
     private final long queryMemoryBytes;
+    private final long gpuMemoryUsedBytes;
+    private final long gpuMemoryCapacityBytes;
+    private final long gpuUtilizationPercent;
+    private final long gpuMemoryBandwidthPercent;
 
     @ThriftConstructor
     @JsonCreator
@@ -70,7 +74,11 @@ public class NodeStatus
             @JsonProperty("heapAvailable") long heapAvailable,
             @JsonProperty("nonHeapUsed") long nonHeapUsed,
             @JsonProperty("asyncDataCacheBytes") long asyncDataCacheBytes,
-            @JsonProperty("queryMemoryBytes") long queryMemoryBytes)
+            @JsonProperty("queryMemoryBytes") long queryMemoryBytes,
+            @JsonProperty("gpuMemoryUsedBytes") long gpuMemoryUsedBytes,
+            @JsonProperty("gpuMemoryCapacityBytes") long gpuMemoryCapacityBytes,
+            @JsonProperty("gpuUtilizationPercent") long gpuUtilizationPercent,
+            @JsonProperty("gpuMemoryBandwidthPercent") long gpuMemoryBandwidthPercent)
     {
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
@@ -88,6 +96,10 @@ public class NodeStatus
         this.nonHeapUsed = nonHeapUsed;
         this.asyncDataCacheBytes = asyncDataCacheBytes;
         this.queryMemoryBytes = queryMemoryBytes;
+        this.gpuMemoryUsedBytes = gpuMemoryUsedBytes;
+        this.gpuMemoryCapacityBytes = gpuMemoryCapacityBytes;
+        this.gpuUtilizationPercent = gpuUtilizationPercent;
+        this.gpuMemoryBandwidthPercent = gpuMemoryBandwidthPercent;
     }
 
     @ThriftField(1)
@@ -200,5 +212,33 @@ public class NodeStatus
     public long getQueryMemoryBytes()
     {
         return queryMemoryBytes;
+    }
+
+    @ThriftField(17)
+    @JsonProperty
+    public long getGpuMemoryUsedBytes()
+    {
+        return gpuMemoryUsedBytes;
+    }
+
+    @ThriftField(18)
+    @JsonProperty
+    public long getGpuMemoryCapacityBytes()
+    {
+        return gpuMemoryCapacityBytes;
+    }
+
+    @ThriftField(19)
+    @JsonProperty
+    public long getGpuUtilizationPercent()
+    {
+        return gpuUtilizationPercent;
+    }
+
+    @ThriftField(20)
+    @JsonProperty
+    public long getGpuMemoryBandwidthPercent()
+    {
+        return gpuMemoryBandwidthPercent;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -629,6 +629,10 @@ public class TestResourceManagerClusterStateProvider
                 2,
                 3,
                 0,
+                0,
+                0,
+                0,
+                0,
                 0);
     }
 
@@ -649,6 +653,10 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
+                0,
+                0,
+                0,
                 0,
                 0);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -633,6 +633,7 @@ public class TestResourceManagerClusterStateProvider
                 0,
                 0,
                 0,
+                0,
                 0);
     }
 
@@ -653,6 +654,7 @@ public class TestResourceManagerClusterStateProvider
                 1,
                 2,
                 3,
+                0,
                 0,
                 0,
                 0,

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
@@ -37,7 +37,8 @@ public class TestNodeStatus
             long gpuMemoryUsedBytes,
             long gpuMemoryCapacityBytes,
             long gpuUtilizationPercent,
-            long gpuMemoryBandwidthPercent)
+            long gpuMemoryBandwidthPercent,
+            long gpuPoolAllocatedBytes)
     {
         return new NodeStatus(
                 "test-node",
@@ -59,7 +60,8 @@ public class TestNodeStatus
                 gpuMemoryUsedBytes,
                 gpuMemoryCapacityBytes,
                 gpuUtilizationPercent,
-                gpuMemoryBandwidthPercent);
+                gpuMemoryBandwidthPercent,
+                gpuPoolAllocatedBytes);
     }
 
     @Test
@@ -67,7 +69,7 @@ public class TestNodeStatus
     {
         // Distinct values for every long field, including a negative one, so the
         // round-trip would catch a swapped, dropped, or sign-mangled field.
-        NodeStatus expected = nodeStatus(-1L, 111L, 222L, 333L, 444L, 55L, 66L);
+        NodeStatus expected = nodeStatus(-1L, 111L, 222L, 333L, 444L, 55L, 66L, 777L);
 
         NodeStatus actual = CODEC.fromJson(CODEC.toJson(expected));
 
@@ -78,6 +80,7 @@ public class TestNodeStatus
         assertEquals(actual.getGpuMemoryCapacityBytes(), 444L);
         assertEquals(actual.getGpuUtilizationPercent(), 55L);
         assertEquals(actual.getGpuMemoryBandwidthPercent(), 66L);
+        assertEquals(actual.getGpuPoolAllocatedBytes(), 777L);
         assertEquals(actual.getHeapUsed(), expected.getHeapUsed());
         assertEquals(actual.getHeapAvailable(), expected.getHeapAvailable());
         assertEquals(actual.getNodeId(), expected.getNodeId());

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestNodeStatus.java
@@ -30,7 +30,14 @@ public class TestNodeStatus
 {
     private static final JsonCodec<NodeStatus> CODEC = jsonCodec(NodeStatus.class);
 
-    private static NodeStatus nodeStatus(long nonHeapUsed, long asyncDataCacheBytes, long queryMemoryBytes)
+    private static NodeStatus nodeStatus(
+            long nonHeapUsed,
+            long asyncDataCacheBytes,
+            long queryMemoryBytes,
+            long gpuMemoryUsedBytes,
+            long gpuMemoryCapacityBytes,
+            long gpuUtilizationPercent,
+            long gpuMemoryBandwidthPercent)
     {
         return new NodeStatus(
                 "test-node",
@@ -48,22 +55,29 @@ public class TestNodeStatus
                 8192,
                 nonHeapUsed,
                 asyncDataCacheBytes,
-                queryMemoryBytes);
+                queryMemoryBytes,
+                gpuMemoryUsedBytes,
+                gpuMemoryCapacityBytes,
+                gpuUtilizationPercent,
+                gpuMemoryBandwidthPercent);
     }
 
     @Test
     public void testJsonRoundTrip()
     {
-        // Distinct values for the three long fields, including a negative one,
-        // so the round-trip would catch a swapped, dropped, or sign-mangled
-        // field.
-        NodeStatus expected = nodeStatus(-1L, 111L, 222L);
+        // Distinct values for every long field, including a negative one, so the
+        // round-trip would catch a swapped, dropped, or sign-mangled field.
+        NodeStatus expected = nodeStatus(-1L, 111L, 222L, 333L, 444L, 55L, 66L);
 
         NodeStatus actual = CODEC.fromJson(CODEC.toJson(expected));
 
         assertEquals(actual.getNonHeapUsed(), -1L);
         assertEquals(actual.getAsyncDataCacheBytes(), 111L);
         assertEquals(actual.getQueryMemoryBytes(), 222L);
+        assertEquals(actual.getGpuMemoryUsedBytes(), 333L);
+        assertEquals(actual.getGpuMemoryCapacityBytes(), 444L);
+        assertEquals(actual.getGpuUtilizationPercent(), 55L);
+        assertEquals(actual.getGpuMemoryBandwidthPercent(), 66L);
         assertEquals(actual.getHeapUsed(), expected.getHeapUsed());
         assertEquals(actual.getHeapAvailable(), expected.getHeapAvailable());
         assertEquals(actual.getNodeId(), expected.getNodeId());

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -96,6 +96,7 @@ public class StatusResource
                 -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
                 -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
                 -1L, // gpuUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
-                -1L); // gpuMemoryBandwidthPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L, // gpuMemoryBandwidthPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L); // gpuPoolAllocatedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatusResource.java
@@ -92,6 +92,10 @@ public class StatusResource
                 memoryMXBean.getHeapMemoryUsage().getMax(),
                 memoryMXBean.getNonHeapMemoryUsage().getUsed(),
                 0L, // asyncDataCacheBytes: native-only (Prestissimo AsyncDataCache); not applicable on JVM
-                0L); // queryMemoryBytes: native-only; JVM query memory is on-heap
+                0L, // queryMemoryBytes: native-only; JVM query memory is on-heap
+                -1L, // gpuMemoryUsedBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuMemoryCapacityBytes: native-only (Prestissimo cuDF); -1 sentinel on JVM
+                -1L, // gpuUtilizationPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
+                -1L); // gpuMemoryBandwidthPercent: native-only (Prestissimo cuDF/NVML); -1 sentinel on JVM
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -319,6 +319,7 @@ public class TestHttpResourceManagerClient
                 0,
                 0,
                 0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestHttpResourceManagerClient.java
@@ -315,6 +315,10 @@ public class TestHttpResourceManagerClient
                 1,
                 1,
                 0,
+                0,
+                0,
+                0,
+                0,
                 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -63,6 +63,7 @@ public class TestResourceManagerClusterStatusSender
             0,
             0,
             0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -59,6 +59,10 @@ public class TestResourceManagerClusterStatusSender
             2,
             3,
             0,
+            0,
+            0,
+            0,
+            0,
             0);
     private static final int HEARTBEAT_INTERVAL = 100;
     private static final int SLEEP_DURATION = 1000;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRetryFunctionality.java
@@ -164,7 +164,7 @@ public class TestRetryFunctionality
                 "loc",
                 "loc",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of()),
-                1, 1, 1, 1, 1, 1, 0, 0);
+                1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0);
     }
 
     private static class FailingHttpClient

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -79,6 +79,21 @@ if(PRESTO_ENABLE_CUDF)
   # The symbols from velox_cudf_exec are not included in the Velox mono library
   # and need to be linked separately.
   target_link_libraries(presto_server_lib velox_cudf_exec)
+  # NVML (libnvidia-ml) for GPU utilization in /v1/status. CUDA::nvml provides
+  # the nvml.h include dir and links the driver stub (real lib comes from the
+  # NVIDIA runtime at run time).
+  find_package(CUDAToolkit REQUIRED)
+  # CUDAToolkit can be found (nvcc, cuda_runtime.h) yet NOT create the CUDA::nvml target when the
+  # NVML stub (libnvidia-ml.so from cuda-nvml-dev) is missing from the build image. Without this
+  # guard, linking would silently no-op and produce a presto_server with zero NVML symbols
+  # (gpuUtilizationPercent stays -1 at runtime). Fail the build loudly instead.
+  if(NOT TARGET CUDA::nvml)
+    message(
+      FATAL_ERROR
+      "CUDA::nvml target not found. Install cuda-nvml-dev (or ensure libnvidia-ml.so is in the CUDA toolkit lib/stubs directory) in the build image."
+    )
+  endif()
+  target_link_libraries(presto_server_lib CUDA::nvml)
 endif()
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -92,6 +92,7 @@
 #include <cuda_runtime.h>
 #include <nvml.h>
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #endif
@@ -2048,6 +2049,8 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuUtilizationPercent_.load(std::memory_order_relaxed);
   const int64_t gpuMemoryBandwidthPercent =
       gpuMemoryBandwidthPercent_.load(std::memory_order_relaxed);
+  const int64_t gpuPoolAllocatedBytes =
+      gpuPoolAllocatedBytes_.load(std::memory_order_relaxed);
 
   protocol::NodeStatus nodeStatus{
       nodeId_,
@@ -2069,7 +2072,8 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       gpuMemoryUsedBytes,
       gpuMemoryCapacityBytes,
       gpuUtilizationPercent,
-      gpuMemoryBandwidthPercent};
+      gpuMemoryBandwidthPercent,
+      gpuPoolAllocatedBytes};
 
   return nodeStatus;
 }
@@ -2098,6 +2102,14 @@ void PrestoServer::updateGpuStatusCache() {
   gpuMemoryCapacityBytes_.store(
       gpuMemoryCapacityBytes, std::memory_order_relaxed);
   gpuMemoryUsedBytes_.store(gpuMemoryUsedBytes, std::memory_order_relaxed);
+
+  // Live bytes currently allocated through the cuDF/RMM memory resource, via
+  // velox's statistics adaptor. Unlike gpuMemoryUsedBytes_ — the retained pool
+  // high-water mark from cudaMemGetInfo — this drops when queries free their
+  // allocations, so it separates an idle worker from a busy one. The accessor
+  // itself returns -1 when cuDF is not registered.
+  gpuPoolAllocatedBytes_.store(
+      velox::cudf_velox::cudfAllocatedBytes(), std::memory_order_relaxed);
 
   // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
   // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -89,6 +89,8 @@
 #include "velox/serializers/UnsafeRowSerializer.h"
 
 #ifdef PRESTO_ENABLE_CUDF
+#include <cuda_runtime.h>
+#include <nvml.h>
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
@@ -1318,6 +1320,21 @@ void PrestoServer::addServerPeriodicTasks() {
       1'000'000, // 1 second
       "populate_mem_cpu_info");
 
+#ifdef PRESTO_ENABLE_CUDF
+  // Sample GPU metrics off the serving path so fetchNodeStatus() (RM heartbeat)
+  // only reads cached atomics — never runs synchronous CUDA/NVML probes.
+  // updateGpuStatusCache() is a no-op unless cuDF is enabled at runtime, so
+  // scheduling it unconditionally here is safe regardless of init ordering.
+  const uint64_t gpuStatusIntervalMs =
+      SystemConfig::instance()->gpuStatusUpdateIntervalMs();
+  if (gpuStatusIntervalMs > 0) {
+    periodicTaskManager_->addTask(
+        [server = this]() { server->updateGpuStatusCache(); },
+        gpuStatusIntervalMs * 1'000, // ms -> micros
+        "update_gpu_status");
+  }
+#endif
+
   periodicTaskManager_->addTask(
       [start = start_]() {
         const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
@@ -2014,6 +2031,23 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
     queryMemoryBytes += pool.second.reservedBytes;
   }
 
+  // GPU metrics. cuDF/RMM allocations do not flow through Velox MemoryPools, so
+  // these are sampled directly from the device/NVML. To keep the synchronous
+  // CUDA/NVML probes off this path (fetchNodeStatus feeds the RM heartbeat — a
+  // stalled probe here can get the worker declared dead), sampling runs on the
+  // periodic 'update_gpu_status' task and we only read the cached atomics here.
+  // -1 sentinel when cuDF is disabled/not registered or a probe has not
+  // succeeded yet (same convention as 'nonHeapUsed'). Semantics of each value
+  // are documented on updateGpuStatusCache().
+  const int64_t gpuMemoryUsedBytes =
+      gpuMemoryUsedBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryCapacityBytes =
+      gpuMemoryCapacityBytes_.load(std::memory_order_relaxed);
+  const int64_t gpuUtilizationPercent =
+      gpuUtilizationPercent_.load(std::memory_order_relaxed);
+  const int64_t gpuMemoryBandwidthPercent =
+      gpuMemoryBandwidthPercent_.load(std::memory_order_relaxed);
+
   protocol::NodeStatus nodeStatus{
       nodeId_,
       {nodeVersion_},
@@ -2030,9 +2064,54 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed,
       asyncDataCacheBytes,
-      queryMemoryBytes};
+      queryMemoryBytes,
+      gpuMemoryUsedBytes,
+      gpuMemoryCapacityBytes,
+      gpuUtilizationPercent,
+      gpuMemoryBandwidthPercent};
 
   return nodeStatus;
+}
+
+void PrestoServer::updateGpuStatusCache() {
+#ifdef PRESTO_ENABLE_CUDF
+  if (!velox::cudf_velox::CudfConfig::getInstance().enabled) {
+    return;
+  }
+  // cudaMemGetInfo reports the whole device: 'used' reflects the retained RMM
+  // pool reservation (high-water mark) — the right notion for "how full is the
+  // GPU". Stored into gpuMemory{Used,Capacity}Bytes_.
+  size_t gpuFree = 0;
+  size_t gpuTotal = 0;
+  if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
+    gpuMemoryCapacityBytes_.store(
+        static_cast<int64_t>(gpuTotal), std::memory_order_relaxed);
+    gpuMemoryUsedBytes_.store(
+        static_cast<int64_t>(gpuTotal - gpuFree), std::memory_order_relaxed);
+  }
+
+  // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
+  // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM
+  // is. NOTE: NVML reports the whole physical device; under fractional/shared
+  // GPU (time-slicing/MPS) this reflects the shared GPU, not just this worker
+  // (see plan Annex A3).
+  // NVML init once for the server lifetime (process exit reclaims it).
+  static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
+  if (nvmlReady) {
+    nvmlDevice_t nvmlDevice;
+    nvmlUtilization_t util;
+    // Index 0: inside the container NVML sees only the GPU(s) exposed to this
+    // pod, so device 0 is this worker's GPU. Multi-GPU-visible containers
+    // would need PCI-bus-id mapping to the active CUDA device.
+    if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
+        nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
+      gpuUtilizationPercent_.store(
+          static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
+      gpuMemoryBandwidthPercent_.store(
+          static_cast<int64_t>(util.memory), std::memory_order_relaxed);
+    }
+  }
+#endif
 }
 
 void PrestoServer::registerDynamicFunctions() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -2036,9 +2036,10 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   // CUDA/NVML probes off this path (fetchNodeStatus feeds the RM heartbeat — a
   // stalled probe here can get the worker declared dead), sampling runs on the
   // periodic 'update_gpu_status' task and we only read the cached atomics here.
-  // -1 sentinel when cuDF is disabled/not registered or a probe has not
-  // succeeded yet (same convention as 'nonHeapUsed'). Semantics of each value
-  // are documented on updateGpuStatusCache().
+  // -1 sentinel when cuDF is disabled/not registered, when no probe has run
+  // yet, or when the most recent probe failed (same convention as
+  // 'nonHeapUsed'). Semantics of each value are documented on
+  // updateGpuStatusCache().
   const int64_t gpuMemoryUsedBytes =
       gpuMemoryUsedBytes_.load(std::memory_order_relaxed);
   const int64_t gpuMemoryCapacityBytes =
@@ -2078,23 +2079,33 @@ void PrestoServer::updateGpuStatusCache() {
   if (!velox::cudf_velox::CudfConfig::getInstance().enabled) {
     return;
   }
+  // Every probe stores unconditionally, writing the -1 sentinel when it fails.
+  // Leaving the previous sample in place would be worse than reporting nothing:
+  // a stale value is indistinguishable from a fresh one, so a GPU that stopped
+  // responding would keep reporting healthy numbers indefinitely.
+
   // cudaMemGetInfo reports the whole device: 'used' reflects the retained RMM
   // pool reservation (high-water mark) — the right notion for "how full is the
   // GPU". Stored into gpuMemory{Used,Capacity}Bytes_.
+  int64_t gpuMemoryUsedBytes = -1;
+  int64_t gpuMemoryCapacityBytes = -1;
   size_t gpuFree = 0;
   size_t gpuTotal = 0;
   if (cudaMemGetInfo(&gpuFree, &gpuTotal) == cudaSuccess) {
-    gpuMemoryCapacityBytes_.store(
-        static_cast<int64_t>(gpuTotal), std::memory_order_relaxed);
-    gpuMemoryUsedBytes_.store(
-        static_cast<int64_t>(gpuTotal - gpuFree), std::memory_order_relaxed);
+    gpuMemoryCapacityBytes = static_cast<int64_t>(gpuTotal);
+    gpuMemoryUsedBytes = static_cast<int64_t>(gpuTotal - gpuFree);
   }
+  gpuMemoryCapacityBytes_.store(
+      gpuMemoryCapacityBytes, std::memory_order_relaxed);
+  gpuMemoryUsedBytes_.store(gpuMemoryUsedBytes, std::memory_order_relaxed);
 
   // GPU compute / memory-bandwidth utilization (%) via NVML — nvidia-smi's
   // "GPU-Util". Says whether the GPU is actually computing, not how full VRAM
   // is. NOTE: NVML reports the whole physical device; under fractional/shared
   // GPU (time-slicing/MPS) this reflects the shared GPU, not just this worker
   // (see plan Annex A3).
+  int64_t gpuUtilizationPercent = -1;
+  int64_t gpuMemoryBandwidthPercent = -1;
   // NVML init once for the server lifetime (process exit reclaims it).
   static const bool nvmlReady = (nvmlInit_v2() == NVML_SUCCESS);
   if (nvmlReady) {
@@ -2105,12 +2116,14 @@ void PrestoServer::updateGpuStatusCache() {
     // would need PCI-bus-id mapping to the active CUDA device.
     if (nvmlDeviceGetHandleByIndex_v2(0, &nvmlDevice) == NVML_SUCCESS &&
         nvmlDeviceGetUtilizationRates(nvmlDevice, &util) == NVML_SUCCESS) {
-      gpuUtilizationPercent_.store(
-          static_cast<int64_t>(util.gpu), std::memory_order_relaxed);
-      gpuMemoryBandwidthPercent_.store(
-          static_cast<int64_t>(util.memory), std::memory_order_relaxed);
+      gpuUtilizationPercent = static_cast<int64_t>(util.gpu);
+      gpuMemoryBandwidthPercent = static_cast<int64_t>(util.memory);
     }
   }
+  gpuUtilizationPercent_.store(
+      gpuUtilizationPercent, std::memory_order_relaxed);
+  gpuMemoryBandwidthPercent_.store(
+      gpuMemoryBandwidthPercent, std::memory_order_relaxed);
 #endif
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -261,6 +261,11 @@ class PrestoServer {
 
   void populateMemAndCPUInfo();
 
+  // Samples GPU device/pool/utilization metrics and stores them into the
+  // gpu*_ atomics. Runs on the periodic-task executor (never on the heartbeat
+  // path). No-op unless built with cuDF and enabled at runtime.
+  void updateGpuStatusCache();
+
   // Periodically yield tasks if there are tasks queued.
   void yieldTasks();
 
@@ -360,6 +365,16 @@ class PrestoServer {
   // the first sample and when no cache instance exists (classic JVM behaviour).
   std::atomic<int64_t> asyncDataCacheBytes_{0};
   CPUMon cpuMon_;
+
+  // Cached GPU metrics. Sampled off the serving path by the periodic
+  // 'update_gpu_status' task (updateGpuStatusCache) and read by
+  // fetchNodeStatus(). This keeps the synchronous CUDA/NVML probes off the
+  // heartbeat path: fetchNodeStatus() feeds the RM heartbeat, and a stalled
+  // probe there can get the worker declared dead. -1 = unavailable.
+  std::atomic<int64_t> gpuMemoryUsedBytes_{-1};
+  std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
+  std::atomic<int64_t> gpuUtilizationPercent_{-1};
+  std::atomic<int64_t> gpuMemoryBandwidthPercent_{-1};
 
   std::string environment_;
   std::string nodeVersion_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -370,7 +370,8 @@ class PrestoServer {
   // 'update_gpu_status' task (updateGpuStatusCache) and read by
   // fetchNodeStatus(). This keeps the synchronous CUDA/NVML probes off the
   // heartbeat path: fetchNodeStatus() feeds the RM heartbeat, and a stalled
-  // probe there can get the worker declared dead. -1 = unavailable.
+  // probe there can get the worker declared dead. -1 = unavailable, which each
+  // sampling pass rewrites on probe failure rather than leaving a stale value.
   std::atomic<int64_t> gpuMemoryUsedBytes_{-1};
   std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
   std::atomic<int64_t> gpuUtilizationPercent_{-1};

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -376,6 +376,7 @@ class PrestoServer {
   std::atomic<int64_t> gpuMemoryCapacityBytes_{-1};
   std::atomic<int64_t> gpuUtilizationPercent_{-1};
   std::atomic<int64_t> gpuMemoryBandwidthPercent_{-1};
+  std::atomic<int64_t> gpuPoolAllocatedBytes_{-1};
 
   std::string environment_;
   std::string nodeVersion_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -264,6 +264,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLogNumZombieTasks, 20),
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 30s
           NUM_PROP(kHeartbeatFrequencyMs, 0),
+          NUM_PROP(kGpuStatusUpdateIntervalMs, 1'000), // 1s
           BOOL_PROP(kHttpClientHttp2Enabled, false),
           NUM_PROP(kHttpClientHttp2MaxStreamsPerConnection, 8),
           NUM_PROP(kHttpClientHttp2InitialStreamWindow, 1 << 23 /*8MB*/),
@@ -1065,6 +1066,10 @@ uint64_t SystemConfig::announcementMaxFrequencyMs() const {
 
 uint64_t SystemConfig::heartbeatFrequencyMs() const {
   return optionalProperty<uint64_t>(kHeartbeatFrequencyMs).value();
+}
+
+uint64_t SystemConfig::gpuStatusUpdateIntervalMs() const {
+  return optionalProperty<uint64_t>(kGpuStatusUpdateIntervalMs).value();
 }
 
 bool SystemConfig::httpClientHttp2Enabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -790,6 +790,14 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHeartbeatFrequencyMs{
       "heartbeat-frequency-ms"};
 
+  /// Period (ms) of the background task that samples GPU memory/utilization
+  /// metrics into the cache read by /v1/status (see PrestoServer::
+  /// updateGpuStatusCache). Keeps CUDA/NVML probes off the heartbeat path.
+  /// 0 disables sampling (GPU fields stay at the -1 sentinel). Only effective
+  /// on cuDF-enabled builds/workers.
+  static constexpr std::string_view kGpuStatusUpdateIntervalMs{
+      "gpu.status-update-interval-ms"};
+
   /// Whether HTTP/2 is enabled for HTTP client connections.
   static constexpr std::string_view kHttpClientHttp2Enabled{
       "http-client.http2-enabled"};
@@ -1294,6 +1302,8 @@ class SystemConfig : public ConfigBase {
   uint64_t announcementMaxFrequencyMs() const;
 
   uint64_t heartbeatFrequencyMs() const;
+
+  uint64_t gpuStatusUpdateIntervalMs() const;
 
   bool httpClientHttp2Enabled() const;
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -247,6 +247,22 @@ TEST_F(ConfigTest, asyncCacheNumShards) {
   ASSERT_EQ(config.asyncCacheNumShards(), 8);
 }
 
+TEST_F(ConfigTest, gpuStatusUpdateIntervalMs) {
+  SystemConfig config;
+  init(config, {});
+  // Default is 1s.
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 1'000);
+
+  // Custom value (e.g. faster sampling).
+  init(
+      config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "250"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 250);
+
+  // 0 disables the GPU sampling task.
+  init(config, {{std::string(SystemConfig::kGpuStatusUpdateIntervalMs), "0"}});
+  ASSERT_EQ(config.gpuStatusUpdateIntervalMs(), 0);
+}
+
 TEST_F(ConfigTest, asyncCacheSsdFlushThresholdBytes) {
   SystemConfig config;
   init(config, {});

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8316,6 +8316,34 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "queryMemoryBytes");
+  to_json_key(
+      j,
+      "gpuMemoryUsedBytes",
+      p.gpuMemoryUsedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryUsedBytes");
+  to_json_key(
+      j,
+      "gpuMemoryCapacityBytes",
+      p.gpuMemoryCapacityBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryCapacityBytes");
+  to_json_key(
+      j,
+      "gpuUtilizationPercent",
+      p.gpuUtilizationPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuUtilizationPercent");
+  to_json_key(
+      j,
+      "gpuMemoryBandwidthPercent",
+      p.gpuMemoryBandwidthPercent,
+      "NodeStatus",
+      "int64_t",
+      "gpuMemoryBandwidthPercent");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8391,6 +8419,44 @@ void from_json(const json& j, NodeStatus& p) {
         "NodeStatus",
         "int64_t",
         "queryMemoryBytes");
+  }
+  if (j.count("gpuMemoryUsedBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryUsedBytes",
+        p.gpuMemoryUsedBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryUsedBytes");
+  }
+  if (j.count("gpuMemoryCapacityBytes")) {
+    from_json_key(
+        j,
+        "gpuMemoryCapacityBytes",
+        p.gpuMemoryCapacityBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryCapacityBytes");
+  }
+  // Backward compatible: guard with j.count() so payloads from older workers
+  // that lack this field still deserialize (defaults to 0 via the struct).
+  if (j.count("gpuUtilizationPercent")) {
+    from_json_key(
+        j,
+        "gpuUtilizationPercent",
+        p.gpuUtilizationPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuUtilizationPercent");
+  }
+  if (j.count("gpuMemoryBandwidthPercent")) {
+    from_json_key(
+        j,
+        "gpuMemoryBandwidthPercent",
+        p.gpuMemoryBandwidthPercent,
+        "NodeStatus",
+        "int64_t",
+        "gpuMemoryBandwidthPercent");
   }
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -8344,6 +8344,13 @@ void to_json(json& j, const NodeStatus& p) {
       "NodeStatus",
       "int64_t",
       "gpuMemoryBandwidthPercent");
+  to_json_key(
+      j,
+      "gpuPoolAllocatedBytes",
+      p.gpuPoolAllocatedBytes,
+      "NodeStatus",
+      "int64_t",
+      "gpuPoolAllocatedBytes");
 }
 
 void from_json(const json& j, NodeStatus& p) {
@@ -8457,6 +8464,15 @@ void from_json(const json& j, NodeStatus& p) {
         "NodeStatus",
         "int64_t",
         "gpuMemoryBandwidthPercent");
+  }
+  if (j.count("gpuPoolAllocatedBytes")) {
+    from_json_key(
+        j,
+        "gpuPoolAllocatedBytes",
+        p.gpuPoolAllocatedBytes,
+        "NodeStatus",
+        "int64_t",
+        "gpuPoolAllocatedBytes");
   }
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2018,6 +2018,7 @@ struct NodeStatus {
   int64_t gpuMemoryCapacityBytes = {};
   int64_t gpuUtilizationPercent = {};
   int64_t gpuMemoryBandwidthPercent = {};
+  int64_t gpuPoolAllocatedBytes = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -2014,6 +2014,10 @@ struct NodeStatus {
   int64_t nonHeapUsed = {};
   int64_t asyncDataCacheBytes = {};
   int64_t queryMemoryBytes = {};
+  int64_t gpuMemoryUsedBytes = {};
+  int64_t gpuMemoryCapacityBytes = {};
+  int64_t gpuUtilizationPercent = {};
+  int64_t gpuMemoryBandwidthPercent = {};
 };
 void to_json(json& j, const NodeStatus& p);
 void from_json(const json& j, NodeStatus& p);

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'
-RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
+RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found" | grep -v "libnvidia-ml") && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 
 #/////////////////////////////////////////////


### PR DESCRIPTION
**Draft — has two open dependencies.** Not ready to merge, opened early so the
dependency chain and the field numbering are visible.

| Depends on | Why |
|---|---|
| prestodb/presto#28370 | This branch is stacked on it. It adds the other four GPU fields and the periodic sampling task this change plugs into, and it owns Thrift ids 17-20; this adds id 21. |
| facebookincubator/velox#18521 | Provides `cudfAllocatedBytes()`, the accessor this change reads. Until it merges and Velox is advanced in this repo, the symbol does not exist. |

**Review only the last commit** (`feat(native): Expose cuDF live-allocated GPU
bytes in /v1/status`). The three preceding commits belong to #28370 and will
disappear from this PR once that merges and this branch is rebased.

**Expected CI state while this is a draft:** `prestocpp-linux-build-gpu-engine`
will fail, because that is the only job that compiles with `PRESTO_ENABLE_CUDF=ON`
and `velox::cudf_velox::cudfAllocatedBytes()` is not in the currently pinned
Velox. Every other job should pass — both the call and its include sit inside
`#ifdef PRESTO_ENABLE_CUDF`, so non-cuDF builds are unaffected. That job should go
green on its own once velox#18521 merges and the periodic
`chore(ci): Advance velox` moves the pin past it; no submodule change is made
here by design.

### Description

Adds `gpuPoolAllocatedBytes` to `NodeStatus` (Thrift id 21), reporting the device
memory cuDF currently holds, as counted by RMM's statistics resource adaptor.

It is sampled on the same periodic task as the other GPU fields
(`update_gpu_status`), so `fetchNodeStatus()` only reads a cached atomic and no
CUDA call happens on the resource-manager heartbeat path. `cudfAllocatedBytes()`
returns `-1` when cuDF is not registered, which is the same sentinel the other GPU
fields use for "unavailable".

### Motivation

`gpuMemoryUsedBytes` (from #28370) comes from `cudaMemGetInfo`, so with an RMM
pool it reports the pool's *retained reservation*. The pool holds device memory
between queries for reuse, so that number stays high on an idle worker and cannot
distinguish "GPU is reserved" from "GPU is working".

The statistics adaptor counts what callers actually hold, so this value drops as
queries free their allocations. For scheduling and autoscaling that is the
difference between a worker that is busy and one that merely warmed a pool.

The two NVML utilization fields in #28370 answer a related but different question
— whether the GPU is computing — while this one says how much device memory is
genuinely in use.

### Impact

- One added `NodeStatus` field. Thrift skips unknown field ids and the JSON
  deserializer ignores unknown properties, so mixed-version coordinator/worker
  pairs keep working. As with the other GPU fields, an absent value deserializes
  to `0`; treat `gpuMemoryCapacityBytes == 0` as "no GPU data".
- No behavior change for non-GPU builds: the sampling is inside
  `#ifdef PRESTO_ENABLE_CUDF` and the field stays `-1`.
- **No submodule change.** The required Velox commit arrives through the existing
  `chore(ci): Advance velox` automation rather than a pin bump in this PR.
- No new configuration properties; sampling reuses
  `gpu.status-update-interval-ms` from #28370.
- No new third-party dependencies.

### Test plan

- `TestNodeStatus` extended so the JSON round-trip covers the new field with a
  distinct value alongside the existing ones.
- Java build and the five affected test classes run locally: 27 tests, no
  failures.
- The cuDF build path cannot be compiled until velox#18521 lands; that is the
  first item on the ready-for-review checklist below.
- Not yet exercised on GPU hardware — no GPU host available. Verifying that the
  value rises under a cuDF query and falls when it completes needs a real device,
  and that is the behavior that distinguishes this field from
  `gpuMemoryUsedBytes`.

### Before this leaves draft

- [ ] velox#18521 merged
- [ ] Velox advanced in this repo past that commit
- [ ] #28370 merged, this branch rebased onto `master` so only one commit remains
- [ ] cuDF build green, including `prestocpp-linux-build-gpu-engine`

### Release notes

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add ``gpuPoolAllocatedBytes`` to the worker status endpoint, reporting the GPU memory cuDF currently holds. Unlike ``gpuMemoryUsedBytes``, this drops as queries free their allocations. The value is ``-1`` unless the worker is a cuDF-enabled build with cuDF enabled at run time.
```

## Summary by Sourcery

Expose cached GPU resource and utilization metrics in worker status for improved GPU scheduling and monitoring.

New Features:
- Expose GPU memory, capacity, utilization, bandwidth, and live cuDF pool allocation metrics through the worker status endpoint.
- Add configurable background sampling for native GPU status metrics, with unavailable values represented by a sentinel and JVM workers remaining GPU-neutral.

Enhancements:
- Keep GPU status collection off the resource-manager heartbeat path by serving cached samples.

Build:
- Link cuDF-enabled native builds with NVML support and validate the required CUDA NVML target.

Documentation:
- Document the GPU status sampling configuration property and the new status metrics.

Tests:
- Extend node status serialization and configuration tests to cover GPU fields and sampling intervals.