### PR TITLE
[WIP] feat(iceberg): Add support for the V3 unknown type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/mohsaka/velox.git

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2999,6 +2999,8 @@ Map of Iceberg types to the relevant PrestoDB types:
     - ``ROW``
   * - ``GEOMETRY``
     - ``GEOMETRY``
+  * - ``UNKNOWN``
+    - ``UNKNOWN``
 
 
 No other types are supported.
@@ -3050,9 +3052,50 @@ Map of PrestoDB types to the relevant Iceberg types:
     - ``MAP``
   * - ``ROW``
     - ``STRUCT``
+  * - ``UNKNOWN``
+    - ``UNKNOWN``
 
 
 No other types are supported.
+
+Unknown type (Iceberg V3)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Iceberg Format Version 3 adds the ``unknown`` type, for a column whose type is not known. Such a
+column only ever holds null values: it is always optional, is not stored in the data files, and
+always reads back as ``NULL``.
+
+A column of this type can be declared in ``CREATE TABLE``, ``ALTER TABLE ADD COLUMN``, and
+``CREATE TABLE AS SELECT``::
+
+    CREATE TABLE iceberg.web.page_views (view_time TIMESTAMP, extra UNKNOWN) WITH ("format-version" = '3');
+
+    ALTER TABLE iceberg.web.page_views ADD COLUMN more UNKNOWN;
+
+    CREATE TABLE iceberg.web.page_view_copy WITH ("format-version" = '3') AS SELECT view_time, NULL AS extra FROM iceberg.web.page_views;
+
+``INSERT`` statements can write ``NULL`` to an ``unknown`` column or leave the column out entirely.
+Writing any other value is an error, because the value cannot be stored.
+
+An ``unknown`` field of a ``ROW`` behaves the same way, at any depth and inside an ``ARRAY`` or a
+``MAP``: the field is left out of the data file, and the other fields of the row are written and read
+back as usual::
+
+    CREATE TABLE iceberg.web.sessions (session_id BIGINT, page ROW(url VARCHAR, extra UNKNOWN)) WITH ("format-version" = '3');
+
+    INSERT INTO iceberg.web.sessions VALUES (1, ROW('http://example.com', NULL));
+
+**Restrictions:**
+
+* The table must use Iceberg format version 3 or higher.
+* An ``unknown`` column cannot be declared ``NOT NULL``.
+* An ``unknown`` column can be partitioned by ``identity`` and can be sorted on, but it cannot be
+  bucketed, because Iceberg defines no hash for it.
+* Writing a value that has nothing left to store is not supported, because a data file needs
+  something to store for every value: an ``ARRAY(UNKNOWN)``, a ``MAP`` whose keys or values are
+  ``unknown``, a ``ROW`` whose fields are all ``unknown``, and a table whose columns are all
+  ``unknown``. Such a table can be created and read.
+* Type promotion from ``unknown`` to another type is not supported.
 
 
 Sorted Tables

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.UNKNOWN_COLUMN_TYPE;
 import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.REPEATABLE_READ;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -117,7 +118,7 @@ public class IcebergConnector
     @Override
     public Set<ConnectorCapabilities> getCapabilities()
     {
-        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT, UNKNOWN_COLUMN_TYPE);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -70,6 +70,10 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWri
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterVersion;
 import static com.facebook.presto.iceberg.TypeConverter.toOrcType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.facebook.presto.iceberg.UnknownFields.fileSchema;
+import static com.facebook.presto.iceberg.UnknownFields.isUnknownType;
+import static com.facebook.presto.iceberg.UnknownFields.pagePruner;
+import static com.facebook.presto.iceberg.UnknownFields.validateWritable;
 import static com.facebook.presto.iceberg.util.PrimitiveTypeMapBuilder.makeTypeMap;
 import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
@@ -118,6 +122,8 @@ public class IcebergFileWriterFactory
             FileFormat fileFormat,
             MetricsConfig metricsConfig)
     {
+        validateWritable(icebergSchema);
+
         switch (fileFormat) {
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext, metricsConfig);
@@ -136,10 +142,11 @@ public class IcebergFileWriterFactory
             HdfsContext hdfsContext,
             MetricsConfig metricsConfig)
     {
-        List<String> fileColumnNames = icebergSchema.columns().stream()
+        Schema fileSchema = fileSchema(icebergSchema);
+        List<String> fileColumnNames = fileSchema.columns().stream()
                 .map(Types.NestedField::name)
                 .collect(toImmutableList());
-        List<Type> fileColumnTypes = icebergSchema.columns().stream()
+        List<Type> fileColumnTypes = fileSchema.columns().stream()
                 .map(column -> toPrestoType(column.type(), typeManager))
                 .collect(toImmutableList());
 
@@ -162,10 +169,11 @@ public class IcebergFileWriterFactory
                     rollbackAction,
                     fileColumnNames,
                     fileColumnTypes,
-                    convert(icebergSchema, "table"),
+                    convert(fileSchema, "table"),
                     makeTypeMap(fileColumnTypes, fileColumnNames),
                     parquetWriterOptions,
-                    IntStream.range(0, fileColumnNames.size()).toArray(),
+                    fileInputColumnIndexes(icebergSchema),
+                    pagePruner(icebergSchema, typeManager),
                     getCompressionCodec(session).getParquetCompressionCodec(),
                     outputPath,
                     hdfsEnvironment,
@@ -193,7 +201,8 @@ public class IcebergFileWriterFactory
                 return null;
             };
 
-            List<Types.NestedField> columnFields = icebergSchema.columns();
+            Schema fileSchema = fileSchema(icebergSchema);
+            List<Types.NestedField> columnFields = fileSchema.columns();
             List<String> fileColumnNames = columnFields.stream()
                     .map(Types.NestedField::name)
                     .collect(toImmutableList());
@@ -223,13 +232,13 @@ public class IcebergFileWriterFactory
             }
 
             return new IcebergOrcFileWriter(
-                    icebergSchema,
+                    fileSchema,
                     orcDataSink,
                     rollbackAction,
                     ORC,
                     fileColumnNames,
                     fileColumnTypes,
-                    toOrcType(icebergSchema),
+                    toOrcType(fileSchema),
                     getCompressionCodec(session).getOrcCompressionKind(),
                     orcFileWriterConfig
                             .toOrcWriterOptionsBuilder()
@@ -241,7 +250,8 @@ public class IcebergFileWriterFactory
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .build(),
-                    IntStream.range(0, fileColumnNames.size()).toArray(),
+                    fileInputColumnIndexes(icebergSchema),
+                    pagePruner(icebergSchema, typeManager),
                     ImmutableMap.<String, String>builder()
                             .put(PRESTO_VERSION_NAME, nodeVersion.toString())
                             .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
@@ -256,5 +266,17 @@ public class IcebergFileWriterFactory
         catch (IOException e) {
             throw new PrestoException(ICEBERG_WRITER_OPEN_ERROR, "Error creating ORC file", e);
         }
+    }
+
+    /**
+     * The input channel each file column is written from. Channels of columns that are not stored in
+     * the data file are left out, so that the writers do not read them.
+     */
+    private static int[] fileInputColumnIndexes(Schema icebergSchema)
+    {
+        List<Types.NestedField> columns = icebergSchema.columns();
+        return IntStream.range(0, columns.size())
+                .filter(channel -> !isUnknownType(columns.get(channel).type()))
+                .toArray();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.Page;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.OrcFileWriter;
@@ -47,6 +48,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static com.google.common.base.Verify.verify;
@@ -61,6 +63,7 @@ public class IcebergOrcFileWriter
 {
     private final Schema icebergSchema;
     private final List<OrcType> orcColumn;
+    private final Optional<UnaryOperator<Page>> pagePruner;
 
     public IcebergOrcFileWriter(
             Schema icebergSchema,
@@ -73,6 +76,7 @@ public class IcebergOrcFileWriter
             CompressionKind compression,
             OrcWriterOptions options,
             int[] fileInputColumnIndexes,
+            Optional<UnaryOperator<Page>> pagePruner,
             Map<String, String> metadata,
             ZoneId hiveStorageTimeZone,
             Optional<Supplier<OrcDataSource>> validationInputFactory,
@@ -84,6 +88,13 @@ public class IcebergOrcFileWriter
         super(dataSink, rollbackAction, orcEncoding, columnNames, fileColumnTypes, Optional.ofNullable(fileColumnOrcTypes), compression, options, fileInputColumnIndexes, metadata, hiveStorageTimeZone, validationInputFactory, validationMode, stats, dwrfEncryptionProvider, dwrfWriterEncryption);
         this.icebergSchema = requireNonNull(icebergSchema, "icebergSchema is null");
         this.orcColumn = fileColumnOrcTypes;
+        this.pagePruner = requireNonNull(pagePruner, "pagePruner is null");
+    }
+
+    @Override
+    public void appendRows(Page dataPage)
+    {
+        super.appendRows(pagePruner.map(pruner -> pruner.apply(dataPage)).orElse(dataPage));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -162,6 +162,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTa
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.facebook.presto.iceberg.UnknownFieldTypes.readType;
 import static com.facebook.presto.iceberg.delete.EqualityDeleteFilter.readEqualityDeletes;
 import static com.facebook.presto.iceberg.delete.PositionDeleteFilter.readPositionDeletes;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -339,6 +340,19 @@ public class IcebergPageSourceProvider
                     }
                     nextStart += block.getRowCount();
                 }
+                else if (block.getColumns().isEmpty()) {
+                    // Zero-column row group from an all-UNKNOWN Iceberg V3 table. There is no
+                    // data page offset to use for split-range filtering; the file has no data
+                    // pages so it always falls within the single split covering the full file.
+                    blocks.add(block);
+                    blockIndexStores.add(null);
+                    blockStarts.add(nextStart);
+                    if (!startRowPosition.isPresent()) {
+                        startRowPosition = Optional.of(nextStart);
+                    }
+                    endRowPosition = Optional.of(nextStart + block.getRowCount());
+                    nextStart += block.getRowCount();
+                }
             }
 
             MessageColumnIO messageColumnIO = getColumnIO(fileSchema, requestedSchema);
@@ -400,7 +414,7 @@ public class IcebergPageSourceProvider
                         if (!parquetField.get().isPrimitive()) {
                             MessageType parquetMessageType = new MessageType("", parquetField.get());
                             Schema icebergSchema = ParquetSchemaUtil.convert(parquetMessageType);
-                            type = toPrestoType(icebergSchema.columns().get(0).type(), typeManager);
+                            type = readType(column.getType(), toPrestoType(icebergSchema.columns().get(0).type(), typeManager));
                         }
                         internalFields.add(constructField(type, lookupColumnByName(messageColumnIO, AvroSchemaUtil.makeCompatibleName(parquetField.get().getName()))));
                     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergParquetFileWriter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergParquetFileWriter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
@@ -29,7 +30,10 @@ import org.joda.time.DateTimeZone;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +45,12 @@ public class IcebergParquetFileWriter
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
     private final MetricsConfig metricsConfig;
+    private final Optional<UnaryOperator<Page>> pagePruner;
+    // When the file schema has no columns (all-UNKNOWN table), ParquetUtil.fileMetrics
+    // fails because the Parquet library's MetadataConverter cannot read a zero-column
+    // footer. Track the row count directly so we can return accurate Metrics in that case.
+    private final boolean zeroColumnSchema;
+    private final AtomicLong rowCount = new AtomicLong();
 
     public IcebergParquetFileWriter(
             OutputStream outputStream,
@@ -51,6 +61,7 @@ public class IcebergParquetFileWriter
             Map<List<String>, Type> primitiveTypes,
             ParquetWriterOptions parquetWriterOptions,
             int[] fileInputColumnIndexes,
+            Optional<UnaryOperator<Page>> pagePruner,
             CompressionCodecName compressionCodecName,
             Path outputPath,
             HdfsEnvironment hdfsEnvironment,
@@ -74,11 +85,28 @@ public class IcebergParquetFileWriter
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
         this.metricsConfig = requireNonNull(metricsConfig, "metricsConfig is null");
+        this.pagePruner = requireNonNull(pagePruner, "pagePruner is null");
+        this.zeroColumnSchema = fileColumnNames.isEmpty();
+    }
+
+    @Override
+    public void appendRows(Page dataPage)
+    {
+        super.appendRows(pagePruner.map(pruner -> pruner.apply(dataPage)).orElse(dataPage));
+        if (zeroColumnSchema) {
+            rowCount.addAndGet(dataPage.getPositionCount());
+        }
     }
 
     @Override
     public Metrics getMetrics()
     {
+        if (zeroColumnSchema) {
+            // ParquetUtil.fileMetrics fails on a zero-column Parquet file because the Parquet
+            // library's MetadataConverter requires at least one schema element. Return just the
+            // row count; there are no column statistics to report for an all-UNKNOWN table.
+            return new Metrics(rowCount.get(), null, null, null, null);
+        }
         return hdfsEnvironment.doAs(hdfsContext.getIdentity().getUser(), () -> ParquetUtil.fileMetrics(new HdfsInputFile(outputPath, hdfsEnvironment, hdfsContext), metricsConfig));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -170,6 +170,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.isMergeOnRead
 import static com.facebook.presto.iceberg.IcebergTableProperties.getWriteDataLocation;
 import static com.facebook.presto.iceberg.IcebergTableProperties.isHiveLocksEnabled;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
+import static com.facebook.presto.iceberg.UnknownFields.isUnknownType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
@@ -202,6 +203,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.hadoop.hive.serde.serdeConstants.VOID_TYPE_NAME;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED;
@@ -533,6 +535,12 @@ public final class IcebergUtil
         // Special handling for GEOMETRY type: geometry stored as well-known binary in iceberg
         if (icebergType.typeId() == org.apache.iceberg.types.Type.TypeID.GEOMETRY) {
             return HiveType.HIVE_BINARY.toString();
+        }
+
+        // Iceberg's HiveSchemaUtil cannot convert the V3 `unknown` type. Hive's `void` is
+        // its all-null type and is what Spark records for NullType, so use it here as well.
+        if (isUnknownType(icebergType)) {
+            return VOID_TYPE_NAME;
         }
 
         if (icebergType.isPrimitiveType()) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BOOLEAN;
@@ -90,6 +91,7 @@ import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListType
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getMapTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getStructTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getVarcharTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.voidTypeInfo;
 
 public final class TypeConverter
 {
@@ -134,6 +136,12 @@ public final class TypeConverter
                 return VarcharType.createUnboundedVarcharType();
             case UUID:
                 return UuidType.UUID;
+            case UNKNOWN:
+                // The Iceberg V3 `unknown` type is always optional, is never stored in data
+                // files, and always reads back as null. Presto's UNKNOWN type has the same
+                // semantics, and is what Iceberg's Spark integration maps `unknown` to
+                // (Spark's NullType).
+                return UNKNOWN;
             case LIST:
                 Types.ListType listType = (Types.ListType) type;
                 return new ArrayType(toPrestoType(listType.elementType(), typeManager));
@@ -227,6 +235,9 @@ public final class TypeConverter
         }
         if (type instanceof UuidType) {
             return Types.UUIDType.get();
+        }
+        if (UNKNOWN.equals(type)) {
+            return Types.UnknownType.get();
         }
         throw new PrestoException(NOT_SUPPORTED, "Type not supported for Iceberg: " + type.getDisplayName());
     }
@@ -366,6 +377,13 @@ public final class TypeConverter
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;
             return new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
+        }
+        if (UNKNOWN.equals(type)) {
+            // Hive has no equivalent of the Iceberg V3 `unknown` type, but `void` is its
+            // all-null type and is what Spark records for NullType. Values are never read
+            // from or written to a file for an `unknown` column, so this type only ever
+            // describes an all-null column.
+            return voidTypeInfo;
         }
         if (isArrayType(type)) {
             TypeInfo elementType = toHiveTypeInfo(type.getTypeParameters().get(0));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnknownFieldTypes.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnknownFieldTypes.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.RowType.Field;
+import com.facebook.presto.common.type.Type;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+
+/**
+ * The Presto types of a table that has fields of type {@code unknown}. A data file never stores such
+ * a field, so the type a file has is the type the table has without those fields, and the reader has
+ * to add them back to what it reads.
+ *
+ * @see UnknownFields for the Iceberg schema and the values written to a file
+ */
+public final class UnknownFieldTypes
+{
+    private UnknownFieldTypes() {}
+
+    /**
+     * Whether the type is, or holds, the {@code unknown} type. The Hive types the readers convert
+     * through have no equivalent of it, so a type that holds it has to be passed around as is.
+     */
+    public static boolean hasUnknownType(Type type)
+    {
+        if (type.equals(UNKNOWN)) {
+            return true;
+        }
+        return type.getTypeParameters().stream().anyMatch(UnknownFieldTypes::hasUnknownType);
+    }
+
+    /**
+     * The type to read a column with, given the type it has in the table and the type it has in the
+     * data file. A file leaves out the {@code unknown} fields of a row, so the type the file has is
+     * the type the table has without them, and reading with the table type is what fills them back in
+     * with nulls.
+     *
+     * <p>Any other difference between the two types, such as a field added to a row after the file was
+     * written, is left alone: the file type is what the reader has always been given for those.
+     */
+    static Type readType(Type tableType, Type fileType)
+    {
+        return isTableTypeWithoutUnknownFields(fileType, tableType) ? tableType : fileType;
+    }
+
+    /**
+     * Whether the file type is the table type with its {@code unknown} fields left out, and so differs
+     * from it in nothing else.
+     */
+    private static boolean isTableTypeWithoutUnknownFields(Type fileType, Type tableType)
+    {
+        if (tableType instanceof RowType && fileType instanceof RowType) {
+            List<Field> tableFields = ((RowType) tableType).getFields();
+            List<Field> fileFields = ((RowType) fileType).getFields();
+            int fileField = 0;
+            for (Field field : tableFields) {
+                if (field.getType().equals(UNKNOWN)) {
+                    continue;
+                }
+                if (fileField >= fileFields.size() ||
+                        !hasSameName(field, fileFields.get(fileField)) ||
+                        !isTableTypeWithoutUnknownFields(fileFields.get(fileField).getType(), field.getType())) {
+                    return false;
+                }
+                fileField++;
+            }
+            return fileField == fileFields.size();
+        }
+        if (tableType instanceof ArrayType && fileType instanceof ArrayType) {
+            return isTableTypeWithoutUnknownFields(((ArrayType) fileType).getElementType(), ((ArrayType) tableType).getElementType());
+        }
+        if (tableType instanceof MapType && fileType instanceof MapType) {
+            return isTableTypeWithoutUnknownFields(((MapType) fileType).getKeyType(), ((MapType) tableType).getKeyType()) &&
+                    isTableTypeWithoutUnknownFields(((MapType) fileType).getValueType(), ((MapType) tableType).getValueType());
+        }
+        return tableType.equals(fileType);
+    }
+
+    private static boolean hasSameName(Field tableField, Field fileField)
+    {
+        if (!tableField.getName().isPresent() || !fileField.getName().isPresent()) {
+            return tableField.getName().equals(fileField.getName());
+        }
+        return tableField.getName().get().equalsIgnoreCase(fileField.getName().get());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnknownFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnknownFields.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.ArrayBlock;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.ColumnarArray;
+import com.facebook.presto.common.block.ColumnarMap;
+import com.facebook.presto.common.block.ColumnarRow;
+import com.facebook.presto.common.block.RowBlock;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+import static com.facebook.presto.common.block.ColumnarArray.toColumnarArray;
+import static com.facebook.presto.common.block.ColumnarMap.toColumnarMap;
+import static com.facebook.presto.common.block.ColumnarRow.toColumnarRow;
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+
+/**
+ * A field of type {@code unknown} is never stored in a data file: it always reads back as null.
+ * Iceberg leaves such a field out of the Parquet and ORC schemas it writes, so Presto has to leave
+ * it out of both the schema it writes and the values it writes.
+ *
+ * @see UnknownFieldTypes for the types such a file is read with
+ */
+final class UnknownFields
+{
+    private UnknownFields() {}
+
+    static boolean isUnknownType(Type type)
+    {
+        return type.typeId() == Type.TypeID.UNKNOWN;
+    }
+
+    static boolean containsUnknownType(Type type)
+    {
+        if (isUnknownType(type)) {
+            return true;
+        }
+        return type.isNestedType() && type.asNestedType().fields().stream()
+                .anyMatch(field -> containsUnknownType(field.type()));
+    }
+
+    /**
+     * The schema of the data file, which is the table schema without its {@code unknown} fields.
+     */
+    static Schema fileSchema(Schema tableSchema)
+    {
+        if (!containsUnknownType(tableSchema.asStruct())) {
+            return tableSchema;
+        }
+        return new Schema(prunedFields(tableSchema.columns()));
+    }
+
+    /**
+     * Transforms a page of the table schema into a page of the file schema, by dropping the
+     * {@code unknown} fields of the row, array and map values it holds. Empty when the schema has no
+     * such field, in which case a page can be written as is.
+     *
+     * <p>Columns that are themselves of type {@code unknown} are left alone: those are dropped a
+     * whole channel at a time, by the input column indexes the writers are given.
+     */
+    static Optional<UnaryOperator<Page>> pagePruner(Schema tableSchema, TypeManager typeManager)
+    {
+        List<Types.NestedField> columns = tableSchema.columns();
+        List<UnaryOperator<Block>> columnPruners = new ArrayList<>(columns.size());
+        boolean anyColumnPruned = false;
+        for (Types.NestedField column : columns) {
+            UnaryOperator<Block> columnPruner = null;
+            if (!isUnknownType(column.type()) && containsUnknownType(column.type())) {
+                columnPruner = blockPruner(column.type(), typeManager);
+                anyColumnPruned = true;
+            }
+            columnPruners.add(columnPruner);
+        }
+
+        if (!anyColumnPruned) {
+            return Optional.empty();
+        }
+
+        return Optional.of(page -> {
+            Block[] blocks = new Block[page.getChannelCount()];
+            for (int channel = 0; channel < blocks.length; channel++) {
+                Block block = page.getBlock(channel);
+                UnaryOperator<Block> columnPruner = channel < columnPruners.size() ? columnPruners.get(channel) : null;
+                blocks[channel] = columnPruner == null ? block : columnPruner.apply(block);
+            }
+            return new Page(page.getPositionCount(), blocks);
+        });
+    }
+
+    /**
+     * Rejects the tables that have an {@code unknown} field in a place where a data file cannot
+     * leave it out. Iceberg's own writers fail on these as well.
+     */
+    static void validateWritable(Schema tableSchema)
+    {
+        for (Types.NestedField column : tableSchema.columns()) {
+            validateWritable(column.type(), column.name());
+        }
+    }
+
+    private static void validateWritable(Type type, String path)
+    {
+        if (!containsUnknownType(type)) {
+            return;
+        }
+
+        switch (type.typeId()) {
+            case STRUCT:
+                List<Types.NestedField> fields = type.asStructType().fields();
+                if (prunedFields(fields).isEmpty()) {
+                    throw new PrestoException(NOT_SUPPORTED, format("Writing to an Iceberg table with a row whose fields are all of type unknown is not supported: %s", path));
+                }
+                for (Types.NestedField field : fields) {
+                    validateWritable(field.type(), path + "." + field.name());
+                }
+                return;
+            case LIST:
+                Types.ListType list = type.asListType();
+                if (isUnknownType(list.elementType())) {
+                    throw new PrestoException(NOT_SUPPORTED, format("Writing to an Iceberg table with an array of type unknown is not supported: %s", path));
+                }
+                validateWritable(list.elementType(), path + ".element");
+                return;
+            case MAP:
+                Types.MapType map = type.asMapType();
+                if (isUnknownType(map.keyType()) || isUnknownType(map.valueType())) {
+                    throw new PrestoException(NOT_SUPPORTED, format("Writing to an Iceberg table with a map of type unknown is not supported: %s", path));
+                }
+                validateWritable(map.keyType(), path + ".key");
+                validateWritable(map.valueType(), path + ".value");
+                return;
+            default:
+                // a column of type unknown is dropped a whole channel at a time
+        }
+    }
+
+    private static List<Types.NestedField> prunedFields(List<Types.NestedField> fields)
+    {
+        return fields.stream()
+                .filter(field -> !isUnknownType(field.type()))
+                .map(UnknownFields::prunedField)
+                .collect(toImmutableList());
+    }
+
+    private static Types.NestedField prunedField(Types.NestedField field)
+    {
+        if (!containsUnknownType(field.type())) {
+            return field;
+        }
+        return Types.NestedField.from(field)
+                .ofType(prunedType(field.type()))
+                .build();
+    }
+
+    private static Type prunedType(Type type)
+    {
+        switch (type.typeId()) {
+            case STRUCT:
+                return Types.StructType.of(prunedFields(type.asStructType().fields()));
+            case LIST:
+                Types.ListType list = type.asListType();
+                Type elementType = prunedType(list.elementType());
+                return list.isElementOptional() ?
+                        Types.ListType.ofOptional(list.elementId(), elementType) :
+                        Types.ListType.ofRequired(list.elementId(), elementType);
+            case MAP:
+                Types.MapType map = type.asMapType();
+                Type keyType = prunedType(map.keyType());
+                Type valueType = prunedType(map.valueType());
+                return map.isValueOptional() ?
+                        Types.MapType.ofOptional(map.keyId(), map.valueId(), keyType, valueType) :
+                        Types.MapType.ofRequired(map.keyId(), map.valueId(), keyType, valueType);
+            default:
+                return type;
+        }
+    }
+
+    private static UnaryOperator<Block> blockPruner(Type type, TypeManager typeManager)
+    {
+        switch (type.typeId()) {
+            case STRUCT:
+                return rowBlockPruner(type.asStructType(), typeManager);
+            case LIST:
+                return arrayBlockPruner(type.asListType(), typeManager);
+            case MAP:
+                return mapBlockPruner(type.asMapType(), typeManager);
+            default:
+                throw new IllegalArgumentException("Type has no unknown field to prune: " + type);
+        }
+    }
+
+    private static UnaryOperator<Block> rowBlockPruner(Types.StructType struct, TypeManager typeManager)
+    {
+        List<Types.NestedField> fields = struct.fields();
+        List<Integer> storedFields = new ArrayList<>(fields.size());
+        List<UnaryOperator<Block>> fieldPruners = new ArrayList<>(fields.size());
+        for (int field = 0; field < fields.size(); field++) {
+            Type fieldType = fields.get(field).type();
+            if (isUnknownType(fieldType)) {
+                continue;
+            }
+            storedFields.add(field);
+            fieldPruners.add(containsUnknownType(fieldType) ? blockPruner(fieldType, typeManager) : null);
+        }
+
+        return block -> {
+            ColumnarRow row = toColumnarRow(block);
+            Block[] fieldBlocks = new Block[storedFields.size()];
+            for (int field = 0; field < fieldBlocks.length; field++) {
+                Block fieldBlock = row.getField(storedFields.get(field));
+                UnaryOperator<Block> fieldPruner = fieldPruners.get(field);
+                fieldBlocks[field] = fieldPruner == null ? fieldBlock : fieldPruner.apply(fieldBlock);
+            }
+            return RowBlock.fromFieldBlocks(block.getPositionCount(), nullPositions(row.getNullCheckBlock()), fieldBlocks);
+        };
+    }
+
+    private static UnaryOperator<Block> arrayBlockPruner(Types.ListType list, TypeManager typeManager)
+    {
+        UnaryOperator<Block> elementPruner = blockPruner(list.elementType(), typeManager);
+
+        return block -> {
+            ColumnarArray array = toColumnarArray(block);
+            int positionCount = array.getPositionCount();
+            int[] offsets = new int[positionCount + 1];
+            for (int position = 0; position <= positionCount; position++) {
+                offsets[position] = array.getOffset(position);
+            }
+            return ArrayBlock.fromElementBlock(
+                    positionCount,
+                    nullPositions(array.getNullCheckBlock()),
+                    offsets,
+                    elementPruner.apply(array.getElementsBlock()));
+        };
+    }
+
+    private static UnaryOperator<Block> mapBlockPruner(Types.MapType map, TypeManager typeManager)
+    {
+        MapType prunedMapType = (MapType) toPrestoType(prunedType(map), typeManager);
+        UnaryOperator<Block> keyPruner = containsUnknownType(map.keyType()) ? blockPruner(map.keyType(), typeManager) : null;
+        UnaryOperator<Block> valuePruner = containsUnknownType(map.valueType()) ? blockPruner(map.valueType(), typeManager) : null;
+
+        return block -> {
+            ColumnarMap columnarMap = toColumnarMap(block);
+            int positionCount = columnarMap.getPositionCount();
+            int[] offsets = new int[positionCount + 1];
+            for (int position = 0; position <= positionCount; position++) {
+                offsets[position] = columnarMap.getOffset(position);
+            }
+            Block keyBlock = columnarMap.getKeysBlock();
+            Block valueBlock = columnarMap.getValuesBlock();
+            return prunedMapType.createBlockFromKeyValue(
+                    positionCount,
+                    nullPositions(columnarMap.getNullCheckBlock()),
+                    offsets,
+                    keyPruner == null ? keyBlock : keyPruner.apply(keyBlock),
+                    valuePruner == null ? valueBlock : valuePruner.apply(valueBlock));
+        };
+    }
+
+    /**
+     * The null mask the block factory methods take, which is left out when nothing is null.
+     */
+    private static Optional<boolean[]> nullPositions(Block nullCheckBlock)
+    {
+        if (!nullCheckBlock.mayHaveNull()) {
+            return Optional.empty();
+        }
+
+        int positionCount = nullCheckBlock.getPositionCount();
+        boolean[] isNull = new boolean[positionCount];
+        boolean anyNull = false;
+        for (int position = 0; position < positionCount; position++) {
+            isNull[position] = nullCheckBlock.isNull(position);
+            anyNull |= isNull[position];
+        }
+        return anyNull ? Optional.of(isNull) : Optional.empty();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.getSynthesizedIcebergColumnHandle;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isParquetDereferencePushdownEnabled;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
+import static com.facebook.presto.iceberg.UnknownFieldTypes.hasUnknownType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -100,6 +101,12 @@ public class IcebergParquetDereferencePushDown
         IcebergColumnHandle icebergBaseColumnHandle = (IcebergColumnHandle) baseColumnHandle;
         Type type = icebergBaseColumnHandle.getType();
         checkArgument(type instanceof RowType, "%s must be type of RowType", subfield.getRootName());
+
+        // A Hive type is of no use for a subfield of the unknown type, which it cannot represent, and
+        // of no need either: the type of the subfield is the type the dereference resolved to
+        if (hasUnknownType(subfieldDataType)) {
+            return getSynthesizedIcebergColumnHandle(subfieldColumnName, subfieldDataType, ImmutableList.of(subfield));
+        }
 
         Optional<HiveType> nestedColumnHiveType = toHiveType(type)
                 .findChildType(subfield.getPath()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
@@ -465,4 +465,30 @@ public class TestIcebergUtil
         assertThat(hiveColumns.get(2).getName()).isEqualTo("name");
         assertThat(hiveColumns.get(2).getType()).isEqualTo(HiveType.HIVE_STRING);
     }
+
+    /**
+     * Hive has no equivalent of the Iceberg V3 unknown type, so it is recorded as Hive's all-null
+     * type, which is also what Spark records for its NullType.
+     */
+    @Test
+    public void testToHiveColumnsWithUnknownType()
+    {
+        List<Types.NestedField> icebergColumns = ImmutableList.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "unknown_column", Types.UnknownType.get()),
+                Types.NestedField.optional(3, "nested", Types.StructType.of(
+                        Types.NestedField.optional(4, "unknown_field", Types.UnknownType.get()))));
+
+        List<Column> hiveColumns = IcebergUtil.toHiveColumns(icebergColumns);
+        assertThat(hiveColumns).hasSize(3);
+
+        assertThat(hiveColumns.get(0).getName()).isEqualTo("id");
+        assertThat(hiveColumns.get(0).getType()).isEqualTo(HiveType.HIVE_LONG);
+
+        assertThat(hiveColumns.get(1).getName()).isEqualTo("unknown_column");
+        assertThat(hiveColumns.get(1).getType()).isEqualTo(HiveType.valueOf("void"));
+
+        assertThat(hiveColumns.get(2).getName()).isEqualTo("nested");
+        assertThat(hiveColumns.get(2).getType()).isEqualTo(HiveType.valueOf("struct<unknown_field:void>"));
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergV3.java
@@ -13,8 +13,11 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -23,6 +26,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -30,6 +34,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -38,15 +44,21 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PARQUET_DEREFERENCE_PUSHDOWN_ENABLED;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.iceberg.IcebergUtil.MAX_FORMAT_VERSION_FOR_METADATA_TABLES;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergV3
         extends AbstractTestQueryFramework
@@ -762,6 +774,520 @@ public class TestIcebergV3
         finally {
             dropTable(tableName);
         }
+    }
+
+    @DataProvider(name = "fileFormats")
+    public Object[][] fileFormats()
+    {
+        return new Object[][] {{"PARQUET"}, {"ORC"}};
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testReadUnknownColumn(String fileFormat)
+    {
+        String tableName = "test_read_unknown_column_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'Alice'), (2, 'Bob')", 2);
+            addUnknownColumn(tableName, "unknown_column", Types.UnknownType.get());
+
+            // An unknown column is never stored in a data file, so it always reads back as null
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'Alice', NULL), (2, 'Bob', NULL)");
+            assertQuery("SELECT unknown_column FROM " + tableName, "VALUES NULL, NULL");
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 2");
+            assertQuery("SELECT count(unknown_column) FROM " + tableName, "VALUES 0");
+            assertEquals(
+                    getQueryRunner().execute("SELECT unknown_column FROM " + tableName).getTypes(),
+                    ImmutableList.of(UNKNOWN));
+
+            // Iceberg binds IS NULL on an unknown column to alwaysTrue and IS NOT NULL to alwaysFalse
+            assertQuery("SELECT id FROM " + tableName + " WHERE unknown_column IS NULL", "VALUES 1, 2");
+            assertQuery("SELECT id FROM " + tableName + " WHERE unknown_column IS NOT NULL", "SELECT 1 WHERE FALSE");
+
+            // Queries that do not reference the unknown column must still plan
+            assertQuery("SELECT id FROM " + tableName + " WHERE name = 'Alice'", "VALUES 1");
+
+            assertQuery(
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '" + tableName + "'",
+                    "VALUES ('id', 'integer'), ('name', 'varchar'), ('unknown_column', 'unknown')");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testReadUnknownColumnInsideStruct(String fileFormat)
+    {
+        String tableName = "test_read_unknown_nested_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1", 1);
+            addUnknownColumn(tableName, "nested", Types.StructType.of(
+                    Types.NestedField.optional(1, "value", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "unknown_field", Types.UnknownType.get())));
+
+            assertQuery("SELECT id FROM " + tableName, "VALUES 1");
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE nested IS NULL", "VALUES 1");
+            assertQuery("SELECT nested.unknown_field FROM " + tableName, "VALUES NULL");
+            assertEquals(
+                    getQueryRunner().execute("SELECT nested FROM " + tableName).getTypes(),
+                    ImmutableList.of(RowType.from(ImmutableList.of(
+                            RowType.field("value", INTEGER),
+                            RowType.field("unknown_field", UNKNOWN)))));
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * A file written before an unknown field was added to a row does not have the field, just like a
+     * file written after it was added, so both read back with the field filled in with nulls.
+     */
+    @Test(dataProvider = "fileFormats")
+    public void testReadUnknownFieldAddedToExistingStruct(String fileFormat)
+    {
+        String tableName = "test_read_unknown_field_added_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, nested ROW(value INTEGER)) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW(10))", 1);
+            loadTable(tableName).updateSchema()
+                    .addColumn("nested", "unknown_field", Types.UnknownType.get())
+                    .commit();
+
+            assertQuery("SELECT id, nested.value, nested.unknown_field FROM " + tableName, "VALUES (1, 10, NULL)");
+            assertEquals(
+                    getQueryRunner().execute("SELECT nested FROM " + tableName).getTypes(),
+                    ImmutableList.of(RowType.from(ImmutableList.of(
+                            RowType.field("value", INTEGER),
+                            RowType.field("unknown_field", UNKNOWN)))));
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, ROW(20, NULL))", 1);
+            assertQuery("SELECT id, nested.value, nested.unknown_field FROM " + tableName, "VALUES (1, 10, NULL), (2, 20, NULL)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Filter pushdown is only executed by the native worker, so this only checks that a table with
+     * an unknown column still plans with pushdown enabled. Planning converts the whole table schema
+     * to Hive columns, which is where an unsupported type would fail.
+     */
+    @Test
+    public void testReadUnknownColumnWithFilterPushdownPlans()
+    {
+        String tableName = "test_read_unknown_column_pushdown";
+        Session pushdownFilterEnabled = Session.builder(getSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'Alice'), (2, 'Bob')", 2);
+            addUnknownColumn(tableName, "unknown_column", Types.UnknownType.get());
+
+            // Filtering on the unknown column itself is not covered here: with pushdown enabled,
+            // statistics are read from the snapshot's schema, which predates any column added
+            // afterwards, so a filter on such a column fails for every type, not just unknown
+            assertQuerySucceeds(pushdownFilterEnabled, "EXPLAIN SELECT * FROM " + tableName + " WHERE id = 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testWriteUnknownColumn(String fileFormat)
+    {
+        String tableName = "test_write_unknown_column_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            Types.NestedField field = loadTable(tableName).schema().findField("unknown_column");
+            assertEquals(field.type(), Types.UnknownType.get());
+            // An unknown column must always be optional
+            assertTrue(field.isOptional());
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, NULL)", 1);
+            // The unknown column can be left out, like any other optional column
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES 2", 1);
+            assertUpdate("INSERT INTO " + tableName + " SELECT 3, NULL", 1);
+
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, NULL), (2, NULL), (3, NULL)");
+            assertQuery("SELECT count(unknown_column) FROM " + tableName, "VALUES 0");
+            assertEquals(
+                    getQueryRunner().execute("SELECT unknown_column FROM " + tableName).getTypes(),
+                    ImmutableList.of(UNKNOWN));
+
+            // The unknown column is not stored in the data files, so the writers report no metrics
+            // for its field id, while the columns that are stored do have metrics
+            assertQuery("SELECT count(*) FROM \"" + tableName + "$files\"", "VALUES 3");
+            assertQuery("SELECT count(*) FROM \"" + tableName + "$files\" WHERE element_at(value_counts, 2) IS NOT NULL", "VALUES 0");
+            assertQuery("SELECT count(*) FROM \"" + tableName + "$files\" WHERE element_at(value_counts, 1) IS NULL", "VALUES 0");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(dataProvider = "fileFormats")
+    public void testAddUnknownColumn(String fileFormat)
+    {
+        String tableName = "test_add_unknown_column_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1", 1);
+
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN unknown_column UNKNOWN");
+            assertEquals(loadTable(tableName).schema().findField("unknown_column").type(), Types.UnknownType.get());
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, NULL)", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, NULL), (2, NULL)");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * The unknown type was added in Iceberg format version 3, so declaring such a column in an older
+     * table is rejected by Iceberg itself.
+     */
+    @Test
+    public void testUnknownColumnRequiresV3()
+    {
+        String tableName = "test_unknown_column_requires_v3";
+        try {
+            assertQueryFails(
+                    "CREATE TABLE " + tableName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '2')",
+                    "(?s).*Invalid type for unknown_column: unknown is not supported until v3.*");
+
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '2')");
+            assertQueryFails(
+                    "ALTER TABLE " + tableName + " ADD COLUMN unknown_column UNKNOWN",
+                    "(?s).*Invalid type for unknown_column: unknown is not supported until v3.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * An unknown column only ever holds null, so it cannot be declared NOT NULL.
+     */
+    @Test
+    public void testUnknownColumnCannotBeRequired()
+    {
+        String tableName = "test_unknown_column_not_null";
+        try {
+            assertQueryFails(
+                    "CREATE TABLE " + tableName + " (id INTEGER, unknown_column UNKNOWN NOT NULL) WITH (\"format-version\" = '3')",
+                    ".*Cannot create required field with unknown type: unknown_column.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Only null can be written to an unknown column, so a value of any other type is rejected while
+     * the insert is analyzed.
+     */
+    @Test
+    public void testWriteValueToUnknownColumnFails()
+    {
+        String tableName = "test_write_value_to_unknown_column";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3')");
+            assertQueryFails(
+                    "INSERT INTO " + tableName + " VALUES (1, 5)",
+                    ".*'unknown_column' is of type unknown but expression is of type integer.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithUnknownColumn()
+    {
+        String tableName = "test_ctas_unknown_column";
+        String copyName = tableName + "_copy";
+        try {
+            // A column that is only ever null keeps the unknown type, instead of having to be cast
+            assertUpdate("CREATE TABLE " + tableName + " WITH (\"format-version\" = '3') AS SELECT 1 id, NULL unknown_column", 1);
+            assertEquals(loadTable(tableName).schema().findField("unknown_column").type(), Types.UnknownType.get());
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, NULL)");
+
+            // Also with column aliases, which are analyzed separately
+            assertUpdate("CREATE TABLE " + copyName + " (id, unknown_column) WITH (\"format-version\" = '3') AS SELECT * FROM " + tableName, 1);
+            assertEquals(loadTable(copyName).schema().findField("unknown_column").type(), Types.UnknownType.get());
+            assertQuery("SELECT * FROM " + copyName, "VALUES (1, NULL)");
+        }
+        finally {
+            dropTable(tableName);
+            dropTable(copyName);
+        }
+    }
+
+    /**
+     * Iceberg allows an unknown column to be partitioned by identity and to be sorted on, but not to
+     * be bucketed, because no hash is defined for it.
+     */
+    @Test
+    public void testUnknownColumnPartitioningAndSorting()
+    {
+        String partitionedName = "test_unknown_column_partitioned";
+        String sortedName = "test_unknown_column_sorted";
+        String bucketedName = "test_unknown_column_bucketed";
+        try {
+            assertUpdate("CREATE TABLE " + partitionedName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3', partitioning = ARRAY['unknown_column'])");
+            assertUpdate("INSERT INTO " + partitionedName + " VALUES (1, NULL), (2, NULL)", 2);
+            // Every value is null, so all rows go to the same partition
+            assertQuery("SELECT count(*) FROM \"" + partitionedName + "$partitions\"", "VALUES 1");
+            assertQuery("SELECT * FROM " + partitionedName, "VALUES (1, NULL), (2, NULL)");
+
+            assertUpdate("CREATE TABLE " + sortedName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3', sorted_by = ARRAY['unknown_column'])");
+            assertUpdate("INSERT INTO " + sortedName + " VALUES (1, NULL), (2, NULL)", 2);
+            assertQuery("SELECT * FROM " + sortedName, "VALUES (1, NULL), (2, NULL)");
+
+            assertQueryFails(
+                    "CREATE TABLE " + bucketedName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3', partitioning = ARRAY['bucket(unknown_column, 2)'])",
+                    ".*Invalid source type unknown for transform: bucket\\[2\\].*");
+        }
+        finally {
+            dropTable(partitionedName);
+            dropTable(sortedName);
+            dropTable(bucketedName);
+        }
+    }
+
+    /**
+     * Iceberg has not implemented promotion from the unknown type to another type, so changing the
+     * type of an unknown column is rejected.
+     */
+    @Test
+    public void testPromoteUnknownColumnUnsupported()
+    {
+        String tableName = "test_promote_unknown_column";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, unknown_column UNKNOWN) WITH (\"format-version\" = '3')");
+            assertQueryFails(
+                    "ALTER TABLE " + tableName + " ALTER COLUMN unknown_column SET DATA TYPE INTEGER",
+                    ".*Cannot change column type: unknown_column: unknown -> int.*");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * An unknown field of a row is left out of the data file, like an unknown column, so the rest of
+     * the row is written and read back as usual.
+     */
+    @Test(dataProvider = "fileFormats")
+    public void testWriteUnknownColumnInsideStruct(String fileFormat)
+    {
+        String tableName = "test_write_unknown_nested_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, nested ROW(value INTEGER, unknown_field UNKNOWN)) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, ROW(10, NULL)), (2, NULL)", 2);
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES 3", 1);
+
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE nested.unknown_field IS NULL", "VALUES 3");
+            assertQuery("SELECT id FROM " + tableName + " WHERE nested IS NULL", "VALUES 2, 3");
+            assertQuery(withoutParquetDereferencePushdown(), "SELECT id, nested.value FROM " + tableName, "VALUES (1, 10), (2, NULL), (3, NULL)");
+            assertEquals(
+                    getQueryRunner().execute("SELECT nested FROM " + tableName).getTypes(),
+                    ImmutableList.of(RowType.from(ImmutableList.of(
+                            RowType.field("value", INTEGER),
+                            RowType.field("unknown_field", UNKNOWN)))));
+
+            // The unknown field has no metrics of its own, while the field stored beside it does
+            Schema schema = loadTable(tableName).schema();
+            int unknownFieldId = schema.findField("nested.unknown_field").fieldId();
+            int storedFieldId = schema.findField("nested.value").fieldId();
+            assertQuery("SELECT count(*) FROM \"" + tableName + "$files\" WHERE element_at(value_counts, " + unknownFieldId + ") IS NOT NULL", "VALUES 0");
+            assertQuery("SELECT count(*) FROM \"" + tableName + "$files\" WHERE element_at(value_counts, " + storedFieldId + ") IS NULL", "VALUES 0");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Deeper nesting works the same way, as long as something is left of the value to store.
+     */
+    @Test(dataProvider = "fileFormats")
+    public void testWriteUnknownColumnInsideNestedTypes(String fileFormat)
+    {
+        String tableName = "test_write_unknown_deeply_nested_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (" +
+                    "id INTEGER, " +
+                    "nested ROW(value INTEGER, inner_row ROW(unknown_field UNKNOWN, other INTEGER)), " +
+                    "rows ARRAY(ROW(value INTEGER, unknown_field UNKNOWN)), " +
+                    "row_by_name MAP(VARCHAR, ROW(value INTEGER, unknown_field UNKNOWN))) " +
+                    "WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (" +
+                    "1, " +
+                    "ROW(10, ROW(NULL, 20)), " +
+                    "ARRAY[ROW(30, NULL), NULL], " +
+                    "MAP(ARRAY['a'], ARRAY[ROW(40, NULL)]))", 1);
+            assertUpdate("INSERT INTO " + tableName + " (id) VALUES 2", 1);
+
+            assertQuery(
+                    withoutParquetDereferencePushdown(),
+                    "SELECT id, nested.value, nested.inner_row.other, rows[1].value, row_by_name['a'].value FROM " + tableName + " WHERE id = 1",
+                    "VALUES (1, 10, 20, 30, 40)");
+            assertQuery("SELECT count(*) FROM " + tableName + " WHERE nested.inner_row.unknown_field IS NULL", "VALUES 2");
+            assertQuery("SELECT cardinality(rows) FROM " + tableName, "VALUES 2, NULL");
+            assertQuery("SELECT id FROM " + tableName + " WHERE nested IS NULL", "VALUES 2");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * Parquet dereference pushdown does not read a field of a row whose value is null, for a row with
+     * an unknown field and for a row without one alike, so the reads that go through a null row are
+     * left to the reader that reads the whole row.
+     */
+    private Session withoutParquetDereferencePushdown()
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PARQUET_DEREFERENCE_PUSHDOWN_ENABLED, "false")
+                .build();
+    }
+
+    /**
+     * A data file needs something to store for every value, so an unknown type that is the whole of an
+     * array element, map key, map value or row is not supported. Iceberg's own writers fail on these
+     * as well.
+     */
+    @Test(dataProvider = "fileFormats")
+    public void testWriteUnknownTypeAsWholeNestedValueUnsupported(String fileFormat)
+    {
+        String suffix = "_" + fileFormat.toLowerCase(ENGLISH);
+        String arrayTable = "test_write_unknown_array" + suffix;
+        String mapTable = "test_write_unknown_map" + suffix;
+        String rowTable = "test_write_unknown_row" + suffix;
+        try {
+            assertUpdate("CREATE TABLE " + arrayTable + " (id INTEGER, unknowns ARRAY(UNKNOWN)) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertQueryFails(
+                    "INSERT INTO " + arrayTable + " (id) VALUES 1",
+                    ".*Writing to an Iceberg table with an array of type unknown is not supported: unknowns.*");
+
+            assertUpdate("CREATE TABLE " + mapTable + " (id INTEGER, unknown_by_name MAP(VARCHAR, UNKNOWN)) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertQueryFails(
+                    "INSERT INTO " + mapTable + " (id) VALUES 1",
+                    ".*Writing to an Iceberg table with a map of type unknown is not supported: unknown_by_name.*");
+
+            assertUpdate("CREATE TABLE " + rowTable + " (id INTEGER, nested ROW(unknown_field UNKNOWN)) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertQueryFails(
+                    "INSERT INTO " + rowTable + " (id) VALUES 1",
+                    ".*Writing to an Iceberg table with a row whose fields are all of type unknown is not supported: nested.*");
+        }
+        finally {
+            dropTable(arrayTable);
+            dropTable(mapTable);
+            dropTable(rowTable);
+        }
+    }
+
+    /**
+     * Iceberg allows sorting, grouping and aggregating on an unknown column, so the same operations
+     * must work here. Every value is null, so they all collapse to a single null group.
+     */
+    @Test
+    public void testUnknownColumnInSortsAndAggregations()
+    {
+        String tableName = "test_unknown_column_sort_aggregate";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1, 2", 2);
+            addUnknownColumn(tableName, "unknown_column", Types.UnknownType.get());
+
+            assertQuery("SELECT id FROM " + tableName + " ORDER BY unknown_column", "VALUES 1, 2");
+            assertQuery("SELECT unknown_column, count(*) FROM " + tableName + " GROUP BY 1", "VALUES (NULL, 2)");
+            assertQuery("SELECT DISTINCT unknown_column FROM " + tableName, "VALUES NULL");
+            assertQuery("SELECT max(unknown_column) FROM " + tableName, "VALUES NULL");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testUnknownColumnMetadataTablesAndStatistics()
+    {
+        String tableName = "test_unknown_column_metadata";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3', partitioning = ARRAY['id'])");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'Alice'), (2, 'Bob')", 2);
+            addUnknownColumn(tableName, "unknown_column", Types.UnknownType.get());
+
+            // An unknown column has no bounds, so it contributes only null min/max to $partitions
+            assertQuerySucceeds("SELECT * FROM \"" + tableName + "$partitions\"");
+            assertQuerySucceeds("SELECT * FROM \"" + tableName + "$files\"");
+            assertQuerySucceeds("SELECT * FROM \"" + tableName + "$manifests\"");
+            assertQuerySucceeds("SHOW STATS FOR " + tableName);
+            assertQuerySucceeds("ANALYZE " + tableName);
+            assertQuerySucceeds("SHOW COLUMNS FROM " + tableName);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testRenameAndDropUnknownColumn()
+    {
+        String tableName = "test_unknown_column_schema_evolution";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INTEGER) WITH (\"format-version\" = '3')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1", 1);
+            addUnknownColumn(tableName, "unknown_column", Types.UnknownType.get());
+
+            assertUpdate("ALTER TABLE " + tableName + " RENAME COLUMN unknown_column TO renamed_unknown");
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, NULL)");
+
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN renamed_unknown");
+            assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    /**
+     * A table of only unknown columns is valid Iceberg v3: all values are null, no data is stored
+     * in the data file. Spark/Iceberg 1.10.1 accepts such writes, so Presto must too.
+     */
+    @Test(dataProvider = "fileFormats")
+    public void testWriteTableOfOnlyUnknownColumns(String fileFormat)
+    {
+        String tableName = "test_only_unknown_columns_" + fileFormat.toLowerCase(ENGLISH);
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (unknown_column UNKNOWN) WITH (\"format-version\" = '3', format = '" + fileFormat + "')");
+            assertUpdate("INSERT INTO " + tableName + " VALUES NULL", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES NULL");
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 1");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    private void addUnknownColumn(String tableName, String columnName, Type type)
+    {
+        loadTable(tableName).updateSchema()
+                .addColumn(columnName, type)
+                .commit();
     }
 
     private Table loadTable(String tableName)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectNam
 import static com.facebook.presto.metadata.MetadataUtil.getConnectorIdOrThrow;
 import static com.facebook.presto.spi.ColumnMetadata.DEFAULT_VALUE_PROPERTY;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.UNKNOWN_COLUMN_TYPE;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_EXISTS;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_COLUMN;
@@ -100,7 +101,7 @@ public class AddColumnTask
         catch (IllegalArgumentException | UnknownTypeException e) {
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
         }
-        if (type.equals(UNKNOWN)) {
+        if (type.equals(UNKNOWN) && !metadata.getConnectorCapabilities(session, connectorId).contains(UNKNOWN_COLUMN_TYPE)) {
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
         }
         if (columnHandles.containsKey(element.getName().getValueLowerCase())) {

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -64,6 +64,7 @@ import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.UNKNOWN_COLUMN_TYPE;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
@@ -132,7 +133,7 @@ public class CreateTableTask
                 catch (IllegalArgumentException | UnknownTypeException e) {
                     throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", column.getType(), column.getName());
                 }
-                if (type.equals(UNKNOWN)) {
+                if (type.equals(UNKNOWN) && !metadata.getConnectorCapabilities(session, connectorId).contains(UNKNOWN_COLUMN_TYPE)) {
                     throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", column.getType(), column.getName());
                 }
                 if (columns.containsKey(name)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -287,6 +287,7 @@ import static com.facebook.presto.spi.StandardWarningCode.SEMANTIC_WARNING;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_CREATE;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_DELETE;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_INSERT;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.UNKNOWN_COLUMN_TYPE;
 import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionOperator;
 import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionType;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
@@ -833,13 +834,14 @@ class StatementAnalyzer
             Scope queryScope = process(node.getQuery(), scope);
 
             ImmutableList.Builder<OutputColumnMetadata> outputColumns = ImmutableList.builder();
+            boolean allowUnknownColumnType = supportsUnknownColumnType(targetTable);
 
             if (node.getColumnAliases().isPresent()) {
                 validateColumnAliases(node.getColumnAliases().get(), queryScope.getRelationType().getVisibleFieldCount());
                 int aliasPosition = 0;
                 // analyze only column types in subquery if column alias exists
                 for (Field field : queryScope.getRelationType().getVisibleFields()) {
-                    if (field.getType().equals(UNKNOWN)) {
+                    if (!allowUnknownColumnType && field.getType().equals(UNKNOWN)) {
                         throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown at position %s", queryScope.getRelationType().indexOf(field) + 1);
                     }
                     String columnName = node.getColumnAliases().get().get(aliasPosition).getValue();
@@ -848,7 +850,7 @@ class StatementAnalyzer
                 }
             }
             else {
-                validateColumns(node, queryScope.getRelationType());
+                validateColumns(node, queryScope.getRelationType(), allowUnknownColumnType);
                 queryScope.getRelationType().getVisibleFields().stream()
                         .map(this::createOutputColumn)
                         .forEach(outputColumns::add);
@@ -1605,6 +1607,11 @@ class StatementAnalyzer
 
         private void validateColumns(Statement node, RelationType descriptor)
         {
+            validateColumns(node, descriptor, false);
+        }
+
+        private void validateColumns(Statement node, RelationType descriptor, boolean allowUnknownColumnType)
+        {
             // verify that all column names are specified and unique
             // TODO: collect errors and return them all at once
             Set<String> names = new HashSet<>();
@@ -1616,10 +1623,20 @@ class StatementAnalyzer
                 if (!names.add(fieldName.get())) {
                     throw new SemanticException(DUPLICATE_COLUMN_NAME, node, "Column name '%s' specified more than once", fieldName.get());
                 }
-                if (field.getType().equals(UNKNOWN)) {
+                if (!allowUnknownColumnType && field.getType().equals(UNKNOWN)) {
                     throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown: %s", fieldName.get());
                 }
             }
+        }
+
+        /**
+         * A connector that can store a column of the unknown type keeps a null column of a CREATE TABLE AS SELECT as
+         * such, instead of requiring it to be cast to a concrete type.
+         */
+        private boolean supportsUnknownColumnType(QualifiedObjectName tableName)
+        {
+            ConnectorId connectorId = getConnectorIdOrThrow(session, metadata, tableName.getCatalogName());
+            return metadata.getConnectorCapabilities(session, connectorId).contains(UNKNOWN_COLUMN_TYPE);
         }
 
         private void validateColumnAliases(List<Identifier> columnAliases, int sourceColumnSize)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -120,6 +120,7 @@ import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabl
 import static com.facebook.presto.SystemSessionProperties.isNativeUpdateMergeEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.MetadataUtil.getConnectorIdOrThrow;
@@ -785,8 +786,11 @@ public class LogicalPlanner
             VariableReferenceExpression output = variableAllocator.newVariable(getSourceLocation(query), column.getName(), column.getType());
             int index = columnHandles.indexOf(columns.get(column.getName()));
             if (index < 0) {
-                Expression cast = new Cast(new NullLiteral(), column.getType().getTypeSignature().toString());
-                assignments.put(output, rowExpression(cast, context, analysis));
+                // A null literal is already of the unknown type, which cannot be cast to
+                Expression nullValue = column.getType().equals(UNKNOWN) ?
+                        new NullLiteral() :
+                        new Cast(new NullLiteral(), column.getType().getTypeSignature().toString());
+                assignments.put(output, rowExpression(nullValue, context, analysis));
             }
             else {
                 VariableReferenceExpression input = plan.getVariable(index);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -138,6 +138,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
@@ -865,7 +866,7 @@ public class QueryPlanner
         // Build the "else" clause for the SearchedCaseExpression
         ImmutableList.Builder<Expression> joinElseBuilder = ImmutableList.builder();
         mergeAnalysis.getTargetColumnsMetadata().forEach(columnMetadata ->
-                joinElseBuilder.add(new Cast(new NullLiteral(), columnMetadata.getType().getDisplayName())));
+                joinElseBuilder.add(nullValueOfType(columnMetadata.getType())));
 
         // The operation number column value: -1
         joinElseBuilder.add(new GenericLiteral("TINYINT", "-1"));
@@ -1053,6 +1054,15 @@ public class QueryPlanner
             return UPDATE_OPERATION_NUMBER;
         }
         throw new IllegalArgumentException("Unrecognized MergeCase: " + mergeCase);
+    }
+
+    private static Expression nullValueOfType(Type type)
+    {
+        // A null literal is already of the unknown type, which cannot be cast to
+        if (type.equals(UNKNOWN)) {
+            return new NullLiteral();
+        }
+        return new Cast(new NullLiteral(), type.getDisplayName());
     }
 
     private static RowType createMergeRowType(List<ColumnMetadata> allColumnsMetadata)

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
+#include "velox/type/Type.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::presto {
@@ -153,6 +154,13 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
       // manifest file are consistent with the field names in
       // parquet data file.
       names.emplace_back(column.name);
+      // Iceberg's UNKNOWN type is recorded as "void" in the Hive metastore.
+      // HiveTypeParser does not recognise "void", so map it directly to the
+      // velox UNKNOWN type (an always-null, zero-width column).
+      if (column.type == "void") {
+        types.push_back(velox::UNKNOWN());
+        continue;
+      }
       auto parsedType = hiveTypeParser.parse(column.type);
       // The type from the metastore may have upper case letters
       // in field names, convert them all to lower case to be

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -599,7 +599,7 @@ TypePtr fieldNamesToLowerCase<TypeKind::ROW>(const TypePtr& type) {
     folly::toLowerAscii(name);
     names.push_back(std::move(name));
     auto& childType = rowType.childAt(i);
-    types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
+    types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
         fieldNamesToLowerCase, childType->kind(), childType));
   }
   return std::make_shared<RowType>(std::move(names), std::move(types));
@@ -610,16 +610,16 @@ TypePtr fieldNamesToLowerCase<TypeKind::MAP>(const TypePtr& type) {
   auto& keyType = type->childAt(0);
   auto& valueType = type->childAt(1);
   return std::make_shared<MapType>(
-      VELOX_DYNAMIC_TYPE_DISPATCH(
+      VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
           fieldNamesToLowerCase, keyType->kind(), keyType),
-      VELOX_DYNAMIC_TYPE_DISPATCH(
+      VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
           fieldNamesToLowerCase, valueType->kind(), valueType));
 }
 
 template <>
 TypePtr fieldNamesToLowerCase<TypeKind::ARRAY>(const TypePtr& type) {
   auto& elementType = type->childAt(0);
-  return std::make_shared<ArrayType>(VELOX_DYNAMIC_TYPE_DISPATCH(
+  return std::make_shared<ArrayType>(VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
       fieldNamesToLowerCase, elementType->kind(), elementType));
 }
 
@@ -634,6 +634,8 @@ template TypePtr fieldNamesToLowerCase<TypeKind::VARCHAR>(const TypePtr&);
 template TypePtr fieldNamesToLowerCase<TypeKind::VARBINARY>(const TypePtr&);
 template TypePtr fieldNamesToLowerCase<TypeKind::TIMESTAMP>(const TypePtr&);
 template TypePtr fieldNamesToLowerCase<TypeKind::HUGEINT>(const TypePtr&);
+template TypePtr fieldNamesToLowerCase<TypeKind::UNKNOWN>(const TypePtr&);
+template TypePtr fieldNamesToLowerCase<TypeKind::OPAQUE>(const TypePtr&);
 
 std::unique_ptr<common::Filter> toFilter(
     const protocol::Domain& domain,

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/AbstractTestSchemaEvolution.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.nativeworker.iceberg;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
 import static java.lang.String.format;
@@ -292,6 +295,298 @@ public abstract class AbstractTestSchemaEvolution
             assertUpdate(format("ALTER TABLE %s ALTER COLUMN a SET DATA TYPE DOUBLE", table));
             assertQuery(format("SELECT a, b FROM %s ORDER BY b", table),
                     "VALUES (DOUBLE '1.5', 'x'), (DOUBLE '2.5', 'y')");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // An unknown column is never stored in a data file and always reads back as null, including
+    // rows written before the column was added (i.e. the file does not have the field at all).
+    @Test
+    public void testWriteUnknownColumn()
+    {
+        String table = "unknown_write";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL)", table), 1);
+            assertUpdate(format("INSERT INTO %s (id) VALUES 2", table), 1);
+            assertQuery(format("SELECT * FROM %s ORDER BY id", table), "VALUES (1, NULL), (2, NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Adding an unknown column to an existing table: rows written before the add read NULL for the
+    // new column (the field is not in their file), and rows written after also read NULL.
+    @Test
+    public void testAddUnknownColumn()
+    {
+        String table = "unknown_add";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES 1", table), 1);
+            assertUpdate(format("ALTER TABLE %s ADD COLUMN u UNKNOWN", table));
+            assertUpdate(format("INSERT INTO %s VALUES (2, NULL)", table), 1);
+            assertQuery(format("SELECT * FROM %s ORDER BY id", table), "VALUES (1, NULL), (2, NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Planning with pushdown_filter_enabled must succeed even when the table has an unknown column.
+    // Filter pushdown converts the full table schema to Hive columns; an unsupported type would fail
+    // at that step.
+    @Test
+    public void testReadUnknownColumnWithFilterPushdownPlans()
+    {
+        String table = "unknown_pushdown";
+        Session pushdownEnabled = Session.builder(getSession())
+                .setCatalogSessionProperty(ICEBERG_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, name VARCHAR) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", table), 2);
+            assertUpdate(format("ALTER TABLE %s ADD COLUMN u UNKNOWN", table));
+            assertQuerySucceeds(pushdownEnabled, format("EXPLAIN SELECT * FROM %s WHERE id = 1", table));
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // The UNKNOWN type was introduced in Iceberg format version 3; older tables must reject it.
+    @Test
+    public void testUnknownColumnRequiresV3()
+    {
+        String table = "unknown_requires_v3";
+        try {
+            assertQueryFails(
+                    format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '2', format = '%s')", table, storageFormat()),
+                    "(?s).*Invalid type for u: unknown is not supported until v3.*");
+            assertUpdate(format("CREATE TABLE %s (id INTEGER) WITH (\"format-version\" = '2', format = '%s')", table, storageFormat()));
+            assertQueryFails(
+                    format("ALTER TABLE %s ADD COLUMN u UNKNOWN", table),
+                    "(?s).*Invalid type for u: unknown is not supported until v3.*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // An unknown column only ever holds null so it cannot be declared NOT NULL.
+    @Test
+    public void testUnknownColumnCannotBeRequired()
+    {
+        String table = "unknown_not_null";
+        try {
+            assertQueryFails(
+                    format("CREATE TABLE %s (id INTEGER, u UNKNOWN NOT NULL) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()),
+                    ".*Cannot create required field with unknown type: u.*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Only null can be written to an unknown column; a non-null value is rejected at analysis time.
+    @Test
+    public void testWriteValueToUnknownColumnFails()
+    {
+        String table = "unknown_write_value_fails";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertQueryFails(
+                    format("INSERT INTO %s VALUES (1, 5)", table),
+                    ".*'u' is of type unknown but expression is of type integer.*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // CTAS preserves the unknown type for a column that is always null.
+    @Test
+    public void testCreateTableAsSelectWithUnknownColumn()
+    {
+        String table = "unknown_ctas";
+        String copy = table + "_copy";
+        try {
+            assertUpdate(format("CREATE TABLE %s WITH (\"format-version\" = '3', format = '%s') AS SELECT 1 id, NULL u", table, storageFormat()), 1);
+            assertQuery(format("SELECT * FROM %s", table), "VALUES (1, NULL)");
+            assertUpdate(format("CREATE TABLE %s (id, u) WITH (\"format-version\" = '3', format = '%s') AS SELECT * FROM %s", copy, storageFormat(), table), 1);
+            assertQuery(format("SELECT * FROM %s", copy), "VALUES (1, NULL)");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+            assertUpdate(format("DROP TABLE IF EXISTS %s", copy));
+        }
+    }
+
+    // A sorted table with an unknown column reads back correctly; bucketing is rejected because
+    // no hash is defined for the unknown type. (Identity-partition inserts are covered by the Java
+    // test suite — Velox does not support identity transforms on UNKNOWN-typed partition columns.)
+    @Test
+    public void testUnknownColumnSortingAndBucketingRejected()
+    {
+        String sorted = "unknown_sorted";
+        String bucketed = "unknown_bucketed";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s', sorted_by = ARRAY['u'])", sorted, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL), (2, NULL)", sorted), 2);
+            assertQuery(format("SELECT * FROM %s ORDER BY id", sorted), "VALUES (1, NULL), (2, NULL)");
+
+            assertQueryFails(
+                    format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s', partitioning = ARRAY['bucket(u, 2)'])", bucketed, storageFormat()),
+                    ".*Invalid source type unknown for transform: bucket\\[2\\].*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", sorted));
+            assertUpdate(format("DROP TABLE IF EXISTS %s", bucketed));
+        }
+    }
+
+    // Iceberg has not implemented promotion from unknown to any other type.
+    @Test
+    public void testPromoteUnknownColumnUnsupported()
+    {
+        String table = "unknown_promote";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertQueryFails(
+                    format("ALTER TABLE %s ALTER COLUMN u SET DATA TYPE INTEGER", table),
+                    ".*Cannot change column type: u: unknown -> int.*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // ORDER BY, GROUP BY, DISTINCT and aggregates on an unknown column all collapse to a single null
+    // group because every value is null.
+    @Test
+    public void testUnknownColumnInSortsAndAggregations()
+    {
+        String table = "unknown_sort_agg";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL), (2, NULL)", table), 2);
+            assertQuery(format("SELECT id FROM %s ORDER BY u, id", table), "VALUES 1, 2");
+            assertQuery(format("SELECT u, count(*) FROM %s GROUP BY 1", table), "VALUES (NULL, 2)");
+            assertQuery(format("SELECT DISTINCT u FROM %s", table), "VALUES NULL");
+            assertQuery(format("SELECT max(u) FROM %s", table), "VALUES NULL");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Metadata tables and SHOW/ANALYZE must not fail when the table has an unknown column.
+    @Test
+    public void testUnknownColumnMetadataTablesAndStatistics()
+    {
+        String table = "unknown_metadata";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, name VARCHAR, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s', partitioning = ARRAY['id'])", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, 'Alice', NULL), (2, 'Bob', NULL)", table), 2);
+            assertQuerySucceeds(format("SELECT * FROM \"%s$partitions\"", table));
+            assertQuerySucceeds(format("SELECT * FROM \"%s$files\"", table));
+            assertQuerySucceeds(format("SELECT * FROM \"%s$manifests\"", table));
+            assertQuerySucceeds(format("SHOW STATS FOR %s", table));
+            assertQuerySucceeds(format("ANALYZE %s", table));
+            assertQuerySucceeds(format("SHOW COLUMNS FROM %s", table));
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Writing to a table whose every column is UNKNOWN is allowed: the data file has
+    // no columns, and the row count is tracked in the Iceberg manifest metadata.
+    // Spark/Iceberg 1.10.1 accepts this as well.
+    @Test
+    public void testWriteTableOfOnlyUnknownColumns()
+    {
+        String table = "only_unknown_columns_" + storageFormat().toLowerCase();
+        try {
+            assertUpdate(format("CREATE TABLE %s (u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES NULL", table), 1);
+            assertQuery(format("SELECT * FROM %s", table), "VALUES NULL");
+            assertQuery(format("SELECT count(*) FROM %s", table), "VALUES 1");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // Writing to a table whose ARRAY, MAP, or ROW column contains UNKNOWN as an
+    // element/value/field type must fail: UNKNOWN is never stored, so a container
+    // whose element type is UNKNOWN cannot be physically encoded in any file format.
+    // (Java Presto enforces this in IcebergFileWriterFactory; native enforces it in
+    // IcebergInsertTableHandle's constructor via Velox.)
+    @Test
+    public void testWriteUnknownTypeAsWholeNestedValueUnsupported()
+    {
+        String arrayTable = "unknown_nested_array";
+        String mapTable = "unknown_nested_map";
+        String rowTable = "unknown_nested_row";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, unknowns ARRAY(UNKNOWN)) WITH (\"format-version\" = '3', format = '%s')", arrayTable, storageFormat()));
+            assertQueryFails(
+                    format("INSERT INTO %s (id) VALUES 1", arrayTable),
+                    ".*UNKNOWN type nested inside a complex type.*");
+
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, unknown_by_name MAP(VARCHAR, UNKNOWN)) WITH (\"format-version\" = '3', format = '%s')", mapTable, storageFormat()));
+            assertQueryFails(
+                    format("INSERT INTO %s (id) VALUES 1", mapTable),
+                    ".*UNKNOWN type nested inside a complex type.*");
+
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, nested ROW(unknown_field UNKNOWN)) WITH (\"format-version\" = '3', format = '%s')", rowTable, storageFormat()));
+            assertQueryFails(
+                    format("INSERT INTO %s (id) VALUES 1", rowTable),
+                    ".*UNKNOWN type nested inside a complex type.*");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", arrayTable));
+            assertUpdate(format("DROP TABLE IF EXISTS %s", mapTable));
+            assertUpdate(format("DROP TABLE IF EXISTS %s", rowTable));
+        }
+    }
+
+    // A ROW column where only some fields are UNKNOWN is allowed: UNKNOWN fields
+    // are pruned from the Parquet schema when writing and always read back as null.
+    // Only an all-UNKNOWN struct (every field UNKNOWN) is rejected.
+    @Test
+    public void testWriteMixedUnknownStructColumn()
+    {
+        String table = "mixed_unknown_struct_" + storageFormat().toLowerCase();
+        try {
+            assertUpdate(format(
+                    "CREATE TABLE %s (id INTEGER, nested ROW(x INTEGER, u UNKNOWN)) WITH (\"format-version\" = '3', format = '%s')",
+                    table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, ROW(42, NULL))", table), 1);
+            assertQuery(format("SELECT id, nested.x FROM %s", table), "VALUES (1, 42)");
+            assertQuery(format("SELECT nested.u FROM %s", table), "VALUES NULL");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE IF EXISTS %s", table));
+        }
+    }
+
+    // An unknown column can be renamed and dropped just like any other column.
+    @Test
+    public void testRenameAndDropUnknownColumn()
+    {
+        String table = "unknown_rename_drop";
+        try {
+            assertUpdate(format("CREATE TABLE %s (id INTEGER, u UNKNOWN) WITH (\"format-version\" = '3', format = '%s')", table, storageFormat()));
+            assertUpdate(format("INSERT INTO %s VALUES (1, NULL)", table), 1);
+            assertUpdate(format("ALTER TABLE %s RENAME COLUMN u TO u2", table));
+            assertQuery(format("SELECT * FROM %s", table), "VALUES (1, NULL)");
+            assertUpdate(format("ALTER TABLE %s DROP COLUMN u2", table));
+            assertQuery(format("SELECT * FROM %s", table), "VALUES 1");
         }
         finally {
             assertUpdate(format("DROP TABLE IF EXISTS %s", table));

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -196,7 +196,12 @@ public final class MetadataReader
                 blockMetaData.setRowCount(rowGroup.getNum_rows());
                 blockMetaData.setTotalByteSize(rowGroup.getTotal_byte_size());
                 List<ColumnChunk> columns = rowGroup.getColumns();
-                validateParquet(!columns.isEmpty(), "No columns in row group: %s", rowGroup);
+                if (columns.isEmpty()) {
+                    // Zero-column row group: valid for Iceberg V3 all-UNKNOWN tables where no
+                    // columns are stored in the data file. The row count is still meaningful.
+                    blocks.add(blockMetaData);
+                    continue;
+                }
                 String filePath = columns.get(0).getFile_path();
                 int columnOrdinal = -1;
                 for (ColumnChunk columnChunk : columns) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -322,9 +322,11 @@ public class ParquetReader
                 blocks[i] = columnChunk.getBlock();
             }
         }
+        List<Type> fieldTypes = field.getType().getTypeParameters();
         for (int i = 0; i < fields.size(); i++) {
             if (blocks[i] == null) {
-                blocks[i] = RunLengthEncodedBlock.create(field.getType(), null, columnChunk.getBlock().getPositionCount());
+                // a field the file does not have reads as null, of the type the field has in the table
+                blocks[i] = RunLengthEncodedBlock.create(fieldTypes.get(i), null, columnChunk.getBlock().getPositionCount());
             }
         }
         BooleanList structIsNull = StructColumnReader.calculateStructOffsets(field, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCapabilities.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCapabilities.java
@@ -22,5 +22,9 @@ public enum ConnectorCapabilities
     UNIQUE_CONSTRAINT,
     ENFORCE_CONSTRAINTS,
     ALTER_COLUMN,
-    SUPPORTS_JOIN_PUSHDOWN
+    SUPPORTS_JOIN_PUSHDOWN,
+    /**
+     * The connector can store a column of the unknown type, which only ever holds null values.
+     */
+    UNKNOWN_COLUMN_TYPE
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Only commit d1d273bcab8c61a76c123d2354ba5161dab87a92 should be reviewed. The other is just to validate with the velox changes for prestissimo. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add end-to-end support for Iceberg V3 UNKNOWN fields while preserving null semantics and omitting unsupported values from physical data files.

New Features:
- Add Iceberg V3 unknown-type support for creating, reading, writing, evolving, and querying UNKNOWN columns and nested fields.
- Support UNKNOWN columns across Parquet and ORC data files, including all-UNKNOWN tables and native execution.

Bug Fixes:
- Ensure missing unknown fields read back as null and zero-column Parquet files retain accurate row counts and metadata handling.

Enhancements:
- Expose UNKNOWN_COLUMN_TYPE as an Iceberg connector capability and integrate unknown-type semantics across planning, type conversion, schema handling, pushdown, and metadata operations.
- Document Iceberg unknown-type behavior and enforce supported nested-value restrictions and format-version constraints.

Documentation:
- Document Iceberg V3 unknown-type support and its usage constraints.

Tests:
- Add comprehensive Java and native Iceberg coverage for unknown columns, nested types, schema evolution, CTAS, writes, reads, metadata, statistics, sorting, aggregation, and unsupported cases.