### PR TITLE
feat(native): Select the cuDF UCX exchange transport per edge and start its Communicator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -35,6 +35,7 @@ import static java.util.Objects.requireNonNull;
 public class NativeWorkerSessionPropertyProvider
         implements WorkerSessionPropertyProvider
 {
+    public static final String NATIVE_CUDF_EXCHANGE_ENABLED = "native_cudf_exchange_enabled";
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
     public static final String NATIVE_EXPRESSION_MAX_ARRAY_SIZE_IN_REDUCE = "native_expression_max_array_size_in_reduce";
     public static final String NATIVE_EXPRESSION_MAX_COMPILED_REGEXES = "native_expression_max_compiled_regexes";
@@ -116,6 +117,13 @@ public class NativeWorkerSessionPropertyProvider
     {
         boolean nativeExecution = requireNonNull(featuresConfig, "featuresConfig is null").isNativeExecutionEnabled();
         sessionProperties = ImmutableList.of(
+                booleanProperty(
+                        NATIVE_CUDF_EXCHANGE_ENABLED,
+                        "Native Execution only. Whether this query's worker-to-worker exchanges may use the cuDF UCX transport. The effective " +
+                                "default is the worker's: on where the transport is registered, off elsewhere. Leaving it unset is therefore " +
+                                "different from setting it true, which fails the query on a worker without the transport.",
+                        false,
+                        !nativeExecution),
                 booleanProperty(
                         NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED,
                         "Native Execution only. Enable simplified path in expression evaluation",

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -237,6 +237,15 @@ set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
 set(VELOX_MONO_LIBRARY ON CACHE BOOL "Build Velox mono library")
 add_subdirectory(velox)
 
+# Velox declares VELOX_ENABLE_UCX_EXCHANGE while resolving cuDF, so its value is
+# only known after add_subdirectory(velox) above. Presto code that touches the
+# UCX exchange must key on this definition rather than on PRESTO_ENABLE_CUDF:
+# cuDF builds fine without UCX, and then neither the ucxx targets nor the
+# ucx-exchange headers exist.
+if(VELOX_ENABLE_UCX_EXCHANGE)
+  add_compile_definitions(PRESTO_ENABLE_UCX_EXCHANGE)
+endif()
+
 if(PRESTO_ENABLE_TESTING)
   set(BUILD_TESTING ON) # some third-party dependency could have disabled this.
   include(CTest) # include after project() but before add_subdirectory()

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -79,6 +79,12 @@ if(PRESTO_ENABLE_CUDF)
   # The symbols from velox_cudf_exec are not included in the Velox mono library
   # and need to be linked separately.
   target_link_libraries(presto_server_lib velox_cudf_exec)
+  # Same for velox_ucx_exchange, which velox_cudf_exec links privately: this is
+  # also what puts the ucxx include directories on the compile line for
+  # PrestoServer.cpp, which starts the UCX Communicator.
+  if(VELOX_ENABLE_UCX_EXCHANGE)
+    target_link_libraries(presto_server_lib velox_ucx_exchange)
+  endif()
 endif()
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -94,6 +94,10 @@
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #endif
 
+#ifdef PRESTO_ENABLE_UCX_EXCHANGE
+#include "velox/experimental/ucx-exchange/Communicator.h"
+#endif
+
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
 #include "presto_cpp/main/RemoteFunctionRegisterer.h"
 #endif
@@ -185,6 +189,61 @@ bool isSharedLibrary(const fs::path& path) {
   return pathExt == kLinuxSharedLibExt || pathExt == kMacOSSharedLibExt;
 }
 
+#ifdef PRESTO_ENABLE_UCX_EXCHANGE
+// Thread driving the UCX Communicator's progress loop. The Communicator itself
+// is a process-lifetime singleton reachable through getInstance(); this only
+// owns the thread, so stopUcxCommunicator() has something to join.
+std::unique_ptr<std::thread> ucxCommunicatorThread;
+#endif
+
+// Starts the UCX exchange listener that serves every other worker's exchange
+// connections. Called only when Velox's 'cudf.exchange' is enabled; a no-op in
+// a build without the UCX exchange, where nothing registers the UCX transport
+// and so no plan can name it.
+void startUcxCommunicator() {
+#ifdef PRESTO_ENABLE_UCX_EXCHANGE
+  if (ucxCommunicatorThread != nullptr) {
+    return;
+  }
+  auto* systemConfig = SystemConfig::instance();
+  const auto port = systemConfig->cudfExchangeServerPort();
+
+  // Take the readiness future before the listener can accept, then wait on it
+  // once the progress thread is running. Returning as soon as the thread is
+  // spawned would let a task resolve the UCX transport and have
+  // UcxExchangeSource connect before the listener exists, turning a startup
+  // ordering problem into an intermittent query failure.
+  velox::ContinueFuture ready{velox::ContinueFuture::makeEmpty()};
+  auto communicator = velox::ucx_exchange::Communicator::initAndGet(
+      port, systemConfig->discoveryUri().value_or(""), &ready);
+  VELOX_CHECK_NOT_NULL(
+      communicator,
+      "Failed to initialize the UCX exchange Communicator on port {}",
+      port);
+  ucxCommunicatorThread = std::make_unique<std::thread>(
+      &velox::ucx_exchange::Communicator::run, communicator.get());
+  if (ready.valid()) {
+    std::move(ready).wait();
+  }
+  PRESTO_STARTUP_LOG(INFO) << "UCX exchange Communicator listening on port "
+                           << port;
+#endif
+}
+
+// Stops the UCX exchange listener and joins its thread. Idempotent, and a no-op
+// when startUcxCommunicator() never ran.
+void stopUcxCommunicator() {
+#ifdef PRESTO_ENABLE_UCX_EXCHANGE
+  if (ucxCommunicatorThread == nullptr) {
+    return;
+  }
+  PRESTO_SHUTDOWN_LOG(INFO) << "Stopping the UCX exchange Communicator";
+  velox::ucx_exchange::Communicator::getInstance()->stop();
+  ucxCommunicatorThread->join();
+  ucxCommunicatorThread.reset();
+#endif
+}
+
 void registerVeloxCudf() {
 #ifdef PRESTO_ENABLE_CUDF
   auto& cudfConfig = velox::cudf_velox::CudfConfig::getInstance();
@@ -199,6 +258,19 @@ void registerVeloxCudf() {
     if (cudfConfig.enabled) {
       velox::cudf_velox::registerCudf();
       velox::cudf_velox::registerPrestoFunctions(cudfConfig.functionNamePrefix);
+      if (cudfConfig.exchange) {
+#ifdef PRESTO_ENABLE_UCX_EXCHANGE
+        // registerCudf() has just registered the UCX transport, so a plan can
+        // name it from here on and the listener has to be up before it does.
+        startUcxCommunicator();
+#else
+        PRESTO_STARTUP_LOG(WARNING)
+            << velox::cudf_velox::CudfConfig::kUcxExchange
+            << "=true, but this worker was built without the UCX exchange "
+               "(VELOX_ENABLE_UCX_EXCHANGE=OFF). Nothing registers the UCX "
+               "transport, so exchanges use the in-memory transport.";
+#endif
+      }
       PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
     }
   }
@@ -211,6 +283,9 @@ void unregisterVeloxCudf() {
   if (systemConfig->values().contains(
           velox::cudf_velox::CudfConfig::kCudfEnabled) &&
       velox::cudf_velox::CudfConfig::getInstance().enabled) {
+    // Before unregisterCudf(), which drops the UCX transport registrations and
+    // resets the cuDF memory resources the Communicator's buffers come from.
+    stopUcxCommunicator();
     velox::cudf_velox::unregisterCudf();
     PRESTO_SHUTDOWN_LOG(INFO) << "cuDF is unregistered.";
   }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -172,6 +172,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NONE_PROP(kHttpsClientCaFile),
+          NONE_PROP(kCudfExchangeServerPort),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
@@ -327,6 +328,15 @@ SystemConfig* SystemConfig::instance() {
 
 int SystemConfig::httpServerHttpPort() const {
   return requiredProperty<int>(kHttpServerHttpPort);
+}
+
+int SystemConfig::cudfExchangeServerPort() const {
+  // The receiving side derives the peer's UCX port from the remote task's HTTP
+  // location by adding 3 (UcxExchangeSource::create), so httpServerHttpPort()
+  // + 3 is the only value that lets a cluster connect. Keep the property for
+  // deployments that change that derivation, but do not require it.
+  return optionalProperty<int>(kCudfExchangeServerPort)
+      .value_or(httpServerHttpPort() + 3);
 }
 
 bool SystemConfig::httpServerReusePort() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -36,6 +36,8 @@ namespace facebook::presto {
 
 namespace {
 
+constexpr int kUcxPortOffset = 3;
+
 // folly::to<> does not generate 'true' and 'false', so we do it ourselves.
 std::string bool2String(bool value) {
   return value ? "true" : "false";
@@ -172,7 +174,6 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NONE_PROP(kHttpsClientCaFile),
-          NONE_PROP(kCudfExchangeServerPort),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
@@ -331,12 +332,9 @@ int SystemConfig::httpServerHttpPort() const {
 }
 
 int SystemConfig::cudfExchangeServerPort() const {
-  // The receiving side derives the peer's UCX port from the remote task's HTTP
-  // location by adding 3 (UcxExchangeSource::create), so httpServerHttpPort()
-  // + 3 is the only value that lets a cluster connect. Keep the property for
-  // deployments that change that derivation, but do not require it.
-  return optionalProperty<int>(kCudfExchangeServerPort)
-      .value_or(httpServerHttpPort() + 3);
+  // UcxExchangeSource derives a peer's UCX port from its advertised HTTP port
+  // using the same offset.
+  return httpServerHttpPort() + kUcxPortOffset;
 }
 
 bool SystemConfig::httpServerReusePort() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -822,6 +822,15 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpClientConnectionReuseCounterEnabled{
       "http-client.connection-reuse-counter-enabled"};
 
+  /// Port the cuDF UCX exchange listens on for the exchange connections of the
+  /// other workers. Only read when Velox's 'cudf.exchange' is enabled and this
+  /// worker was built with the UCX exchange. Optional: it defaults to
+  /// kHttpServerHttpPort + 3, which is the port the receiving side derives from
+  /// a remote task's HTTP location, so overriding it only makes sense together
+  /// with that derivation.
+  static constexpr std::string_view kCudfExchangeServerPort{
+      "cudf.exchange.server.port"};
+
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
@@ -1017,6 +1026,10 @@ class SystemConfig : public ConfigBase {
   static SystemConfig* instance();
 
   int httpServerHttpPort() const;
+
+  /// Returns kCudfExchangeServerPort, or httpServerHttpPort() + 3 when it is
+  /// unset. See kCudfExchangeServerPort.
+  int cudfExchangeServerPort() const;
 
   bool httpServerReusePort() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -822,15 +822,6 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpClientConnectionReuseCounterEnabled{
       "http-client.connection-reuse-counter-enabled"};
 
-  /// Port the cuDF UCX exchange listens on for the exchange connections of the
-  /// other workers. Only read when Velox's 'cudf.exchange' is enabled and this
-  /// worker was built with the UCX exchange. Optional: it defaults to
-  /// kHttpServerHttpPort + 3, which is the port the receiving side derives from
-  /// a remote task's HTTP location, so overriding it only makes sense together
-  /// with that derivation.
-  static constexpr std::string_view kCudfExchangeServerPort{
-      "cudf.exchange.server.port"};
-
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
@@ -1027,8 +1018,7 @@ class SystemConfig : public ConfigBase {
 
   int httpServerHttpPort() const;
 
-  /// Returns kCudfExchangeServerPort, or httpServerHttpPort() + 3 when it is
-  /// unset. See kCudfExchangeServerPort.
+  /// Returns the UCX listener port derived from the HTTP server port.
   int cudfExchangeServerPort() const;
 
   bool httpServerReusePort() const;

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -236,6 +236,20 @@ TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }
 
+TEST_F(ConfigTest, cudfExchangeServerPort) {
+  SystemConfig config;
+  // Unset: the port the receiving side derives from a remote task's HTTP
+  // location, which is the HTTP port plus 3.
+  init(config, {{std::string(SystemConfig::kHttpServerHttpPort), "7777"}});
+  ASSERT_EQ(config.cudfExchangeServerPort(), 7780);
+
+  init(
+      config,
+      {{std::string(SystemConfig::kHttpServerHttpPort), "7777"},
+       {std::string(SystemConfig::kCudfExchangeServerPort), "19003"}});
+  ASSERT_EQ(config.cudfExchangeServerPort(), 19003);
+}
+
 TEST_F(ConfigTest, asyncCacheNumShards) {
   SystemConfig config;
   init(config, {});

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -238,16 +238,8 @@ TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
 
 TEST_F(ConfigTest, cudfExchangeServerPort) {
   SystemConfig config;
-  // Unset: the port the receiving side derives from a remote task's HTTP
-  // location, which is the HTTP port plus 3.
   init(config, {{std::string(SystemConfig::kHttpServerHttpPort), "7777"}});
   ASSERT_EQ(config.cudfExchangeServerPort(), 7780);
-
-  init(
-      config,
-      {{std::string(SystemConfig::kHttpServerHttpPort), "7777"},
-       {std::string(SystemConfig::kCudfExchangeServerPort), "19003"}});
-  ASSERT_EQ(config.cudfExchangeServerPort(), 19003);
 }
 
 TEST_F(ConfigTest, asyncCacheNumShards) {

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedExchange.cpp
@@ -55,10 +55,15 @@ MaterializedExchange::MaterializedExchange(
     : Exchange(
           operatorId,
           ctx,
+          // Stand-in node for the Exchange base class. Materialized exchange
+          // reads from durable storage, not a worker-to-worker transport, so it
+          // names the in-memory one explicitly rather than inheriting a
+          // default.
           std::make_shared<core::ExchangeNode>(
               materializedExchangeNode->id(),
               materializedExchangeNode->outputType(),
-              "CompactRow"),
+              "CompactRow",
+              std::string{core::TransportKind::kInMemory}),
           exchangeClient,
           "MaterializedExchange") {}
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -32,10 +32,15 @@ ShuffleRead::ShuffleRead(
     : Exchange(
           operatorId,
           ctx,
+          // Stand-in node for the Exchange base class. Shuffle read is served
+          // by a ShuffleInterface, not by a worker-to-worker transport, so it
+          // names the in-memory one explicitly rather than inheriting a
+          // default.
           std::make_shared<core::ExchangeNode>(
               shuffleReadNode->id(),
               shuffleReadNode->outputType(),
-              "CompactRow"),
+              "CompactRow",
+              std::string{core::TransportKind::kInMemory}),
           exchangeClient,
           "ShuffleRead") {
   initStats();

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -14,7 +14,10 @@
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include <folly/Conv.h>
 #include "presto_cpp/main/common/Utils.h"
+#include "velox/core/PlanNode.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/exec/ExchangeTransportRegistry.h"
+#include "velox/exec/OutputTransportRegistry.h"
 #include "velox/type/Type.h"
 
 using namespace facebook::velox;
@@ -27,11 +30,45 @@ SessionProperties* SessionProperties::instance() {
   return instance.get();
 }
 
+bool SessionProperties::isCudfExchangeAvailable(
+    const velox::core::QueryCtx* queryCtx) {
+  const std::string kUcx{velox::core::TransportKind::kUcx};
+  // Both ends: the producing task resolves the output transport and the
+  // consuming task the exchange one, so an edge is only usable when both are
+  // registered.
+  if (queryCtx != nullptr) {
+    return velox::exec::ExchangeTransportRegistry::tryGet(*queryCtx, kUcx) !=
+        nullptr &&
+        velox::exec::OutputTransportRegistry::tryGet(*queryCtx, kUcx) !=
+        nullptr;
+  }
+  return velox::exec::ExchangeTransportRegistry::tryGet(kUcx) != nullptr &&
+      velox::exec::OutputTransportRegistry::tryGet(kUcx) != nullptr;
+}
+
 // List of native session properties is kept as the source of truth here.
 SessionProperties::SessionProperties() {
   using velox::core::QueryConfig;
   // Use empty instance to get default property values.
   QueryConfig c{{}};
+
+  // The default follows this worker: on where the cuDF UCX transport is
+  // registered, off where it is not. This runs when the singleton is first used
+  // -- serving /v1/properties/session, or converting the first plan -- which is
+  // after registerCudf() has registered the transport.
+  addSessionProperty(
+      kCudfExchangeEnabled,
+      "Native Execution only. Whether this query's worker-to-worker exchanges "
+      "may use the cuDF UCX transport. Defaults to true on a worker that has "
+      "the transport registered, which is a worker with 'cudf.exchange' enabled "
+      "in a build that has the UCX exchange, and to false on every other "
+      "worker. Setting it false always uses the in-memory transport; setting it "
+      "true on a worker without the transport fails the query instead of "
+      "silently using the in-memory transport.",
+      BOOLEAN(),
+      false,
+      kCudfExchangeEnabledConfig,
+      util::boolToLowerCaseString(isCudfExchangeAvailable()));
 
   addSessionProperty(
       kExprEvalSimplified,

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.h
@@ -15,6 +15,10 @@
 
 #include "presto_cpp/main/properties/session/SessionPropertiesProvider.h"
 
+namespace facebook::velox::core {
+class QueryCtx;
+} // namespace facebook::velox::core
+
 namespace facebook::presto {
 
 /// Defines all system session properties supported by native worker to ensure
@@ -22,6 +26,34 @@ namespace facebook::presto {
 /// session properties. Also maps the native session properties to velox.
 class SessionProperties : public SessionPropertiesProvider {
  public:
+  /// Whether this query's worker-to-worker exchanges may use the cuDF UCX
+  /// transport. Unset means the worker decides, which is what
+  /// isCudfExchangeAvailable() answers; false always uses the in-memory
+  /// transport; true on a worker that has no UCX transport registered fails the
+  /// query rather than silently using the in-memory transport.
+  static constexpr const char* kCudfExchangeEnabled =
+      "native_cudf_exchange_enabled";
+
+  /// Velox query-config key kCudfExchangeEnabled maps to. Deliberately NOT
+  /// cuDF's own "cudf.exchange": that one is a worker-level switch read once at
+  /// registerCudf() to decide whether the UCX transports are registered at all,
+  /// whereas this is a per-query choice evaluated for each exchange edge.
+  static constexpr const char* kCudfExchangeEnabledConfig =
+      "cudf.exchange_enabled";
+
+  /// True when this worker can build both ends of a UCX exchange edge, that is
+  /// when the cuDF UCX transport is registered in the exchange (receive) and
+  /// the output (send) transport registry. registerCudf() registers it at
+  /// startup when 'cudf.exchange' is enabled and the worker was built with the
+  /// UCX exchange, so this one question covers both configuration and build.
+  ///
+  /// Pass the query's QueryCtx to honor its per-query transport registries, the
+  /// way exec::Task resolves a transport; null consults only the global
+  /// registries, which is what the default value of kCudfExchangeEnabled is
+  /// derived from.
+  static bool isCudfExchangeAvailable(
+      const velox::core::QueryCtx* queryCtx = nullptr);
+
   /// Enable simplified path in expression evaluation.
   static constexpr const char* kExprEvalSimplified =
       "native_simplified_expression_evaluation_enabled";

--- a/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/tests/SessionPropertiesTest.cpp
@@ -23,6 +23,8 @@ class SessionPropertiesTest : public testing::Test {};
 
 TEST_F(SessionPropertiesTest, validateMapping) {
   const std::unordered_map<std::string, std::string> expectedMappings = {
+      {SessionProperties::kCudfExchangeEnabled,
+       SessionProperties::kCudfExchangeEnabledConfig},
       {SessionProperties::kExprEvalSimplified,
        core::QueryConfig::kExprEvalSimplified},
       {SessionProperties::kExprMaxArraySizeInReduce,

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -15,6 +15,7 @@
 // clang-format off
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
+#include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/main/types/PrestoTaskId.h"
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include <folly/io/IOBuf.h>
@@ -2718,6 +2719,64 @@ protocol::PlanNodeId toPartitionedOutputNodeId(const protocol::PlanNodeId& id) {
 
 } // namespace
 
+std::string VeloxQueryPlanConverterBase::toVeloxTransportType(
+    const std::shared_ptr<protocol::TransportType>& transportType) const {
+  const std::string kInMemory{core::TransportKind::kInMemory};
+
+  // A missing annotation and HTTP both mean the built-in in-memory output
+  // buffering that the consumer drains over HTTP.
+  if (transportType == nullptr ||
+      *transportType == protocol::TransportType::HTTP) {
+    return kInMemory;
+  }
+  VELOX_CHECK(
+      *transportType == protocol::TransportType::ANY,
+      "Unsupported transport type: {}",
+      fmt::underlying(*transportType));
+
+  // ANY is permission, not instruction: BasePlanFragmenter sets it for every
+  // worker-to-worker edge without checking what any worker can do, so this
+  // worker decides.
+  //
+  // What it decides against is what is registered, rather than cuDF's own
+  // 'cudf.exchange'. That switch is read once, at registerCudf(), to decide
+  // whether the UCX transports get registered at all, and it says nothing about
+  // a build without the UCX exchange compiled in; probing the registries asks
+  // the question exec::Task will ask when it resolves the transport this
+  // converter names.
+  const bool available = SessionProperties::isCudfExchangeAvailable(queryCtx_);
+  const auto enabled = queryCtx_ != nullptr
+      ? queryCtx_->queryConfig().get<bool>(
+            SessionProperties::kCudfExchangeEnabledConfig)
+      : std::optional<bool>{};
+  const std::string kUcx{core::TransportKind::kUcx};
+
+  if (!enabled.has_value()) {
+    // The property is only sent when the query sets it, so an absent value
+    // means nobody asked for either transport. This is where the documented
+    // default of native_cudf_exchange_enabled applies: on where the transport
+    // is registered, off everywhere else.
+    return available ? kUcx : kInMemory;
+  }
+  if (!enabled.value()) {
+    return kInMemory;
+  }
+  // Explicitly enabled. Naming a transport that nothing registered is a hard
+  // user error in exec::Task and LocalPlanner, so this could be left to fail
+  // there, but it would fail per fragment with a message about an unknown
+  // transport id. Say what is wrong and which switch controls it instead.
+  VELOX_USER_CHECK(
+      available,
+      "{}=true, but the cuDF UCX exchange is disabled on this worker: no "
+      "transport is registered under '{}'. Enable it with 'cudf.exchange=true' "
+      "on a worker built with the UCX exchange, or unset {} to use the "
+      "in-memory exchange.",
+      SessionProperties::kCudfExchangeEnabled,
+      kUcx,
+      SessionProperties::kCudfExchangeEnabled);
+  return kUcx;
+}
+
 core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const protocol::PlanFragment& fragment,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
@@ -2777,6 +2836,12 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   auto outputType = toRowType(partitioningScheme.outputLayout, typeParser_);
   const auto partitionedOutputNodeId =
       toPartitionedOutputNodeId(fragment.root->id);
+  // The transport this fragment sends its results over. The coordinator puts
+  // the same annotation on the consuming fragment's RemoteSourceNode, and both
+  // ends resolve it through toVeloxTransportType() against the same registries,
+  // so the two ends of an exchange edge agree.
+  const auto outputTransportKind =
+      toVeloxTransportType(fragment.outputTransportType);
 
   if (auto systemPartitioningHandle =
           std::dynamic_pointer_cast<protocol::SystemPartitioningHandle>(
@@ -2792,6 +2857,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
             partitionedOutputNodeId,
             outputType,
             toVeloxSerdeKind(partitioningScheme.encoding),
+            outputTransportKind,
             sourceNode);
         return planFragment;
       case protocol::SystemPartitioning::FIXED: {
@@ -2806,6 +2872,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
                   partitionedOutputNodeId,
                   outputType,
                   toVeloxSerdeKind(partitioningScheme.encoding),
+                  outputTransportKind,
                   sourceNode);
               return planFragment;
             }
@@ -2819,6 +2886,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
                     std::make_shared<RoundRobinPartitionFunctionSpec>(),
                     outputType,
                     toVeloxSerdeKind(partitioningScheme.encoding),
+                    outputTransportKind,
                     sourceNode);
             return planFragment;
           }
@@ -2832,6 +2900,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
                   partitionedOutputNodeId,
                   outputType,
                   toVeloxSerdeKind(partitioningScheme.encoding),
+                  outputTransportKind,
                   sourceNode);
               return planFragment;
             }
@@ -2846,6 +2915,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
                         inputType, keyChannels, constValues),
                     outputType,
                     toVeloxSerdeKind(partitioningScheme.encoding),
+                    outputTransportKind,
                     sourceNode);
             return planFragment;
           }
@@ -2855,6 +2925,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
                 1,
                 outputType,
                 toVeloxSerdeKind(partitioningScheme.encoding),
+                outputTransportKind,
                 sourceNode);
             return planFragment;
           }
@@ -2874,6 +2945,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
             partitionedOutputNodeId,
             std::move(outputType),
             toVeloxSerdeKind(partitioningScheme.encoding),
+            outputTransportKind,
             std::move(sourceNode));
         return planFragment;
       }
@@ -2893,6 +2965,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
         partitionedOutputNodeId,
         outputType,
         toVeloxSerdeKind(partitioningScheme.encoding),
+        outputTransportKind,
         sourceNode);
     return planFragment;
   }
@@ -2909,6 +2982,7 @@ core::PlanFragment VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       std::shared_ptr(std::move(spec)),
       toRowType(partitioningScheme.outputLayout, typeParser_),
       toVeloxSerdeKind(partitioningScheme.encoding),
+      outputTransportKind,
       sourceNode);
   return planFragment;
 }
@@ -2917,10 +2991,15 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::OutputNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
+  // The output stage's results are fetched by the coordinator, which speaks
+  // only HTTP, so this edge is always the in-memory transport regardless of any
+  // annotation. BasePlanFragmenter agrees — it marks coordinator-facing edges
+  // HTTP — but this does not depend on that.
   return core::PartitionedOutputNode::single(
       node->id,
       toRowType(node->outputVariables, typeParser_),
       "Presto",
+      std::string{core::TransportKind::kInMemory},
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 
@@ -2929,6 +3008,10 @@ core::PlanNodePtr VeloxInteractiveQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<protocol::TableWriteInfo>& /*tableWriteInfo*/,
     const protocol::TaskId& taskId) {
   auto rowType = toRowType(node->outputVariables, typeParser_);
+  // The transport this fragment reads its input over. The producing fragment's
+  // output carries the same annotation and resolves it the same way, so both
+  // ends of the exchange edge agree.
+  auto inputTransportKind = toVeloxTransportType(node->transportType);
   if (node->orderingScheme) {
     std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
     std::vector<core::SortOrder> sortingOrders;
@@ -2944,10 +3027,14 @@ core::PlanNodePtr VeloxInteractiveQueryPlanConverter::toVeloxQueryPlan(
         rowType,
         sortingKeys,
         sortingOrders,
-        toVeloxSerdeKind(node->encoding));
+        toVeloxSerdeKind(node->encoding),
+        std::move(inputTransportKind));
   }
   return std::make_shared<core::ExchangeNode>(
-      node->id, rowType, toVeloxSerdeKind(node->encoding));
+      node->id,
+      rowType,
+      toVeloxSerdeKind(node->encoding),
+      std::move(inputTransportKind));
 }
 
 connector::CommitStrategy
@@ -2986,11 +3073,14 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
             "broadcast-write-gather",
             std::vector{partitionedOutputNode->sources()}));
 
+    // Batch broadcast results are written to storage by BroadcastWrite and read
+    // back from there, so this edge never crosses a worker-to-worker transport.
     planFragment.planNode = core::PartitionedOutputNode::broadcast(
         partitionedOutputNode->id(),
         1,
         broadcastWriteNode->outputType(),
         "Presto",
+        std::string{core::TransportKind::kInMemory},
         {broadcastWriteNode});
     return planFragment;
   }
@@ -3086,9 +3176,14 @@ core::PlanNodePtr VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
     const std::shared_ptr<protocol::TableWriteInfo>& /* tableWriteInfo */,
     const protocol::TaskId& taskId) {
   auto rowType = toRowType(node->outputVariables, typeParser_);
-  // Broadcast exchange source.
+  // Broadcast exchange source. Batch broadcast data is read back from storage,
+  // so this edge never crosses a worker-to-worker transport.
   if (node->exchangeType == protocol::ExchangeNodeType::REPLICATE) {
-    return std::make_shared<core::ExchangeNode>(node->id, rowType, "Presto");
+    return std::make_shared<core::ExchangeNode>(
+        node->id,
+        rowType,
+        "Presto",
+        std::string{core::TransportKind::kInMemory});
   }
   // Partitioned shuffle exchange source.
   // Use MaterializedExchangeNode when batch exchange I/O is enabled, unless the

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -280,6 +280,23 @@ class VeloxQueryPlanConverterBase {
       std::vector<velox::core::AggregationNode::Aggregate>& aggregates,
       std::vector<std::string>& aggregateNames);
 
+  /// Resolves the coordinator's per-edge transport annotation onto the Velox
+  /// transport id the plan node will name. A missing annotation and HTTP both
+  /// mean the built-in in-memory transport. ANY means "this edge MAY use the
+  /// fastest transport this worker registered" -- not "use UCX" -- because the
+  /// coordinator sets it for every worker-to-worker edge without knowing what
+  /// any particular worker supports, so the decision is made here, from the
+  /// native_cudf_exchange_enabled session property and what this worker has
+  /// registered:
+  ///
+  ///   property unset  -> UCX where the transport is registered, in-memory
+  ///                      elsewhere (the property's documented default)
+  ///   property false  -> in-memory, whatever is registered
+  ///   property true   -> UCX, or a user error naming the property where the
+  ///                      transport is not registered
+  std::string toVeloxTransportType(
+      const std::shared_ptr<protocol::TransportType>& transportType) const;
+
   velox::memory::MemoryPool* const pool_;
   velox::core::QueryCtx* const queryCtx_;
   VeloxExprConverter exprConverter_;

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -23,9 +23,15 @@
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
 #include "presto_cpp/main/operators/ShuffleWrite.h"
+#include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/main/types/tests/TestUtils.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
+#include "velox/exec/ExchangeTransportRegistry.h"
+#include "velox/exec/InMemoryExchangeClient.h"
+#include "velox/exec/OutputTransportRegistry.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::presto;
@@ -56,6 +62,87 @@ std::shared_ptr<const core::PlanNode> assertToVeloxQueryPlan(
     memory::MemoryPool* pool = nullptr) {
   return assertToVeloxFragment(fileName, pool).planNode;
 }
+
+json parseFragmentJson(const std::string& fileName) {
+  return json::parse(slurp(test::utils::getDataPath(fileName)));
+}
+
+// Converts an interactive plan fragment from already parsed JSON, so that a
+// test can annotate transport types on the fragment before conversion, and with
+// 'queryConfigs' as the query's config, so that it can set session properties.
+core::PlanFragment toVeloxFragment(
+    const json& fragmentJson,
+    std::unordered_map<std::string, std::string> queryConfigs = {}) {
+  const protocol::PlanFragment prestoPlan = fragmentJson;
+  auto pool = memory::deprecatedAddDefaultLeafMemoryPool();
+  auto queryCtx = core::QueryCtx::create(
+      nullptr, core::QueryConfig{std::move(queryConfigs)});
+  VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool.get());
+  return converter.toVeloxQueryPlan(
+      prestoPlan, nullptr, "20201107_130540_00011_wrpkw.1.2.3");
+}
+
+// Annotates every RemoteSourceNode found in 'node' with 'transportType', the
+// way the coordinator annotates the input edges of a fragment.
+void annotateRemoteSources(json& node, const std::string& transportType) {
+  if (node.is_object()) {
+    const auto type = node.find("@type");
+    if (type != node.end() && type->is_string() &&
+        type->get<std::string>().find("RemoteSourceNode") !=
+            std::string::npos) {
+      node["transportType"] = transportType;
+    }
+    for (auto& element : node.items()) {
+      annotateRemoteSources(element.value(), transportType);
+    }
+  } else if (node.is_array()) {
+    for (auto& element : node) {
+      annotateRemoteSources(element, transportType);
+    }
+  }
+}
+
+// Returns the first ExchangeNode found in the plan rooted at 'node', or nullptr
+// when the plan has none.
+const core::ExchangeNode* findExchangeNode(const core::PlanNodePtr& node) {
+  if (const auto* exchange =
+          dynamic_cast<const core::ExchangeNode*>(node.get())) {
+    return exchange;
+  }
+  for (const auto& source : node->sources()) {
+    if (const auto* found = findExchangeNode(source)) {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
+// Registers a transport under the UCX id in both registries for as long as it
+// is in scope, standing in for what registerCudf() does on a worker built with
+// the cuDF UCX exchange. Converting a plan only asks whether the id resolves,
+// never builds an operator from it, so the built-in in-memory entries stand in
+// for the UCX ones and no cuDF or UCX dependency is needed here.
+class ScopedUcxTransports {
+ public:
+  ScopedUcxTransports() {
+    exec::OutputTransportRegistry::global().insert(
+        kUcx_,
+        exec::DefaultOutputBufferManager::makeDefaultTransportEntry(),
+        /*overwrite=*/true);
+    exec::ExchangeTransportRegistry::global().insert(
+        kUcx_,
+        exec::InMemoryExchangeClient::makeDefaultTransportEntry(),
+        /*overwrite=*/true);
+  }
+
+  ~ScopedUcxTransports() {
+    exec::OutputTransportRegistry::global().erase(kUcx_);
+    exec::ExchangeTransportRegistry::global().erase(kUcx_);
+  }
+
+ private:
+  const std::string kUcx_{core::TransportKind::kUcx};
+};
 
 std::shared_ptr<const core::PlanNode> assertToBatchVeloxQueryPlan(
     const std::string& fileName,
@@ -182,6 +269,219 @@ TEST_F(PlanConverterTest, offsetLimit) {
   }
 
   ASSERT_TRUE(foundLimit);
+}
+
+// A coordinator that annotates no transport at all leaves both ends of the
+// exchange edge on the default in-memory transport.
+TEST_F(PlanConverterTest, transportTypeAbsentDefaultsToInMemory) {
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  ASSERT_FALSE(fragmentJson.count("outputTransportType"));
+  ASSERT_FALSE(
+      fragmentJson["root"]["source"]["sources"][0].count("transportType"));
+
+  const auto fragment = toVeloxFragment(fragmentJson);
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kInMemory);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kInMemory);
+}
+
+// HTTP maps to the in-memory transport: the producer buffers its output in
+// memory and the consumer drains it over HTTP.
+TEST_F(PlanConverterTest, transportTypeHttp) {
+  ScopedUcxTransports ucxTransports;
+
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "HTTP";
+  annotateRemoteSources(fragmentJson["root"], "HTTP");
+
+  const auto fragment = toVeloxFragment(fragmentJson);
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kInMemory);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kInMemory);
+}
+
+// ANY on a worker with the UCX transport registered, with the session property
+// unset: the property's default is this worker's capability, so the edge uses
+// UCX.
+TEST_F(PlanConverterTest, transportTypeAnyWithUcxRegistered) {
+  ScopedUcxTransports ucxTransports;
+
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  const auto fragment = toVeloxFragment(fragmentJson);
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kUcx);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kUcx);
+}
+
+// ANY on a worker that has no UCX transport, with the session property unset:
+// the same default resolves the other way, and the query runs over the
+// in-memory transport instead of failing.
+TEST_F(PlanConverterTest, transportTypeAnyWithoutUcxRegistered) {
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  const auto fragment = toVeloxFragment(fragmentJson);
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kInMemory);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kInMemory);
+}
+
+// The session property set false keeps the query on the in-memory transport
+// even where UCX is registered and the coordinator allows it.
+TEST_F(PlanConverterTest, transportTypeAnyDisabledBySessionProperty) {
+  ScopedUcxTransports ucxTransports;
+
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  const auto fragment = toVeloxFragment(
+      fragmentJson, {{SessionProperties::kCudfExchangeEnabledConfig, "false"}});
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kInMemory);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kInMemory);
+}
+
+// The session property set true where the transport is not registered fails the
+// query, rather than silently running over the in-memory transport. Explicitly
+// asking for UCX and getting HTTP performance without being told is worse than
+// a failure that names the switch.
+TEST_F(PlanConverterTest, transportTypeAnyEnabledWithoutUcxFails) {
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  VELOX_ASSERT_USER_THROW(
+      toVeloxFragment(
+          fragmentJson,
+          {{SessionProperties::kCudfExchangeEnabledConfig, "true"}}),
+      "the cuDF UCX exchange is disabled on this worker");
+}
+
+// The same property set true resolves to UCX where the transport is registered.
+TEST_F(PlanConverterTest, transportTypeAnyEnabledWithUcxRegistered) {
+  ScopedUcxTransports ucxTransports;
+
+  auto fragmentJson = parseFragmentJson("FinalAgg.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  const auto fragment = toVeloxFragment(
+      fragmentJson, {{SessionProperties::kCudfExchangeEnabledConfig, "true"}});
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kUcx);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kUcx);
+}
+
+// A sorted remote source becomes a MergeExchangeNode, which carries the
+// transport just like a plain ExchangeNode. The fragment's own output goes to
+// the coordinator, which speaks only HTTP, so that edge stays in-memory even
+// though the fragment is annotated ANY.
+TEST_F(PlanConverterTest, transportTypeMergeExchange) {
+  ScopedUcxTransports ucxTransports;
+
+  auto fragmentJson = parseFragmentJson("OffsetLimit.json");
+  fragmentJson["outputTransportType"] = "ANY";
+  annotateRemoteSources(fragmentJson["root"], "ANY");
+
+  const auto fragment = toVeloxFragment(fragmentJson);
+
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(fragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kInMemory);
+
+  const auto* exchange = findExchangeNode(fragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+  ASSERT_NE(dynamic_cast<const core::MergeExchangeNode*>(exchange), nullptr);
+  ASSERT_EQ(exchange->transportKind(), core::TransportKind::kUcx);
+}
+
+// An exchange edge spans two fragments: the producer's PartitionedOutputNode
+// and the consumer's ExchangeNode. Velox resolves each end independently from
+// its own node, so the two must name the same transport. Both ends reach that
+// answer from the same annotation, the same session property and the same
+// registries, which is what keeps them in step.
+TEST_F(PlanConverterTest, transportTypeEdgeAgreement) {
+  ScopedUcxTransports ucxTransports;
+
+  // Producer fragment of the edge.
+  auto producerJson = parseFragmentJson("ScanAgg.json");
+  producerJson["outputTransportType"] = "ANY";
+  const auto producerFragment = toVeloxFragment(producerJson);
+  const auto* partitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(
+          producerFragment.planNode.get());
+  ASSERT_NE(partitionedOutput, nullptr);
+
+  // Consumer fragment of the same edge, annotated with the same value.
+  auto consumerJson = parseFragmentJson("FinalAgg.json");
+  annotateRemoteSources(consumerJson["root"], "ANY");
+  const auto consumerFragment = toVeloxFragment(consumerJson);
+  const auto* exchange = findExchangeNode(consumerFragment.planNode);
+  ASSERT_NE(exchange, nullptr);
+
+  ASSERT_EQ(partitionedOutput->transportKind(), exchange->transportKind());
+  ASSERT_EQ(partitionedOutput->transportKind(), core::TransportKind::kUcx);
+
+  // The same edge with the query opted out agrees on the in-memory transport.
+  const std::unordered_map<std::string, std::string> disabled{
+      {SessionProperties::kCudfExchangeEnabledConfig, "false"}};
+  const auto disabledProducer = toVeloxFragment(producerJson, disabled);
+  const auto* disabledPartitionedOutput =
+      dynamic_cast<const core::PartitionedOutputNode*>(
+          disabledProducer.planNode.get());
+  ASSERT_NE(disabledPartitionedOutput, nullptr);
+  const auto disabledConsumer = toVeloxFragment(consumerJson, disabled);
+  const auto* disabledExchange = findExchangeNode(disabledConsumer.planNode);
+  ASSERT_NE(disabledExchange, nullptr);
+
+  ASSERT_EQ(
+      disabledPartitionedOutput->transportKind(),
+      disabledExchange->transportKind());
+  ASSERT_EQ(
+      disabledPartitionedOutput->transportKind(),
+      core::TransportKind::kInMemory);
 }
 
 // IndexSourceNode is converted to a TableScanNode with the same output type


### PR DESCRIPTION
> **Depends on velox facebookincubator/velox#18695**, which registers the cuDF UCX transport
> and turns on its build. Until that merges, the submodule bump is deliberately not part of
> this PR, so a build from this branch alone sees no UCX exchange — every path here then
> resolves to the in-memory transport, which the tests cover as its own case.

Lets a native worker put a worker-to-worker exchange on the cuDF UCX transport, and starts the
listener that transport needs. Two commits, reviewable separately.

## 1. Start the UCX exchange Communicator on the worker

The exchange needs a listener before any plan can name its transport: `UcxExchangeSource`
connects to a peer's UCX port, and nothing accepts there until `Communicator::run()` is
progressing. Velox registers the transport from `registerCudf()` and deliberately starts nothing,
so the process that owns the worker's lifecycle owns the thread.

- `registerVeloxCudf()` starts it when cuDF exchange is enabled; `unregisterVeloxCudf()` stops it
  **ahead of** `unregisterCudf()`, so the thread is joined before the cuDF memory resources its
  buffers come from are reset.
- Startup blocks until the listener accepts. `initAndGet()` hands out a readiness future that
  `run()` fulfils; returning as soon as the thread is spawned would let a task resolve the UCX
  transport and connect before the listener exists, turning a startup ordering problem into an
  intermittent query failure.
- The thread handle is a file-local `unique_ptr` beside the start/stop pair rather than a value
  threaded through `run()` and `shutdownServer()`. That keeps both functions idempotent and
  leaves `PrestoServer`'s interface alone.

**Build gate.** Velox declares `VELOX_ENABLE_UCX_EXCHANGE` while resolving cuDF, so its value is
only known after `add_subdirectory(velox)`, and `PRESTO_ENABLE_CUDF` is not a substitute: cuDF
builds fine without UCX, and then neither the ucxx targets nor the ucx-exchange headers exist.
The top-level `CMakeLists.txt` turns it into `PRESTO_ENABLE_UCX_EXCHANGE`, `presto_server_lib`
links `velox_ucx_exchange` — which `velox_cudf_exec` links privately, so this is also what puts
the ucxx include directories on `PrestoServer.cpp`'s compile line — and every reference to the
Communicator sits behind that macro. A cuDF-without-UCX build says once at startup that
`cudf.exchange=true` has no transport behind it, and keeps using the in-memory exchange.

**Port.** The UCX listener uses `http-server.http.port + 3`, matching the only endpoint that `UcxExchangeSource::create` can derive from the advertised remote-task HTTP location. The port is not independently configurable because task locations do not advertise a UCX endpoint. A configurable offset is tracked by facebookincubator/velox#17279.

## 2. Resolve the exchange transport per edge on the worker

`BasePlanFragmenter` annotates every worker-to-worker exchange edge `ANY` and leaves
coordinator-facing edges `HTTP`. It does that without knowing what any particular worker can do,
so `ANY` is permission rather than instruction and the worker has to decide. The plan converter
was discarding the annotation, which is why every plan resolved to the in-memory transport no
matter what was registered.

`toVeloxTransportType()` maps a missing annotation and `HTTP` to `kInMemory`, and resolves `ANY`
from the new `native_cudf_exchange_enabled` session property against what this worker has
registered:

| `native_cudf_exchange_enabled` | UCX transport registered | resolves to |
|---|---|---|
| unset | yes | UCX |
| unset | no | in-memory |
| `false` | either | in-memory |
| `true` | yes | UCX |
| `true` | no | user error naming the property |

Unset resolving by capability is what makes the property's default the worker's own: a worker
with the transport uses it without the query asking, and every other worker is unaffected,
because the coordinator only sends a system property that the query actually set. Explicitly
`true` failing is the case worth spelling out — a query that asks for RDMA and silently gets HTTP
performance is worse off than one that is told which switch is off. Velox already fails such a
plan in `Task` and `LocalPlanner`, but per fragment and as an unknown transport id, so the
message here says what is actually wrong and which switch controls it.

Registration is the right thing to test against because it is what `Task` will ask. cuDF's own
`cudf.exchange` is read once, at `registerCudf()`, and says nothing about a build with the UCX
exchange compiled out. Both registries must have the transport: the producing task resolves the
output transport and the consuming task the exchange one, so an edge is only usable when both
ends can be built. The probe lives next to the property whose default it decides, so the value
reported over `/v1/properties/session` and the per-query decision cannot disagree, and it takes
the `QueryCtx` so per-query registry overrides are honored the way `Task` honors them.

The resolved id is threaded onto the nine `PartitionedOutputNode` constructions and onto the
`ExchangeNode` and `MergeExchangeNode` built from a `RemoteSourceNode`. Four places name
`kInMemory` outright, each for a reason unrelated to the annotation: the output stage is drained
by the coordinator, which speaks only HTTP; batch broadcast is written to and read back from
storage; and the stand-in `ExchangeNode`s in `ShuffleRead` and `MaterializedExchange` are served
by a shuffle interface and by durable storage.

The Java side only declares the property, so that `SET SESSION` accepts it. Its declared default
is `false`, because the coordinator cannot know what a worker registered; a sidecar publishes the
worker's own default.

## Testing

Built with cuDF and the UCX exchange on, `-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1`.

- `PlanConverterTest` — nine new cases covering every row of the table above, plus a merge
  exchange carrying the transport and both ends of one edge agreeing. They register the built-in
  in-memory entries under the UCX id as stand-ins, so the tests need neither cuDF nor UCX and run
  in a default build.
- `ConfigTest.cudfExchangeServerPort` — the fixed `http-server.http.port + 3` derivation.
- `SessionPropertiesTest` — the new property's Velox config mapping.
- The cuDF-without-UCX configuration of `PrestoServer.cpp` compiles: rebuilt from its own
  `compile_commands.json` entry with `-DPRESTO_ENABLE_UCX_EXCHANGE` removed.

## Summary by Sourcery

Enable capability-aware cuDF UCX exchange transport selection and lifecycle management for native workers.

New Features:
- Enable native workers to use the cuDF UCX transport for worker-to-worker exchanges when supported.
- Add the native_cudf_exchange_enabled session property for per-query exchange transport control.

Bug Fixes:
- Preserve and resolve coordinator exchange transport annotations instead of defaulting all worker exchanges to in-memory transport.

Enhancements:
- Start and cleanly stop the UCX exchange communicator with the cuDF worker lifecycle, including readiness synchronization.
- Resolve exchange transports per edge based on worker capabilities and query settings, with explicit errors for unavailable requested UCX support.
- Derive the UCX listener port from the HTTP server port and retain in-memory handling for coordinator, storage-backed, and shuffle exchanges.

Build:
- Add conditional UCX exchange compilation and link the Velox UCX exchange library when available.

Tests:
- Add coverage for transport resolution, session-property mapping, UCX port derivation, merge exchanges, and producer/consumer edge agreement.
