### PR TITLE
fix(plugin-iceberg): Enable MV base-table query rewrite for Iceberg

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -2086,29 +2086,40 @@ public abstract class IcebergAbstractMetadata
     {
         requireNonNull(tableName, "tableName is null");
         ImmutableList.Builder<SchemaTableName> referencingViews = ImmutableList.builder();
-        List<SchemaTableName> candidateViews;
+
+        List<String> schemas;
         try {
-            candidateViews = listMaterializedViews(session, tableName.getSchemaName());
+            schemas = listSchemaNames(session);
         }
         catch (Exception e) {
-            log.warn(e, "Failed to list materialized views in schema: %s", tableName.getSchemaName());
-            return Optional.empty();
+            log.warn(e, "Failed to list schema names. Falling back to the table's schema: %s", tableName.getSchemaName());
+            schemas = ImmutableList.of(tableName.getSchemaName());
         }
 
-        for (SchemaTableName mvName : candidateViews) {
+        for (String schemaName : schemas) {
+            List<SchemaTableName> candidateViews;
             try {
-                Optional<MaterializedViewDefinition> mvDefinition = getMaterializedView(session, mvName);
-                if (mvDefinition.isPresent() && mvDefinition.get().getBaseTables().contains(tableName)) {
-                    referencingViews.add(mvName);
-                }
+                candidateViews = listMaterializedViews(session, schemaName);
             }
             catch (Exception e) {
-                log.warn(e, "Failed to get materialized view definition for: %s", mvName);
+                log.warn(e, "Failed to list materialized views in schema: %s", schemaName);
+                continue;
+            }
+
+            for (SchemaTableName mvName : candidateViews) {
+                try {
+                    Optional<MaterializedViewDefinition> mvDefinition = getMaterializedView(session, mvName);
+                    if (mvDefinition.isPresent() && mvDefinition.get().getBaseTables().contains(tableName)) {
+                        referencingViews.add(mvName);
+                    }
+                }
+                catch (Exception e) {
+                    log.warn(e, "Failed to get materialized view definition for candidate: %s", mvName);
+                }
             }
         }
 
-        List<SchemaTableName> result = referencingViews.build();
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
+        return Optional.of(referencingViews.build());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -2082,6 +2082,36 @@ public abstract class IcebergAbstractMetadata
     }
 
     @Override
+    public Optional<List<SchemaTableName>> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
+    {
+        requireNonNull(tableName, "tableName is null");
+        ImmutableList.Builder<SchemaTableName> referencingViews = ImmutableList.builder();
+        List<SchemaTableName> candidateViews;
+        try {
+            candidateViews = listMaterializedViews(session, tableName.getSchemaName());
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to list materialized views in schema: %s", tableName.getSchemaName());
+            return Optional.empty();
+        }
+
+        for (SchemaTableName mvName : candidateViews) {
+            try {
+                Optional<MaterializedViewDefinition> mvDefinition = getMaterializedView(session, mvName);
+                if (mvDefinition.isPresent() && mvDefinition.get().getBaseTables().contains(tableName)) {
+                    referencingViews.add(mvName);
+                }
+            }
+            catch (Exception e) {
+                log.warn(e, "Failed to get materialized view definition for: %s", mvName);
+            }
+        }
+
+        List<SchemaTableName> result = referencingViews.build();
+        return result.isEmpty() ? Optional.empty() : Optional.of(result);
+    }
+
+    @Override
     public Optional<MaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         Optional<IcebergViewMetadata> viewMetadata = getViewMetadata(session, viewName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
@@ -2041,4 +2041,316 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("DROP TABLE IF EXISTS " + base);
         }
     }
+
+    @Test
+    public void testBaseTableQueryRewriteWithMutationsAndStaleness()
+    {
+        String base = "base_table_mutations_test";
+        String mv = "mv_mutations_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, value BIGINT)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 100), (2, 200)", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, value FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // 1. Fresh state: should scan MV storage table
+            assertPlan(sessionWithMvRewrite, "SELECT id, value FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // 2. Insert into base table (makes MV stale)
+            assertUpdate("INSERT INTO " + base + " VALUES (3, 300)", 1);
+
+            // Unpartitioned table fallback on staleness: should scan MV storage table as it is rewritten to storage table
+            assertPlan(sessionWithMvRewrite, "SELECT id, value FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // 3. Delete from base table
+            assertUpdate("DELETE FROM " + base + " WHERE id = 1", 1);
+
+            // Still stale: should scan MV storage table as it is rewritten to storage table
+            assertPlan(sessionWithMvRewrite, "SELECT id, value FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // 4. Refresh the MV
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // 5. Fresh again: should scan MV storage table
+            assertPlan(sessionWithMvRewrite, "SELECT id, value FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteWithMutationsAndStalenessResults()
+    {
+        String base = "base_mutations_results_test";
+        String mv = "mv_mutations_results_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, value BIGINT)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 100), (2, 200)", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, value FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // 1. Fresh state: should return correct fresh results from MV storage
+            assertQuery(sessionWithMvRewrite, "SELECT id, value FROM " + base + " ORDER BY id", "VALUES (1, 100), (2, 200)");
+
+            // 2. Insert into base table (makes MV stale)
+            assertUpdate("INSERT INTO " + base + " VALUES (3, 300)", 1);
+
+            // Stale unpartitioned query with USE_VIEW_QUERY:
+            // Since it is unpartitioned and the optimizer rewrites to storage table directly,
+            // we read the stale pre-computed data from the storage table.
+            assertQuery(sessionWithMvRewrite, "SELECT id, value FROM " + base + " ORDER BY id", "VALUES (1, 100), (2, 200)");
+
+            // 3. Delete from base table (still stale)
+            assertUpdate("DELETE FROM " + base + " WHERE id = 1", 1);
+
+            // Still stale: we still read the stale pre-computed data (1, 2) from the storage table.
+            assertQuery(sessionWithMvRewrite, "SELECT id, value FROM " + base + " ORDER BY id", "VALUES (1, 100), (2, 200)");
+
+            // 4. Refresh the MV
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // 5. Fresh again: should scan MV storage table and return correct refreshed results (2, 3)
+            assertQuery(sessionWithMvRewrite, "SELECT id, value FROM " + base + " ORDER BY id", "VALUES (2, 200), (3, 300)");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testMultipleMaterializedViewsForSameBaseTable()
+    {
+        String base = "base_multi_mv_test";
+        String mv1 = "mv_subset_1";
+        String mv2 = "mv_subset_2";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, a VARCHAR, b VARCHAR, c VARCHAR)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 'a1', 'b1', 'c1'), (2, 'a2', 'b2', 'c2')", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv1 + " AS SELECT id, a, b FROM " + base);
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv2 + " AS SELECT id, c FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv1);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv2);
+
+            // Query matching mv1 columns only
+            assertPlan(sessionWithMvRewrite, "SELECT id, a, b FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv1)));
+
+            // Query matching mv2 columns only
+            assertPlan(sessionWithMvRewrite, "SELECT id, c FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv2)));
+
+            // Query needing columns from both MVs falls back to base table
+            assertPlan(sessionWithMvRewrite, "SELECT a, c FROM " + base,
+                    anyTree(tableScan(base)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv1);
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv2);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteWithProjectionsAndFunctions()
+    {
+        String base = "base_proj_func_test";
+        String mv = "mv_proj_func_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, x BIGINT, y BIGINT, name VARCHAR)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 10, 20, 'alice'), (2, 30, 40, 'bob')", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, x, y, name FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Scalar projection and arithmetic expression on base table columns
+            assertPlan(sessionWithMvRewrite, "SELECT id, x + y, UPPER(name) FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Arithmetic and functions: UPPER, CAST, CONCAT, COALESCE
+            assertPlan(sessionWithMvRewrite, "SELECT id, x + y, CAST(x AS DOUBLE), CONCAT(name, '_suffix'), COALESCE(name, 'default') FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Query with columns not in MV or un-rewritable expressions falls back to base table
+            assertPlan(sessionWithMvRewrite, "SELECT id, ABS(x), name FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteWithGroupByAndAggregation()
+    {
+        String base = "base_agg_test";
+        String mv = "mv_agg_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (cust_id BIGINT, region VARCHAR, amount DOUBLE)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 'US', 100.0), (1, 'US', 200.0), (2, 'EU', 300.0)", 3);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT cust_id, region, SUM(amount) AS total_amount, COUNT(*) AS count_rows FROM " + base + " GROUP BY cust_id, region");
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Exact match GROUP BY
+            assertPlan(sessionWithMvRewrite, "SELECT cust_id, region, SUM(amount) AS total_amount FROM " + base + " GROUP BY cust_id, region",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Rollup aggregation: grouping by a subset (cust_id)
+            assertPlan(sessionWithMvRewrite, "SELECT cust_id, SUM(amount) AS total_amount FROM " + base + " GROUP BY cust_id",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Global aggregate rollup without GROUP BY
+            assertPlan(sessionWithMvRewrite, "SELECT SUM(amount) AS grand_total FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Rollup with compatible aggregate functions: COUNT and SUM
+            assertPlan(sessionWithMvRewrite, "SELECT region, SUM(amount) AS total_amount, COUNT(*) AS region_count FROM " + base + " GROUP BY region",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // GROUP BY with different column order than MV definition
+            assertPlan(sessionWithMvRewrite, "SELECT region, cust_id, SUM(amount) AS total_amount FROM " + base + " GROUP BY region, cust_id",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteAllTypes()
+    {
+        String base = "base_all_types_test";
+        String mv = "mv_all_types_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (" +
+                    "c_bool BOOLEAN, " +
+                    "c_int INTEGER, " +
+                    "c_bigint BIGINT, " +
+                    "c_real REAL, " +
+                    "c_double DOUBLE, " +
+                    "c_decimal DECIMAL(10, 2), " +
+                    "c_varchar VARCHAR, " +
+                    "c_varbinary VARBINARY, " +
+                    "c_date DATE, " +
+                    "c_timestamp TIMESTAMP, " +
+                    "c_array ARRAY(VARCHAR), " +
+                    "c_map MAP(VARCHAR, VARCHAR), " +
+                    "c_row ROW(f1 VARCHAR, f2 BIGINT))");
+
+            assertUpdate("INSERT INTO " + base + " VALUES (" +
+                    "true, 1, 100, REAL '1.5', 2.5, DECIMAL '12.34', 'test_str', X'6568', DATE '2024-01-01', TIMESTAMP '2024-01-01 10:00:00', " +
+                    "ARRAY['a', 'b'], MAP(ARRAY['k'], ARRAY['v']), ROW('field1', 42))", 1);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT c_bool, c_int, c_bigint, c_real, c_double, c_decimal, c_varchar, c_varbinary, c_date, c_timestamp, c_array, c_map, c_row FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Querying all columns of various types on base table should rewrite to MV storage
+            assertPlan(sessionWithMvRewrite, "SELECT c_bool, c_int, c_bigint, c_real, c_double, c_decimal, c_varchar, c_varbinary, c_date, c_timestamp, c_array, c_map, c_row FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Query subset of diverse types
+            assertPlan(sessionWithMvRewrite, "SELECT c_bool, c_bigint, c_double, c_decimal, c_date, c_timestamp FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteCrossSchema()
+    {
+        String baseSchema = "tpch";
+        String mvSchema = "mv_schema";
+        String baseTableName = "base_cross_schema_test";
+        String mvName = "mv_cross_schema_test";
+        String base = baseSchema + "." + baseTableName;
+        String mv = mvSchema + "." + mvName;
+
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE SCHEMA IF NOT EXISTS " + mvSchema);
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, name VARCHAR)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 'alice'), (2, 'bob')", 2);
+
+            // Create Materialized View in a different schema
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, name FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Querying base table should successfully rewrite to the storage table of the MV in the other schema
+            assertPlan(sessionWithMvRewrite, "SELECT id, name FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mvName)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+            assertUpdate("DROP SCHEMA IF EXISTS " + mvSchema);
+        }
+    }
+
+    @Test
+    public void testBaseTableQueryRewriteWithSubqueries()
+    {
+        String base = "base_subquery_test";
+        String mv = "mv_subquery_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, name VARCHAR)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 'alice'), (2, 'bob')", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, name FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Case 1: Base table occurs in a subquery => should trigger MV rewrite
+            assertPlan(sessionWithMvRewrite, "SELECT id, name FROM (SELECT id, name FROM " + base + ") WHERE id > 0",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+
+            // Case 2: Querying from the MV directly/as a subquery => should NOT trigger MV query rewrite of base tables
+            assertPlan(sessionWithMvRewrite, "SELECT id, name FROM " + mv,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+            assertPlan(sessionWithMvRewrite, "SELECT id, name FROM (SELECT id, name FROM " + mv + ") WHERE id > 0",
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
@@ -2016,4 +2016,29 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("DROP TABLE IF EXISTS " + base);
         }
     }
+
+    @Test
+    public void testBaseTableQueryRewrite()
+    {
+        String base = "base_table_rewrite_test";
+        String mv = "mv_rewrite_test";
+        Session sessionWithMvRewrite = Session.builder(getSession())
+                .setSystemProperty("query_optimization_with_materialized_view_enabled", "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + base + " (id BIGINT, value BIGINT)");
+            assertUpdate("INSERT INTO " + base + " VALUES (1, 100), (2, 200)", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW " + mv + " AS SELECT id, value FROM " + base);
+            getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + mv);
+
+            // Querying the base table with MV query optimization enabled should rewrite to scan the MV storage table
+            assertPlan(sessionWithMvRewrite, "SELECT id, value FROM " + base,
+                    anyTree(tableScan("__mv_storage__" + mv)));
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS " + mv);
+            assertUpdate("DROP TABLE IF EXISTS " + base);
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR implements `getReferencedMaterializedViews` in `IcebergAbstractMetadata` to enable automatic query rewrite with Materialized Views in the Iceberg connector.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
`EXPLAIN SELECT orderkey, orderpriority, ds FROM iceberg.test_q_write.test_table1;
`

```
- Output[PlanNodeId 5][orderkey, orderpriority, ds] => [orderkey:bigint, orderpriority:varchar, ds:varchar]
        Estimates: {source: CostBasedSourceInfo, rows: 20 (2.32kB), cpu: 2,380.00, memory: 0.00, network: 2,380.00}
    - RemoteStreamingExchange[PlanNodeId 129][GATHER - COLUMNAR] => [orderkey:bigint, orderpriority:varchar, ds:varchar]
            Estimates: {source: CostBasedSourceInfo, rows: 20 (2.32kB), cpu: 2,380.00, memory: 0.00, network: 2,380.00}
        - TableScan[PlanNodeId 0][TableHandle {connectorId='iceberg', connectorHandle='__mv_storage__test_mv1$data@7341145638548711640', layout='Optional[__mv_storage__test_mv1$data@7341145638548711640]'}] => [orderkey:bigint, orderpriority:varchar, ds:varchar]
                Estimates: {source: CostBasedSourceInfo, rows: 20 (2.32kB), cpu: 2,380.00, memory: 0.00, network: 0.00}
                orderpriority := 2:orderpriority:varchar
                ds := 3:ds:varchar
                orderkey := 1:orderkey:bigint

```


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable Iceberg materialized view optimization to rewrite eligible base-table queries to materialized view storage.

New Features:
- Enable Iceberg materialized views to rewrite queries issued against their base tables.

Enhancements:
- Support selecting applicable materialized views by inspecting base-table references, with graceful handling of metadata lookup failures.

Tests:
- Add coverage for base-table rewrites across freshness and mutations, multiple materialized views, projections and functions, aggregation rollups, and diverse data types.