### PR TITLE
feat: Load expression optimizers on the Presto-on-Spark driver

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -110,6 +110,22 @@ public class ExpressionOptimizerManager
         loadExpressionOptimizerFactory(factoryName, optimizerName, properties, authClientConfigs);
     }
 
+    public void loadExpressionOptimizers(Map<String, Map<String, String>> optimizerProperties, AuthClientConfigs authClientConfigs)
+    {
+        requireNonNull(optimizerProperties, "optimizerProperties is null");
+        for (Map.Entry<String, Map<String, String>> entry : optimizerProperties.entrySet()) {
+            String optimizerName = entry.getKey();
+            checkArgument(!isNullOrEmpty(optimizerName), "Expression optimizer name is empty");
+            checkArgument(!optimizerName.equals(DEFAULT_EXPRESSION_OPTIMIZER_NAME), "Cannot name an expression optimizer instance %s", DEFAULT_EXPRESSION_OPTIMIZER_NAME);
+
+            Map<String, String> properties = new HashMap<>(entry.getValue());
+            String factoryName = properties.remove(EXPRESSION_MANAGER_FACTORY_NAME);
+            checkArgument(!isNullOrEmpty(factoryName), "Expression optimizer %s does not contain %s", optimizerName, EXPRESSION_MANAGER_FACTORY_NAME);
+
+            loadExpressionOptimizerFactory(factoryName, optimizerName, properties, authClientConfigs);
+        }
+    }
+
     public void loadExpressionOptimizerFactory(String factoryName, String optimizerName, Map<String, String> properties, AuthClientConfigs authClientConfigs)
     {
         requireNonNull(factoryName, "factoryName is null");

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -126,6 +127,89 @@ public class TestExpressionOptimizerManager
         assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizerFactories(defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier())));
     }
 
+    @Test
+    public void testLoadFromMap()
+    {
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("foo"));
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("bar"));
+
+        manager.loadExpressionOptimizers(
+                ImmutableMap.of(
+                        "ai-function-rewrite", ImmutableMap.of("expression-manager-factory.name", "foo"),
+                        "bar", ImmutableMap.of("expression-manager-factory.name", "bar")),
+                defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier()));
+
+        // Resolving by name is the exact call RewriteRowExpressions makes during planning.
+        assertEquals(
+                manager.getExpressionOptimizer("ai-function-rewrite").optimize(expression("1+1"), OPTIMIZED, testSessionBuilder().build().toConnectorSession()),
+                expression("'foo'"));
+        assertEquals(
+                manager.getExpressionOptimizer("bar").optimize(expression("1+1"), OPTIMIZED, testSessionBuilder().build().toConnectorSession()),
+                expression("'bar'"));
+
+        assertOptimizedExpression("1+1", "2", ImmutableMap.of());
+        assertOptimizedExpression("1+1", "'foo'", ImmutableMap.of("expression_optimizer_name", "ai-function-rewrite"));
+    }
+
+    @Test
+    public void testLoadFromMapPassesConfigThroughWithoutFactoryName()
+    {
+        Map<String, String> received = new HashMap<>();
+        manager.addExpressionOptimizerFactory(getConfigCapturingFactory("capturing", received));
+
+        manager.loadExpressionOptimizers(
+                ImmutableMap.of("ai-function-rewrite", ImmutableMap.of(
+                        "expression-manager-factory.name", "capturing",
+                        "allowed-catalogs", "meta")),
+                defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier()));
+
+        assertEquals(received, ImmutableMap.of("allowed-catalogs", "meta"));
+    }
+
+    @Test
+    public void testLoadFromMapDoesNotMutateCallerMap()
+    {
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("foo"));
+
+        Map<String, Map<String, String>> properties = ImmutableMap.of("ai-function-rewrite", ImmutableMap.of("expression-manager-factory.name", "foo"));
+        manager.loadExpressionOptimizers(properties, defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier()));
+
+        assertEquals(properties.get("ai-function-rewrite"), ImmutableMap.of("expression-manager-factory.name", "foo"));
+    }
+
+    @Test
+    public void testLoadFromMapNoNewOptimizerNameCalledDefault()
+    {
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("default"));
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizers(
+                ImmutableMap.of("default", ImmutableMap.of("expression-manager-factory.name", "default")),
+                defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier())));
+    }
+
+    @Test
+    public void testLoadFromMapNoFactoryName()
+    {
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("foo"));
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizers(
+                ImmutableMap.of("ai-function-rewrite", ImmutableMap.of()),
+                defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier())));
+    }
+
+    @Test
+    public void testLoadFromMapNoFactoryRegistered()
+    {
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizers(
+                ImmutableMap.of("ai-function-rewrite", ImmutableMap.of("expression-manager-factory.name", "ai-function-rewrite")),
+                defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier())));
+    }
+
+    @Test
+    public void testLoadFromEmptyMapIsNoOp()
+    {
+        manager.loadExpressionOptimizers(ImmutableMap.of(), defaultAuthClientConfigs(pluginNodeManager.getCurrentNode().getNodeIdentifier()));
+        assertOptimizedExpression("1+1", "2", ImmutableMap.of());
+    }
+
     private void assertOptimizedExpression(String originalExpression, String optimizedExpression, Map<String, String> systemProperties)
     {
         Session.SessionBuilder sessionBuilder = testSessionBuilder();
@@ -165,6 +249,25 @@ public class TestExpressionOptimizerManager
                 return (expression, level, session, variableResolver) -> constant(
                         Slices.utf8Slice(name),
                         METADATA.getType(TypeSignature.parseTypeSignature(format("varchar(%s)", name.length()))));
+            }
+
+            @Override
+            public String getName()
+            {
+                return name;
+            }
+        };
+    }
+
+    private ExpressionOptimizerFactory getConfigCapturingFactory(String name, Map<String, String> received)
+    {
+        return new ExpressionOptimizerFactory()
+        {
+            @Override
+            public ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context)
+            {
+                received.putAll(config);
+                return (expression, level, session, variableResolver) -> expression;
             }
 
             @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.storage.TempStorageModule;
@@ -70,6 +71,7 @@ public class PrestoSparkInjectorFactory
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
     private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
+    private final Optional<Map<String, Map<String, String>>> expressionManagerProperties;
     private final SqlParserOptions sqlParserOptions;
     private final List<Module> additionalModules;
     private final boolean isForTesting;
@@ -83,6 +85,7 @@ public class PrestoSparkInjectorFactory
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties,
+            Optional<Map<String, Map<String, String>>> expressionManagerProperties,
             SqlParserOptions sqlParserOptions,
             List<Module> additionalModules)
     {
@@ -95,6 +98,7 @@ public class PrestoSparkInjectorFactory
                 sessionPropertyConfigurationProperties,
                 functionNamespaceProperties,
                 tempStorageProperties,
+                expressionManagerProperties,
                 sqlParserOptions,
                 additionalModules,
                 false);
@@ -109,6 +113,7 @@ public class PrestoSparkInjectorFactory
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties,
+            Optional<Map<String, Map<String, String>>> expressionManagerProperties,
             SqlParserOptions sqlParserOptions,
             List<Module> additionalModules,
             boolean isForTesting)
@@ -124,6 +129,9 @@ public class PrestoSparkInjectorFactory
                 .map(map -> map.entrySet().stream()
                         .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue()))));
         this.tempStorageProperties = requireNonNull(tempStorageProperties, "tempStorageProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue()))));
+        this.expressionManagerProperties = requireNonNull(expressionManagerProperties, "expressionManagerProperties is null")
                 .map(map -> map.entrySet().stream()
                         .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue()))));
         this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
@@ -236,6 +244,13 @@ public class PrestoSparkInjectorFactory
             if (sparkProcessType.equals(DRIVER) && featuresConfig.isBuiltInSidecarFunctionsEnabled()) {
                 List<? extends SqlFunction> functions = injector.getInstance(WorkerFunctionRegistryTool.class).getWorkerFunctions();
                 injector.getInstance(FunctionAndTypeManager.class).registerWorkerFunctions(functions);
+            }
+
+            // Driver only: expression optimizers are consulted during planning, which happens
+            // exclusively on the driver, so executors never resolve an optimizer by name.
+            if (sparkProcessType.equals(DRIVER) && expressionManagerProperties.isPresent()) {
+                injector.getInstance(ExpressionOptimizerManager.class)
+                        .loadExpressionOptimizers(expressionManagerProperties.get(), defaultAuthClientConfigs(nodeInfo.getNodeId()));
             }
             bootstrapTimer.endDriverModulesLoading();
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -59,6 +59,7 @@ public class PrestoSparkServiceFactory
                 configuration.getSessionPropertyConfigurationProperties(),
                 configuration.getFunctionNamespaceProperties(),
                 configuration.getTempStorageProperties(),
+                configuration.getExpressionManagerProperties(),
                 getSqlParserOptions(),
                 getAdditionalModules(configuration));
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -349,6 +349,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 new SqlParserOptions(),
                 moduleBuilder.build(),
                 true);

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -37,6 +37,7 @@ public class PrestoSparkConfiguration
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
     private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
+    private final Optional<Map<String, Map<String, String>>> expressionManagerProperties;
 
     public PrestoSparkConfiguration(
             Map<String, String> configProperties,
@@ -49,7 +50,8 @@ public class PrestoSparkConfiguration
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
-            Optional<Map<String, Map<String, String>>> tempStorageProperties)
+            Optional<Map<String, Map<String, String>>> tempStorageProperties,
+            Optional<Map<String, Map<String, String>>> expressionManagerProperties)
     {
         this.configProperties = unmodifiableMap(new HashMap<>(requireNonNull(configProperties, "configProperties is null")));
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
@@ -69,6 +71,9 @@ public class PrestoSparkConfiguration
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
         this.tempStorageProperties = requireNonNull(tempStorageProperties, "tempStorageProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
+        this.expressionManagerProperties = requireNonNull(expressionManagerProperties, "expressionManagerProperties is null")
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
@@ -131,5 +136,10 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, Map<String, String>>> getTempStorageProperties()
     {
         return tempStorageProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getExpressionManagerProperties()
+    {
+        return expressionManagerProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -40,6 +40,7 @@ public class PrestoSparkDistribution
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
     private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
+    private final Optional<Map<String, Map<String, String>>> expressionManagerProperties;
 
     @Deprecated
     public PrestoSparkDistribution(
@@ -85,6 +86,37 @@ public class PrestoSparkDistribution
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties)
     {
+        this(
+                sparkContext,
+                packageSupplier,
+                configProperties,
+                catalogProperties,
+                prestoSparkProperties,
+                nativeWorkerConfigProperties,
+                nativeWorkerCatalogConfigProperties,
+                eventListenerProperties,
+                accessControlProperties,
+                sessionPropertyConfigurationProperties,
+                functionNamespaceProperties,
+                tempStorageProperties,
+                Optional.empty());
+    }
+
+    public PrestoSparkDistribution(
+            SparkContext sparkContext,
+            PackageSupplier packageSupplier,
+            Map<String, String> configProperties,
+            Map<String, Map<String, String>> catalogProperties,
+            Map<String, String> prestoSparkProperties,
+            Optional<Map<String, String>> nativeWorkerConfigProperties,
+            Optional<Map<String, Map<String, String>>> nativeWorkerCatalogConfigProperties,
+            Optional<Map<String, String>> eventListenerProperties,
+            Optional<Map<String, String>> accessControlProperties,
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties,
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
+            Optional<Map<String, Map<String, String>>> tempStorageProperties,
+            Optional<Map<String, Map<String, String>>> expressionManagerProperties)
+    {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
         this.configProperties = ImmutableMap.copyOf(requireNonNull(configProperties, "configProperties is null"));
@@ -103,6 +135,9 @@ public class PrestoSparkDistribution
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
         this.tempStorageProperties = requireNonNull(tempStorageProperties, "tempStorageProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
+        this.expressionManagerProperties = requireNonNull(expressionManagerProperties, "expressionManagerProperties is null")
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
@@ -165,5 +200,10 @@ public class PrestoSparkDistribution
     public Optional<Map<String, Map<String, String>>> getTempStorageProperties()
     {
         return tempStorageProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getExpressionManagerProperties()
+    {
+        return expressionManagerProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -78,6 +78,7 @@ public class PrestoSparkRunner
                 distribution.getSessionPropertyConfigurationProperties(),
                 distribution.getFunctionNamespaceProperties(),
                 distribution.getTempStorageProperties(),
+                distribution.getExpressionManagerProperties(),
                 Optional.empty());
     }
 
@@ -245,6 +246,7 @@ public class PrestoSparkRunner
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties,
+            Optional<Map<String, Map<String, String>>> expressionManagerProperties,
             Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
     {
         PrestoSparkBootstrapTimer bootstrapTimer = new PrestoSparkBootstrapTimer(systemTicker(), !sparkProcessType.equals(SparkProcessType.DRIVER));
@@ -263,7 +265,8 @@ public class PrestoSparkRunner
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
                 functionNamespaceProperties,
-                tempStorageProperties);
+                tempStorageProperties,
+                expressionManagerProperties);
         IPrestoSparkServiceFactory serviceFactory = createServiceFactory(checkDirectory(new File(packagePath, "lib")));
         IPrestoSparkService service = serviceFactory.createService(sparkProcessType, configuration, bootstrapTimer);
         bootstrapTimer.endRunnerServiceCreation();
@@ -292,6 +295,7 @@ public class PrestoSparkRunner
         private final Map<String, String> sessionPropertyConfigurationProperties;
         private final Map<String, Map<String, String>> functionNamespaceProperties;
         private final Map<String, Map<String, String>> tempStorageProperties;
+        private final Map<String, Map<String, String>> expressionManagerProperties;
         private final CollectionAccumulator<Map<String, Long>> bootstrapMetricsCollector;
         private final boolean isLocal;
 
@@ -313,6 +317,7 @@ public class PrestoSparkRunner
             this.sessionPropertyConfigurationProperties = distribution.getSessionPropertyConfigurationProperties().orElse(null);
             this.functionNamespaceProperties = distribution.getFunctionNamespaceProperties().orElse(null);
             this.tempStorageProperties = distribution.getTempStorageProperties().orElse(null);
+            this.expressionManagerProperties = distribution.getExpressionManagerProperties().orElse(null);
             this.isLocal = distribution.getSparkContext().isLocal();
         }
 
@@ -344,6 +349,7 @@ public class PrestoSparkRunner
         private static Map<String, String> currentSessionPropertyConfigurationProperties;
         private static Map<String, Map<String, String>> currentFunctionNamespaceProperties;
         private static Map<String, Map<String, String>> currentTempStorageProperties;
+        private static Map<String, Map<String, String>> currentExpressionManagerProperties;
 
         private IPrestoSparkService getOrCreatePrestoSparkService()
         {
@@ -362,6 +368,7 @@ public class PrestoSparkRunner
                             Optional.ofNullable(sessionPropertyConfigurationProperties),
                             Optional.ofNullable(functionNamespaceProperties),
                             Optional.ofNullable(tempStorageProperties),
+                            Optional.ofNullable(expressionManagerProperties),
                             Optional.of(bootstrapMetricsCollector));
 
                     currentPackagePath = getPackagePath(packageSupplier);
@@ -375,6 +382,7 @@ public class PrestoSparkRunner
                     currentSessionPropertyConfigurationProperties = sessionPropertyConfigurationProperties;
                     currentFunctionNamespaceProperties = functionNamespaceProperties;
                     currentTempStorageProperties = tempStorageProperties;
+                    currentExpressionManagerProperties = expressionManagerProperties;
                 }
                 else {
                     checkEquals("packagePath", currentPackagePath, getPackagePath(packageSupplier));
@@ -390,6 +398,7 @@ public class PrestoSparkRunner
                             sessionPropertyConfigurationProperties);
                     checkEquals("functionNamespaceProperties", currentFunctionNamespaceProperties, functionNamespaceProperties);
                     checkEquals("tempStorageProperties", currentTempStorageProperties, tempStorageProperties);
+                    checkEquals("expressionManagerProperties", currentExpressionManagerProperties, expressionManagerProperties);
                 }
                 return service;
             }


### PR DESCRIPTION
## What this does

ExpressionOptimizerManager can only create expression optimizers by scanning a directory on local disk. Presto-on-Spark doesn't have one — it receives its whole configuration at startup — so on Presto-on-Spark no optimizer is ever created, and any query that needs one fails at plan time.

Registering a factory isn't the same as creating an instance. That's the gap.

## The change

Adds a map-based way to load optimizers, alongside the existing directory scan, and passes the configuration down to the Presto-on-Spark driver. This mirrors StaticFunctionNamespaceStore, which already does exactly this for function namespaces.

The load runs on the driver only, after plugins are loaded — planning only happens on the driver, and plugin loading is what registers the factories.

## Compatibility

No behaviour change when no configuration is supplied. Existing constructors keep their signatures; PrestoSparkDistribution gains one overload so an out-of-repo caller keeps compiling.## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add support for loading expression optimizers on the Presto on Spark driver from configuration
  supplied at startup, for deployments that have no ``etc/expression-manager/`` directory on local
  disk. Previously such deployments could register an expression optimizer factory but never
  instantiate it.
```