### PR TITLE
fix(native): Prevent timezone lookup failures in Ubuntu runtime

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -45,6 +45,13 @@ FROM ${BASE_IMAGE}
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
 
+RUN if command -v apt-get > /dev/null 2>&1; then \
+        apt-get update \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            tzdata \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/
 COPY --chmod=0755 ./etc /opt/presto-server/etc


### PR DESCRIPTION
On Ubuntu-based Prestissimo workers, even `SELECT 1 = 1` fails with `discover_tz_dir failed to find zoneinfo`. The runtime image has no timezone database for Velox to load.

The runtime stage now installs `tzdata` when its base provides `apt-get`. The default CentOS Stream 9 path is unchanged because it already contains `/usr/share/zoneinfo`.

Closes https://github.com/prestodb/presto/issues/25531.

The same packaging gap was fixed downstream in https://github.com/y-scope/presto/pull/26 and later restored in https://github.com/y-scope/presto/pull/154.

## Testing

The probe compiles `__libcpp_tzdb_directory()` from Velox commit `b7be48aaa3a1300cbc2099d42d244ec42511297d`, the submodule pinned by Presto master. The timezone lookup reached by the failing basic query errors in the current Ubuntu runtime and returns `/usr/share/zoneinfo` with this change.

<details>
<summary>Self-contained probe and raw logs</summary>

```bash
$ curl -fsSL \
    https://raw.githubusercontent.com/facebookincubator/velox/b7be48aaa3a1300cbc2099d42d244ec42511297d/velox/external/tzdb/tzdb.cpp \
    -o tzdb.cpp
$ {
    cat <<'CPP'
#include <sys/stat.h>
#include <unistd.h>
#include <cstdlib>
#include <iostream>
#include <stdexcept>
#include <string>
#define CONSTDATA constexpr
namespace facebook::velox::tzdb {
CPP
    sed -n '/std::string __libcpp_tzdb_directory()/,/^}/p' tzdb.cpp
    cat <<'CPP'
}
int main() {
  try {
    std::cout << facebook::velox::tzdb::__libcpp_tzdb_directory() << '\n';
    return 0;
  } catch (const std::exception& error) {
    std::cerr << error.what();
    return 1;
  }
}
CPP
  } > probe.cpp
```

Both images compile that probe in an Ubuntu build stage and copy it into a bare `ubuntu:22.04` runtime stage. The second image includes the exact `RUN` block from this PR.

```dockerfile
# Dockerfile.before
FROM ubuntu:22.04 AS build
RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y g++
COPY probe.cpp /
RUN g++ -std=c++20 /probe.cpp -o /tzdb-probe
FROM ubuntu:22.04
COPY --from=build /tzdb-probe /
ENTRYPOINT ["/tzdb-probe"]
```

```dockerfile
# Dockerfile.after
FROM ubuntu:22.04 AS build
RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y g++
COPY probe.cpp /
RUN g++ -std=c++20 /probe.cpp -o /tzdb-probe
FROM ubuntu:22.04
RUN if command -v apt-get > /dev/null 2>&1; then \
        apt-get update \
        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
            tzdata \
        && rm -rf /var/lib/apt/lists/*; \
    fi
COPY --from=build /tzdb-probe /
ENTRYPOINT ["/tzdb-probe"]
```

```dockerfile
# Dockerfile.centos
FROM quay.io/centos/centos:stream9
RUN if command -v apt-get > /dev/null 2>&1; then \
        apt-get update \
        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
            tzdata \
        && rm -rf /var/lib/apt/lists/*; \
    fi
RUN test ! -e /usr/bin/apt-get && test -d /usr/share/zoneinfo
```

```console
$ docker build -q -f Dockerfile.before -t presto-25531-before .
$ docker run --rm presto-25531-before
discover_tz_dir failed to find zoneinfo
$ echo $?
1

$ docker build -q -f Dockerfile.after -t presto-25531-after .
$ docker run --rm presto-25531-after
/usr/share/zoneinfo
$ echo $?
0

$ docker build -q -f Dockerfile.centos -t presto-25531-centos-check .
$ docker run --rm presto-25531-centos-check /bin/sh -c \
    'printf "apt-get="; command -v apt-get || printf "absent\n"; test -d /usr/share/zoneinfo; printf "zoneinfo=/usr/share/zoneinfo\n"'
apt-get=absent
zoneinfo=/usr/share/zoneinfo
```

</details>

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix Ubuntu-based worker images failing queries because timezone data is unavailable.
```
