### PR TITLE
fix(plugin-hive): Support NULL in create_empty_partition

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedPartitionUpdateSerializationEnabled;
 import static com.facebook.presto.hive.HiveUtil.serializeZstdCompressed;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
@@ -116,7 +117,7 @@ public class CreateEmptyPartitionProcedure
         }
 
         List<String> partitionStringValues = partitionValues.stream()
-                .map(String.class::cast)
+                .map(value -> value == null ? HIVE_DEFAULT_DYNAMIC_PARTITION : String.class.cast(value))
                 .collect(toImmutableList());
 
         if (metastore.getPartition(new MetastoreContext(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1377,6 +1377,9 @@ public class TestHiveIntegrationSmokeTest
     public void testCreateEmptyNonBucketedPartition(boolean optimizedPartitionUpdateSerializationEnabled)
     {
         String tableName = "test_insert_empty_partitioned_unbucketed_table";
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, optimizedPartitionUpdateSerializationEnabled + "")
+                .build();
         assertUpdate("" +
                 "CREATE TABLE " + tableName + " (" +
                 "  dummy_col bigint," +
@@ -1389,11 +1392,37 @@ public class TestHiveIntegrationSmokeTest
 
         // create an empty partition
         assertUpdate(
-                Session.builder(getSession())
-                        .setCatalogSessionProperty(catalog, OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, optimizedPartitionUpdateSerializationEnabled + "")
-                        .build(),
+                session,
                 format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'])", TPCH_SCHEMA, tableName, "empty"));
-        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 1");
+        assertUpdate(
+                session,
+                format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY[NULL])", TPCH_SCHEMA, tableName));
+        assertQuery(format("SELECT part FROM \"%s$partitions\"", tableName), "VALUES 'empty', NULL");
+        assertQueryFails(
+                format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY[NULL])", TPCH_SCHEMA, tableName),
+                "Partition already exists.*");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testCreateEmptyPartitionWithMixedNullValues()
+    {
+        String tableName = "test_insert_empty_partitioned_table_with_null";
+        assertUpdate("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  dummy_col bigint," +
+                "  part1 varchar," +
+                "  part2 varchar)" +
+                "WITH (" +
+                "  format = 'ORC', " +
+                "  partitioned_by = ARRAY[ 'part1', 'part2' ] " +
+                ")");
+
+        assertUpdate(format(
+                "CALL system.create_empty_partition('%s', '%s', ARRAY['part1', 'part2'], ARRAY[NULL, 'value'])",
+                TPCH_SCHEMA,
+                tableName));
+        assertQuery(format("SELECT part1, part2 FROM \"%s$partitions\"", tableName), "VALUES (NULL, 'value')");
         assertUpdate("DROP TABLE " + tableName);
     }
 


### PR DESCRIPTION
## Description

`CALL system.create_empty_partition(..., ARRAY[NULL])` fails with a `NullPointerException`. Null partition values now use Hive's existing default-partition sentinel, matching the normal insert path.

## Motivation and Context

The procedure collected partition values into a Guava immutable list, which rejects null elements before the metastore or partition path code runs.

Fixes https://github.com/prestodb/presto/issues/28188

## Impact

Hive users can create an empty partition with null values. Non-null values are unchanged.

## Test Plan

<details>
<summary>Raw before/after output</summary>

On `origin/master` (`e657e49a2bc`), with the regression test applied:

```console
$ ./mvnw -pl presto-hive \
    -Dtest=TestHiveIntegrationSmokeTest#testCreateEmptyNonBucketedPartition \
    -Dair.check.skip-all test
Caused by: java.lang.NullPointerException
    at com.facebook.presto.hive.CreateEmptyPartitionProcedure.doCreateEmptyPartition(CreateEmptyPartitionProcedure.java:120)
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
BUILD FAILURE
```

This branch:

```console
$ ./mvnw -pl presto-hive \
    -Dtest='TestHiveIntegrationSmokeTest#testCreateEmptyNonBucketedPartition+testCreateEmptyPartitionWithMixedNullValues' \
    test
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

$ ./mvnw -pl presto-hive \
    -Dtest=TestHiveIntegrationSmokeTest \
    -Dair.check.skip-all test
Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

</details>

## Contributor checklist

- [x] Reviewed the contributing guide; checkstyle and license checks pass.
- [x] The description links the issue and states the behavior change.
- [x] No properties or dependencies were added.
- [x] The release note follows the repository format.
- [x] Integration coverage includes null, non-null, mixed, duplicate, and both serialization modes.
- CI will run after PR creation.

## Release Notes

```text
== RELEASE NOTES ==

Hive Connector Changes
* Add support for NULL partition values in system.create_empty_partition.
```

## Summary by Sourcery

Support NULL partition values in the Hive create_empty_partition procedure using the connector’s existing default-partition behavior.

Bug Fixes:
- Allow Hive users to create empty partitions with NULL values, including mixed NULL and non-NULL partition values, without triggering a null-pointer failure.

Tests:
- Expand Hive integration coverage for NULL partition values, duplicate partitions, and both partition serialization modes.