### PR TITLE
fix: Avoid reading delete manifests for Iceberg statistics

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -40,6 +40,8 @@ import com.facebook.presto.spi.statistics.StringRange;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -47,16 +49,19 @@ import jakarta.annotation.Nullable;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.CompactSketch;
 import org.apache.iceberg.ContentFile;
-import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -293,15 +298,41 @@ public class TableStatisticsMaker
     {
         // Iceberg's expression binder rejects predicates on metadata columns; strip them here.
         TupleDomain<IcebergColumnHandle> nonMetadataIntersection = IcebergUtil.getNonMetadataColumnConstraints(intersection);
-        TableScan tableScan = icebergTable.newScan()
-                .metricsReporter(new RuntimeStatsMetricsReporter(session.getRuntimeStats()))
-                .filter(toIcebergExpression(nonMetadataIntersection))
-                .select(selectedColumns.stream().map(IcebergColumnHandle::getName).collect(Collectors.toList()))
-                .useSnapshot(tableHandle.getIcebergTableName().getSnapshotId().get())
-                .includeColumnStats();
+        Expression filter = toIcebergExpression(nonMetadataIntersection);
+        Snapshot snapshot = icebergTable.snapshot(tableHandle.getIcebergTableName().getSnapshotId().get());
+        List<ManifestFile> manifests = snapshot.dataManifests(icebergTable.io()).stream()
+                .filter(manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles())
+                .filter(manifest -> ManifestEvaluator.forRowFilter(filter, icebergTable.specs().get(manifest.partitionSpecId()), true).eval(manifest))
+                .collect(toImmutableList());
 
-        CloseableIterable<ContentFile<?>> files = CloseableIterable.transform(tableScan.planFiles(), ContentScanTask::file);
+        Set<Integer> columnIds = selectedColumns.stream()
+                .map(IcebergColumnHandle::getId)
+                .collect(toImmutableSet());
+        Iterable<CloseableIterable<DataFile>> dataFileIterables = manifests.stream()
+                .map(manifest -> readDataManifest(manifest, filter, columnIds))
+                .collect(toImmutableList());
+        CloseableIterable<ContentFile<?>> files = CloseableIterable.withNoopClose(Iterables.concat(dataFileIterables));
         return getSummaryFromFiles(files, idToTypeMapping, nonPartitionPrimitiveColumns, partitionFields);
+    }
+
+    private CloseableIterable<DataFile> readDataManifest(ManifestFile manifest, Expression filter, Set<Integer> columnIds)
+    {
+        return CloseableIterable.transform(
+                org.apache.iceberg.IcebergLibUtils.liveEntries(
+                                ManifestFiles.read(manifest, icebergTable.io(), icebergTable.specs())
+                                        .select(ImmutableSet.of(
+                                                "partition",
+                                                "file_path",
+                                                "file_size_in_bytes",
+                                                "column_sizes",
+                                                "value_counts",
+                                                "null_value_counts",
+                                                "nan_value_counts",
+                                                "lower_bounds",
+                                                "upper_bounds",
+                                                "record_count"))
+                                        .filterRows(filter)),
+                entry -> entry.copyWithStats(columnIds));
     }
 
     private Partition getEqualityDeleteTableSummary(IcebergTableHandle tableHandle,

--- a/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
+++ b/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
@@ -13,6 +13,8 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.io.CloseableIterable;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -35,5 +37,10 @@ public class IcebergLibUtils
     public static TableScanContext getScanContext(DataTableScan tableScan)
     {
         return tableScan.context();
+    }
+
+    public static <F extends ContentFile<F>> CloseableIterable<F> liveEntries(ManifestReader<F> manifestReader)
+    {
+        return CloseableIterable.transform(manifestReader.liveEntries(), ManifestEntry::file);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Avoid planning and reading Iceberg delete manifests while computing table statistics. The statistics path now reads only applicable data manifests and the required data-file statistics fields.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Iceberg table statistics computation currently uses the table scan planning path, which may construct and read delete-file metadata even though delete files are not needed for the data-file statistics calculation. This change reduces unnecessary manifest processing during statistics aggregation.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No public API or user-facing behavior changes are introduced. Iceberg statistics computation should perform less metadata I/O and use less memory for tables with delete manifests.


## Test Plan
<!---Please fill in how you tested your change-->
- Full Iceberg test execution.


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Improve Iceberg table statistics computation by avoiding unnecessary reads of delete manifests.
```

## Summary by Sourcery

Enhancements:
- Optimize Iceberg table statistics computation by reading only applicable data manifests and the statistics fields required for aggregation, avoiding delete-manifest processing.