### PR TITLE
fix(planner): Copy the filtering source when pushing a semi join through a union

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushSemiJoinThroughUnion.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushSemiJoinThroughUnion.java
@@ -16,11 +16,16 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.Session;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
@@ -35,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.isPushSemiJoinThroughUnion;
+import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
 import static com.facebook.presto.sql.planner.optimizations.SetOperationNodeUtils.fromListMultimap;
 import static com.facebook.presto.sql.planner.plan.Patterns.semiJoin;
 
@@ -68,6 +74,9 @@ import static com.facebook.presto.sql.planner.plan.Patterns.semiJoin;
  *         - filteringSource
  * </pre>
  * In this case, the project is pushed into each union branch before the semi join.
+ * <p>
+ * The filtering source is duplicated into every union branch, so it is copied with freshly allocated
+ * plan node ids. The rule does not fire when that subtree cannot be copied.
  */
 public class PushSemiJoinThroughUnion
         implements Rule<SemiJoinNode>
@@ -115,6 +124,12 @@ public class PushSemiJoinThroughUnion
         ImmutableList.Builder<PlanNode> newSources = ImmutableList.builder();
         ImmutableListMultimap.Builder<VariableReferenceExpression, VariableReferenceExpression> outputMappings =
                 ImmutableListMultimap.builder();
+
+        // Every branch gets its own semi join, and therefore its own copy of the filtering source. The same
+        // subtree cannot be shared by the branches: the plan is a tree, so sharing it leaves the plan with
+        // duplicated plan node ids, which the plan checker rejects. Materialize the subtree behind the group
+        // reference so it can be copied node by node with freshly allocated ids.
+        PlanNode filteringSource = resolveGroupReferences(semiJoinNode.getFilteringSource(), context.getLookup());
 
         for (int i = 0; i < unionNode.getSources().size(); i++) {
             Map<VariableReferenceExpression, VariableReferenceExpression> unionVarMap = unionNode.sourceVariableMap(i);
@@ -196,12 +211,19 @@ public class PushSemiJoinThroughUnion
             VariableReferenceExpression newSemiJoinOutput =
                     context.getVariableAllocator().newVariable(semiJoinNode.getSemiJoinOutput());
 
+            // Copy the filtering source for this branch. The copy keeps the original variables, so the
+            // filtering source join and hash variables stay valid, but every node in it gets a new id.
+            Optional<PlanNode> branchFilteringSource = copyWithNewPlanNodeIds(filteringSource, context.getIdAllocator());
+            if (!branchFilteringSource.isPresent()) {
+                return Result.empty();
+            }
+
             // Build new SemiJoinNode for this branch
             SemiJoinNode newSemiJoin = new SemiJoinNode(
                     semiJoinNode.getSourceLocation(),
                     context.getIdAllocator().getNextId(),
                     branchSource,
-                    semiJoinNode.getFilteringSource(),
+                    branchFilteringSource.get(),
                     mappedSourceJoinVar,
                     semiJoinNode.getFilteringSourceJoinVariable(),
                     newSemiJoinOutput,
@@ -224,6 +246,103 @@ public class PushSemiJoinThroughUnion
                 newSources.build(),
                 ImmutableList.copyOf(semiJoinNode.getOutputVariables()),
                 fromListMultimap(mappings)));
+    }
+
+    /**
+     * Rebuilds the subtree with a freshly allocated plan node id for every node. Variables are left
+     * untouched, so the copy produces exactly the same output variables as the original.
+     * <p>
+     * Returns {@link Optional#empty()} for a subtree containing a node type this method cannot rebuild,
+     * in which case the rule does not fire.
+     */
+    private static Optional<PlanNode> copyWithNewPlanNodeIds(PlanNode node, PlanNodeIdAllocator idAllocator)
+    {
+        if (node instanceof TableScanNode) {
+            TableScanNode tableScanNode = (TableScanNode) node;
+            return Optional.of(new TableScanNode(
+                    tableScanNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    tableScanNode.getStatsEquivalentPlanNode(),
+                    tableScanNode.getTable(),
+                    tableScanNode.getOutputVariables(),
+                    tableScanNode.getAssignments(),
+                    tableScanNode.getTableConstraints(),
+                    tableScanNode.getCurrentConstraint(),
+                    tableScanNode.getEnforcedConstraint(),
+                    tableScanNode.getCteMaterializationInfo()));
+        }
+
+        if (node instanceof ValuesNode) {
+            ValuesNode valuesNode = (ValuesNode) node;
+            return Optional.of(new ValuesNode(
+                    valuesNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    valuesNode.getStatsEquivalentPlanNode(),
+                    valuesNode.getOutputVariables(),
+                    valuesNode.getRows(),
+                    valuesNode.getValuesNodeLabel()));
+        }
+
+        if (node instanceof FilterNode) {
+            FilterNode filterNode = (FilterNode) node;
+            return copyWithNewPlanNodeIds(filterNode.getSource(), idAllocator)
+                    .map(newSource -> new FilterNode(
+                            filterNode.getSourceLocation(),
+                            idAllocator.getNextId(),
+                            filterNode.getStatsEquivalentPlanNode(),
+                            newSource,
+                            filterNode.getPredicate()));
+        }
+
+        if (node instanceof ProjectNode) {
+            ProjectNode project = (ProjectNode) node;
+            return copyWithNewPlanNodeIds(project.getSource(), idAllocator)
+                    .map(newSource -> new ProjectNode(
+                            project.getSourceLocation(),
+                            idAllocator.getNextId(),
+                            project.getStatsEquivalentPlanNode(),
+                            newSource,
+                            project.getAssignments(),
+                            project.getLocality()));
+        }
+
+        if (node instanceof AggregationNode) {
+            AggregationNode aggregationNode = (AggregationNode) node;
+            return copyWithNewPlanNodeIds(aggregationNode.getSource(), idAllocator)
+                    .map(newSource -> new AggregationNode(
+                            aggregationNode.getSourceLocation(),
+                            idAllocator.getNextId(),
+                            aggregationNode.getStatsEquivalentPlanNode(),
+                            newSource,
+                            aggregationNode.getAggregations(),
+                            aggregationNode.getGroupingSets(),
+                            aggregationNode.getPreGroupedVariables(),
+                            aggregationNode.getStep(),
+                            aggregationNode.getHashVariable(),
+                            aggregationNode.getGroupIdVariable(),
+                            aggregationNode.getAggregationId()));
+        }
+
+        if (node instanceof UnionNode) {
+            UnionNode unionNode = (UnionNode) node;
+            ImmutableList.Builder<PlanNode> newSources = ImmutableList.builder();
+            for (PlanNode source : unionNode.getSources()) {
+                Optional<PlanNode> newSource = copyWithNewPlanNodeIds(source, idAllocator);
+                if (!newSource.isPresent()) {
+                    return Optional.empty();
+                }
+                newSources.add(newSource.get());
+            }
+            return Optional.of(new UnionNode(
+                    unionNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    unionNode.getStatsEquivalentPlanNode(),
+                    newSources.build(),
+                    unionNode.getOutputVariables(),
+                    unionNode.getVariableMapping()));
+        }
+
+        return Optional.empty();
     }
 
     private static Map<String, VariableReferenceExpression> remapDynamicFilters(

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushSemiJoinThroughUnion.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushSemiJoinThroughUnion.java
@@ -13,14 +13,20 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.PUSH_SEMI_JOIN_THROUGH_UNION;
@@ -35,6 +41,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
+import static org.testng.Assert.assertEquals;
 
 public class TestPushSemiJoinThroughUnion
         extends BaseRuleTest
@@ -257,5 +264,84 @@ public class TestPushSemiJoinThroughUnion
                             p.values(filterJoinVar));
                 })
                 .doesNotFire();
+    }
+
+    @Test
+    public void testFilteringSourceIsCopiedWithNewPlanNodeIds()
+    {
+        PlanNode plan = tester().assertThat(new PushSemiJoinThroughUnion())
+                .setSystemProperty(PUSH_SEMI_JOIN_THROUGH_UNION, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a");
+                    VariableReferenceExpression b = p.variable("b");
+                    VariableReferenceExpression c = p.variable("c");
+                    VariableReferenceExpression filterJoinVar = p.variable("filterJoinVar");
+                    VariableReferenceExpression semiJoinOutput = p.variable("semiJoinOutput", BOOLEAN);
+                    return p.semiJoin(
+                            c,
+                            filterJoinVar,
+                            semiJoinOutput,
+                            Optional.empty(),
+                            Optional.empty(),
+                            p.union(
+                                    ImmutableListMultimap.<VariableReferenceExpression, VariableReferenceExpression>builder()
+                                            .put(c, a)
+                                            .put(c, b)
+                                            .build(),
+                                    ImmutableList.of(
+                                            p.values(a),
+                                            p.values(b))),
+                            p.values(filterJoinVar));
+                })
+                .get();
+
+        List<PlanNodeId> planNodeIds = new ArrayList<>();
+        collectPlanNodeIds(plan, planNodeIds);
+        assertEquals(
+                planNodeIds.size(),
+                ImmutableSet.copyOf(planNodeIds).size(),
+                "Rewritten plan contains duplicated plan node ids: " + planNodeIds);
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilteringSourceCannotBeCopied()
+    {
+        tester().assertThat(new PushSemiJoinThroughUnion())
+                .setSystemProperty(PUSH_SEMI_JOIN_THROUGH_UNION, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a");
+                    VariableReferenceExpression b = p.variable("b");
+                    VariableReferenceExpression c = p.variable("c");
+                    VariableReferenceExpression filterJoinVar = p.variable("filterJoinVar");
+                    VariableReferenceExpression semiJoinOutput = p.variable("semiJoinOutput", BOOLEAN);
+                    return p.semiJoin(
+                            c,
+                            filterJoinVar,
+                            semiJoinOutput,
+                            Optional.empty(),
+                            Optional.empty(),
+                            p.union(
+                                    ImmutableListMultimap.<VariableReferenceExpression, VariableReferenceExpression>builder()
+                                            .put(c, a)
+                                            .put(c, b)
+                                            .build(),
+                                    ImmutableList.of(
+                                            p.values(a),
+                                            p.values(b))),
+                            // LimitNode is not a node type the per-branch copy knows how to rebuild
+                            p.limit(10, p.values(filterJoinVar)));
+                })
+                .doesNotFire();
+    }
+
+    private static void collectPlanNodeIds(PlanNode node, List<PlanNodeId> planNodeIds)
+    {
+        planNodeIds.add(node.getId());
+        // Subtrees the rule left untouched are still group references, which cannot be walked into. Sharing
+        // one of them between two branches is exactly the bug this asserts against, so their ids are counted.
+        if (node instanceof GroupReference) {
+            return;
+        }
+        node.getSources().forEach(source -> collectPlanNodeIds(source, planNodeIds));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -87,6 +87,7 @@ import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_FILTER_EXPRE
 import static com.facebook.presto.SystemSessionProperties.PUSH_FILTER_THROUGH_SELECTING_AGGREGATION;
 import static com.facebook.presto.SystemSessionProperties.PUSH_PROJECTION_THROUGH_CROSS_JOIN;
 import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID;
+import static com.facebook.presto.SystemSessionProperties.PUSH_SEMI_JOIN_THROUGH_UNION;
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_NULL_SOURCE_KEY_IN_SEMI_JOIN_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
@@ -812,6 +813,56 @@ public abstract class AbstractTestQueries
                 "  CROSS JOIN UNNEST(sequence(1, (o.orderkey % 5) + 1)) WITH ORDINALITY AS t(elem, ord)" +
                 "  GROUP BY o.custkey)";
         assertQueryWithSameQueryRunner(enabled, withOrdinality, disabled);
+    }
+
+    @Test
+    public void testPushSemiJoinThroughUnion()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(PUSH_SEMI_JOIN_THROUGH_UNION, "true")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(PUSH_SEMI_JOIN_THROUGH_UNION, "false")
+                .build();
+
+        // The semi join is pushed into both union branches, so the filtering source ends up in the plan
+        // twice and has to be copied with fresh plan node ids.
+        @Language("SQL") String semiJoinOverUnion =
+                "SELECT to_hex(checksum(orderkey)) FROM (" +
+                "  SELECT orderkey FROM orders WHERE orderkey % 3 = 0" +
+                "  UNION ALL" +
+                "  SELECT orderkey FROM lineitem WHERE partkey % 7 = 0) t" +
+                " WHERE orderkey IN (SELECT orderkey FROM orders WHERE custkey % 5 = 0)";
+        assertQueryWithSameQueryRunner(enabled, semiJoinOverUnion, disabled);
+
+        // Aggregation in the filtering source: every node below the aggregation is copied as well.
+        @Language("SQL") String aggregatedFilteringSource =
+                "SELECT to_hex(checksum(orderkey)) FROM (" +
+                "  SELECT orderkey FROM orders" +
+                "  UNION ALL" +
+                "  SELECT orderkey FROM lineitem) t" +
+                " WHERE orderkey IN (SELECT DISTINCT orderkey FROM orders WHERE custkey % 5 = 0)";
+        assertQueryWithSameQueryRunner(enabled, aggregatedFilteringSource, disabled);
+
+        // Three branches, with a projection between the semi join and the union.
+        @Language("SQL") String projectOverUnion =
+                "SELECT to_hex(checksum(k)) FROM (" +
+                "  SELECT orderkey * 2 AS k FROM orders" +
+                "  UNION ALL" +
+                "  SELECT orderkey * 2 AS k FROM lineitem" +
+                "  UNION ALL" +
+                "  SELECT custkey * 2 AS k FROM customer) t" +
+                " WHERE k IN (SELECT orderkey FROM orders WHERE custkey % 5 = 0)";
+        assertQueryWithSameQueryRunner(enabled, projectOverUnion, disabled);
+
+        // NOT IN, so the semi join output is consumed by a negated filter.
+        @Language("SQL") String notInOverUnion =
+                "SELECT to_hex(checksum(orderkey)) FROM (" +
+                "  SELECT orderkey FROM orders WHERE orderkey % 3 = 0" +
+                "  UNION ALL" +
+                "  SELECT orderkey FROM lineitem WHERE partkey % 7 = 0) t" +
+                " WHERE orderkey NOT IN (SELECT orderkey FROM orders WHERE custkey % 5 = 0)";
+        assertQueryWithSameQueryRunner(enabled, notInOverUnion, disabled);
     }
 
     @Test


### PR DESCRIPTION
## Description

`PushSemiJoinThroughUnion` rewrites

```
SemiJoin(Union(s1, s2), f)  ->  Union(SemiJoin(s1, f), SemiJoin(s2, f))
```

placing the same filtering source subtree `f` under every branch. A plan is a tree, so the shared
subtree ends up in the plan once per branch carrying the same plan node ids, and planning fails in
`NoDuplicatePlanNodeIdsChecker` with

```
Generated plan contains nodes with duplicated id 24:
com.facebook.presto.spi.plan.AggregationNode@... and com.facebook.presto.spi.plan.AggregationNode@...
```

This change gives each branch its own copy of the filtering source, rebuilt node by node with freshly
allocated plan node ids. The copy keeps the original variables, so the filtering source join and hash
variables stay valid. The rule does not fire when the subtree contains a node type the copy cannot
rebuild.

The rule remains gated behind the default-off `push_semi_join_through_union` session property.

## Motivation and Context

A union always has at least two branches, so this happened every time the rule fired: the optimization
was unusable, and any session that enabled the property and hit the pattern failed at planning time.
Because the property is off by default, only sessions that opted in were affected. No incorrect results
were possible, since the plan never got past validation.

## Impact

Queries with `IN`/`NOT IN` over a `UNION ALL` now plan successfully when `push_semi_join_through_union`
is enabled. No change with the property off, which is the default. No new or changed configuration
properties, SQL syntax or functions.

## Test Plan

- Unit: `TestPushSemiJoinThroughUnion` — new `testFilteringSourceIsCopiedWithNewPlanNodeIds` collects
  every plan node id in the rewritten plan and asserts they are unique (it fails on the unfixed rule
  with a repeated id), and `testDoesNotFireWhenFilteringSourceCannotBeCopied` covers the bail-out.
  `mvn test -pl presto-main-base -Dtest=TestPushSemiJoinThroughUnion` -> 8/8.
- e2e: new `AbstractTestQueries#testPushSemiJoinThroughUnion` compares results with the optimization
  enabled versus disabled over a semi join above a two-branch union, an aggregated (`DISTINCT`)
  filtering source, a three-branch union under a projection, and `NOT IN`. Verified that this test
  reproduces the planning failure without the fix and passes with it, and that the rule really fires on
  all four queries (2/2/3/2 semi joins in the plan versus 1 when disabled).
- Full `TestLocalQueries` suite (543 tests) passes.
- `mvn validate -pl presto-main-base,presto-tests` (checkstyle) and `mvn modernizer:modernizer` pass.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

The fixed optimization is off by default and never produced a usable plan when enabled, so this is not
visible to users running with the default configuration.

```
== NO RELEASE NOTE ==
```
