### PR TITLE
fix(parser): Treat CALL argument names as identifiers

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.tree.CallArgument;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -42,11 +43,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
@@ -69,6 +72,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Locale.ENGLISH;
 
 public class CallTask
         implements DDLDefinitionTask<Call>
@@ -147,17 +151,38 @@ public class CallTask
             throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, call, "Named and positional arguments cannot be mixed");
         }
 
+        Map<String, Integer> canonicalPositions = new HashMap<>();
+        Set<String> ambiguousCanonicalPositions = new HashSet<>();
+        if (anyNamed) {
+            for (int i = 0; i < procedure.getArguments().size(); i++) {
+                String name = procedure.getArguments().get(i).getName();
+                String canonicalName = name.toUpperCase(ENGLISH);
+                if (canonicalPositions.putIfAbsent(canonicalName, i) != null) {
+                    ambiguousCanonicalPositions.add(canonicalName);
+                }
+            }
+        }
+
         // get the argument names in call order
         Map<String, CallArgument> names = new LinkedHashMap<>();
+        Set<String> canonicalNames = new HashSet<>();
         for (int i = 0; i < call.getArguments().size(); i++) {
             CallArgument argument = call.getArguments().get(i);
-            if (argument.getName().isPresent()) {
-                String name = argument.getName().get();
-                if (names.put(name, argument) != null) {
-                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Duplicate procedure argument: %s", name);
+            if (argument.getNameIdentifier().isPresent()) {
+                Identifier name = argument.getNameIdentifier().get();
+                if (!canonicalNames.add(name.getCanonicalValue())) {
+                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Duplicate procedure argument: %s", name.getValue());
                 }
-                if (!positions.containsKey(name)) {
-                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Unknown argument name: %s", name);
+                if (!name.isDelimited() && ambiguousCanonicalPositions.contains(name.getCanonicalValue())) {
+                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Ambiguous argument name: %s", name.getValue());
+                }
+                Integer position = name.isDelimited() ? positions.get(name.getValue()) : canonicalPositions.get(name.getCanonicalValue());
+                if (position == null) {
+                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Unknown argument name: %s", name.getValue());
+                }
+                String declaredName = procedure.getArguments().get(position).getName();
+                if (names.put(declaredName, argument) != null) {
+                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, argument, "Duplicate procedure argument: %s", name.getValue());
                 }
             }
             else if (i < procedure.getArguments().size()) {

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestCallTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestCallTask.java
@@ -41,23 +41,63 @@ public class TestCallTask
     private static final Map<NodeRef<Parameter>, Expression> NO_PARAMETERS = ImmutableMap.of();
 
     @Test
-    public void testCanonicalArgumentNamesMatchProcedure()
+    public void testJdbcExecuteProcedureNamedArgument()
     {
-        Call call = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 1, \"Mixed\" => 2)");
+        Call call = (Call) SQL_PARSER.createStatement("CALL system.execute(QUERY => 'SELECT 1')");
         Procedure procedure = new Procedure(
-                "schema",
-                "foo",
-                ImmutableList.of(
-                        new Procedure.Argument("upper", "bigint"),
-                        new Procedure.Argument("Mixed", "bigint")));
+                "system",
+                "execute",
+                ImmutableList.of(new Procedure.Argument("QUERY", "varchar")));
 
         assertEquals(
                 CallTask.extractParameterValuesInOrder(call, procedure, METADATA, SESSION, NO_PARAMETERS),
-                new Object[] {1L, 2L});
+                new Object[] {"SELECT 1"});
     }
 
     @Test
-    public void testDuplicateArgumentNamesUseCanonicalIdentity()
+    public void testUnquotedArgumentMatchesProcedureDeclarationCaseInsensitively()
+    {
+        Call lowercaseCall = (Call) SQL_PARSER.createStatement("CALL foo(lower => 1)");
+        Procedure uppercaseProcedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(new Procedure.Argument("LOWER", "bigint")));
+        assertEquals(
+                CallTask.extractParameterValuesInOrder(lowercaseCall, uppercaseProcedure, METADATA, SESSION, NO_PARAMETERS),
+                new Object[] {1L});
+
+        Call uppercaseCall = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 2)");
+        Procedure lowercaseProcedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(new Procedure.Argument("upper", "bigint")));
+        assertEquals(
+                CallTask.extractParameterValuesInOrder(uppercaseCall, lowercaseProcedure, METADATA, SESSION, NO_PARAMETERS),
+                new Object[] {2L});
+    }
+
+    @Test
+    public void testDelimitedArgumentMatchesExactly()
+    {
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(new Procedure.Argument("Mixed", "bigint")));
+
+        Call exactCall = (Call) SQL_PARSER.createStatement("CALL foo(\"Mixed\" => 1)");
+        assertEquals(
+                CallTask.extractParameterValuesInOrder(exactCall, procedure, METADATA, SESSION, NO_PARAMETERS),
+                new Object[] {1L});
+
+        Call mismatchedCall = (Call) SQL_PARSER.createStatement("CALL foo(\"mixed\" => 1)");
+        SemanticException exception = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(mismatchedCall, procedure, METADATA, SESSION, NO_PARAMETERS));
+        assertEquals(exception.getMessage(), "line 1:10: Unknown argument name: mixed");
+    }
+
+    @Test
+    public void testDuplicateUnquotedArgumentNamesUseCanonicalIdentity()
     {
         Call call = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 1, upper => 2)");
         Procedure procedure = new Procedure(
@@ -70,5 +110,66 @@ public class TestCallTask
                 () -> CallTask.extractParameterValuesInOrder(call, procedure, METADATA, SESSION, NO_PARAMETERS));
 
         assertEquals(exception.getMessage(), "line 1:22: Duplicate procedure argument: upper");
+    }
+
+    @Test
+    public void testQuotedAndUnquotedArgumentCanonicalIdentity()
+    {
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(new Procedure.Argument("foo", "bigint")));
+
+        Call sameCanonicalName = (Call) SQL_PARSER.createStatement("CALL foo(foo => 1, \"FOO\" => 2)");
+        SemanticException sameCanonicalNameException = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(sameCanonicalName, procedure, METADATA, SESSION, NO_PARAMETERS));
+        assertEquals(sameCanonicalNameException.getMessage(), "line 1:20: Duplicate procedure argument: FOO");
+
+        Call differentCanonicalName = (Call) SQL_PARSER.createStatement("CALL foo(foo => 1, \"foo\" => 2)");
+        SemanticException differentCanonicalNameException = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(differentCanonicalName, procedure, METADATA, SESSION, NO_PARAMETERS));
+        assertEquals(differentCanonicalNameException.getMessage(), "line 1:20: Duplicate procedure argument: foo");
+    }
+
+    @Test
+    public void testDelimitedArgumentsDisambiguateDeclarationCase()
+    {
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(
+                        new Procedure.Argument("foo", "bigint"),
+                        new Procedure.Argument("FOO", "bigint")));
+
+        Call delimitedCall = (Call) SQL_PARSER.createStatement("CALL foo(\"foo\" => 1, \"FOO\" => 2)");
+        assertEquals(
+                CallTask.extractParameterValuesInOrder(delimitedCall, procedure, METADATA, SESSION, NO_PARAMETERS),
+                new Object[] {1L, 2L});
+
+        Call unquotedCall = (Call) SQL_PARSER.createStatement("CALL foo(foo => 1)");
+        SemanticException exception = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(unquotedCall, procedure, METADATA, SESSION, NO_PARAMETERS));
+        assertEquals(exception.getMessage(), "line 1:10: Ambiguous argument name: foo");
+    }
+
+    @Test
+    public void testNamedAndPositionalArgumentsCannotBeMixed()
+    {
+        Call call = (Call) SQL_PARSER.createStatement("CALL foo(1, second => 2)");
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(
+                        new Procedure.Argument("first", "bigint"),
+                        new Procedure.Argument("second", "bigint")));
+
+        SemanticException exception = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(call, procedure, METADATA, SESSION, NO_PARAMETERS));
+
+        assertEquals(exception.getMessage(), "line 1:1: Named and positional arguments cannot be mixed");
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestCallTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestCallTask.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Call;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.Parameter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+public class TestCallTask
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+    private static final Session SESSION = testSessionBuilder().build();
+    private static final Map<NodeRef<Parameter>, Expression> NO_PARAMETERS = ImmutableMap.of();
+
+    @Test
+    public void testCanonicalArgumentNamesMatchProcedure()
+    {
+        Call call = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 1, \"Mixed\" => 2)");
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(
+                        new Procedure.Argument("upper", "bigint"),
+                        new Procedure.Argument("Mixed", "bigint")));
+
+        assertEquals(
+                CallTask.extractParameterValuesInOrder(call, procedure, METADATA, SESSION, NO_PARAMETERS),
+                new Object[] {1L, 2L});
+    }
+
+    @Test
+    public void testDuplicateArgumentNamesUseCanonicalIdentity()
+    {
+        Call call = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 1, upper => 2)");
+        Procedure procedure = new Procedure(
+                "schema",
+                "foo",
+                ImmutableList.of(new Procedure.Argument("upper", "bigint")));
+
+        SemanticException exception = expectThrows(
+                SemanticException.class,
+                () -> CallTask.extractParameterValuesInOrder(call, procedure, METADATA, SESSION, NO_PARAMETERS));
+
+        assertEquals(exception.getMessage(), "line 1:22: Duplicate procedure argument: upper");
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -155,6 +155,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
 import static com.facebook.presto.sql.ExpressionFormatter.formatGroupBy;
+import static com.facebook.presto.sql.ExpressionFormatter.formatIdentifier;
 import static com.facebook.presto.sql.ExpressionFormatter.formatOrderBy;
 import static com.facebook.presto.sql.ExpressionFormatter.formatStringLiteral;
 import static com.facebook.presto.sql.tree.ConstraintSpecification.ConstraintType.UNIQUE;
@@ -1635,7 +1636,7 @@ public final class SqlFormatter
         protected Void visitCallArgument(CallArgument node, Integer indent)
         {
             if (node.getName().isPresent()) {
-                builder.append(node.getName().get())
+                builder.append(formatIdentifier(node.getName().get()))
                         .append(" => ");
             }
             builder.append(formatExpression(node.getValue(), parameters));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -155,7 +155,6 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
 import static com.facebook.presto.sql.ExpressionFormatter.formatGroupBy;
-import static com.facebook.presto.sql.ExpressionFormatter.formatIdentifier;
 import static com.facebook.presto.sql.ExpressionFormatter.formatOrderBy;
 import static com.facebook.presto.sql.ExpressionFormatter.formatStringLiteral;
 import static com.facebook.presto.sql.tree.ConstraintSpecification.ConstraintType.UNIQUE;
@@ -1635,8 +1634,8 @@ public final class SqlFormatter
         @Override
         protected Void visitCallArgument(CallArgument node, Integer indent)
         {
-            if (node.getName().isPresent()) {
-                builder.append(formatIdentifier(node.getName().get()))
+            if (node.getNameIdentifier().isPresent()) {
+                builder.append(formatExpression(node.getNameIdentifier().get(), parameters))
                         .append(" => ");
             }
             builder.append(formatExpression(node.getValue(), parameters));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2591,7 +2591,7 @@ class AstBuilder
     public Node visitNamedArgument(SqlBaseParser.NamedArgumentContext context)
     {
         Identifier name = (Identifier) visit(context.identifier());
-        return new CallArgument(getLocation(context), name.isDelimited() ? name.getValue() : name.getValueLowerCase(), (Expression) visit(context.expression()));
+        return new CallArgument(getLocation(context), name, (Expression) visit(context.expression()));
     }
 
     // ***************** helpers *****************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2590,7 +2590,8 @@ class AstBuilder
     @Override
     public Node visitNamedArgument(SqlBaseParser.NamedArgumentContext context)
     {
-        return new CallArgument(getLocation(context), context.identifier().getText(), (Expression) visit(context.expression()));
+        Identifier name = (Identifier) visit(context.identifier());
+        return new CallArgument(getLocation(context), name.isDelimited() ? name.getValue() : name.getValueLowerCase(), (Expression) visit(context.expression()));
     }
 
     // ***************** helpers *****************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CallArgument.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CallArgument.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 public final class CallArgument
         extends Node
 {
-    private final Optional<String> name;
+    private final Optional<Identifier> name;
     private final Expression value;
 
     public CallArgument(Expression value)
@@ -43,19 +43,41 @@ public final class CallArgument
         this(Optional.empty(), Optional.of(name), value);
     }
 
+    public CallArgument(Identifier name, Expression value)
+    {
+        this(Optional.empty(), name, value);
+    }
+
     public CallArgument(NodeLocation location, String name, Expression value)
     {
         this(Optional.of(location), Optional.of(name), value);
     }
 
+    public CallArgument(NodeLocation location, Identifier name, Expression value)
+    {
+        this(Optional.of(location), name, value);
+    }
+
     public CallArgument(Optional<NodeLocation> location, Optional<String> name, Expression value)
     {
         super(location);
-        this.name = requireNonNull(name, "name is null");
+        this.name = requireNonNull(name, "name is null").map(Identifier::new);
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    private CallArgument(Optional<NodeLocation> location, Identifier name, Expression value)
+    {
+        super(location);
+        this.name = Optional.of(requireNonNull(name, "name is null"));
         this.value = requireNonNull(value, "value is null");
     }
 
     public Optional<String> getName()
+    {
+        return name.map(Identifier::getValue);
+    }
+
+    public Optional<Identifier> getNameIdentifier()
     {
         return name;
     }
@@ -101,7 +123,7 @@ public final class CallArgument
     public String toString()
     {
         return toStringHelper(this)
-                .add("name", name.orElse(null))
+                .add("name", getName().orElse(null))
                 .add("value", value)
                 .omitNullValues()
                 .toString();

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2856,9 +2856,18 @@ public class TestSqlParser
                 new CallArgument("a", new LongLiteral("1")),
                 new CallArgument("b", new StringLiteral("go")),
                 new CallArgument(new LongLiteral("456")))));
-        assertStatement("CALL foo(UPPER => 1, \"Mixed\" => 2)", new Call(QualifiedName.of("foo"), ImmutableList.of(
-                new CallArgument("upper", new LongLiteral("1")),
-                new CallArgument("Mixed", new LongLiteral("2")))));
+        Call call = (Call) SQL_PARSER.createStatement("CALL foo(UPPER => 1, \"Mixed\" => 2)");
+        assertEquals(call, new Call(QualifiedName.of("foo"), ImmutableList.of(
+                new CallArgument(new Identifier("UPPER", false), new LongLiteral("1")),
+                new CallArgument(new Identifier("Mixed", true), new LongLiteral("2")))));
+        assertFalse(call.getArguments().get(0).getNameIdentifier().orElseThrow(AssertionError::new).isDelimited());
+        assertTrue(call.getArguments().get(1).getNameIdentifier().orElseThrow(AssertionError::new).isDelimited());
+
+        String formatted = formatSql(call, Optional.empty());
+        assertEquals(formatted, "CALL foo(UPPER => 1, \"Mixed\" => 2)");
+        Call reparsed = (Call) SQL_PARSER.createStatement(formatted);
+        assertFalse(reparsed.getArguments().get(0).getNameIdentifier().orElseThrow(AssertionError::new).isDelimited());
+        assertTrue(reparsed.getArguments().get(1).getNameIdentifier().orElseThrow(AssertionError::new).isDelimited());
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2856,6 +2856,9 @@ public class TestSqlParser
                 new CallArgument("a", new LongLiteral("1")),
                 new CallArgument("b", new StringLiteral("go")),
                 new CallArgument(new LongLiteral("456")))));
+        assertStatement("CALL foo(UPPER => 1, \"Mixed\" => 2)", new Call(QualifiedName.of("foo"), ImmutableList.of(
+                new CallArgument("upper", new LongLiteral("1")),
+                new CallArgument("Mixed", new LongLiteral("2")))));
     }
 
     @Test

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -156,7 +156,7 @@ public class DefaultTreeRewriter<C>
             return node;
         }
 
-        return node.getName().isPresent() ? new CallArgument(node.getName().get(), (Expression) value) : new CallArgument((Expression) value);
+        return node.getNameIdentifier().isPresent() ? new CallArgument(node.getNameIdentifier().get(), (Expression) value) : new CallArgument((Expression) value);
     }
 
     @Override


### PR DESCRIPTION
## Description

`CALL foo(UPPER => 1, "Mixed" => 2)` fails even when the procedure declares `upper` and `Mixed`. Call arguments now retain their parsed `Identifier`: unquoted names match declarations case-insensitively, while delimited names match exact case.

## Motivation and context

Named `CALL` arguments were stored as raw text. Existing connector procedures also declare uppercase argument names such as `QUERY`, so matching must canonicalize both unquoted sides while retaining delimiter provenance for exact matches.

Fixes #28187.

## Impact

Named procedure arguments now follow SQL identifier rules. There is no performance change.

## Test plan

<details>
<summary>Raw before/after output</summary>

On `origin/master` (`3db86de3387`):

```console
$ ./mvnw -pl presto-parser -am -Dtest=TestSqlParser#testCall -Dsurefire.failIfNoSpecifiedTests=false test
Tests run: 1, Failures: 1
expected names: upper, Mixed
actual names:   UPPER, "Mixed"
```

This branch:

```console
$ ./mvnw -pl presto-parser,presto-main-base,presto-tests -am \
    -Dtest=TestSqlParser,TestCallTask,TestProcedureCall \
    -Dsurefire.failIfNoSpecifiedTests=false test
TestSqlParser: 146 passed
TestCallTask: 7 passed
TestProcedureCall: 2 passed
BUILD SUCCESS
```

</details>

## Contributor checklist

- [x] Reviewed the contributing guide; checkstyle and license checks pass.
- [x] The description links the issue and states the behavior change.
- [x] No properties or dependencies were added.
- [x] The release note follows the repository format.
- [x] Parser and procedure execution tests pass.
- CI is running; local affected-module checks pass.

## Release notes

```text
== RELEASE NOTES ==

General Changes
* Fix named `CALL` arguments to follow SQL identifier case-folding and quoting rules.
```

## Summary by Sourcery

Fix named CALL argument resolution to respect SQL identifier case and quoting semantics.

Bug Fixes:
- Make named CALL arguments follow SQL identifier case-folding and quoting rules when matching procedure declarations.

Enhancements:
- Preserve identifier delimiter information throughout parsing, formatting, and expression rewriting so unquoted names match case-insensitively while quoted names require exact matches.
- Detect duplicate and ambiguous named procedure arguments using canonical identifier identity.

Tests:
- Add parser and procedure execution coverage for case-insensitive unquoted names, exact quoted names, duplicate and ambiguous arguments, and mixed argument validation.