### PR TITLE
fix(docs): Resolve remaining docs warnings

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -428,7 +428,7 @@ to make the query plan easier to read.
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.optimize-hash-generation\`\``.
 
 ``rewrite_approx_distinct_if_to_mask``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -940,7 +940,7 @@ to make the query plan easier to read.
 The corresponding session property is :ref:`admin/properties-session:\`\`optimize_hash_generation\`\``.
 
 ``optimizer.rewrite-approx-distinct-if-to-mask``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -193,8 +193,8 @@ For example, if the base URL is ``http://localhost:8080`` and you have a
 function ``my_schema.my_function``, the endpoint would be:
 ``http://localhost:8080/v1/functions/my_schema/my_function/...``
 
-``remote-function-server.serde``
-""""""""""""""""""""""""""""""""
+``remote-function-server.serde`` (rest)
+"""""""""""""""""""""""""""""""""""""""
 
 * **Type:** ``string``
 * **Default value:** ``"presto_page"``


### PR DESCRIPTION
## Description
The PR fixes the following warnings including recently introduced:
```
./presto-docs/src/main/sphinx/admin/properties.rst:943: WARNING: Title underline too short.

``optimizer.rewrite-approx-distinct-if-to-mask``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
./presto-docs/src/main/sphinx/admin/properties.rst:943: WARNING: Title underline too short.
                                                   
``optimizer.rewrite-approx-distinct-if-to-mask``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
./presto-docs/src/main/sphinx/admin/properties-session.rst:431: WARNING: Title underline too short.

``rewrite_approx_distinct_if_to_mask``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
./presto-docs/src/main/sphinx/admin/properties-session.rst:431: WARNING: Title underline too short.

``rewrite_approx_distinct_if_to_mask``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]



./presto-docs/src/main/sphinx/presto_cpp/features.rst:197: WARNING: duplicate label presto_cpp/features:``remote-function-server.serde``, other instance in ./presto-docs/src/main/sphinx/presto_cpp/features.rst [autosectionlabel.presto_cpp/features]
```

## Motivation and Context
Reduce the number of warnings during the documentation build process.

## Impact
_No_

## Test Plan
Build the documentation and check there are no warnings.
```shell
make clean html SPHINXOPTS=""
```
Before changes: `build succeeded, 5 warnings.`
After changes: `build succeeded.`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix remaining documentation build warnings.

Bug Fixes:
- Resolve Sphinx documentation warnings caused by undersized property-title underlines and a duplicate C++ feature label.

Documentation:
- Clean up documentation markup and labels so the HTML documentation builds without warnings.

Tests:
- Verify the documentation build completes successfully with no warnings.