### PR TITLE
chore(ci): Advance velox

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -225,7 +225,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-build-test-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -128,7 +128,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -253,7 +253,7 @@ jobs:
         storage-format: [PARQUET, DWRF]
         enable-sidecar: [true, false]
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -382,7 +382,7 @@ jobs:
       group: ${{ github.workflow }}-prestocpp-linux-presto-on-spark-e2e-tests-${{ matrix.storage-format }}-${{ matrix.enable-sidecar }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -495,7 +495,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -607,7 +607,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.299-202607281131-55ac7c49
+      image: prestodb/presto-native-dependency:0.300-202608311415-6d54ae18
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/czentgr/velox.git

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -195,31 +195,23 @@ find_package(OpenSSL REQUIRED)
 
 find_package(Sodium REQUIRED)
 find_library(PROXYGEN proxygen)
-find_library(PROXYGEN_HTTP_SERVER proxygenhttpserver)
+find_library(PROXYGEN_HTTPSERVER proxygen_httpserver)
 find_library(FIZZ fizz)
 find_library(WANGLE wangle)
-find_library(MVFST_EXCEPTION mvfst_exception)
-find_library(MVFST_FOLLY_UTILS mvfst_folly_utils)
-find_library(MVFST_CODEC_TYPES mvfst_codec_types)
-find_library(MVFST_CONTIGUOUS_CURSOR mvfst_contiguous_cursor)
-
+find_library(MVFST mvfst)
 find_library(RE2 re2)
-
 find_package(fizz CONFIG)
 find_package(wangle CONFIG)
-find_package(FBThrift)
+find_package(FBThrift CONFIG REQUIRED)
 include_directories(SYSTEM ${FBTHRIFT_INCLUDE_DIR})
 
 set(
   PROXYGEN_LIBRARIES
-  ${PROXYGEN_HTTP_SERVER}
+  ${PROXYGEN_HTTPSERVER}
   ${PROXYGEN}
   ${WANGLE}
   ${FIZZ}
-  ${MVFST_EXCEPTION}
-  ${MVFST_FOLLY_UTILS}
-  ${MVFST_CODEC_TYPES}
-  ${MVFST_CONTIGUOUS_CURSOR}
+  ${MVFST}
 )
 find_path(PROXYGEN_DIR NAMES include/proxygen)
 set(PROXYGEN_INCLUDE_DIR "${PROXYGEN_DIR}/include/")

--- a/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
@@ -11,15 +11,6 @@
 # limitations under the License.
 
 find_program(THRIFT1 thrift1)
-find_library(THRIFTCPP2 thriftcpp2)
-find_library(THRIFT_CORE thrift-core)
-find_library(THRIFT_PROTOCOL thriftprotocol)
-find_library(THRIFT_METADATA thriftmetadata)
-find_library(THRIFT_TRANSPORT transport)
-find_library(THRIFT_ASYNC async)
-find_library(THRIFT_RPC_METADATA rpcmetadata)
-find_library(THRIFT_TYPEREP thrifttyperep)
-
 find_path(THRIFT_INCLUDES thrift/lib/cpp2/gen/module_data_h.h PATH_SUFFIXES include REQUIRED)
 
 # In the CI /opt/homebrew/include is not included and it leads to missing
@@ -28,17 +19,7 @@ if(APPLE AND EXISTS "/opt/homebrew")
   include_directories(SYSTEM /opt/homebrew/include)
 endif()
 
-set(
-  presto_thrift_library_dependencies
-  ${THRIFT_PROTOCOL}
-  ${THRIFT_METADATA}
-  ${THRIFT_CORE}
-  ${THRIFT_TYPEREP}
-  ${THRIFT_ASYNC}
-  ${THRIFT_TRANSPORT}
-  ${THRIFT_RPC_METADATA}
-  ${FOLLY_WITH_DEPENDENCIES}
-)
+set(presto_thrift_library_dependencies FBThrift::thriftcpp2 ${FOLLY_WITH_DEPENDENCIES})
 
 include(ThriftLibrary.cmake)
 

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -34,8 +34,6 @@ COPY velox/scripts /velox/scripts
 COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /velox
 COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /velox
 ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
-COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
-ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 # from https://github.com/facebookincubator/velox/pull/18470
 COPY velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /velox
 ENV VELOX_OPENZL_CMAKE_PATCH=/velox/openzl-cxx-standard.patch

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -39,8 +39,6 @@ COPY velox/CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /vel
 ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testing-boost.patch"
 COPY CMake/arrow/arrow-flight.patch /scripts
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
-COPY velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /velox
-ENV VELOX_FBTHRIFT_CMAKE_PATCH=/velox/compactv1-protocol-refiller.patch
 # from https://github.com/facebookincubator/velox/pull/18470
 COPY velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /velox
 ENV VELOX_OPENZL_CMAKE_PATCH=/velox/openzl-cxx-standard.patch

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -55,7 +55,7 @@ function install_gperf {
 
 function install_proxygen {
   wget_and_untar https://github.com/facebook/proxygen/archive/refs/tags/${FB_OS_VERSION}.tar.gz proxygen
-  cmake_install_dir proxygen -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
+  cmake_install_dir proxygen -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_datasketches {

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -38,7 +38,7 @@ function install_presto_deps_from_brew {
 
 function install_proxygen {
   wget_and_untar https://github.com/facebook/proxygen/archive/refs/tags/${FB_OS_VERSION}.tar.gz proxygen
-  cmake_install_dir proxygen -DBUILD_TESTS=OFF
+  cmake_install_dir proxygen -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_gperf {

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -26,7 +26,7 @@ function install_proxygen {
   ${SUDO} apt update
   ${SUDO} apt install -y gperf python3 libc-ares-dev
   wget_and_untar https://github.com/facebook/proxygen/archive/refs/tags/${FB_OS_VERSION}.tar.gz proxygen
-  cmake_install_dir proxygen -DBUILD_TESTS=OFF
+  cmake_install_dir proxygen -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_datasketches {


### PR DESCRIPTION
Advances the Velox submodule from `b7be48aaa3` to `aa63768200` (15 commits).

The range pulls in FBOS `v2026.07.13.00` (facebookincubator/velox#18194), which deletes `CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch`. Both native dependency dockerfiles `COPY` that patch out of the submodule, so the `COPY` (and the now-unused `VELOX_FBTHRIFT_CMAKE_PATCH`) is removed here to keep the dependency image build green.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Advance Velox and update native dependency integration for the newer FBOS release.

Bug Fixes:
- Update native dependency images and build configuration to remain compatible with the advanced Velox and FBOS dependencies.

Enhancements:
- Advance the Velox submodule and align Proxygen, MVFST, and FBThrift integration with the updated dependency layout.
- Build Proxygen statically across supported dependency setup scripts.
- Remove the obsolete FBThrift compact protocol patch from native dependency image builds.

Build:
- Update native dependency Docker images used by CI workflows.