### PR TITLE
feat(planner): Improve distinct check in PushAggregationThroughOuterJoin

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -36,11 +36,13 @@ import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +85,7 @@ import static java.util.Objects.requireNonNull;
  *  - Aggregate(Group by: all columns from the left table, aggregation:
  *    avg("n2.nationkey"))
  *      - LeftJoin("regionkey" = "regionkey")
- *          - AssignUniqueId (nation)
+ *          - AssignUniqueId (nation) // Or any other node which has distinct output variables as inferred by logical properties
  *              - Tablescan (nation)
  *          - Tablescan (nation)
  * </pre>
@@ -138,7 +140,7 @@ public class PushAggregationThroughOuterJoin
         if (join.getFilter().isPresent()
                 || !(join.getType() == JoinType.LEFT || join.getType() == JoinType.RIGHT)
                 || !groupsOnAllColumns(aggregation, getOuterTable(join).getOutputVariables())
-                || !isDistinct(context.getLookup().resolve(getOuterTable(join)), context.getLookup()::resolve)) {
+                || !isDistinctInternal(getOuterTable(join), context.getLookup())) {
             return Result.empty();
         }
 
@@ -312,7 +314,6 @@ public class PushAggregationThroughOuterJoin
         }
         return Optional.of(new ProjectNode(idAllocator.getNextId(), finalJoinNode, assignmentsBuilder.build()));
     }
-
     private Optional<MappedAggregationInfo> createAggregationOverNull(AggregationNode referenceAggregation, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
     {
         // Create a values node that consists of a single row of nulls.
@@ -400,6 +401,20 @@ public class PushAggregationThroughOuterJoin
 
         ImmutableMap<VariableReferenceExpression, SortOrder> orderingMap = ordering.build();
         return new OrderingScheme(orderBy.build().stream().map(variable -> new Ordering(variable, orderingMap.get(variable))).collect(toImmutableList()));
+    }
+
+    private static boolean isDistinctInternal(PlanNode node, Lookup lookup)
+    {
+        // Try distinct check first with logical properties
+        if (node instanceof GroupReference
+                && ((GroupReference) node).getLogicalProperties()
+                .map(logicalProperties -> logicalProperties.isAtMostSingleRow() ||
+                        (!node.getOutputVariables().isEmpty() && logicalProperties.isDistinct(ImmutableSet.copyOf(node.getOutputVariables()))))
+                .orElse(false)) {
+            return true;
+        }
+
+        return isDistinct(lookup.resolve(node), lookup::resolve);
     }
 
     private static boolean isUsingVariables(AggregationNode.Aggregation aggregation, Set<VariableReferenceExpression> sourceVariables)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -115,7 +115,28 @@ public class OptimizerAssert
         Plan result = queryRunner.inTransaction(session -> queryRunner.createPlan(session, sql, getMinimalOptimizers(), Optimizer.PlanStage.OPTIMIZED, WarningCollector.NOOP));
         plan = result.getRoot();
         types = result.getTypes();
+        // The initial plan was built with its own id allocator, so advance this one past every id already handed out
+        // to keep the ids of the nodes created by the rules under test unique
+        int maxPlanNodeId = maxPlanNodeId(plan);
+        for (int i = 0; i <= maxPlanNodeId; i++) {
+            idAllocator.getNextId();
+        }
         return this;
+    }
+
+    private static int maxPlanNodeId(PlanNode node)
+    {
+        int maxId = -1;
+        for (PlanNode source : node.getSources()) {
+            maxId = Math.max(maxId, maxPlanNodeId(source));
+        }
+        try {
+            maxId = Math.max(maxId, Integer.parseInt(node.getId().toString()));
+        }
+        catch (NumberFormatException e) {
+            // ids handed out by PlanNodeIdAllocator are numeric, anything else cannot collide with them
+        }
+        return maxId;
     }
 
     public void matches(PlanMatchPattern pattern)
@@ -141,7 +162,8 @@ public class OptimizerAssert
 
     private Plan applyRules()
     {
-        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(), idAllocator, WarningCollector.NOOP).getPlanNode();
+        // Seed the allocator with the variables already in the plan, otherwise newly allocated variables can collide with existing ones
+        PlanNode actual = optimizer.optimize(plan, session, types, new VariableAllocator(types.allVariables()), idAllocator, WarningCollector.NOOP).getPlanNode();
 
         if (!ImmutableSet.copyOf(plan.getOutputVariables()).equals(ImmutableSet.copyOf(actual.getOutputVariables()))) {
             fail(String.format(

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -18,10 +18,14 @@ import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.sql.planner.TestTableConstraintsConnectorFactory;
+import com.facebook.presto.sql.planner.iterative.properties.LogicalPropertiesProviderImpl;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,12 +39,15 @@ import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.globalAggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
@@ -51,10 +58,19 @@ import static java.util.Collections.emptyList;
 public class TestPushAggregationThroughOuterJoin
         extends BaseRuleTest
 {
+    private LogicalPropertiesProviderImpl logicalPropertiesProvider;
+
     @BeforeClass
     public final void setUp()
     {
-        tester = new RuleTester(emptyList(), ImmutableMap.of(USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS, Boolean.toString(false)));
+        tester = new RuleTester(emptyList(),
+                ImmutableMap.of(
+                        "exploit_constraints", Boolean.toString(true),
+                        USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS, Boolean.toString(false)),
+                Optional.of(1),
+                new TestTableConstraintsConnectorFactory(1));
+
+        logicalPropertiesProvider = new LogicalPropertiesProviderImpl(new FunctionResolution(tester.getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver()));
     }
 
     @Test
@@ -192,6 +208,49 @@ public class TestPushAggregationThroughOuterJoin
                                                 Optional.empty(),
                                                 SINGLE,
                                                 values(ImmutableMap.of("null_literal", 0))))));
+    }
+
+    @Test
+    public void testUsesLogicalPropertiesForDistinctCheck()
+    {
+        // Sub-query of TPCH Q13. `customer` has a primary key constraint on `custkey`, so the outer side of the join is
+        // known to be distinct only through its logical properties, which is what allows the aggregation to be pushed down.
+        // The predicate on the inner side is written as a derived table because this test does not run PredicatePushDown,
+        // and the rule does not fire while the predicate is still a join filter.
+        tester().assertThat(ImmutableSet.of(new PushAggregationThroughOuterJoin(getFunctionManager())), logicalPropertiesProvider)
+                .on("select\n" +
+                        "    c.custkey,\n" +
+                        "    count(o.orderkey) as c_count\n" +
+                        "from\n" +
+                        "    customer c\n" +
+                        "    left outer join (\n" +
+                        "        select orderkey, custkey from orders where comment not like '%special%requests%'\n" +
+                        "    ) o on c.custkey = o.custkey\n" +
+                        "group by\n" +
+                        "    c.custkey")
+                .matches(output(
+                        project(ImmutableMap.of("COUNT", expression("coalesce(COUNT, COUNT_NULL)")),
+                                join(JoinType.INNER, ImmutableList.of(),
+                                        join(JoinType.LEFT, ImmutableList.of(equiJoinClause("CUSTKEY", "O_CUSTKEY")),
+                                                tableScan("customer", ImmutableMap.of("CUSTKEY", "custkey")),
+                                                aggregation(
+                                                        singleGroupingSet("O_CUSTKEY"),
+                                                        ImmutableMap.of(Optional.of("COUNT"), functionCall("count", ImmutableList.of("ORDERKEY"))),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        project(
+                                                                filter(
+                                                                        tableScan(
+                                                                                "orders",
+                                                                                ImmutableMap.of("ORDERKEY", "orderkey", "O_CUSTKEY", "custkey")))))),
+                                        aggregation(
+                                                globalAggregation(),
+                                                ImmutableMap.of(Optional.of("COUNT_NULL"), functionCall("count", ImmutableList.of("null_literal"))),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                SINGLE,
+                                                values(ImmutableList.of("null_literal", "null_literal2")))))));
     }
 
     @Test


### PR DESCRIPTION
by exploiting the constraints framework

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve aggregation pushdown below outer join when constraints (session property `exploit_constraints=true`) can be used to establish that the outer side of a join is distinct
```

## Summary by Sourcery

Use constraint-derived logical properties to expand safe aggregation pushdown through outer joins.

Enhancements:
- Improve outer-join aggregation pushdown by using logical properties and constraints to establish that the outer side is distinct or single-row.

Tests:
- Add coverage for aggregation pushdown enabled by primary-key constraints and logical-property-based distinctness checks.
- Make rule tests use unique plan node and variable identifiers when optimizing prebuilt plans.