### PR TITLE
fix(analyzer): Resolve MV-only properties in SHOW CREATE MATERIALIZED VIEW

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -536,8 +536,8 @@ final class ShowQueriesRewrite
 
                 ConnectorTableMetadata connectorTableMetadata = metadata.getTableMetadata(session, tableHandle.get()).getMetadata();
                 Map<String, Object> properties = connectorTableMetadata.getProperties();
-                Map<String, PropertyMetadata<?>> allTableProperties = metadata.getTablePropertyManager().getAllProperties().get(tableHandle.get().getConnectorId());
-                List<Property> propertyNodes = buildProperties("materialized view " + objectName, INVALID_TABLE_PROPERTY, properties, allTableProperties);
+                Map<String, PropertyMetadata<?>> allMaterializedViewProperties = metadata.getMaterializedViewPropertyManager().getAllProperties().get(tableHandle.get().getConnectorId());
+                List<Property> propertyNodes = buildProperties("materialized view " + objectName, INVALID_TABLE_PROPERTY, properties, allMaterializedViewProperties);
 
                 Optional<ViewSecurity> security = SystemSessionProperties.isLegacyMaterializedViews(session)
                         ? Optional.empty()


### PR DESCRIPTION
Summary:
`SHOW CREATE MATERIALIZED VIEW` threw a `NullPointerException` when the
materialized view was created with a property that exists only in the
connector's materialized-view property list and not in its table
property list. Resolve the metadata
from the materialized-view property manager instead, matching how
`CreateMaterializedViewTask` resolves the same properties.

Differential Revision: D116977115

## Summary by Sourcery

Bug Fixes:
- Fix `SHOW CREATE MATERIALIZED VIEW` failures for views using connector properties defined only for materialized views.

```
== RELEASE NOTES ==

General Changes
* Fix ``SHOW CREATE MATERIALIZED VIEW`` failure for materialized views
  created with materialized-view-only properties.
```