### PR TITLE
perf(connector): Cache JDBC metadata within transactions (#28402)

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -172,6 +172,7 @@ public class JdbcMetadata
         }
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
         jdbcClient.dropTable(session, JdbcIdentity.from(session), handle);
+        jdbcMetadataCache.invalidateTable(session, handle);
     }
 
     @Override
@@ -240,6 +241,7 @@ public class JdbcMetadata
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         jdbcClient.addColumn(session, JdbcIdentity.from(session), tableHandle, columnMetadata);
+        jdbcMetadataCache.invalidateTable(session, tableHandle);
     }
 
     @Override
@@ -248,6 +250,7 @@ public class JdbcMetadata
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
         jdbcClient.dropColumn(session, JdbcIdentity.from(session), tableHandle, columnHandle);
+        jdbcMetadataCache.invalidateTable(session, tableHandle);
     }
 
     @Override
@@ -256,6 +259,7 @@ public class JdbcMetadata
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
         jdbcClient.renameColumn(session, JdbcIdentity.from(session), tableHandle, columnHandle, target);
+        jdbcMetadataCache.invalidateTable(session, tableHandle);
     }
 
     @Override
@@ -263,6 +267,8 @@ public class JdbcMetadata
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         jdbcClient.renameTable(session, JdbcIdentity.from(session), tableHandle, newTableName);
+        jdbcMetadataCache.invalidateTable(session, tableHandle);
+        jdbcMetadataCache.invalidateTableHandle(session, newTableName);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 
 import java.util.List;
@@ -32,6 +33,7 @@ import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.cache.CacheLoader.asyncReloading;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -39,6 +41,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class JdbcMetadataCache
 {
     private final JdbcClient jdbcClient;
+    private final JdbcMetadataCache delegate;
 
     private final LoadingCache<KeyAndSession<SchemaTableName>, Optional<JdbcTableHandle>> tableHandleCache;
     private final LoadingCache<KeyAndSession<JdbcTableHandle>, List<JdbcColumnHandle>> columnHandlesCache;
@@ -52,7 +55,8 @@ public class JdbcMetadataCache
                 stats,
                 OptionalLong.of(config.getMetadataCacheTtl().toMillis()),
                 config.getMetadataCacheRefreshInterval().toMillis() >= config.getMetadataCacheTtl().toMillis() ? OptionalLong.empty() : OptionalLong.of(config.getMetadataCacheRefreshInterval().toMillis()),
-                config.getMetadataCacheMaximumSize());
+                config.getMetadataCacheMaximumSize(),
+                null);
     }
 
     public JdbcMetadataCache(
@@ -63,7 +67,27 @@ public class JdbcMetadataCache
             OptionalLong refreshInterval,
             long cacheMaximumSize)
     {
+        this(
+                executor,
+                jdbcClient,
+                stats,
+                cacheTtl,
+                refreshInterval,
+                cacheMaximumSize,
+                null);
+    }
+
+    private JdbcMetadataCache(
+            ExecutorService executor,
+            JdbcClient jdbcClient,
+            JdbcMetadataCacheStats stats,
+            OptionalLong cacheTtl,
+            OptionalLong refreshInterval,
+            long cacheMaximumSize,
+            @Nullable JdbcMetadataCache delegate)
+    {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.delegate = delegate;
 
         this.tableHandleCache = newCacheBuilder(cacheTtl, refreshInterval, cacheMaximumSize)
                 .build(asyncReloading(CacheLoader.from(this::loadTableHandle), executor));
@@ -74,9 +98,32 @@ public class JdbcMetadataCache
         stats.setColumnHandlesCache(columnHandlesCache);
     }
 
+    public static JdbcMetadataCache createTransactionCache(JdbcMetadataCache delegate, long maximumSize)
+    {
+        return createTransactionCache(delegate, new JdbcMetadataCacheStats(), maximumSize);
+    }
+
+    static JdbcMetadataCache createTransactionCache(JdbcMetadataCache delegate, JdbcMetadataCacheStats stats, long maximumSize)
+    {
+        requireNonNull(delegate, "delegate is null");
+        return new JdbcMetadataCache(
+                newDirectExecutorService(),
+                delegate.jdbcClient,
+                stats,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                maximumSize,
+                delegate);
+    }
+
     public JdbcTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        return get(tableHandleCache, new KeyAndSession<>(session, tableName)).orElse(null);
+        KeyAndSession<SchemaTableName> key = new KeyAndSession<>(session, tableName);
+        Optional<JdbcTableHandle> tableHandle = get(tableHandleCache, key);
+        if (!tableHandle.isPresent()) {
+            tableHandleCache.invalidate(key);
+        }
+        return tableHandle.orElse(null);
     }
 
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle jdbcTableHandle)
@@ -84,14 +131,37 @@ public class JdbcMetadataCache
         return get(columnHandlesCache, new KeyAndSession<>(session, jdbcTableHandle));
     }
 
+    public void invalidateTable(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        tableHandleCache.invalidate(new KeyAndSession<>(session, tableHandle.getSchemaTableName()));
+        columnHandlesCache.invalidate(new KeyAndSession<>(session, tableHandle));
+        if (delegate != null) {
+            delegate.invalidateTable(session, tableHandle);
+        }
+    }
+
+    public void invalidateTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        tableHandleCache.invalidate(new KeyAndSession<>(session, tableName));
+        if (delegate != null) {
+            delegate.invalidateTableHandle(session, tableName);
+        }
+    }
+
     private Optional<JdbcTableHandle> loadTableHandle(KeyAndSession<SchemaTableName> tableName)
     {
         // The returned tableHandle can be null if it does not contain the table
+        if (delegate != null) {
+            return Optional.ofNullable(delegate.getTableHandle(tableName.getSession(), tableName.getKey()));
+        }
         return Optional.ofNullable(jdbcClient.getTableHandle(tableName.getSession(), JdbcIdentity.from(tableName.getSession()), tableName.getKey()));
     }
 
     private List<JdbcColumnHandle> loadColumnHandles(KeyAndSession<JdbcTableHandle> tableHandle)
     {
+        if (delegate != null) {
+            return delegate.getColumns(tableHandle.getSession(), tableHandle.getKey());
+        }
         return jdbcClient.getColumns(tableHandle.getSession(), tableHandle.getKey());
     }
 
@@ -139,8 +209,6 @@ public class JdbcMetadataCache
             return key;
         }
 
-        // Session object changes for every query. For caching to be effective across multiple queries,
-        // we should NOT include session in equals() and hashCode() methods below.
         @Override
         public boolean equals(Object o)
         {

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataConfig.java
@@ -25,9 +25,11 @@ import java.util.concurrent.TimeUnit;
 public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
+    private boolean metadataTransactionCacheEnabled = true;
     private Duration metadataCacheTtl = new Duration(0, TimeUnit.SECONDS);
     private Duration metadataCacheRefreshInterval = new Duration(0, TimeUnit.SECONDS);
     private long metadataCacheMaximumSize = 10000;
+    private long metadataTransactionCacheMaximumSize = 1000;
 
     public boolean isAllowDropTable()
     {
@@ -39,6 +41,19 @@ public class JdbcMetadataConfig
     public JdbcMetadataConfig setAllowDropTable(boolean allowDropTable)
     {
         this.allowDropTable = allowDropTable;
+        return this;
+    }
+
+    public boolean isMetadataTransactionCacheEnabled()
+    {
+        return metadataTransactionCacheEnabled;
+    }
+
+    @Config("metadata-transaction-cache-enabled")
+    @ConfigDescription("Enable metadata caching within a connector transaction")
+    public JdbcMetadataConfig setMetadataTransactionCacheEnabled(boolean metadataTransactionCacheEnabled)
+    {
+        this.metadataTransactionCacheEnabled = metadataTransactionCacheEnabled;
         return this;
     }
 
@@ -80,6 +95,20 @@ public class JdbcMetadataConfig
     public JdbcMetadataConfig setMetadataCacheMaximumSize(long metadataCacheMaximumSize)
     {
         this.metadataCacheMaximumSize = metadataCacheMaximumSize;
+        return this;
+    }
+
+    public long getMetadataTransactionCacheMaximumSize()
+    {
+        return metadataTransactionCacheMaximumSize;
+    }
+
+    @Min(1)
+    @Config("metadata-transaction-cache-maximum-size")
+    @ConfigDescription("Maximum number of metadata entries cached within a connector transaction")
+    public JdbcMetadataConfig setMetadataTransactionCacheMaximumSize(long metadataTransactionCacheMaximumSize)
+    {
+        this.metadataTransactionCacheMaximumSize = metadataTransactionCacheMaximumSize;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
@@ -22,6 +22,8 @@ public class JdbcMetadataFactory
     private final JdbcMetadataCache jdbcMetadataCache;
     private final JdbcClient jdbcClient;
     private final boolean allowDropTable;
+    private final boolean metadataTransactionCacheEnabled;
+    private final long metadataTransactionCacheMaximumSize;
     private final TableLocationProvider tableLocationProvider;
 
     @Inject
@@ -31,11 +33,16 @@ public class JdbcMetadataFactory
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         requireNonNull(config, "config is null");
         this.allowDropTable = config.isAllowDropTable();
+        this.metadataTransactionCacheEnabled = config.isMetadataTransactionCacheEnabled();
+        this.metadataTransactionCacheMaximumSize = config.getMetadataTransactionCacheMaximumSize();
         this.tableLocationProvider = requireNonNull(tableLocationProvider, "tableLocationProvider is null");
     }
 
     public JdbcMetadata create()
     {
-        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable, tableLocationProvider);
+        JdbcMetadataCache transactionMetadataCache = metadataTransactionCacheEnabled ?
+                JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, metadataTransactionCacheMaximumSize) :
+                jdbcMetadataCache;
+        return new JdbcMetadata(transactionMetadataCache, jdbcClient, allowDropTable, tableLocationProvider);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -15,11 +15,13 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -44,6 +46,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
@@ -58,6 +61,8 @@ public class TestJdbcMetadata
     private TestingDatabase database;
     private JdbcMetadata metadata;
     private JdbcMetadataCache jdbcMetadataCache;
+    private JdbcMetadataCacheStats globalMetadataCacheStats;
+    private JdbcMetadataCacheStats transactionMetadataCacheStats;
     private JdbcTableHandle tableHandle;
 
     @BeforeMethod
@@ -66,12 +71,14 @@ public class TestJdbcMetadata
     {
         database = new TestingDatabase();
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
-        jdbcMetadataCache = new JdbcMetadataCache(executor, database.getJdbcClient(), new JdbcMetadataCacheStats(), OptionalLong.of(0), OptionalLong.of(0), 100);
+        globalMetadataCacheStats = new JdbcMetadataCacheStats();
+        jdbcMetadataCache = new JdbcMetadataCache(executor, database.getJdbcClient(), globalMetadataCacheStats, OptionalLong.of(0), OptionalLong.of(0), 100);
+        transactionMetadataCacheStats = new JdbcMetadataCacheStats();
 
         BaseJdbcConfig baseConfig = new BaseJdbcConfig();
         baseConfig.setConnectionUrl("jdbc:h2:mem:test");
 
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new DefaultTableLocationProvider(baseConfig));
+        metadata = new JdbcMetadata(JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, transactionMetadataCacheStats, 100), database.getJdbcClient(), false, new DefaultTableLocationProvider(baseConfig));
         tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
     }
 
@@ -109,7 +116,188 @@ public class TestJdbcMetadata
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown"));
-        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown"));
+        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "unknown"), null, "example", "unknown"));
+    }
+
+    @Test
+    public void testColumnMetadataReuseIsTransactionScoped()
+    {
+        ConnectorSession firstSession = new TestingConnectorSession(ImmutableList.of());
+        metadata.getTableMetadata(firstSession, tableHandle);
+        metadata.getColumnHandles(firstSession, tableHandle);
+        assertEquals(transactionMetadataCacheStats.getColumnHandlesCacheMiss(), 1);
+
+        ConnectorSession secondSession = new TestingConnectorSession(ImmutableList.of());
+        metadata.getColumnHandles(secondSession, tableHandle);
+        metadata.getTableMetadata(secondSession, tableHandle);
+        assertEquals(transactionMetadataCacheStats.getColumnHandlesCacheMiss(), 1);
+
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig();
+        baseConfig.setConnectionUrl("jdbc:h2:mem:test");
+        JdbcMetadataCacheStats otherTransactionCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadata otherTransactionMetadata = new JdbcMetadata(JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, otherTransactionCacheStats, 100), database.getJdbcClient(), false, new DefaultTableLocationProvider(baseConfig));
+
+        otherTransactionMetadata.getColumnHandles(secondSession, tableHandle);
+        otherTransactionMetadata.getTableMetadata(secondSession, tableHandle);
+        assertEquals(transactionMetadataCacheStats.getColumnHandlesCacheMiss(), 1);
+        assertEquals(otherTransactionCacheStats.getColumnHandlesCacheMiss(), 1);
+    }
+
+    @Test
+    public void testTransactionCacheDoesNotReuseMetadataAcrossTransactionsWhenGlobalCacheIsDisabled()
+    {
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig();
+        baseConfig.setConnectionUrl("jdbc:h2:mem:test");
+        JdbcMetadataFactory metadataFactory = new JdbcMetadataFactory(
+                jdbcMetadataCache,
+                database.getJdbcClient(),
+                new JdbcMetadataConfig().setMetadataTransactionCacheEnabled(true),
+                new DefaultTableLocationProvider(baseConfig));
+        SchemaTableName tableName = new SchemaTableName("example", "numbers");
+        ConnectorSession firstSession = new TestingConnectorSession(ImmutableList.of());
+        ConnectorSession secondSession = new TestingConnectorSession(ImmutableList.of());
+
+        long initialTableHandleMisses = globalMetadataCacheStats.getTableHandleCacheMiss();
+        long initialColumnHandleMisses = globalMetadataCacheStats.getColumnHandlesCacheMiss();
+
+        JdbcMetadata firstTransaction = metadataFactory.create();
+        JdbcTableHandle firstTableHandle = firstTransaction.getTableHandle(firstSession, tableName);
+        firstTransaction.getTableHandle(firstSession, tableName);
+        firstTransaction.getTableMetadata(firstSession, firstTableHandle);
+        firstTransaction.getColumnHandles(firstSession, firstTableHandle);
+
+        assertEquals(globalMetadataCacheStats.getTableHandleCacheMiss(), initialTableHandleMisses + 1);
+        assertEquals(globalMetadataCacheStats.getColumnHandlesCacheMiss(), initialColumnHandleMisses + 1);
+
+        JdbcMetadata secondTransaction = metadataFactory.create();
+        JdbcTableHandle secondTableHandle = secondTransaction.getTableHandle(secondSession, tableName);
+        secondTransaction.getTableMetadata(secondSession, secondTableHandle);
+
+        assertEquals(globalMetadataCacheStats.getTableHandleCacheMiss(), initialTableHandleMisses + 2);
+        assertEquals(globalMetadataCacheStats.getColumnHandlesCacheMiss(), initialColumnHandleMisses + 2);
+    }
+
+    @Test
+    public void testColumnMetadataReuseCanBeDisabled()
+    {
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig();
+        baseConfig.setConnectionUrl("jdbc:h2:mem:test");
+        JdbcMetadataFactory metadataFactory = new JdbcMetadataFactory(
+                jdbcMetadataCache,
+                database.getJdbcClient(),
+                new JdbcMetadataConfig().setMetadataTransactionCacheEnabled(false),
+                new DefaultTableLocationProvider(baseConfig));
+        JdbcMetadata uncachedMetadata = metadataFactory.create();
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        long initialMisses = globalMetadataCacheStats.getColumnHandlesCacheMiss();
+        uncachedMetadata.getTableMetadata(session, tableHandle);
+        uncachedMetadata.getColumnHandles(session, tableHandle);
+
+        assertEquals(globalMetadataCacheStats.getColumnHandlesCacheMiss(), initialMisses + 2);
+    }
+
+    @Test
+    public void testTransactionCacheUsesGlobalCacheWhenEnabled()
+    {
+        ListeningExecutorService executor = newDirectExecutorService();
+        JdbcMetadataCacheStats globalCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadataCache globalCache = new JdbcMetadataCache(
+                executor,
+                database.getJdbcClient(),
+                globalCacheStats,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                100);
+
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig();
+        baseConfig.setConnectionUrl("jdbc:h2:mem:test");
+        JdbcMetadata firstTransaction = new JdbcMetadata(
+                JdbcMetadataCache.createTransactionCache(globalCache, 100),
+                database.getJdbcClient(),
+                false,
+                new DefaultTableLocationProvider(baseConfig));
+        JdbcMetadata secondTransaction = new JdbcMetadata(
+                JdbcMetadataCache.createTransactionCache(globalCache, 100),
+                database.getJdbcClient(),
+                false,
+                new DefaultTableLocationProvider(baseConfig));
+
+        firstTransaction.getTableMetadata(SESSION, tableHandle);
+        secondTransaction.getTableMetadata(SESSION, tableHandle);
+
+        assertEquals(globalCacheStats.getColumnHandlesCacheMiss(), 1);
+        assertEquals(globalCacheStats.getColumnHandlesCacheHit(), 1);
+    }
+
+    @Test
+    public void testMissingTableHandleIsNotCached()
+    {
+        ListeningExecutorService executor = newDirectExecutorService();
+        JdbcMetadataCacheStats globalCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadataCache globalCache = new JdbcMetadataCache(
+                executor,
+                database.getJdbcClient(),
+                globalCacheStats,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                100);
+        JdbcMetadataCacheStats firstTransactionCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadataCache firstTransactionCache = JdbcMetadataCache.createTransactionCache(globalCache, firstTransactionCacheStats, 100);
+        SchemaTableName missingTable = new SchemaTableName("example", "unknown");
+
+        assertNull(firstTransactionCache.getTableHandle(SESSION, missingTable));
+        assertNull(firstTransactionCache.getTableHandle(SESSION, missingTable));
+
+        assertEquals(firstTransactionCacheStats.getTableHandleCacheMiss(), 2);
+        assertEquals(globalCacheStats.getTableHandleCacheMiss(), 2);
+
+        JdbcMetadataCacheStats secondTransactionCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadataCache secondTransactionCache = JdbcMetadataCache.createTransactionCache(globalCache, secondTransactionCacheStats, 100);
+        assertNull(secondTransactionCache.getTableHandle(SESSION, missingTable));
+
+        assertEquals(secondTransactionCacheStats.getTableHandleCacheMiss(), 1);
+        assertEquals(globalCacheStats.getTableHandleCacheMiss(), 3);
+    }
+
+    @Test
+    public void testSchemaChangeInvalidatesTransactionAndGlobalCaches()
+    {
+        ListeningExecutorService executor = newDirectExecutorService();
+        JdbcMetadataCacheStats globalCacheStats = new JdbcMetadataCacheStats();
+        JdbcMetadataCache globalCache = new JdbcMetadataCache(
+                executor,
+                database.getJdbcClient(),
+                globalCacheStats,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                100);
+        JdbcMetadataCacheStats cacheStats = new JdbcMetadataCacheStats();
+
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig();
+        baseConfig.setConnectionUrl("jdbc:h2:mem:test");
+        JdbcMetadata cachedMetadata = new JdbcMetadata(
+                JdbcMetadataCache.createTransactionCache(globalCache, cacheStats, 100),
+                database.getJdbcClient(),
+                false,
+                new DefaultTableLocationProvider(baseConfig));
+        JdbcTableHandle cachedTableHandle = cachedMetadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
+        JdbcTableHandle unaffectedTableHandle = cachedMetadata.getTableHandle(SESSION, new SchemaTableName("example", "view"));
+
+        assertEquals(cachedMetadata.getTableMetadata(SESSION, cachedTableHandle).getColumns().size(), 3);
+        cachedMetadata.getTableMetadata(SESSION, unaffectedTableHandle);
+        assertEquals(cacheStats.getColumnHandlesCacheMiss(), 2);
+        assertEquals(globalCacheStats.getColumnHandlesCacheMiss(), 2);
+
+        cachedMetadata.addColumn(SESSION, cachedTableHandle, ColumnMetadata.builder().setName("new_column").setType(VARCHAR).build());
+
+        cachedMetadata.getTableMetadata(SESSION, unaffectedTableHandle);
+        assertEquals(cacheStats.getColumnHandlesCacheMiss(), 2);
+        assertEquals(globalCacheStats.getColumnHandlesCacheMiss(), 2);
+
+        assertEquals(cachedMetadata.getTableMetadata(SESSION, cachedTableHandle).getColumns().size(), 4);
+        assertEquals(cacheStats.getColumnHandlesCacheMiss(), 3);
+        assertEquals(globalCacheStats.getColumnHandlesCacheMiss(), 3);
     }
 
     private void unknownTableColumnHandle(JdbcTableHandle tableHandle)
@@ -143,8 +331,8 @@ public class TestJdbcMetadata
 
         // unknown tables should produce null
         unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("u", "numbers"), null, "unknown", "unknown"));
-        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown"));
-        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "unknown", "numbers"));
+        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "unknown"), null, "example", "unknown"));
+        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "numbers"), null, "unknown", "numbers"));
     }
 
     @Test
@@ -269,7 +457,7 @@ public class TestJdbcMetadata
         // Create BaseJdbcConfig with connection URL for drop table test
         BaseJdbcConfig dropConfig = new BaseJdbcConfig();
         dropConfig.setConnectionUrl("jdbc:h2:mem:test");
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), true, new DefaultTableLocationProvider(dropConfig));
+        metadata = new JdbcMetadata(JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, 100), database.getJdbcClient(), true, new DefaultTableLocationProvider(dropConfig));
         metadata.dropTable(SESSION, tableHandle);
 
         try {
@@ -295,7 +483,7 @@ public class TestJdbcMetadata
         };
 
         // Create JdbcMetadata with the custom provider
-        JdbcMetadata customMetadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, customProvider);
+        JdbcMetadata customMetadata = new JdbcMetadata(JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, 100), database.getJdbcClient(), false, customProvider);
 
         // Verify that the metadata can be created and basic operations work
         JdbcTableHandle customTableHandle = customMetadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -32,9 +32,11 @@ public class TestJdbcMetadataConfig
     {
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
                 .setAllowDropTable(false)
+                .setMetadataTransactionCacheEnabled(true)
                 .setMetadataCacheTtl(new Duration(0, SECONDS))
                 .setMetadataCacheRefreshInterval(new Duration(0, SECONDS))
-                .setMetadataCacheMaximumSize(10000));
+                .setMetadataCacheMaximumSize(10000)
+                .setMetadataTransactionCacheMaximumSize(1000));
     }
 
     @Test
@@ -42,16 +44,20 @@ public class TestJdbcMetadataConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("allow-drop-table", "true")
+                .put("metadata-transaction-cache-enabled", "false")
                 .put("metadata-cache-ttl", "1h")
                 .put("metadata-cache-refresh-interval", "10s")
                 .put("metadata-cache-maximum-size", "100")
+                .put("metadata-transaction-cache-maximum-size", "200")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
                 .setAllowDropTable(true)
+                .setMetadataTransactionCacheEnabled(false)
                 .setMetadataCacheTtl(new Duration(1, HOURS))
                 .setMetadataCacheRefreshInterval(new Duration(10, SECONDS))
-                .setMetadataCacheMaximumSize(100);
+                .setMetadataCacheMaximumSize(100)
+                .setMetadataTransactionCacheMaximumSize(200);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Summary:

JDBC connectors can request the same table and column metadata multiple
times while analyzing a query. When global metadata caching is disabled,
each request reaches the remote database and increases planning latency.

Cache table and column metadata for the lifetime of each connector
transaction. Cache misses delegate to the existing global cache, preserving
cross-transaction reuse when it is configured.

The transaction cache is enabled by default, bounded by a configurable
maximum size, and discarded with the transaction. Schema changes invalidate
only the affected table in both cache layers. With global caching disabled,
metadata is fetched again in each new transaction. Missing table-handle
lookups are not cached in either layer.

Differential Revision: D117311811

```
== RELEASE NOTES ==

JDBC Driver Changes
* Add JDBC metadata cache within transactions
```
## Summary by Sourcery

Cache JDBC table and column metadata within connector transactions to reduce repeated remote database lookups during query planning.

New Features:
- Add configurable, bounded JDBC metadata caching scoped to each connector transaction, enabled by default.
- Reuse global metadata cache entries on transaction-cache misses while avoiding caching missing table handles.

Bug Fixes:
- Invalidate affected transaction and global metadata entries after table and column schema changes.

Tests:
- Add coverage for transaction scoping, global-cache reuse, disabled caching, missing handles, and schema-change invalidation.