### PR TITLE
fix(native-pos): Fix memory reservation leak in materialized output buffer (#28379)

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -550,6 +550,7 @@ void MaterializedOutputBuffer::noMoreData() {
   if (!state_.compare_exchange_strong(expected, State::kDraining)) {
     return;
   }
+  auto releaseGuard = folly::makeGuard([this]() { pool_->release(); });
   LOG(INFO) << fmt::format(
       "MaterializedOutputBuffer noMoreData: draining, bufferedBytes={}",
       velox::succinctBytes(bufferedBytes_));
@@ -586,6 +587,7 @@ void MaterializedOutputBuffer::abort() {
   if (!state_.compare_exchange_strong(expected, State::kAborted)) {
     return;
   }
+  auto releaseGuard = folly::makeGuard([this]() { pool_->release(); });
 
   // Unpark any producers blocked on backpressure so they observe kAborted.
   maybeWakeBlockedDrivers();

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
@@ -174,6 +174,48 @@ TEST_F(ReclaimerTest, reclaimSkippedAfterClose) {
   buffer.pool()->free(allocation, 10 * kMB);
 }
 
+TEST_F(ReclaimerTest, terminalStateReleasesPinnedReservation) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "release.0.0.0.0",
+      rootPool_.get());
+
+  void* allocation = buffer.pool()->allocate(16 * kMB);
+  buffer.ensureDrainMemoryHeadroom();
+  buffer.pool()->free(allocation, 16 * kMB);
+  ASSERT_GT(buffer.pool()->reservedBytes(), 0);
+
+  buffer.noMoreData();
+
+  EXPECT_EQ(buffer.state(), MaterializedOutputBuffer::State::kClosed);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+  EXPECT_EQ(buffer.pool()->reservedBytes(), 0);
+}
+
+TEST_F(ReclaimerTest, abortReleasesPinnedReservation) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "aborted.0.0.0.0",
+      rootPool_.get());
+
+  void* allocation = buffer.pool()->allocate(16 * kMB);
+  buffer.ensureDrainMemoryHeadroom();
+  buffer.pool()->free(allocation, 16 * kMB);
+  ASSERT_GT(buffer.pool()->reservedBytes(), 0);
+
+  buffer.abort();
+
+  EXPECT_EQ(buffer.state(), MaterializedOutputBuffer::State::kAborted);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+  EXPECT_EQ(buffer.pool()->reservedBytes(), 0);
+}
+
 TEST_F(ReclaimerTest, reclaimBlockedWhenAborted) {
   NoOpShuffleFactory factory;
   MaterializedOutputBuffer buffer(


### PR DESCRIPTION
Summary:

Release the MaterializedOutputBuffer drain-headroom reservation when successful close or abort reaches a terminal state. This prevents empty completed buffers from retaining their peak pool reservation until destruction, or when destructors don't fire

Differential Revision: D116664446

## Summary by Sourcery

Ensure materialized output buffers release drain headroom reservations when reaching terminal states.

Bug Fixes:
- Release pinned memory reservations when materialized output buffers successfully close or abort, preventing completed buffers from retaining drain headroom indefinitely.

Tests:
- Add coverage verifying that terminal close and abort states release all pinned reservations.

```
== NO RELEASE NOTE ==
```