### PR TITLE
fix(native): Report processCpuLoad scoped to the worker's cgroup

### DIFF
--- a/presto-native-execution/presto_cpp/main/CPUMon.cpp
+++ b/presto-native-execution/presto_cpp/main/CPUMon.cpp
@@ -12,11 +12,92 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/CPUMon.h"
+#include <sys/stat.h>
+#include <algorithm>
+#include <chrono>
 #include <cinttypes>
+#include "fmt/format.h"
+#include "folly/Conv.h"
 #include "folly/File.h"
 #include "folly/FileUtil.h"
+#include "folly/Optional.h"
+#include "folly/String.h"
+#include "glog/logging.h"
 
 namespace facebook::presto {
+
+namespace {
+
+// cgroup v2 keeps the CPU accounting of a cgroup in these two files, relative
+// to the cgroup's own directory under the mount root.
+constexpr const char* kCgroupV2UsageFile = "cpu.stat";
+constexpr const char* kCgroupV2QuotaFile = "cpu.max";
+constexpr const char* const kCgroupV2Dirs[] = {"/sys/fs/cgroup"};
+
+// cgroup v1 splits the accounting across the 'cpuacct' and 'cpu' controllers,
+// which may be mounted separately or together, and which can sit at different
+// paths in the hierarchy.
+constexpr const char* kCgroupV1UsageFile = "cpuacct.usage";
+constexpr const char* kCgroupV1QuotaFile = "cpu.cfs_quota_us";
+constexpr const char* kCgroupV1PeriodFile = "cpu.cfs_period_us";
+constexpr const char* const kCgroupV1UsageDirs[] = {
+    "/sys/fs/cgroup/cpuacct",
+    "/sys/fs/cgroup/cpu,cpuacct"};
+constexpr const char* const kCgroupV1QuotaDirs[] = {
+    "/sys/fs/cgroup/cpu",
+    "/sys/fs/cgroup/cpu,cpuacct"};
+
+bool fileExists(const std::string& path) {
+  struct stat buffer;
+  return !path.empty() && stat(path.c_str(), &buffer) == 0;
+}
+
+// Returns the directory the CPU accounting should be read from: the first of
+// 'dirs' that holds 'probe', preferring '<dir><relative>' over '<dir>' so a
+// process in a nested cgroup reads its own accounting rather than the mount
+// root's. Empty when 'probe' is nowhere to be found.
+template <size_t N>
+std::string findCgroupDir(
+    const char* const (&dirs)[N],
+    const std::string& relative,
+    const char* probe) {
+  if (!relative.empty()) {
+    for (const auto* dir : dirs) {
+      const auto nested = dir + relative;
+      if (fileExists(fmt::format("{}/{}", nested, probe))) {
+        return nested;
+      }
+    }
+  }
+  for (const auto* dir : dirs) {
+    if (fileExists(fmt::format("{}/{}", dir, probe))) {
+      return dir;
+    }
+  }
+  return "";
+}
+
+// Reads a small pseudo-file in full. False when it cannot be read.
+bool readSmallFile(const std::string& path, std::string& out) {
+  return !path.empty() && folly::readFile(path.c_str(), out);
+}
+
+// Parses a pseudo-file holding a single number, ignoring trailing whitespace.
+// Returns 'folly::none' when the contents are not a number.
+folly::Optional<int64_t> parseSingleValue(const std::string& content) {
+  const auto value =
+      folly::tryTo<int64_t>(folly::trimWhitespace(folly::StringPiece(content)));
+  return value.hasValue() ? folly::Optional<int64_t>(value.value())
+                          : folly::none;
+}
+
+int64_t nowMonotonicUsec() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+} // namespace
 
 static bool readProcStat(std::vector<uint64_t>& counters) {
   auto cpuStatFile = folly::File("/proc/stat", O_RDONLY);
@@ -44,6 +125,264 @@ static bool readProcStat(std::vector<uint64_t>& counters) {
   }
 
   return true;
+}
+
+namespace {
+
+// True when 'controllers' - the comma-separated second field of a
+// '/proc/self/cgroup' line - is the entry being looked for. An empty 'wanted'
+// selects the cgroup v2 entry, whose controller list is empty by definition.
+bool matchesController(
+    folly::StringPiece controllers,
+    folly::StringPiece wanted) {
+  if (wanted.empty()) {
+    return controllers.empty();
+  }
+  std::vector<folly::StringPiece> names;
+  folly::split(',', controllers, names);
+  return std::find(names.begin(), names.end(), wanted) != names.end();
+}
+
+} // namespace
+
+std::string CPUMon::parseCgroupRelativePath(
+    const std::string& procSelf,
+    folly::StringPiece controller) {
+  // Lines are '<hierarchy-id>:<controllers>:<path>'. The cgroup v2 entry has an
+  // empty controller list; a v1 entry lists its controllers comma-separated. A
+  // cgroup path may itself contain a colon, so the fields are split by position
+  // rather than by counting separators.
+  std::vector<folly::StringPiece> lines;
+  folly::split('\n', procSelf, lines);
+  for (const auto& line : lines) {
+    const auto firstColon = line.find(':');
+    if (firstColon == std::string::npos) {
+      continue;
+    }
+    const auto secondColon = line.find(':', firstColon + 1);
+    if (secondColon == std::string::npos) {
+      continue;
+    }
+    const auto controllers =
+        line.subpiece(firstColon + 1, secondColon - firstColon - 1);
+    if (!matchesController(controllers, controller)) {
+      continue;
+    }
+    const auto path = folly::trimWhitespace(line.subpiece(secondColon + 1));
+    // The root cgroup adds no prefix, and is what a container started with
+    // 'cgroupns=private' sees for its own cgroup.
+    return path == "/" ? "" : path.str();
+  }
+  return "";
+}
+
+void CPUMon::detectCgroupFiles() {
+  // With 'cgroupns=host' the mount roots describe the whole machine rather than
+  // this container, so the process' own cgroup path has to be appended. With
+  // 'cgroupns=private' the process already sees its own cgroup as the root and
+  // /proc/self/cgroup reports '/', leaving nothing to append. Reading the file
+  // is best effort: an unreadable one leaves the paths empty and the mount
+  // roots are used, which is the right answer in the common case.
+  std::string procSelf;
+  folly::readFile("/proc/self/cgroup", procSelf);
+
+  // cgroup v2 first: a host running it has no v1 controller directories, while
+  // a host running v1 has no 'cpu.max' under the mount root.
+  const auto v2Dir = findCgroupDir(
+      kCgroupV2Dirs, parseCgroupRelativePath(procSelf, ""), kCgroupV2QuotaFile);
+  if (!v2Dir.empty()) {
+    cgroupV2_ = true;
+    const auto usageFile = fmt::format("{}/{}", v2Dir, kCgroupV2UsageFile);
+    if (fileExists(usageFile)) {
+      cgroupUsageFile_ = usageFile;
+      cgroupQuotaFile_ = fmt::format("{}/{}", v2Dir, kCgroupV2QuotaFile);
+    }
+  } else {
+    cgroupV2_ = false;
+    // 'cpuacct' and 'cpu' are separate v1 controllers and can sit at different
+    // paths in the hierarchy, so each is resolved against its own entry.
+    const auto usageDir = findCgroupDir(
+        kCgroupV1UsageDirs,
+        parseCgroupRelativePath(procSelf, "cpuacct"),
+        kCgroupV1UsageFile);
+    const auto quotaDir = findCgroupDir(
+        kCgroupV1QuotaDirs,
+        parseCgroupRelativePath(procSelf, "cpu"),
+        kCgroupV1QuotaFile);
+    if (!usageDir.empty() && !quotaDir.empty()) {
+      cgroupUsageFile_ = fmt::format("{}/{}", usageDir, kCgroupV1UsageFile);
+      cgroupQuotaFile_ = fmt::format("{}/{}", quotaDir, kCgroupV1QuotaFile);
+      const auto periodFile =
+          fmt::format("{}/{}", quotaDir, kCgroupV1PeriodFile);
+      if (fileExists(periodFile)) {
+        cgroupPeriodFile_ = periodFile;
+      } else {
+        cgroupUsageFile_.clear();
+        cgroupQuotaFile_.clear();
+      }
+    }
+  }
+
+  if (cgroupUsageFile_.empty()) {
+    LOG(INFO) << "No cgroup CPU accounting found. Reporting host-wide CPU load "
+                 "as the process CPU load.";
+    return;
+  }
+  LOG(INFO) << "Using cgroup " << (cgroupV2_ ? "v2" : "v1")
+            << " CPU accounting from " << cgroupUsageFile_ << " (quota from "
+            << cgroupQuotaFile_ << ").";
+}
+
+int64_t CPUMon::readCgroupCpuUsageUsec() const {
+  std::string content;
+  if (!readSmallFile(cgroupUsageFile_, content)) {
+    return -1;
+  }
+
+  if (cgroupV2_) {
+    // 'cpu.stat' holds one 'key value' pair per line. 'usage_usec' is the
+    // cgroup's cumulative CPU time, in microseconds.
+    constexpr folly::StringPiece kUsageKey{"usage_usec "};
+    std::vector<folly::StringPiece> lines;
+    folly::split('\n', content, lines);
+    for (const auto& line : lines) {
+      if (!line.startsWith(kUsageKey)) {
+        continue;
+      }
+      const auto value = folly::trimWhitespace(line.subpiece(kUsageKey.size()));
+      const auto usageUsec = folly::tryTo<int64_t>(value);
+      if (!usageUsec.hasValue() || usageUsec.value() < 0) {
+        return -1;
+      }
+      return usageUsec.value();
+    }
+    return -1;
+  }
+
+  // cgroup v1's 'cpuacct.usage' is a single number, in nanoseconds.
+  const auto usageNsec = parseSingleValue(content);
+  if (!usageNsec.hasValue() || usageNsec.value() < 0) {
+    return -1;
+  }
+  return usageNsec.value() / 1000;
+}
+
+double CPUMon::readCgroupCpuQuotaCores() const {
+  std::string content;
+  if (!readSmallFile(cgroupQuotaFile_, content)) {
+    return 0;
+  }
+
+  int64_t quotaUsec = 0;
+  int64_t periodUsec = 0;
+  if (cgroupV2_) {
+    // 'cpu.max' holds '<quota> <period>', both in microseconds, where a quota
+    // of the literal 'max' means no limit is set.
+    std::vector<folly::StringPiece> parts;
+    folly::split(
+        ' ', folly::trimWhitespace(folly::StringPiece(content)), parts);
+    if (parts.size() != 2) {
+      return 0;
+    }
+    const auto quota = folly::tryTo<int64_t>(parts[0]);
+    const auto period = folly::tryTo<int64_t>(parts[1]);
+    if (!quota.hasValue() || !period.hasValue()) {
+      return 0;
+    }
+    quotaUsec = quota.value();
+    periodUsec = period.value();
+  } else {
+    // cgroup v1 keeps the quota and the period in separate files, and uses -1
+    // for 'no limit set'.
+    const auto quota = parseSingleValue(content);
+    std::string periodContent;
+    if (!quota.hasValue() || !readSmallFile(cgroupPeriodFile_, periodContent)) {
+      return 0;
+    }
+    const auto period = parseSingleValue(periodContent);
+    if (!period.hasValue()) {
+      return 0;
+    }
+    quotaUsec = quota.value();
+    periodUsec = period.value();
+  }
+
+  if (quotaUsec <= 0 || periodUsec <= 0) {
+    return 0;
+  }
+  // Kept fractional: a Kubernetes '500m' limit is half a core, and rounding it
+  // to zero would silently fall back to the host-wide load.
+  return static_cast<double>(quotaUsec) / static_cast<double>(periodUsec);
+}
+
+double CPUMon::computeCgroupCpuLoadPct(
+    int64_t prevUsageUsec,
+    int64_t usageUsec,
+    int64_t prevElapsedUsec,
+    int64_t elapsedUsec,
+    double quotaCores) {
+  if (quotaCores <= 0 || prevUsageUsec < 0 || usageUsec < 0 ||
+      prevElapsedUsec < 0 || elapsedUsec < 0) {
+    return -1;
+  }
+
+  const auto usageDiff = usageUsec - prevUsageUsec;
+  const auto elapsedDiff = elapsedUsec - prevElapsedUsec;
+  // Both counters are monotonic, so anything else means the cgroup was replaced
+  // underneath us. Wait for the next window instead of reporting a spike.
+  if (usageDiff < 0 || elapsedDiff <= 0) {
+    return -1;
+  }
+
+  const double loadPct = static_cast<double>(usageDiff) /
+      (static_cast<double>(elapsedDiff) * quotaCores) * 100;
+  // CFS throttling is applied per period rather than instantaneously, so a
+  // cgroup can slightly exceed its quota within a single window.
+  return std::min(loadPct, 100.0);
+}
+
+void CPUMon::setCgroupFilesForTest(
+    bool useV2,
+    const std::string& usageFile,
+    const std::string& quotaFile,
+    const std::string& periodFile) {
+  cgroupDetected_ = true;
+  cgroupV2_ = useV2;
+  cgroupUsageFile_ = usageFile;
+  cgroupQuotaFile_ = quotaFile;
+  cgroupPeriodFile_ = periodFile;
+}
+
+void CPUMon::updateCgroupCpuLoad(double hostLoadPct) {
+  if (!cgroupDetected_) {
+    detectCgroupFiles();
+    cgroupDetected_ = true;
+  }
+
+  const double quotaCores = readCgroupCpuQuotaCores();
+  const auto usageUsec = readCgroupCpuUsageUsec();
+  const auto elapsedUsec = nowMonotonicUsec();
+  const double loadPct = computeCgroupCpuLoadPct(
+      prevCgroupUsageUsec_,
+      usageUsec,
+      prevCgroupElapsedUsec_,
+      elapsedUsec,
+      quotaCores);
+  prevCgroupUsageUsec_ = usageUsec;
+  prevCgroupElapsedUsec_ = elapsedUsec;
+
+  if (quotaCores <= 0) {
+    // No CPU limit applies, so the cgroup may use every core the machine has
+    // and the host-wide load already answers 'how busy is this worker'. This is
+    // the bare-metal case, and keeps the reported value unchanged there.
+    cgroupCpuLoadPct_.store(hostLoadPct);
+    return;
+  }
+
+  // A quota exists but this window produced no usable delta: the first sample,
+  // or a counter that went backwards. Report idle rather than the host-wide
+  // number, which is on a different scale and would misreport a busy worker.
+  cgroupCpuLoadPct_.store(loadPct < 0 ? 0.0 : loadPct);
 }
 
 void CPUMon::update() {
@@ -86,6 +425,11 @@ void CPUMon::update() {
     prev_ = std::move(cur);
   }
   cpuLoadPct_.store(cpuUtil);
+
+  // '/proc/stat' is not namespaced, so the value above covers the whole machine
+  // no matter how little of it this worker is allowed to use. Derive the
+  // cgroup-scoped load as well, and let callers pick the one they need.
+  updateCgroupCpuLoad(cpuUtil);
 #endif
 }
 

--- a/presto-native-execution/presto_cpp/main/CPUMon.h
+++ b/presto-native-execution/presto_cpp/main/CPUMon.h
@@ -13,7 +13,10 @@
  */
 #pragma once
 
+#include <folly/Range.h>
 #include <atomic>
+#include <cstdint>
+#include <string>
 #include <vector>
 
 namespace facebook::presto {
@@ -24,15 +27,98 @@ class CPUMon {
   /// Call this periodically to update the CPU load. Not thread-safe.
   void update();
 
-  /// Returns the current (latest) CPU load. Thread-safe.
-  inline double getCPULoadPct() {
+  /// Returns the latest host-wide CPU load, as a percentage of all the CPU time
+  /// available on the machine. Thread-safe.
+  inline double getCPULoadPct() const {
     return cpuLoadPct_.load();
   }
 
+  /// Returns the latest CPU load of this process' cgroup, as a percentage of
+  /// the CPU quota assigned to it. Thread-safe.
+  ///
+  /// Inside a container the host-wide load above is not a usable signal: the
+  /// kernel exposes the machine's '/proc/stat' regardless of the cgroup, so a
+  /// worker saturating a 10-core quota on an 80-core node never reports more
+  /// than 12.5%, and the value also moves with unrelated co-tenants sharing the
+  /// node. This one is derived from the cgroup's own CPU accounting, so 100%
+  /// means the worker is using all the CPU it is allowed to use.
+  ///
+  /// Falls back to getCPULoadPct() when no CPU quota applies - bare metal, or a
+  /// container without a CPU limit - where the two are equivalent.
+  inline double getCgroupCPULoadPct() const {
+    return cgroupCpuLoadPct_.load();
+  }
+
+  /// Computes the cgroup CPU load percentage from two samples of the cgroup's
+  /// cumulative CPU usage. Returns -1 when the inputs cannot produce a
+  /// meaningful value, either because a sample is missing, because no quota is
+  /// known, or because the counters did not advance. Exposed for testing.
+  static double computeCgroupCpuLoadPct(
+      int64_t prevUsageUsec,
+      int64_t usageUsec,
+      int64_t prevElapsedUsec,
+      int64_t elapsedUsec,
+      double quotaCores);
+
+  /// Returns the path of the current process' cgroup relative to the controller
+  /// mount root, parsed out of the contents of '/proc/self/cgroup'.
+  /// 'controller' names the cgroup v1 controller to look for ('cpu' or
+  /// 'cpuacct'); pass an empty string for cgroup v2, whose entry has no
+  /// controller list. Empty when
+  /// the process is in the root cgroup - which is what a container started with
+  /// 'cgroupns=private' reports, as the kernel shows it its own cgroup as the
+  /// root - or when no matching entry is present. Exposed for testing.
+  static std::string parseCgroupRelativePath(
+      const std::string& procSelf,
+      folly::StringPiece controller);
+
+  /// Overrides the files the cgroup accounting is read from. 'periodFile' is
+  /// only used for cgroup v1, where the quota and the period live in separate
+  /// files. Test only.
+  void setCgroupFilesForTest(
+      bool useV2,
+      const std::string& usageFile,
+      const std::string& quotaFile,
+      const std::string& periodFile = "");
+
+  /// Reads the cgroup's cumulative CPU usage in microseconds, or -1 when it
+  /// cannot be read. Exposed for testing.
+  int64_t readCgroupCpuUsageUsec() const;
+
+  /// Reads the number of cores the cgroup's CPU quota allows, or 0 when no
+  /// quota applies or it cannot be read. Fractional quotas are preserved, so a
+  /// 500m Kubernetes limit returns 0.5. Exposed for testing.
+  double readCgroupCpuQuotaCores() const;
+
  private:
+  /// Locates the cgroup files to read, honouring both cgroup versions and both
+  /// cgroup namespace modes. Leaves the paths empty when the accounting is not
+  /// available, which turns getCgroupCPULoadPct() into getCPULoadPct(). Runs on
+  /// the first update() rather than in the constructor, so that what it finds
+  /// can be logged - a CPUMon is built before logging is initialized.
+  void detectCgroupFiles();
+
+  /// Recomputes cgroupCpuLoadPct_. Reports 'hostLoadPct' when no CPU quota
+  /// applies, where the two are the same measure, and 0 when a quota applies
+  /// but this window produced no usable delta - reporting the host-wide value
+  /// there would mix two scales.
+  void updateCgroupCpuLoad(double hostLoadPct);
+
   std::vector<uint64_t> prev_{8};
   bool firstTime_{true};
   std::atomic<double> cpuLoadPct_{0.0};
+
+  // Paths stay empty when the cgroup CPU accounting could not be located.
+  bool cgroupDetected_{false};
+  bool cgroupV2_{true};
+  std::string cgroupUsageFile_;
+  std::string cgroupQuotaFile_;
+  std::string cgroupPeriodFile_;
+
+  // Previous cgroup sample. -1 marks "no sample taken yet".
+  int64_t prevCgroupUsageUsec_{-1};
+  int64_t prevCgroupElapsedUsec_{-1};
+  std::atomic<double> cgroupCpuLoadPct_{0.0};
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1816,7 +1816,12 @@ void PrestoServer::checkOverload() {
   const auto overloadedThresholdQueuedDrivers = hwConcurrency *
       systemConfig->workerOverloadedThresholdNumQueuedDriversHwMultiplier();
   if (overloadedThresholdCpuPct > 0 && overloadedThresholdQueuedDrivers > 0) {
-    const auto currentUsedCpuPct = cpuMon_.getCPULoadPct();
+    // Scoped to this worker's cgroup, so the threshold means 'this worker is
+    // using most of the CPU it was given'. The host-wide load would instead
+    // report how busy the machine is, which on a shared node can neither reach
+    // the threshold when this worker saturates its quota nor stay below it when
+    // a co-tenant is busy.
+    const auto currentUsedCpuPct = cpuMon_.getCgroupCPULoadPct();
     const auto currentQueuedDrivers = taskManager_->numQueuedDrivers();
     const bool cpuOverloaded =
         (currentUsedCpuPct > overloadedThresholdCpuPct) &&
@@ -1991,7 +1996,13 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
   auto systemConfig = SystemConfig::instance();
   const int64_t nodeMemoryGb = systemConfig->systemMemoryGb();
 
-  const double cpuLoadPct{cpuMon_.getCPULoadPct()};
+  // 'processCpuLoad' is scoped to this worker's cgroup and 'systemCpuLoad' to
+  // the whole machine, matching what the names mean on a Java worker. The two
+  // differ on any deployment that caps the worker's CPU: a worker saturating a
+  // 10-core quota on an 80-core node reports 100% process load and 12.5% system
+  // load. They are equal when no CPU limit applies.
+  const double processCpuLoadPct{cpuMon_.getCgroupCPULoadPct()};
+  const double systemCpuLoadPct{cpuMon_.getCPULoadPct()};
 
   // 'nonHeapUsed' is a JVM/GC concept that does not apply to native workers.
   // Kept at 0 to avoid breaking existing tooling that consumes this field; it
@@ -2026,8 +2037,8 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       address_,
       memoryInfo,
       (int)folly::available_concurrency(),
-      cpuLoadPct,
-      cpuLoadPct,
+      processCpuLoadPct,
+      systemCpuLoadPct,
       pool_ ? pool_->usedBytes() : 0,
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed,

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -12,6 +12,7 @@
 add_executable(
   presto_server_test
   AnnouncerTest.cpp
+  CPUMonTest.cpp
   ConnectorTest.cpp
   CoordinatorDiscovererTest.cpp
   HttpServerWrapper.cpp

--- a/presto-native-execution/presto_cpp/main/tests/CPUMonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/CPUMonTest.cpp
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/CPUMon.h"
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include "velox/common/testutil/TempFilePath.h"
+
+namespace facebook::presto {
+namespace {
+
+using velox::common::testutil::TempFilePath;
+
+class CPUMonTest : public testing::Test {
+ protected:
+  // Writes 'content' to a temporary file kept alive for the whole test, and
+  // returns its path. Used to stand in for the cgroup pseudo-files.
+  std::string writeFile(const std::string& content) {
+    auto file = TempFilePath::create();
+    file->append(content);
+    files_.push_back(file);
+    return file->getPath();
+  }
+
+  void useCgroupV2(const std::string& cpuStat, const std::string& cpuMax) {
+    mon_.setCgroupFilesForTest(
+        /*useV2=*/true, writeFile(cpuStat), writeFile(cpuMax));
+  }
+
+  void useCgroupV1(
+      const std::string& cpuacctUsage,
+      const std::string& cfsQuota,
+      const std::string& cfsPeriod) {
+    mon_.setCgroupFilesForTest(
+        /*useV2=*/false,
+        writeFile(cpuacctUsage),
+        writeFile(cfsQuota),
+        writeFile(cfsPeriod));
+  }
+
+  CPUMon mon_;
+  std::vector<std::shared_ptr<TempFilePath>> files_;
+
+  // A real 'cpu.stat'. The keys are deliberately not in the order we scan for.
+  const std::string kCpuStat_ =
+      "usage_usec 5000000\n"
+      "user_usec 4000000\n"
+      "system_usec 1000000\n"
+      "nr_periods 100\n"
+      "nr_throttled 3\n"
+      "throttled_usec 12345\n";
+
+  // One second, in microseconds - the interval CPUMon::update() runs at.
+  static constexpr int64_t kOneSecond = 1'000'000;
+};
+
+// ---------------------------- quota parsing ----------------------------
+
+TEST_F(CPUMonTest, cgroupV2Quota) {
+  // 'cpu.max' is '<quota> <period>' in microseconds: 10 cores.
+  useCgroupV2(kCpuStat_, "1000000 100000\n");
+  ASSERT_DOUBLE_EQ(mon_.readCgroupCpuQuotaCores(), 10.0);
+}
+
+TEST_F(CPUMonTest, cgroupV2FractionalQuota) {
+  // A Kubernetes '500m' limit is half a core, and must not round to zero - that
+  // would be read as 'no limit' and fall back to the host-wide load.
+  useCgroupV2(kCpuStat_, "50000 100000\n");
+  ASSERT_DOUBLE_EQ(mon_.readCgroupCpuQuotaCores(), 0.5);
+}
+
+TEST_F(CPUMonTest, cgroupV2NoQuota) {
+  // A quota of the literal 'max' means no CPU limit is set.
+  useCgroupV2(kCpuStat_, "max 100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuQuotaCores(), 0);
+}
+
+TEST_F(CPUMonTest, cgroupV2MalformedQuota) {
+  for (const auto& content : {"garbage\n", "1000000\n", "\n", "a b\n"}) {
+    SCOPED_TRACE(content);
+    useCgroupV2(kCpuStat_, content);
+    ASSERT_EQ(mon_.readCgroupCpuQuotaCores(), 0);
+  }
+}
+
+TEST_F(CPUMonTest, cgroupV1Quota) {
+  useCgroupV1("5000000000\n", "1000000\n", "100000\n");
+  ASSERT_DOUBLE_EQ(mon_.readCgroupCpuQuotaCores(), 10.0);
+}
+
+TEST_F(CPUMonTest, cgroupV1NoQuota) {
+  // cgroup v1 uses -1 for 'no limit set'.
+  useCgroupV1("5000000000\n", "-1\n", "100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuQuotaCores(), 0);
+}
+
+TEST_F(CPUMonTest, quotaUnavailable) {
+  // No cgroup accounting was found, so nothing can be read.
+  mon_.setCgroupFilesForTest(/*useV2=*/true, "", "");
+  ASSERT_EQ(mon_.readCgroupCpuQuotaCores(), 0);
+  ASSERT_EQ(mon_.readCgroupCpuUsageUsec(), -1);
+}
+
+// ---------------------------- usage parsing ----------------------------
+
+TEST_F(CPUMonTest, cgroupV2Usage) {
+  useCgroupV2(kCpuStat_, "1000000 100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuUsageUsec(), 5'000'000);
+}
+
+TEST_F(CPUMonTest, cgroupV2UsageKeyMissing) {
+  // 'user_usec' is not 'usage_usec', and a prefix match must not accept it.
+  useCgroupV2("user_usec 4000000\nnr_periods 100\n", "1000000 100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuUsageUsec(), -1);
+}
+
+TEST_F(CPUMonTest, cgroupV1Usage) {
+  // 'cpuacct.usage' is a single value in nanoseconds.
+  useCgroupV1("5000000000\n", "1000000\n", "100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuUsageUsec(), 5'000'000);
+}
+
+TEST_F(CPUMonTest, cgroupV1UsageMalformed) {
+  useCgroupV1("not a number\n", "1000000\n", "100000\n");
+  ASSERT_EQ(mon_.readCgroupCpuUsageUsec(), -1);
+}
+
+// ------------------------- load percentage math -------------------------
+
+TEST_F(CPUMonTest, loadPctAcrossQuota) {
+  // 10 cores for one second is 10s of CPU time available.
+  struct {
+    int64_t usedUsec;
+    double expectedPct;
+  } testCases[] = {
+      {0, 0.0},
+      {2'500'000, 25.0},
+      {5'000'000, 50.0},
+      {10'000'000, 100.0},
+      // CFS throttling is applied per period rather than instantaneously, so a
+      // cgroup can slightly exceed its quota within one window.
+      {12'000'000, 100.0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(fmt::format("usedUsec: {}", testCase.usedUsec));
+    ASSERT_DOUBLE_EQ(
+        CPUMon::computeCgroupCpuLoadPct(
+            /*prevUsageUsec=*/0,
+            /*usageUsec=*/testCase.usedUsec,
+            /*prevElapsedUsec=*/0,
+            /*elapsedUsec=*/kOneSecond,
+            /*quotaCores=*/10.0),
+        testCase.expectedPct);
+  }
+}
+
+TEST_F(CPUMonTest, loadPctFractionalQuota) {
+  // Half a core for one second: 250ms of CPU time is half of what is allowed.
+  ASSERT_DOUBLE_EQ(
+      CPUMon::computeCgroupCpuLoadPct(0, 250'000, 0, kOneSecond, 0.5), 50.0);
+}
+
+TEST_F(CPUMonTest, loadPctUsesTheDeltaNotTheTotal) {
+  // The counters are cumulative since the cgroup was created, so only what was
+  // consumed within the window counts.
+  ASSERT_DOUBLE_EQ(
+      CPUMon::computeCgroupCpuLoadPct(
+          /*prevUsageUsec=*/900'000'000,
+          /*usageUsec=*/905'000'000,
+          /*prevElapsedUsec=*/50'000'000,
+          /*elapsedUsec=*/50'000'000 + kOneSecond,
+          /*quotaCores=*/10.0),
+      50.0);
+}
+
+TEST_F(CPUMonTest, loadPctUnknown) {
+  // Every case where no meaningful percentage exists reports -1, which
+  // update() turns into either the host-wide load or idle.
+  struct {
+    const char* name;
+    int64_t prevUsageUsec;
+    int64_t usageUsec;
+    int64_t prevElapsedUsec;
+    int64_t elapsedUsec;
+    double quotaCores;
+  } testCases[] = {
+      {"no quota", 0, 5'000'000, 0, kOneSecond, 0.0},
+      {"negative quota", 0, 5'000'000, 0, kOneSecond, -1.0},
+      {"first sample", -1, 5'000'000, -1, kOneSecond, 10.0},
+      {"usage unreadable", 0, -1, 0, kOneSecond, 10.0},
+      {"no time elapsed", 0, 5'000'000, kOneSecond, kOneSecond, 10.0},
+      {"clock went backwards", 0, 5'000'000, kOneSecond, 0, 10.0},
+      // A counter that goes backwards means the cgroup was replaced underneath
+      // us; wait for the next window rather than report a spike.
+      {"counter reset", 5'000'000, 1'000'000, 0, kOneSecond, 10.0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    ASSERT_EQ(
+        CPUMon::computeCgroupCpuLoadPct(
+            testCase.prevUsageUsec,
+            testCase.usageUsec,
+            testCase.prevElapsedUsec,
+            testCase.elapsedUsec,
+            testCase.quotaCores),
+        -1);
+  }
+}
+
+// --------------------- cgroup v2 path from /proc/self ---------------------
+
+TEST_F(CPUMonTest, cgroupV2PathPrivateNamespace) {
+  // A container started with 'cgroupns=private' sees its own cgroup as the
+  // root, so the files at the mount root are already the right ones.
+  ASSERT_EQ(CPUMon::parseCgroupRelativePath("0::/\n", ""), "");
+}
+
+TEST_F(CPUMonTest, cgroupV2PathHostNamespace) {
+  // With 'cgroupns=host' the mount root describes the machine, and the cgroup
+  // of this process has to be appended to reach its own accounting.
+  const std::string path =
+      "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice"
+      "/cri-containerd-abc.scope";
+  ASSERT_EQ(CPUMon::parseCgroupRelativePath("0::" + path + "\n", ""), path);
+}
+
+TEST_F(CPUMonTest, cgroupV2PathAmongV1Entries) {
+  // On a host running cgroup v1, or in the hybrid layout, only the entry with
+  // an empty controller list is the v2 one.
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(
+          "12:cpu,cpuacct:/kubepods/pod123\n"
+          "11:memory:/kubepods/pod123\n"
+          "0::/kubepods/pod123\n",
+          ""),
+      "/kubepods/pod123");
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(
+          "12:cpu,cpuacct:/kubepods/pod123\n11:memory:/kubepods/pod123\n", ""),
+      "");
+}
+
+TEST_F(CPUMonTest, cgroupV2PathWithColon) {
+  // A cgroup name may contain a colon, so the path is everything after the
+  // second separator rather than the third field of a split.
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath("0::/machine.slice/unit:name\n", ""),
+      "/machine.slice/unit:name");
+}
+
+TEST_F(CPUMonTest, cgroupV2PathMissing) {
+  for (const auto& content : {"", "\n", "garbage\n", "0:cpu\n"}) {
+    SCOPED_TRACE(content);
+    ASSERT_EQ(CPUMon::parseCgroupRelativePath(content, ""), "");
+  }
+}
+
+// --------------------- cgroup v1 path from /proc/self ---------------------
+
+// A realistic '/proc/self/cgroup' on a cgroup v1 host, where 'cpu' and
+// 'cpuacct' are mounted together and the process sits in a nested cgroup.
+const char* kProcSelfCgroupV1 =
+    "11:memory:/kubepods/burstable/pod123\n"
+    "10:cpu,cpuacct:/kubepods/burstable/pod123/abc\n"
+    "9:cpuset:/kubepods/burstable/pod123\n";
+
+TEST_F(CPUMonTest, cgroupV1PathPerController) {
+  // Both controller names must resolve through the shared 'cpu,cpuacct' entry.
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(kProcSelfCgroupV1, "cpu"),
+      "/kubepods/burstable/pod123/abc");
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(kProcSelfCgroupV1, "cpuacct"),
+      "/kubepods/burstable/pod123/abc");
+}
+
+TEST_F(CPUMonTest, cgroupV1PathSeparateMounts) {
+  // 'cpu' and 'cpuacct' can be mounted separately, and then they may sit at
+  // different paths, so each has to be resolved against its own entry.
+  const char* procSelf =
+      "10:cpuacct:/kubepods/pod123/acct\n"
+      "9:cpu:/kubepods/pod123/quota\n";
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(procSelf, "cpuacct"),
+      "/kubepods/pod123/acct");
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath(procSelf, "cpu"),
+      "/kubepods/pod123/quota");
+}
+
+TEST_F(CPUMonTest, cgroupV1PathControllerNotPresent) {
+  // A controller the process is not in must not fall through to another entry.
+  ASSERT_EQ(CPUMon::parseCgroupRelativePath(kProcSelfCgroupV1, "blkio"), "");
+  // 'cpu' must not match 'cpuset' by prefix, nor the v2 entry.
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath("9:cpuset:/kubepods/pod123\n", "cpu"),
+      "");
+  ASSERT_EQ(
+      CPUMon::parseCgroupRelativePath("0::/kubepods/pod123\n", "cpu"), "");
+}
+
+TEST_F(CPUMonTest, cgroupV1PathPrivateNamespace) {
+  // As with v2, a container that sees its own cgroup as the root reports '/'
+  // and there is nothing to append.
+  ASSERT_EQ(CPUMon::parseCgroupRelativePath("10:cpu,cpuacct:/\n", "cpu"), "");
+}
+
+} // namespace
+} // namespace facebook::presto


### PR DESCRIPTION
## Description

`CPUMon` derives the worker's CPU load from `/proc/stat`, and `PrestoServer::fetchNodeStatus()` passes
that single value to both `processCpuLoad` and `systemCpuLoad` in `NodeStatus`.

This change reads the worker's own cgroup CPU accounting as well and reports that as
`processCpuLoad`, leaving `systemCpuLoad` as the host-wide figure:

- cgroup v2: `cpu.stat`'s `usage_usec` against the quota in `cpu.max`
- cgroup v1: `cpuacct.usage` against `cpu.cfs_quota_us` / `cpu.cfs_period_us`
- load = `Δusage / (Δelapsed × quotaCores) × 100`, clamped to `[0, 100]`

`checkOverload()` switches to the cgroup-scoped value too, so
`worker-overloaded-threshold-cpu-pct` comes to mean "this worker is using most of the CPU it was
given" rather than "the machine is busy".

Both cgroup namespace modes are handled, for both versions. With cgroupns=private the container sees its own cgroup at the mount root and /proc/self/cgroup reports /, leaving nothing to append; with cgroupns=host the process' own path is read from /proc/self/cgroup and appended to the mount root. On v1 that lookup is per controller, because cpu and cpuacct may be mounted separately and can then sit at different paths in the hierarchy. Both versions share a helper that falls back to the mount root when the nested path is absent, so an unreadable or unexpected /proc/self/cgroup degrades to the previous behaviour rather than failing.

Sampling rides on the existing one-second `populate_mem_cpu_info` periodic task, which already calls
`CPUMon::update()`. Nothing new runs on the `/v1/status` request path.

## Motivation and Context

`/proc/stat` is not namespaced. Inside a container it reports every core on the machine and every
process on it, regardless of what share of them the worker is allowed to use. On any deployment that
caps the worker's CPU, the reported value is not a usable signal for that worker:

- A worker saturating a 10-core quota on an 80-core node reports **12.5 %**, so a threshold above
  that can never be reached no matter how busy the worker is.
- The value moves with unrelated co-tenants, so every worker pod on a node reports the same number
  and none of them says anything about that particular worker.

That makes `processCpuLoad` unusable for autoscaling or capacity decisions in a containerized
deployment, and it silently degrades `checkOverload()`, whose CPU threshold is compared against the
same value.

The two field names come from the Java worker, where they are
`OperatingSystemMXBean.getProcessCpuLoad()` and `getSystemCpuLoad()` — genuinely different measures.
The native worker reporting one host-wide number for both is the inconsistency being fixed, which is
why this corrects the existing field rather than adding a third one: no protocol change, no new
Thrift id, and existing consumers keep the same units and range.

## Impact

**Behavior change, `processCpuLoad` only**, and only where a CPU quota applies:

| Deployment | Before | After |
|---|---|---|
| No CPU limit (bare metal, unconstrained container) | host-wide | **unchanged** — with no quota the cgroup may use the whole machine, so the value falls back to the host-wide figure |
| CPU limit set | host-wide, identical to `systemCpuLoad` | percentage of the worker's own quota |

`systemCpuLoad` is unchanged in all cases. Units and range are unchanged (percentage, `0`–`100`), so
no consumer needs to be adapted — only its interpretation on capped deployments improves.

`checkOverload()` behaves differently only if `worker-overloaded-threshold-cpu-pct` is set; it
defaults to `0` (disabled). Operators who did set it on a capped deployment should revisit the value,
since a threshold calibrated against a host-wide reading will now be reached much sooner.

No new configuration properties. No new dependencies. Performance impact is two small pseudo-file
reads per second on an existing periodic task.

Out of scope, noted for completeness: `presto-ui`'s worker page multiplies these fields by 100
(`WorkerStatus.jsx`), which assumes the Java `0..1` fraction and already misrenders the native
worker's percentage. That is pre-existing and untouched here.

## Test Plan

**Unit tests** — new `presto_cpp/main/tests/CPUMonTest.cpp`, 24 tests, all passing. Every case injects
temporary files, so no cgroup, container or GPU is needed:

- quota parsing: cgroup v2 `cpu.max`, v1 `cfs_quota_us`/`cfs_period_us`, the unlimited forms
  (`max`, `-1`), fractional quotas (a `500m` limit must yield 0.5 cores, not 0), malformed contents
- usage parsing: v2 `cpu.stat` multi-line (and that `user_usec` is not accepted as a prefix match for
  `usage_usec`), v1 nanoseconds, unreadable and malformed files
- the percentage math: 25/50/100 %, the over-quota clamp, delta versus cumulative total, fractional
  quota, and the seven inputs that must report "unknown" (no quota, first sample, unreadable counter,
  no elapsed time, clock or counter going backwards)
- /proc/self/cgroup parsing, for both cgroup versions: the two namespace modes, v1 entries mixed in with the v2 one, a cgroup path containing a colon, per-controller resolution through a shared cpu,cpuacct entry, cpu and cpuacct mounted separately at different paths, and a controller the process is not in — including that cpu must not match cpuset by prefix

```
[==========] 24 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 24 tests.
```

**On a Kubernetes cluster** — worker with `limits.cpu: "20"` on a 24 vCPU node
(`cpu.max` = `2000000 100000`), driven with 20 busy-loop processes inside the pod:

| Metric | Idle | Saturated |
|---|---|---|
| `processCpuLoad` | 0.01 % | **99.61 %** |
| `systemCpuLoad` | 1.12 % | **84.04 %** |
| `processors` | 24 | 24 |

The two fields now differ, and the numbers cross-check: 20 saturated quota cores out of 24 host cores
is 83.3 %, against the 84.04 % reported for `systemCpuLoad`. `cpu.stat`'s `nr_throttled` incremented
during the run, confirming the kernel was enforcing the quota.

**Hand-computed against `cpu.stat`** over 10-second windows, to validate the formula rather than just
the plumbing:

| | Δusage_usec | ÷ (10 s × 20 cores) | Reported |
|---|---|---|---|
| Idle | 31,240 | 0.0156 % | 0.0176 % |
| Saturated | 199,407,324 | 99.70 % | 99.64 % |

Agreement within 0.06 %.

The startup log reports which files were located, so a deployment where the accounting is not found
is diagnosable rather than silent:

```
Using cgroup v2 CPU accounting from /sys/fs/cgroup/cpu.stat (quota from /sys/fs/cgroup/cpu.max).
```

or, when no cgroup accounting is available:

```
No cgroup CPU accounting found. Reporting host-wide CPU load as the process CPU load.
```

Not covered: cgroup v1 and `cgroupns=host` are exercised by the unit tests but have not been run on a
live cluster, since no v1 or host-namespace deployment was available.

## Contributor checklist

- [x] Please make sure your submission complies with our contributing guide, in particular code style
      and commit standards.
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other
      functionality. — *no new properties; the behavior change is described under Impact*
- [x] If release notes are required, they follow the release notes guidelines.
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an OpenSSF Scorecard score of 5.0 or higher. —
      *no new dependencies*

## Release Notes

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix ``processCpuLoad`` in ``/v1/status`` to report the worker's CPU usage as a percentage of its
  own cgroup CPU quota instead of a percentage of the whole host, so the value is meaningful on
  deployments that cap the worker's CPU. ``systemCpuLoad`` continues to report the host-wide figure.
  Deployments without a CPU limit are unaffected. The ``worker-overloaded-threshold-cpu-pct``
  threshold is now compared against the cgroup-scoped value; it is disabled by default.
```

## Summary by Sourcery

Report worker CPU usage against its assigned cgroup quota so process load and overload detection reflect the worker’s actual CPU capacity.

New Features:
- Report native workers’ process CPU load relative to their cgroup CPU quota while preserving host-wide system CPU load reporting.

Bug Fixes:
- Correct process CPU load and CPU-based overload detection for CPU-capped container deployments.

Enhancements:
- Support cgroup v1 and v2 CPU accounting across private and host cgroup namespaces, with fallback behavior when no quota is available.

Tests:
- Add comprehensive unit coverage for cgroup discovery, quota and usage parsing, load calculation, malformed inputs, and namespace path handling.

## Summary by Sourcery

Report native worker CPU usage against its cgroup quota so status metrics and overload detection reflect the worker’s available CPU capacity.

New Features:
- Report native workers’ process CPU load as a percentage of their assigned cgroup CPU quota while retaining host-wide system CPU load.

Bug Fixes:
- Correct CPU-based overload detection and process load reporting for CPU-limited container deployments.

Enhancements:
- Support cgroup v1 and v2 accounting across private and host cgroup namespaces, with graceful fallback when quota accounting is unavailable.

Tests:
- Add comprehensive unit coverage for cgroup discovery, accounting parsing, quota-relative load calculation, and malformed or unavailable inputs.