### PR TITLE
refactor(native): Use IcebergTableHandle in Presto to Velox conversion

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -24,6 +24,7 @@
 #include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::presto {
@@ -116,7 +117,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
     const std::string& tableName,
     const protocol::List<protocol::Column>& dataColumns,
     const protocol::TableHandle& tableHandle,
-    const std::vector<velox::connector::hive::HiveColumnHandlePtr>&
+    const std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>&
         columnHandles,
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser) {
@@ -176,13 +177,14 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toIcebergTableHandle(
     finalDataColumns = ROW(std::move(names), std::move(types));
   }
 
-  return std::make_unique<velox::connector::hive::HiveTableHandle>(
+  return std::make_unique<velox::connector::hive::iceberg::IcebergTableHandle>(
       tableHandle.connectorId,
       tableName,
       std::move(subfieldFilters),
       remainingFilter,
       finalDataColumns,
-      std::unordered_map<std::string, std::string>{},
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
       columnHandles);
 }
 
@@ -495,12 +497,13 @@ IcebergPrestoToVeloxConnector::toVeloxTableHandle(
       tableHandle.connectorTableLayout->_type);
 
   std::unordered_set<std::string> columnNames;
-  std::vector<velox::connector::hive::HiveColumnHandlePtr> columnHandles;
+  std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
+      columnHandles;
   for (const auto& entry : icebergLayout->partitionColumns) {
     if (columnNames.emplace(entry.columnIdentity.name).second) {
       columnHandles.emplace_back(
           std::dynamic_pointer_cast<
-              const velox::connector::hive::HiveColumnHandle>(
+              const velox::connector::hive::iceberg::IcebergColumnHandle>(
               std::shared_ptr(toVeloxColumnHandle(&entry, typeParser))));
     }
   }
@@ -510,7 +513,7 @@ IcebergPrestoToVeloxConnector::toVeloxTableHandle(
     if (columnNames.emplace(entry.second.columnIdentity.name).second) {
       columnHandles.emplace_back(
           std::dynamic_pointer_cast<
-              const velox::connector::hive::HiveColumnHandle>(
+              const velox::connector::hive::iceberg::IcebergColumnHandle>(
               std::shared_ptr(toVeloxColumnHandle(&entry.second, typeParser))));
     }
   }

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Filter.h"
 
@@ -150,7 +151,8 @@ TEST_F(PrestoToVeloxConnectorTest, icebergPreservesColumnNameCase) {
       tableHandle, *exprConverter_, *typeParser_);
 
   ASSERT_NE(result, nullptr);
-  auto* handle = dynamic_cast<connector::hive::HiveTableHandle*>(result.get());
+  auto* handle =
+      dynamic_cast<connector::hive::iceberg::IcebergTableHandle*>(result.get());
   ASSERT_NE(handle, nullptr);
 
   // Verify Iceberg preserves column name case.


### PR DESCRIPTION
## Description
Changes Iceberg Presto to Velox conversion code to use newly introduced IcebergTableHandle replacing HiveTableHandle.

## Motivation and Context
We recently added IcebergTableHandle to support Iceberg specific features. Iceberg protocol conversion needs change to use this class.

## Impact
No impact

## Test Plan
Existing native E2E tests will cover this change.

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Use Iceberg-specific table and column handles throughout the native Iceberg protocol.

Enhancements:
- Update the native Iceberg protocol to construct and consume Iceberg-specific table and column handles instead of Hive handles.

Tests:
- Update connector tests to verify native Iceberg conversions return Iceberg table handles.