### PR TITLE
chore: Add @pgupta2 (Arjun Gupta) and @singcha (Chandrashekhar Kumar Singh) as module committers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -119,16 +119,16 @@ CODEOWNERS @prestodb/team-tsc
 
 #####################################################################
 # Prestissimo module
-/presto-native-execution @prestodb/team-velox @prestodb/committers
+/presto-native-execution @pgupta2 @singcha @prestodb/team-velox @prestodb/committers
 /presto-native-sidecar-plugin @pdabre12 @kevintang2022 @prestodb/team-velox @prestodb/committers
-/presto-native-tests @prestodb/team-velox @prestodb/committers
+/presto-native-tests @pgupta2 @singcha @prestodb/team-velox @prestodb/committers
 /presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java  @prestodb/team-velox @prestodb/committers
 /.github/workflows/prestocpp-* @prestodb/team-velox @prestodb/committers
 
 #####################################################################
 # Presto on Spark module
-/presto-spark* @shrinidhijoshi @prestodb/committers
-/presto-native-execution/*/com/facebook/presto/spark/* @shrinidhijoshi @prestodb/committers
+/presto-spark* @shrinidhijoshi @pgupta2 @singcha @prestodb/committers
+/presto-native-execution/*/com/facebook/presto/spark/* @shrinidhijoshi @pgupta2 @singcha @prestodb/committers
 
 #####################################################################
 # Presto connectors and plugins


### PR DESCRIPTION
The TSC voted and approved @pgupta2 and @singcha to be module committers for the native execution (Prestissimo) and Presto on Spark modules. Updating the codeowner file to reflect that.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Recognize the new module committers and update repository ownership assignments accordingly.

Enhancements:
- Add Arjun Gupta and Chandrashekhar Kumar Singh as module committers for native execution and Presto on Spark ownership areas.

Chores:
- Update CODEOWNERS to reflect the new module committers.