### PR TITLE
chore(ci): Advance velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -838,8 +838,9 @@ void PrestoServer::stopAnnouncer() {
 void PrestoServer::joinExecutors() {
   // Join exchange HTTP CPU executor first. Exchange CPU threads run
   // PrestoExchangeSource::handleDataResponse which dispatches callbacks to
-  // driverExecutor_ (MonitoredExecutor) via ExchangeClient. We must drain
-  // these threads before destroying driverExecutor_ to avoid use-after-free.
+  // driverExecutor_ (MonitoredExecutor) via InMemoryExchangeClient. We must
+  // drain these threads before destroying driverExecutor_ to avoid
+  // use-after-free.
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Joining Exchange Http CPU executor '"
       << exchangeHttpCpuExecutor_->getName()

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
@@ -51,7 +51,7 @@ MaterializedExchange::MaterializedExchange(
     DriverCtx* ctx,
     const std::shared_ptr<const MaterializedExchangeNode>&
         materializedExchangeNode,
-    std::shared_ptr<ExchangeClient> exchangeClient)
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient)
     : Exchange(
           operatorId,
           ctx,
@@ -199,7 +199,7 @@ std::unique_ptr<Operator> MaterializedExchangeTranslator::toOperator(
     DriverCtx* ctx,
     int32_t id,
     const core::PlanNodePtr& node,
-    std::shared_ptr<ExchangeClient> exchangeClient) {
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient) {
   if (auto materializedExchangeNode =
           std::dynamic_pointer_cast<const MaterializedExchangeNode>(node)) {
     return std::make_unique<MaterializedExchange>(

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.h
@@ -32,8 +32,8 @@ class MaterializedExchangeNode : public velox::core::PlanNode {
     return outputType_;
   }
 
-  /// Leaf node — no child plan nodes. Data comes from ExchangeClient via
-  /// splits (RemoteConnectorSplit), not from upstream operators.
+  /// Leaf node — no child plan nodes. Data comes from InMemoryExchangeClient
+  /// via splits (RemoteConnectorSplit), not from upstream operators.
   const std::vector<velox::core::PlanNodePtr>& sources() const override {
     static const std::vector<velox::core::PlanNodePtr> kEmptySources;
     return kEmptySources;
@@ -65,8 +65,8 @@ class MaterializedExchangeNode : public velox::core::PlanNode {
 
 /// Operator for reading shuffle data written by MaterializedOutput.
 ///
-/// Reads pages from ExchangeClient (via ShuffleExchangeSource), strips the
-/// kFormatBatched prefix, and parses RowGroupHeader + TRowSize-framed
+/// Reads pages from InMemoryExchangeClient (via ShuffleExchangeSource), strips
+/// the kFormatBatched prefix, and parses RowGroupHeader + TRowSize-framed
 /// CompactRow data into RowVectors. Only handles batched format — no
 /// kFormatRaw/legacy support (that's in ShuffleRead).
 ///
@@ -87,7 +87,7 @@ class MaterializedExchange : public velox::exec::Exchange {
       velox::exec::DriverCtx* ctx,
       const std::shared_ptr<const MaterializedExchangeNode>&
           materializedExchangeNode,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient);
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient);
 
   velox::RowVectorPtr getOutput() override;
 
@@ -135,7 +135,8 @@ class MaterializedExchangeTranslator
       velox::exec::DriverCtx* ctx,
       int32_t id,
       const velox::core::PlanNodePtr& node,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient) override;
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient)
+      override;
 };
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
@@ -72,7 +72,8 @@ folly::SemiFuture<ShuffleExchangeSource::Response>
 ShuffleExchangeSource::requestDataSizes(std::chrono::microseconds /*maxWait*/) {
   std::vector<int64_t> remainingBytes;
   if (!atEnd_) {
-    // Use default value of ExchangeClient::getAveragePageSize() for now.
+    // Use default value of InMemoryExchangeClient::getAveragePageSize() for
+    // now.
     //
     // TODO: Change ShuffleReader to return the next batch size.
     remainingBytes.push_back(1 << 20);

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -28,7 +28,7 @@ ShuffleRead::ShuffleRead(
     int32_t operatorId,
     DriverCtx* ctx,
     const std::shared_ptr<const ShuffleReadNode>& shuffleReadNode,
-    std::shared_ptr<ExchangeClient> exchangeClient)
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient)
     : Exchange(
           operatorId,
           ctx,
@@ -172,7 +172,7 @@ std::unique_ptr<Operator> ShuffleReadTranslator::toOperator(
     DriverCtx* ctx,
     int32_t id,
     const core::PlanNodePtr& node,
-    std::shared_ptr<ExchangeClient> exchangeClient) {
+    std::shared_ptr<InMemoryExchangeClient> exchangeClient) {
   if (auto shuffleReadNode =
           std::dynamic_pointer_cast<const ShuffleReadNode>(node)) {
     return std::make_unique<ShuffleRead>(

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
@@ -97,7 +97,7 @@ class ShuffleRead : public velox::exec::Exchange {
       int32_t operatorId,
       velox::exec::DriverCtx* ctx,
       const std::shared_ptr<const ShuffleReadNode>& shuffleReadNode,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient);
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient);
 
   velox::RowVectorPtr getOutput() override;
 
@@ -134,6 +134,7 @@ class ShuffleReadTranslator : public velox::exec::Operator::PlanNodeTranslator {
       velox::exec::DriverCtx* ctx,
       int32_t id,
       const velox::core::PlanNodePtr& node,
-      std::shared_ptr<velox::exec::ExchangeClient> exchangeClient) override;
+      std::shared_ptr<velox::exec::InMemoryExchangeClient> exchangeClient)
+      override;
 };
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/operators/ShuffleWrite.h"
-#include "velox/exec/ExchangeClient.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox;

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -32,8 +32,8 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/ExchangeClient.h"
 #include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"

--- a/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
@@ -29,7 +29,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/ExchangeClient.h"
+#include "velox/exec/InMemoryExchangeClient.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"

--- a/presto-native-execution/presto_cpp/main/tests/ShutdownOrderTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ShutdownOrderTest.cpp
@@ -55,8 +55,9 @@ struct SyncState {
 //
 // Production scenario:
 //   - PrestoExchangeSource::handleDataResponse runs on exchangeHttpCpuExecutor_
-//   - It calls requestPromise.setValue() which dispatches the ExchangeClient
-//     callback to driverExecutor_ (a MonitoredExecutor) via raw pointer
+//   - It calls requestPromise.setValue() which dispatches the
+//     InMemoryExchangeClient callback to driverExecutor_ (a MonitoredExecutor)
+//     via raw pointer
 //   - If driverExecutor_ is already destroyed, this is use-after-free
 //
 // This test forces the exact interleaving:
@@ -79,8 +80,8 @@ TEST(ShutdownOrderTest, exchangeCallbacksDrainBeforeDriverExecutorDestroyed) {
   auto exchangeCpu = std::make_unique<folly::CPUThreadPoolExecutor>(
       2, std::make_shared<folly::NamedThreadFactory>("TestExchangeCPU"));
 
-  // Raw pointer, same as ExchangeClient::executor_ and the pointer stored
-  // inside folly future cores by .via(executor_).
+  // Raw pointer, same as InMemoryExchangeClient::executor_ and the pointer
+  // stored inside folly future cores by .via(executor_).
   auto* driverRawPtr = driverExecutor.get();
 
   auto sync = std::make_shared<SyncState>();
@@ -122,7 +123,7 @@ TEST(ShutdownOrderTest, exchangeCallbacksDrainBeforeDriverExecutorDestroyed) {
 }
 
 // Same scenario but using folly Promise/SemiFuture with .via(executor) to
-// match the exact production code path in ExchangeClient::request().
+// match the exact production code path in InMemoryExchangeClient::request().
 TEST(ShutdownOrderTest, promiseChainDispatchesSafelyDuringShutdown) {
   auto driverExecutor = std::make_unique<NoKeepAliveExecutor>(
       std::make_unique<folly::CPUThreadPoolExecutor>(
@@ -134,7 +135,8 @@ TEST(ShutdownOrderTest, promiseChainDispatchesSafelyDuringShutdown) {
 
   // Set up a promise/future chain matching the production pattern:
   //   source->request() returns SemiFuture
-  //   ExchangeClient does: future.via(driverExecutor).thenValue(callback)
+  //   InMemoryExchangeClient does:
+  //     future.via(driverExecutor).thenValue(callback)
   //   PrestoExchangeSource does: promise.setValue() on exchange CPU thread
   auto requestPromise = std::make_shared<folly::Promise<int>>();
   auto clientCallbackRan = std::make_shared<std::atomic<bool>>(false);


### PR DESCRIPTION
## Description

Advances the velox pin, and adapts `presto_cpp` to the one API break in the range.

velox [#18110](https://github.com/facebookincubator/velox/pull/18110) renamed `velox::exec::ExchangeClient` to `velox::exec::InMemoryExchangeClient`. `velox/exec/ExchangeClient.h` still exists, but it now defines the old name only as an alias, and only under `VELOX_ENABLE_BACKWARD_COMPATIBILITY` — a macro the read-only-synced internal build sets and the open source build never does. So the OSS `presto_cpp` build fails on the old name and the rename has to be applied here.

The adaptation is mechanical:

- `ShuffleRead` and `MaterializedExchange` (both `velox::exec::Exchange` subclasses) and their `PlanNodeTranslator::toOperator` overrides now take `std::shared_ptr<InMemoryExchangeClient>`, matching the virtual they override and the `Exchange` base constructor.
- The three direct includes of `velox/exec/ExchangeClient.h` now name `velox/exec/InMemoryExchangeClient.h`. The new header includes the same `ExchangeQueue.h` and `ExchangeSource.h` as the old one, so the transitive declarations `ShuffleTest.cpp` and `MaterializedExchangeTest.cpp` rely on are unchanged.
- Comments naming the class were updated with it.

The class is otherwise byte-identical to the one it replaces (diffing the two headers modulo the rename shows only comments and rewrapping), so there is no behavior change. `requiresExchangeClient()` keeps its name upstream and is untouched.

The bump and the adaptation are in one commit deliberately: the pin alone does not compile, and CONTRIBUTING requires every commit in a PR to pass tests.

## Motivation and Context

Periodic velox advance. Old pin `76b8c194c555f2e58ab3edeb9bf3cba13487f6d0`, new pin `7c2b38147bb9bb814deffe02fc263c1b2eb4fd17` (25 commits).

## Impact

None at runtime — a type rename with no behavior change.

## Test Plan

CI. The C++ formatting was verified locally with clang-format 20.1.8, the version pinned in `.pre-commit-config.yaml`, and is idempotent.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.

## Release Notes

```
== NO RELEASE NOTE ==
```
