### PR TITLE
fix(security): Upgrade Netty to 4.2.17.Final to address CVE-2026-59902

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
         <dep.protobuf-java.version>4.34.1</dep.protobuf-java.version>
         <dep.jetty.version>12.0.38</dep.jetty.version>
-        <dep.netty.version>4.2.16.Final</dep.netty.version>
+        <dep.netty.version>4.2.17.Final</dep.netty.version>
         <dep.reactor-netty.version>1.3.6</dep.reactor-netty.version>
         <dep.snakeyaml.version>2.5</dep.snakeyaml.version>
         <dep.gson.version>2.14.0</dep.gson.version>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Upgrade Netty to 4.2.17.Final to address CVE-2026-59902 and CVE-2026-59903

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade Netty to 4.2.17.Final to address `CVE-2026-59902 <https://github.com/advisories/GHSA-2qj4-mmr9-4v2f>`_ and `CVE-2026-59903 <https://github.com/advisories/GHSA-8c42-7qj2-3j46>`_ .

```

