### PR TITLE
fix(native): Fix Iceberg default value format for DATE, TIMESTAMP columns

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -23,8 +23,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.Types;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -275,11 +281,11 @@ public class IcebergColumnHandle
     {
         Optional<String> defaultValue = Optional.empty();
         if (column.initialDefault() != null) {
-            defaultValue = Optional.of(String.valueOf(column.initialDefault()));
+            defaultValue = Optional.of(icebergDefaultToString(column.type().typeId(), column.initialDefault()));
         }
         Optional<String> writeDefaultValue = Optional.empty();
         if (column.writeDefault() != null) {
-            writeDefaultValue = Optional.of(String.valueOf(column.writeDefault()));
+            writeDefaultValue = Optional.of(icebergDefaultToString(column.type().typeId(), column.writeDefault()));
         }
         return new IcebergColumnHandle(
                 createColumnIdentity(column),
@@ -316,5 +322,42 @@ public class IcebergColumnHandle
                 requiredSubfields,
                 Optional.empty(),
                 Optional.empty());
+    }
+
+    /**
+     * Converts an Iceberg initial-default value to a string that both the Java
+     * deserialization path ({@link IcebergUtil#deserializeIcebergValue}) and the
+     * native C++ worker ({@code PartitionValue::fromString}) can parse.
+     *
+     * DATE defaults are stored internally as integer days-since-epoch; we emit
+     * them as ISO-8601 strings (e.g. {@code "2023-01-01"}) so the C++ path can
+     * parse them without the {@code kDaysSinceEpoch} flag.
+     *
+     * TIMESTAMP defaults are stored as microseconds-since-epoch; we emit them as
+     * ISO-8601 datetime strings with microsecond precision
+     * (e.g. {@code "2023-01-01 11:00:00.000000"}).
+     */
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    private static String icebergDefaultToString(TypeID typeId, Object value)
+    {
+        switch (typeId) {
+            case DATE: {
+                // Iceberg stores DATE defaults as Integer days since epoch.
+                int daysSinceEpoch = (Integer) value;
+                return LocalDate.ofEpochDay(daysSinceEpoch).toString();
+            }
+            case TIMESTAMP: {
+                // Iceberg stores TIMESTAMP defaults as Long microseconds since epoch.
+                long microsSinceEpoch = (Long) value;
+                long seconds = Math.floorDiv(microsSinceEpoch, 1_000_000L);
+                int nanos = (int) Math.floorMod(microsSinceEpoch, 1_000_000L) * 1_000;
+                LocalDateTime dt = LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanos), ZoneOffset.UTC);
+                return dt.format(TIMESTAMP_FORMATTER);
+            }
+            default:
+                return String.valueOf(value);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -103,6 +103,11 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -930,10 +935,41 @@ public final class IcebergUtil
                 return parseDouble(valueString);
             }
             if (type.equals(TIMESTAMP) || type.equals(TIME)) {
-                return MICROSECONDS.toMillis(parseLong(valueString));
+                // Default values are serialised as ISO datetime strings
+                // (e.g. "2023-01-01 11:00:00.000000"); partition values arrive
+                // as microseconds-since-epoch numeric strings.  Accept both.
+                try {
+                    return MICROSECONDS.toMillis(parseLong(valueString));
+                }
+                catch (NumberFormatException ignored) {
+                    // ISO string: parse to epoch-millis via LocalDateTime
+                    try {
+                        LocalDateTime ldt = LocalDateTime.parse(
+                                valueString,
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSS]"));
+                        return ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+                    }
+                    catch (DateTimeParseException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                }
             }
             if (type.equals(DATE) || type.equals(TIMESTAMP_MICROSECONDS)) {
-                return parseLong(valueString);
+                // Default values are serialised as ISO date strings
+                // (e.g. "2023-01-01"); partition values arrive as integer
+                // days-since-epoch numeric strings.  Accept both.
+                try {
+                    return parseLong(valueString);
+                }
+                catch (NumberFormatException ignored) {
+                    // ISO date string
+                    try {
+                        return LocalDate.parse(valueString).toEpochDay();
+                    }
+                    catch (DateTimeParseException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                }
             }
             if (type instanceof VarcharType) {
                 return utf8Slice(valueString);

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3DefaultColumnValues.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/iceberg/TestIcebergV3DefaultColumnValues.java
@@ -294,6 +294,135 @@ public class TestIcebergV3DefaultColumnValues
         }
     }
 
+    @Test(dataProvider = "pushdownFilterEnabled")
+    public void testDefaultDateColumnForHistoricalRows(boolean pushdownFilterEnabled)
+    {
+        Session session = sessionWithPushdown(pushdownFilterEnabled);
+        // Iceberg stores DATE defaults as integer days since the Unix epoch.
+        // The native worker must decode that integer and return the correct DATE
+        // value for rows written before the column was added.
+        String tableName = "orders_v3_default_date";
+        try {
+            // Write two rows before the date column exists.
+            createTableWithRows(session, tableName, "(id BIGINT, name VARCHAR)", "VALUES (1, 'Alice'), (2, 'Bob')", 2);
+
+            // Add a DATE column with an initial-default (2023-01-01 = day 19358 since epoch).
+            assertUpdate(String.format(
+                    "ALTER TABLE %s ADD COLUMN created_date DATE DEFAULT DATE '2023-01-01'", tableName));
+
+            // Historical rows must surface the initial-default.
+            assertQuery(
+                    String.format("SELECT id, created_date FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', DATE '2023-01-01'), (BIGINT '2', DATE '2023-01-01')");
+
+            // New row written with an explicit date value must use that value.
+            assertUpdate(String.format(
+                    "INSERT INTO %s VALUES (3, 'Charlie', DATE '2024-06-15')", tableName), 1);
+            assertQuery(
+                    String.format("SELECT id, created_date FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', DATE '2023-01-01'), "
+                            + "(BIGINT '2', DATE '2023-01-01'), "
+                            + "(BIGINT '3', DATE '2024-06-15')");
+
+            // New row written without a date value must return NULL (not the initial-default).
+            assertUpdate(String.format(
+                    "INSERT INTO %s (id, name) VALUES (4, 'David')", tableName), 1);
+            assertQuery(
+                    String.format("SELECT id, created_date FROM %s WHERE id = 4", tableName),
+                    "VALUES (BIGINT '4', NULL)");
+
+            // SELECT * must return all columns for all rows, mixing the initial-default,
+            // an explicit file value, and NULL in the same result set.
+            assertQuery(
+                    String.format("SELECT * FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', 'Alice', DATE '2023-01-01'), "
+                            + "(BIGINT '2', 'Bob',   DATE '2023-01-01'), "
+                            + "(BIGINT '3', 'Charlie', DATE '2024-06-15'), "
+                            + "(BIGINT '4', 'David',   NULL)");
+
+            // Filter pushdown on the default date value must return only historical rows.
+            assertQuery(
+                    String.format("SELECT id FROM %s WHERE created_date = DATE '2023-01-01' ORDER BY id", tableName),
+                    "VALUES (1), (2)");
+
+            // Filter on the explicit date must return only row 3.
+            assertQuery(
+                    String.format("SELECT id FROM %s WHERE created_date = DATE '2024-06-15'", tableName),
+                    "VALUES (3)");
+        }
+        finally {
+            dropTableIfExists(session, tableName);
+        }
+    }
+
+    @Test(dataProvider = "pushdownFilterEnabled")
+    public void testDefaultTimestampColumnForHistoricalRows(boolean pushdownFilterEnabled)
+    {
+        Session session = sessionWithPushdown(pushdownFilterEnabled);
+        // Iceberg stores TIMESTAMP defaults as integer microseconds since the Unix epoch.
+        // The native worker must decode that integer and return the correct TIMESTAMP
+        // value for rows written before the column was added.
+        String tableName = "orders_v3_default_timestamp";
+        try {
+            // Write two rows before the timestamp column exists.
+            createTableWithRows(session, tableName, "(id BIGINT, name VARCHAR)", "VALUES (1, 'Alice'), (2, 'Bob')", 2);
+
+            // Add a TIMESTAMP column with an initial-default
+            // (2023-01-01 11:00:00 UTC = 1672570800000000 microseconds since epoch).
+            assertUpdate(String.format(
+                    "ALTER TABLE %s ADD COLUMN created_at TIMESTAMP DEFAULT TIMESTAMP '2023-01-01 11:00:00.000000'",
+                    tableName));
+
+            // Historical rows must surface the initial-default.
+            assertQuery(
+                    String.format("SELECT id, created_at FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', TIMESTAMP '2023-01-01 11:00:00.000000'), "
+                            + "(BIGINT '2', TIMESTAMP '2023-01-01 11:00:00.000000')");
+
+            // New row written with an explicit timestamp must use that value.
+            assertUpdate(String.format(
+                    "INSERT INTO %s VALUES (3, 'Charlie', TIMESTAMP '2024-12-25 15:30:00.000000')", tableName), 1);
+            assertQuery(
+                    String.format("SELECT id, created_at FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', TIMESTAMP '2023-01-01 11:00:00.000000'), "
+                            + "(BIGINT '2', TIMESTAMP '2023-01-01 11:00:00.000000'), "
+                            + "(BIGINT '3', TIMESTAMP '2024-12-25 15:30:00.000000')");
+
+            // New row written without a timestamp value must return NULL (not the initial-default).
+            assertUpdate(String.format(
+                    "INSERT INTO %s (id, name) VALUES (4, 'David')", tableName), 1);
+            assertQuery(
+                    String.format("SELECT id, created_at FROM %s WHERE id = 4", tableName),
+                    "VALUES (BIGINT '4', NULL)");
+
+            // SELECT * must return all columns for all rows, mixing the initial-default,
+            // an explicit file value, and NULL in the same result set.
+            assertQuery(
+                    String.format("SELECT * FROM %s ORDER BY id", tableName),
+                    "VALUES (BIGINT '1', 'Alice',   TIMESTAMP '2023-01-01 11:00:00.000000'), "
+                            + "(BIGINT '2', 'Bob',     TIMESTAMP '2023-01-01 11:00:00.000000'), "
+                            + "(BIGINT '3', 'Charlie', TIMESTAMP '2024-12-25 15:30:00.000000'), "
+                            + "(BIGINT '4', 'David',   NULL)");
+
+            // Filter pushdown on the default timestamp must return only historical rows.
+            assertQuery(
+                    String.format(
+                            "SELECT id FROM %s WHERE created_at = TIMESTAMP '2023-01-01 11:00:00.000000' ORDER BY id",
+                            tableName),
+                    "VALUES (1), (2)");
+
+            // Filter on the explicit timestamp must return only row 3.
+            assertQuery(
+                    String.format(
+                            "SELECT id FROM %s WHERE created_at = TIMESTAMP '2024-12-25 15:30:00.000000'",
+                            tableName),
+                    "VALUES (3)");
+        }
+        finally {
+            dropTableIfExists(session, tableName);
+        }
+    }
+
     private Session sessionWithPushdown(boolean pushdownFilterEnabled)
     {
         return Session.builder(getSession())


### PR DESCRIPTION
## Description
Fixes default value parsing issue for DATE and TIMESTAMP columns. Values read by Presto are in epoch duration. Velox expects them in ISO string format. And Adds E2E tests for default value reads for DATE, TIMESTAMP columns. Depends on a small velox fix in https://github.com/facebookincubator/velox/pull/18783

## Motivation and Context
DATE, TIMESTAMP values are stored in epoch duration for Iceberg already and velox fails during parsing assuming the source values are in ISO string format. This is fixed and E2E tests are also added in this PR.

## Impact
No impact

## Test Plan
Added tests in TestIcebergV3DefaultColumnValues.java

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix Iceberg DATE and TIMESTAMP default value handling and verify native reads and filtering across historical and newly written rows.

Bug Fixes:
- Correct DATE and TIMESTAMP Iceberg default values so they are parsed consistently by Java and native execution paths.
- Preserve support for numeric epoch-based partition values while accepting ISO-formatted temporal defaults.

Tests:
- Add native end-to-end coverage for historical DATE and TIMESTAMP defaults, explicit values, NULLs, and predicate filtering with pushdown enabled and disabled.