### PR TITLE
fix: Dynamic filtering causes query planning failure when using min/max/count functions in a scalar subquery using Iceberg connector #28364

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -140,6 +140,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZER_USE_HISTOGRAMS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -5325,6 +5326,31 @@ public abstract class IcebergDistributedTestBase
             catch (Exception e) {
                 // ignored for hive catalog compatibility
             }
+        }
+    }
+
+    @Test
+    public void testScalarSubqueryWithAggregationAndDynamicFiltering()
+    {
+        String tableName = "test_dynamic_filter_subquery";
+        Session session = Session.builder(getSession())
+                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INT)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1), (2)", 2);
+            assertQuery(session,
+                    "SELECT id FROM " + tableName + " WHERE id <= (SELECT count(*) FROM " + tableName + ")",
+                    "VALUES 1, 2");
+            assertQuery(session,
+                    "SELECT t.id " +
+                    "FROM " + tableName + " t " +
+                    "JOIN (SELECT min(id) as min_id FROM " + tableName + ") q " +
+                    "ON t.id = q.min_id",
+                    "VALUES 1");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -225,6 +225,7 @@ public class PruneUnreferencedOutputs
                 rightInputsBuilder.add(node.getRightHashVariable().get());
             }
             rightInputsBuilder.addAll(expectedFilterInputs);
+            rightInputsBuilder.addAll(node.getDynamicFilters().values());
             Set<VariableReferenceExpression> rightInputs = rightInputsBuilder.build();
 
             PlanNode left = context.rewrite(node.getLeft(), leftInputs);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
@@ -487,6 +487,45 @@ public class TestDynamicFilter
                                                         exchange(project(tableScan("nation", ImmutableMap.of("NATION_NK", "nationkey"))))))))));
     }
 
+    @Test
+    public void testScalarSubqueryWithAggregation()
+    {
+        // Regression test for https://github.com/prestodb/presto/issues/28364
+        // Verify that a scalar subquery with aggregation functions works correctly
+        // with dynamic filtering enabled. Previously, PruneUnreferencedOutputs
+        // would drop dynamic filter variables from the right side of the join,
+        // causing an IllegalArgumentException during plan optimization.
+        assertPlan(
+                "SELECT * FROM orders WHERE orderkey <= (SELECT count(*) FROM lineitem)",
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                anyTree(tableScan("orders")),
+                                node(EnforceSingleRowNode.class,
+                                        anyTree(tableScan("lineitem"))))));
+
+        assertPlan(
+                "SELECT * FROM orders WHERE orderkey <= (SELECT min(orderkey) FROM lineitem)",
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                anyTree(tableScan("orders")),
+                                node(EnforceSingleRowNode.class,
+                                        anyTree(tableScan("lineitem"))))));
+
+        assertPlan(
+                "SELECT * FROM orders WHERE orderkey <= (SELECT max(orderkey) FROM lineitem)",
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                anyTree(tableScan("orders")),
+                                node(EnforceSingleRowNode.class,
+                                        anyTree(tableScan("lineitem"))))));
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(this.getQueryRunner().getDefaultSession())

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DataOrganizationSpecification;
+import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.IndexJoinNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.Ordering;
@@ -48,9 +49,11 @@ import static com.facebook.presto.metadata.MetadataManager.createTestMetadataMan
 import static com.facebook.presto.spi.plan.WindowNode.Frame.BoundType.UNBOUNDED_FOLLOWING;
 import static com.facebook.presto.spi.plan.WindowNode.Frame.BoundType.UNBOUNDED_PRECEDING;
 import static com.facebook.presto.spi.plan.WindowNode.Frame.WindowType.RANGE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.except;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.intersect;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictIndexSource;
@@ -216,6 +219,40 @@ public class TestPruneUnreferencedOutputs
                         output(
                                 project(
                                         values("a", "b"))));
+    }
+
+    @Test
+    public void testJoinDynamicFiltersNotPruned()
+    {
+        // Verify that PruneUnreferencedOutputs preserves dynamic filter variables
+        // referenced by JoinNode, even when those variables are not in the
+        // downstream output. This is a regression test for:
+        // https://github.com/prestodb/presto/issues/28364
+        assertRuleApplication()
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey", BIGINT);
+                    VariableReferenceExpression rightKey = p.variable("rightKey", BIGINT);
+                    return p.output(
+                            ImmutableList.of("leftKey"),
+                            ImmutableList.of(leftKey),
+                            p.join(
+                                    JoinType.INNER,
+                                    p.values(leftKey),
+                                    p.values(rightKey),
+                                    ImmutableList.of(new EquiJoinClause(leftKey, rightKey)),
+                                    ImmutableList.of(leftKey, rightKey),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    ImmutableMap.of("dynamicFilter1", rightKey)));
+                })
+                .matches(
+                        output(
+                                join(
+                                        JoinType.INNER,
+                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                        values("leftKey"),
+                                        values("rightKey"))));
     }
 
     private OptimizerAssert assertRuleApplication()


### PR DESCRIPTION
## Description
In issue #27085, the `IcebergAggregationOptimizer` was added to push down `min`, `max`, and `count` aggregation functions directly into Iceberg file statistics, swapping the aggregation node for a constant `ProjectNode`. However, `visitJoin` fails to add dynamic filter variables to `rightInputs`. As a result, `PruneUnreferencedOutputs` strips out the output variables on the right side, which ultimately triggers a validation failure inside the `JoinNode` constructor.

## Motivation and Context
This change fixes a plan validation failure where dynamic filter references were prematurely pruned after constant folding by the `IcebergAggregationOptimizer`.

- Closes #28364 

## Impact
This is an internal optimizer fix that prevents query planning errors without breaking public APIs or changing user-facing behaviors.

## Test Plan
- Add `testJoinDynamicFiltersNotPruned` in `TestPruneUnreferencedOutputs.java` to verify dynamic filter variables are preserved.
- Add `testScalarSubqueryWithAggregation` in `TestDynamicFilter.java`.
- Add `testScalarSubqueryWithAggregationAndDynamicFiltering` in `IcebergDistributedTestBase.java` for Iceberg connector integration testing.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix query planning failure with dynamic filtering enabled when using scalar subqueries with ``min/max/count`` aggregation functions.
```

## Summary by Sourcery

Preserve join-side dynamic filter inputs during output pruning to support scalar aggregation subqueries and prevent plan validation failures.

Bug Fixes:
- Prevent query planning failures by preserving dynamic filter variables required by join nodes during unreferenced-output pruning.

Tests:
- Add planner regression coverage for dynamic filter preservation and scalar subqueries using min, max, and count aggregations.
- Add Iceberg integration coverage for scalar aggregation subqueries with dynamic filtering.

## Summary by Sourcery

Preserve join dynamic-filter inputs so scalar subqueries with min, max, and count aggregations plan successfully.

Bug Fixes:
- Prevent query planning failures by preserving dynamic filter variables required by join nodes during unreferenced-output pruning.

Tests:
- Add planner regression coverage for dynamic filter preservation and scalar subqueries using min, max, and count aggregations.
- Add Iceberg integration coverage for scalar aggregation subqueries with dynamic filtering.