### PR TITLE
fix(native-pos): Release the native task eagerly when Presto-on-Spark stops it (#28404)

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -905,8 +905,11 @@ void TaskManager::maybeStartNextQueuedTask() {
   }
 }
 
-std::unique_ptr<TaskInfo>
-TaskManager::deleteTask(const TaskId& taskId, bool /*abort*/, bool summarize) {
+std::unique_ptr<TaskInfo> TaskManager::deleteTask(
+    const TaskId& taskId,
+    bool /*abort*/,
+    bool summarize,
+    bool shouldDropTask) {
   LOG(INFO) << "Deleting task " << taskId;
   // Fast. non-blocking delete and cancel serialized on 'taskMap'.
   std::shared_ptr<facebook::presto::PrestoTask> prestoTask;
@@ -923,34 +926,54 @@ TaskManager::deleteTask(const TaskId& taskId, bool /*abort*/, bool summarize) {
     prestoTask = findOrCreateTask(taskId, 0);
   }
 
-  std::lock_guard<std::mutex> l(prestoTask->mutex);
-  prestoTask->updateHeartbeatLocked();
-  prestoTask->updateCoordinatorHeartbeatLocked();
-  auto execTask = prestoTask->task;
-  if (execTask) {
-    auto state = execTask->state();
-    if (state == exec::TaskState::kRunning) {
-      execTask->requestAbort();
+  std::unique_ptr<TaskInfo> taskInfo;
+  bool dropTask{false};
+  {
+    std::lock_guard<std::mutex> l(prestoTask->mutex);
+    prestoTask->updateHeartbeatLocked();
+    prestoTask->updateCoordinatorHeartbeatLocked();
+    auto execTask = prestoTask->task;
+    if (execTask) {
+      auto state = execTask->state();
+      if (state == exec::TaskState::kRunning) {
+        execTask->requestAbort();
+      }
+      prestoTask->info.stats.endTimeInMillis = velox::getCurrentTimeMs();
+      prestoTask->updateInfoLocked(summarize);
+
+      // Do not erase the finished/aborted tasks, because someone might still
+      // want to get some results from them. Instead, we run a periodic task to
+      // clean up the old finished/aborted tasks.
+      if (prestoTask->info.taskStatus.state == protocol::TaskState::RUNNING) {
+        prestoTask->info.taskStatus.state = protocol::TaskState::ABORTED;
+      }
+      dropTask = shouldDropTask;
+    } else {
+      // If task is not found than we observe DELETE message coming before
+      // CREATE. In that case we create the task with ABORTED state, so we know
+      // we don't need to do anything on CREATE message and can clean up the
+      // cancelled task later. This marker holds no Velox Task and so pins
+      // nothing; it is kept even under 'shouldDropTask', because dropping it
+      // would let the later CREATE start the task the client just cancelled.
+      prestoTask->info.taskStatus.state = protocol::TaskState::ABORTED;
     }
-    prestoTask->info.stats.endTimeInMillis = velox::getCurrentTimeMs();
-    prestoTask->updateInfoLocked(summarize);
-  } else {
-    // If task is not found than we observe DELETE message coming before
-    // CREATE. In that case we create the task with ABORTED state, so we know
-    // we don't need to do anything on CREATE message and can clean up the
-    // cancelled task later.
-    prestoTask->info.taskStatus.state = protocol::TaskState::ABORTED;
-    return std::make_unique<TaskInfo>(prestoTask->info);
+    taskInfo = std::make_unique<TaskInfo>(prestoTask->info);
   }
 
-  // Do not erase the finished/aborted tasks, because someone might still want
-  // to get some results from them. Instead, we run a periodic task to clean up
-  // the old finished/aborted tasks.
-  if (prestoTask->info.taskStatus.state == protocol::TaskState::RUNNING) {
-    prestoTask->info.taskStatus.state = protocol::TaskState::ABORTED;
+  // The deferral above assumes cleanOldTasks() will eventually reclaim the
+  // task, but it declines to erase any task whose Drivers have not finished
+  // unwinding (see the zombie check there), so a task left in 'taskMap_' can
+  // pin its Velox Task -- and every resource its operators hold on the shared
+  // per-query memory pool -- for the lifetime of the worker process. Drop the
+  // reference here when the caller states it will never read the task again.
+  // The Velox Task itself stays alive until its Drivers finish unwinding the
+  // abort requested above, so this only releases what is already finished
+  // with.
+  if (dropTask) {
+    taskMap_.withWLock([&](auto& taskMap) { taskMap.erase(taskId); });
   }
 
-  return std::make_unique<TaskInfo>(prestoTask->info);
+  return taskInfo;
 }
 
 size_t TaskManager::cleanOldTasks() {

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -95,8 +95,20 @@ class TaskManager {
       const std::unordered_map<int64_t, std::shared_ptr<ResultRequest>>&
           resultRequests);
 
-  std::unique_ptr<protocol::TaskInfo>
-  deleteTask(const protocol::TaskId& taskId, bool abort, bool summarize);
+  /// Aborts the task and returns its final info.
+  ///
+  /// 'shouldDropTask' makes the task be dropped from 'taskMap_' before
+  /// returning, instead of being left behind for the periodic cleanOldTasks()
+  /// sweep to reclaim. Only callers that will never read from the task again
+  /// may set it.
+  /// It has no effect on a DELETE that arrives before its CREATE: the ABORTED
+  /// marker recorded for that case pins nothing and must survive so the later
+  /// CREATE still no-ops.
+  std::unique_ptr<protocol::TaskInfo> deleteTask(
+      const protocol::TaskId& taskId,
+      bool abort,
+      bool summarize,
+      bool shouldDropTask);
 
   /// Remove old Finished, Cancelled, Failed and Aborted tasks.
   /// Old is being defined by the lifetime of the task.

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -27,6 +27,11 @@ namespace facebook::presto {
 
 namespace {
 
+// Query parameter on DELETE /v1/task/<taskId> with which a client states that
+// it will never read from the task again, so the task can be released now
+// rather than left for the periodic cleanOldTasks() sweep.
+constexpr const char* kDropTaskOnDeleteUrlParam{"dropTaskOnDelete"};
+
 void sendTaskNotFound(
     proxygen::ResponseHandler* downstream,
     const protocol::TaskId& taskId) {
@@ -442,19 +447,25 @@ proxygen::RequestHandler* TaskResource::deleteTask(
         message->getQueryParam(protocol::PRESTO_ABORT_TASK_URL_PARAM) == "true";
   }
   bool summarize = message->hasQueryParam("summarize");
+  bool dropTaskOnDelete = false;
+  if (message->hasQueryParam(kDropTaskOnDeleteUrlParam)) {
+    dropTaskOnDelete =
+        message->getQueryParam(kDropTaskOnDeleteUrlParam) == "true";
+  }
   const auto sendThrift = shouldUseThrift(*message);
 
   return new http::CallbackRequestHandler(
-      [this, taskId, abort, summarize, sendThrift](
+      [this, taskId, abort, summarize, dropTaskOnDelete, sendThrift](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
             httpSrvCpuExecutor_,
-            [this, taskId, abort, downstream, summarize]() {
+            [this, taskId, abort, downstream, summarize, dropTaskOnDelete]() {
               std::unique_ptr<protocol::TaskInfo> taskInfo;
-              taskInfo = taskManager_.deleteTask(taskId, abort, summarize);
+              taskInfo = taskManager_.deleteTask(
+                  taskId, abort, summarize, dropTaskOnDelete);
               return std::move(taskInfo);
             })
             .via(

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -222,7 +222,7 @@ TEST_F(ServerOperationTest, taskEndpoint) {
 
   // Cleanup and shutdown
   for (const auto& taskId : taskIds) {
-    taskManager->deleteTask(taskId, true, true);
+    taskManager->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
   }
   taskManager->shutdown();
   connector::unregisterConnector("test-hive");

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/TaskManager.h"
+#include <folly/ScopeGuard.h>
 #include <folly/executors/ThreadedExecutor.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <string_view>
 #include "folly/synchronization/EventCount.h"
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/TaskResource.h"
@@ -22,6 +24,7 @@
 #include "presto_cpp/main/common/tests/MutableConfigs.h"
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
+#include "presto_cpp/main/http/HttpClient.h"
 #include "presto_cpp/main/operators/MaterializedOutput.h"
 #include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
@@ -264,13 +267,13 @@ class TaskManagerTest : public exec::test::OperatorTestBase,
     httpServerWrapper_ =
         std::make_unique<facebook::presto::test::HttpServerWrapper>(
             std::move(httpServer));
-    auto serverAddress = httpServerWrapper_->start().get();
+    serverAddress_ = httpServerWrapper_->start().get();
 
     taskManager_->setBaseUri(
         fmt::format(
             "http://{}:{}",
-            serverAddress.getAddressStr(),
-            serverAddress.getPort()));
+            serverAddress_.getAddressStr(),
+            serverAddress_.getPort()));
     writerFactory_ =
         dwio::common::getWriterFactory(dwio::common::FileFormat::DWRF);
   }
@@ -571,7 +574,7 @@ class TaskManagerTest : public exec::test::OperatorTestBase,
       EXPECT_TRUE(resultsOrFailures.status != nullptr);
       EXPECT_EQ(resultsOrFailures.status->state, protocol::TaskState::FAILED);
       for (const auto& taskId : allTaskIds) {
-        taskManager_->deleteTask(taskId, true, true);
+        taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
       }
     }
 
@@ -661,11 +664,44 @@ class TaskManagerTest : public exec::test::OperatorTestBase,
         taskId, updateRequest, planFragment, summarize, std::move(queryCtx), 0);
   }
 
+  // Sends DELETE /v1/task/<taskId> to the test HTTP server so that the
+  // TaskResource query parameter parsing is exercised rather than bypassed.
+  // Returns the status code for the caller to assert on: a fatal assertion
+  // here would return from this helper with 'eventBaseThread' still joinable.
+  uint16_t sendDeleteTask(
+      const protocol::TaskId& taskId,
+      std::string_view queryParams) {
+    folly::EventBase eventBase;
+    std::thread eventBaseThread([&]() { eventBase.loopForever(); });
+    const auto stopEventBase = folly::makeGuard([&]() {
+      eventBase.terminateLoopSoon();
+      eventBaseThread.join();
+    });
+    auto client = std::make_shared<http::HttpClient>(
+        &eventBase,
+        /*connPool=*/nullptr,
+        proxygen::Endpoint(
+            serverAddress_.getAddressStr(), serverAddress_.getPort(), false),
+        serverAddress_,
+        std::chrono::milliseconds(10'000),
+        std::chrono::milliseconds(10'000),
+        pool_,
+        /*sslContext=*/nullptr);
+    return http::RequestBuilder()
+        .method(proxygen::HTTPMethod::DELETE)
+        .url(fmt::format("/v1/task/{}?{}", taskId, queryParams))
+        .send(client.get())
+        .get()
+        ->headers()
+        ->getStatusCode();
+  }
+
   RowTypePtr rowType_;
   exec::test::DuckDbQueryRunner duckDbQueryRunner_;
   std::unique_ptr<TaskManager> taskManager_;
   std::unique_ptr<TaskResource> taskResource_;
   std::unique_ptr<facebook::presto::test::HttpServerWrapper> httpServerWrapper_;
+  folly::SocketAddress serverAddress_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> exchangeCpuExecutor_ =
       std::make_shared<folly::CPUThreadPoolExecutor>(1);
   std::shared_ptr<folly::IOThreadPoolExecutor> exchangeIoExecutor_ =
@@ -903,7 +939,7 @@ TEST_P(TaskManagerTest, taskCleanupWithPendingResultData) {
   std::exception e;
   taskManager_->createOrUpdateErrorTask(
       taskId, std::make_exception_ptr(e), true, 0);
-  taskManager_->deleteTask(taskId, true, true);
+  taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
   for (int i = 0; i < 10; ++i) {
     // 'results' holds a reference on the presto task which prevents the old
     // task cleanup.
@@ -1033,7 +1069,7 @@ TEST_P(TaskManagerTest, queuedTaskAbortDoesNotBlockSiblings) {
   // Simulate the coordinator aborting one task (e.g. its fragment completed on
   // other workers). This sets the task state to ABORTED but does not remove it
   // from the queue.
-  taskManager_->deleteTask(taskId1, true, false);
+  taskManager_->deleteTask(taskId1, true, false, /*shouldDropTask=*/false);
 
   // Verify task1 is aborted but task2 is still planned.
   ASSERT_EQ(prestoTask1->info.taskStatus.state, protocol::TaskState::ABORTED);
@@ -1502,10 +1538,138 @@ TEST_P(TaskManagerTest, getResultsFromFailedTask) {
   ASSERT_EQ(results->data->capacity(), 0);
 }
 
+TEST_P(TaskManagerTest, deleteTaskDropTaskOnDeleteDropsTask) {
+  const std::vector<RowVectorPtr> batches = makeVectors(1, 16);
+  const auto planFragment =
+      exec::test::PlanBuilder()
+          .values(batches)
+          .partitionedOutputArbitrary({"c0", "c1"}, GetParam())
+          .planFragment();
+
+  // Default: the aborted task is retained for cleanOldTasks() to reclaim.
+  const protocol::TaskId retainedTaskId = "eager-cleanup-task.0.0.0.0";
+  createOrUpdateTask(retainedTaskId, {}, planFragment);
+  taskManager_->deleteTask(
+      retainedTaskId, true, true, /*shouldDropTask=*/false);
+  EXPECT_EQ(taskManager_->tasks().count(retainedTaskId), 1);
+
+  // With eager cleanup the task is dropped right away.
+  const protocol::TaskId eagerTaskId = "eager-cleanup-task.0.0.1.0";
+  createOrUpdateTask(eagerTaskId, {}, planFragment);
+  taskManager_->deleteTask(eagerTaskId, true, true, /*shouldDropTask=*/true);
+  EXPECT_EQ(taskManager_->tasks().count(eagerTaskId), 0);
+}
+
+TEST_P(TaskManagerTest, deleteTaskDropTaskOnDeleteKeepsEarlyCancellation) {
+  // A DELETE arriving before its CREATE records an ABORTED marker so that the
+  // later CREATE no-ops. That marker holds no Velox Task, so eager cleanup has
+  // nothing to reclaim and must not remove it.
+  const protocol::TaskId taskId = "eager-cleanup-early.0.0.0.0";
+  taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/true);
+  ASSERT_EQ(taskManager_->tasks().count(taskId), 1);
+  EXPECT_EQ(
+      taskManager_->tasks().at(taskId)->info.taskStatus.state,
+      protocol::TaskState::ABORTED);
+}
+
+TEST_P(TaskManagerTest, deleteTaskDropTaskOnDeleteUrlParam) {
+  const std::vector<RowVectorPtr> batches = makeVectors(1, 16);
+  const auto planFragment =
+      exec::test::PlanBuilder()
+          .values(batches)
+          .partitionedOutputArbitrary({"c0", "c1"}, GetParam())
+          .planFragment();
+
+  // Sapphire Velox's DELETE carries 'dropTaskOnDelete'; TaskResource must
+  // forward it, otherwise the task is only released by the periodic sweep.
+  const protocol::TaskId eagerTaskId = "eager-cleanup-param.0.0.0.0";
+  createOrUpdateTask(eagerTaskId, {}, planFragment);
+  ASSERT_EQ(
+      sendDeleteTask(eagerTaskId, "abort=true&dropTaskOnDelete=true"),
+      http::kHttpOk);
+  EXPECT_EQ(taskManager_->tasks().count(eagerTaskId), 0);
+
+  // Without it the aborted task is retained for cleanOldTasks() to reclaim.
+  const protocol::TaskId retainedTaskId = "eager-cleanup-param.0.0.1.0";
+  createOrUpdateTask(retainedTaskId, {}, planFragment);
+  ASSERT_EQ(
+      sendDeleteTask(retainedTaskId, "abort=true&dropTaskOnDelete=false"),
+      http::kHttpOk);
+  EXPECT_EQ(taskManager_->tasks().count(retainedTaskId), 1);
+
+  // A client that does not know the parameter keeps the old behaviour.
+  const protocol::TaskId legacyTaskId = "eager-cleanup-param.0.0.2.0";
+  createOrUpdateTask(legacyTaskId, {}, planFragment);
+  ASSERT_EQ(sendDeleteTask(legacyTaskId, "abort=true"), http::kHttpOk);
+  EXPECT_EQ(taskManager_->tasks().count(legacyTaskId), 1);
+}
+
+// Eager cleanup skips the zombie check cleanOldTasks() applies, so it can drop
+// a task whose Drivers have not finished unwinding. Park a Driver inside the
+// operator to hold 'DriverCtx::task' across the delete and pin that state.
+DEBUG_ONLY_TEST_P(TaskManagerTest, dropTaskOnDeleteWithBlockedDriver) {
+  // Held by shared_ptr and captured by value: the parked Driver can still be
+  // inside the callback when TestBody() returns, so these must not live on the
+  // test's stack.
+  struct BlockState {
+    folly::EventCount enteredWait;
+    std::atomic<bool> entered{false};
+    folly::EventCount releaseWait;
+    std::atomic<bool> released{false};
+  };
+  auto block = std::make_shared<BlockState>();
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Values::getOutput",
+      std::function<void(const velox::exec::Values*)>(
+          [block](const velox::exec::Values* /*values*/) {
+            block->entered = true;
+            block->enteredWait.notifyAll();
+            block->releaseWait.await([&]() { return block->released.load(); });
+          }));
+
+  const std::vector<RowVectorPtr> batches = makeVectors(1, 1'000);
+  const auto planFragment =
+      exec::test::PlanBuilder()
+          .values(batches)
+          .partitionedOutputArbitrary({"c0", "c1"}, GetParam())
+          .planFragment();
+  const protocol::TaskId taskId = "eager-cleanup-blocked.0.0.0.0";
+  createOrUpdateTask(taskId, {}, planFragment);
+
+  // 'tasks()' returns the map by value, so this leaves no strong reference of
+  // our own to confuse the lifetime assertion below.
+  std::weak_ptr<exec::Task> weakTask = taskManager_->tasks().at(taskId)->task;
+  block->enteredWait.await([&]() { return block->entered.load(); });
+
+  taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/true);
+
+  // The task is no longer findable, but the parked Driver still owns the Velox
+  // Task, so dropping the map entry cannot free it out from under running work.
+  EXPECT_EQ(taskManager_->tasks().count(taskId), 0);
+  EXPECT_FALSE(weakTask.expired());
+
+  // A read arriving after the erase must never be told the task completed;
+  // findOrCreateTask() gives it an un-started task and it comes back empty.
+  const auto result =
+      taskManager_
+          ->getResults(
+              taskId,
+              0,
+              0,
+              protocol::DataSize("32MB"),
+              protocol::Duration("100ms"),
+              http::CallbackRequestHandlerState::create())
+          .getVia(folly::EventBaseManager::get()->getEventBase());
+  EXPECT_FALSE(result->complete);
+
+  block->released = true;
+  block->releaseWait.notifyAll();
+}
+
 TEST_P(TaskManagerTest, getResultsFromAbortedTask) {
   const protocol::TaskId taskId = "aborted-task.0.0.0.0";
   // deleting a non existing task creates an aborted task
-  taskManager_->deleteTask(taskId, true, true);
+  taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
 
   // We expect to get empty results, rather than an exception.
   const uint64_t startTimeUs = velox::getCurrentTimeMicro();
@@ -1722,7 +1886,7 @@ TEST_P(TaskManagerTest, buildSpillDirectoryFailure) {
       ASSERT_FALSE(veloxTask->spillDirectory().empty());
     }
 
-    taskManager_->deleteTask(taskId, true, true);
+    taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
     if (!buildSpillDirectoryFailure) {
       auto taskMap = taskManager_->tasks();
       ASSERT_EQ(taskMap.size(), 1);
@@ -1807,7 +1971,8 @@ TEST_P(TaskManagerTest, summarize) {
   // pipeline stats available when summarize set to false and task is finished
   ASSERT_GT(taskInfo->stats.pipelines.size(), 0);
 
-  taskInfo = taskManager_->deleteTask(taskId, true, true);
+  taskInfo =
+      taskManager_->deleteTask(taskId, true, true, /*shouldDropTask=*/false);
   // pipeline stats available when summarize set to false and task is finished
   ASSERT_GT(taskInfo->stats.pipelines.size(), 0);
 }
@@ -1880,7 +2045,7 @@ TEST_P(TaskManagerTest, duplicateCreateTaskWithMaterializedOutput) {
 
   // Clean up: remove buffer, delete task, wait for cleanup.
   operators::MaterializedOutputBuffer::removeBuffer(taskId);
-  taskManager_->deleteTask(taskId, false, false);
+  taskManager_->deleteTask(taskId, false, false, /*shouldDropTask=*/false);
   waitForAllOldTasksToBeCleaned(taskManager_.get(), 10'000'000);
 }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -95,6 +95,7 @@ import static java.util.Objects.requireNonNull;
 public class PrestoSparkHttpTaskClient
 {
     private static final String TASK_URI = "/v1/task/";
+    private static final String DROP_TASK_ON_DELETE_URL_PARAM = "dropTaskOnDelete";
     private static final Logger log = Logger.get(PrestoSparkHttpTaskClient.class);
     private final OkHttpClient httpClient;
     private final URI location;
@@ -190,10 +191,24 @@ public class PrestoSparkHttpTaskClient
         return result;
     }
 
+    /**
+     * Whether the worker should release a deleted task immediately rather than leaving it for the periodic
+     * cleanOldTasks() sweep. Only correct where nothing reads the task after the DELETE, so it is off here and
+     * opted into by the subclass whose deployment guarantees that.
+     */
+    protected boolean isDropTaskOnDeleteEnabled()
+    {
+        return false;
+    }
+
     public void deleteTask(TaskId taskId)
     {
+        HttpUrl.Builder url = HttpUrl.get(getTaskUri(taskId)).newBuilder();
+        if (isDropTaskOnDeleteEnabled()) {
+            url.addQueryParameter(DROP_TASK_ON_DELETE_URL_PARAM, "true");
+        }
         Request request = new Request.Builder()
-                .url(getTaskUri(taskId).toString())
+                .url(url.build())
                 .delete()
                 .build();
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -658,8 +658,22 @@ public class PrestoSparkNativeTaskExecutorFactory
                         terminateWithCoreTimeout));
             }
             catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+                // Spark kills a task by interrupting its thread, so this is the path a cancelled stage or a losing
+                // speculative attempt takes out of the wait above. Without completing the task here no DELETE is
+                // ever sent, and the worker keeps the task and everything it pins.
+                RuntimeException failure = new RuntimeException(e);
+                try {
+                    completeTask(false, taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec, cpuTracker);
+                }
+                catch (RuntimeException completionFailure) {
+                    // Keep the interrupt as the reported cause. A failure to complete is
+                    // secondary and would otherwise replace it, hiding why the task stopped.
+                    failure.addSuppressed(completionFailure);
+                }
+                finally {
+                    Thread.currentThread().interrupt();
+                }
+                throw failure;
             }
 
             // Reaching here marks the end of task processing

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -80,6 +80,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
@@ -103,6 +104,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
@@ -190,6 +192,27 @@ public class TestPrestoSparkHttpClient
                 new Duration(1, TimeUnit.SECONDS));
     }
 
+    private PrestoSparkHttpTaskClient createDropTaskOnDeleteWorkerClient(TestingOkHttpClient httpClient)
+    {
+        return new PrestoSparkHttpTaskClient(
+                httpClient,
+                BASE_URI,
+                TASK_INFO_JSON_CODEC,
+                PLAN_FRAGMENT_JSON_CODEC,
+                TASK_UPDATE_REQUEST_JSON_CODEC,
+                new Duration(1, TimeUnit.SECONDS),
+                scheduledExecutorService,
+                scheduledExecutorService,
+                new Duration(1, TimeUnit.SECONDS))
+        {
+            @Override
+            protected boolean isDropTaskOnDeleteEnabled()
+            {
+                return true;
+            }
+        };
+    }
+
     private PrestoSparkHttpTaskClient createWorkerClient(TestingOkHttpClient httpClient)
     {
         return new PrestoSparkHttpTaskClient(
@@ -243,6 +266,7 @@ public class TestPrestoSparkHttpClient
     {
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         AtomicInteger deleteTaskCount = new AtomicInteger();
+        AtomicReference<String> dropTaskOnDeleteParam = new AtomicReference<>();
         TestingResponseManager responseManager = new TestingResponseManager(taskId.toString())
         {
             @Override
@@ -251,16 +275,21 @@ public class TestPrestoSparkHttpClient
                 if (request.method().equalsIgnoreCase("DELETE") &&
                         request.url().encodedPath().equals(TASK_ROOT_PATH + "/" + taskId)) {
                     deleteTaskCount.incrementAndGet();
+                    dropTaskOnDeleteParam.set(request.url().queryParameter("dropTaskOnDelete"));
                 }
                 return super.createDummyResultResponse(request);
             }
         };
 
-        PrestoSparkHttpTaskClient workerClient = createWorkerClient(
-                new TestingOkHttpClient(scheduledExecutorService, responseManager));
-        workerClient.deleteTask(taskId);
+        createWorkerClient(new TestingOkHttpClient(scheduledExecutorService, responseManager)).deleteTask(taskId);
 
         assertEquals(deleteTaskCount.get(), 1);
+        assertNull(dropTaskOnDeleteParam.get());
+
+        createDropTaskOnDeleteWorkerClient(new TestingOkHttpClient(scheduledExecutorService, responseManager)).deleteTask(taskId);
+
+        assertEquals(deleteTaskCount.get(), 2);
+        assertEquals(dropTaskOnDeleteParam.get(), "true");
     }
 
     @Test
@@ -902,6 +931,7 @@ public class TestPrestoSparkHttpClient
         queryConfig.setRemoteTaskMaxErrorDuration(new Duration(1, TimeUnit.MINUTES));
         List<TaskSource> sources = new ArrayList<>();
         AtomicInteger deleteTaskCount = new AtomicInteger();
+        AtomicReference<String> dropTaskOnDeleteParam = new AtomicReference<>();
         TestingResponseManager responseManager = new TestingResponseManager(taskId.toString(),
                 new TimeoutResponseManager(0, 10, 0))
         {
@@ -911,6 +941,7 @@ public class TestPrestoSparkHttpClient
                 if (request.method().equalsIgnoreCase("DELETE") &&
                         request.url().encodedPath().equals(TASK_ROOT_PATH + "/" + taskId)) {
                     deleteTaskCount.incrementAndGet();
+                    dropTaskOnDeleteParam.set(request.url().queryParameter("dropTaskOnDelete"));
                 }
                 return super.createDummyResultResponse(request);
             }
@@ -956,6 +987,7 @@ public class TestPrestoSparkHttpClient
 
             task.stop(true);
             assertEquals(deleteTaskCount.get(), 1);
+            assertNull(dropTaskOnDeleteParam.get());
         }
         catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
Summary:

## Problem

When a Presto-on-Spark task finishes, the native worker aborts the Velox task but deliberately leaves the `PrestoTask` in `taskMap_`, so a late `getResults` can still read it. Reclamation is deferred to the periodic `cleanOldTasks()` sweep.

The sweep does not reliably take it back. It counts a task with any live `Driver` reference as a zombie and skips the erase, and every live `Driver` holds a strong `shared_ptr<Task>` through `DriverCtx::task`. A task whose drivers have not finished unwinding is therefore one the sweep structurally declines to reclaim, not one it reclaims later. Each retained task pins a `Task`, its `QueryCtx` and that query's root memory pool for the life of the worker process.

## Change

The Spark task knows when it is done with a native task, so it now says so:

- `PrestoSparkHttpTaskClient.deleteTask` adds a `dropTaskOnDelete` query parameter when the new `protected boolean isDropTaskOnDeleteEnabled()` returns true. The base returns `false`, so OSS Presto-on-Spark sends a byte-identical request to today.
- `TaskResource::deleteTask` parses that parameter the way it already parses `abort` and `summarize`, and forwards it.
- `TaskManager::deleteTask` takes `shouldDropTask` and erases the task from `taskMap_` when set. Unlike the sweep, this erase is unconditional. The parameter is required rather than defaulted, so every caller states its intent; adding it surfaced two existing callers that had been silently taking the old behaviour.

The erase applies only where a Velox task existed. A DELETE arriving before its CREATE records an ABORTED marker that pins nothing, and erasing it would let the later CREATE start the task the client just cancelled.

Nothing here turns the parameter on. The opt-in is one `Override` in a subclass, in the diff stacked on top of this one.

## Also fixed

`PrestoSparkNativeTaskExecutorFactory.computeNext()` waits on `taskFinishedOrHasResult`. Spark cancels a task by interrupting its thread, so a cancelled stage or a losing speculative attempt left through `catch (InterruptedException)`, which rethrew without calling `completeTask` while the `RuntimeException` arm above it did — meaning no DELETE was ever sent. That path now completes the task, with the interrupt flag restored unconditionally and the original `InterruptedException` preserved as the thrown cause.

## Safety

Dropping the map reference cannot free anything in use: every reference on the path is a `shared_ptr`, and the Velox `Task` stays alive while any `Driver` holds it. A lookup arriving after the erase does not see null — `findOrCreateTask()` fabricates a fresh `PrestoTask`, so the worst case is a task-level error and a retry. `createCompleteResult` is returned only once the task reaches `kFinished`, so no path here can silently truncate output.

Differential Revision: D116106936

## Release Notes

```
== NO RELEASE NOTE ==
```