### PR TITLE
chore(security): Update parquet-jackson to 1.18.0 in Iceberg connector

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-jackson</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
Upgrades `parquet-jackson` to version `1.18.0` to resolve three HIGH severity security vulnerabilities:

- GHSA-r7wm-3cxj-wff9
- CVE-2026-54512
- CVE-2026-54513


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
*  Upgrade parquet-jackson to 1.18.0 in response to `GHSA-r7wm-3cxj-wff9 <https://github.com/advisories/GHSA-r7wm-3cxj-wff9>`_, `CVE-2026-54512 <https://github.com/advisories/GHSA-j3rv-43j4-c7qm>`_ and `CVE-2026-54513 <https://github.com/advisories/GHSA-rmj7-2vxq-3g9f>`_.

```
