### PR TITLE
fix(planner): Strip plan JSON representation from Spark task descriptors

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
@@ -240,6 +240,23 @@ public class PlanFragment
                 Optional.empty());
     }
 
+    public PlanFragment withoutJsonRepresentation()
+    {
+        if (!jsonRepresentation.isPresent()) {
+            return this;
+        }
+        return new PlanFragment(
+                id, root, variables, partitioning,
+                tableScanSchedulingOrder,
+                partitioningScheme,
+                outputOrderingScheme,
+                stageExecutionDescriptor,
+                outputTableWriterFragment,
+                outputTransportType,
+                statsAndCosts,
+                Optional.empty());
+    }
+
     public List<Type> getTypes()
     {
         return types;

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestPlanFragment.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestPlanFragment.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.google.common.base.Strings;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.execution.TaskTestUtils.createPlanFragment;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestPlanFragment
+{
+    private static final int JSON_REPRESENTATION_LENGTH = 4_096;
+
+    @Test
+    public void testWithoutJsonRepresentationClearsOnlyTheJsonRepresentation()
+    {
+        PlanFragment fragment = withJsonRepresentation(Strings.repeat("x", JSON_REPRESENTATION_LENGTH));
+        assertTrue(fragment.getJsonRepresentation().isPresent());
+
+        PlanFragment stripped = fragment.withoutJsonRepresentation();
+
+        assertFalse(stripped.getJsonRepresentation().isPresent());
+        assertTrue(stripped.getStatsAndCosts().isPresent());
+        assertEquals(stripped.getId(), fragment.getId());
+        assertEquals(stripped.getVariables(), fragment.getVariables());
+        assertSame(stripped.getRoot(), fragment.getRoot());
+    }
+
+    @Test
+    public void testWithoutJsonRepresentationIsIdentityWhenAlreadyAbsent()
+    {
+        PlanFragment fragment = createPlanFragment();
+        assertFalse(fragment.getJsonRepresentation().isPresent());
+
+        assertSame(fragment.withoutJsonRepresentation(), fragment);
+    }
+
+    private static PlanFragment withJsonRepresentation(String jsonRepresentation)
+    {
+        PlanFragment base = createPlanFragment();
+        return new PlanFragment(
+                base.getId(),
+                base.getRoot(),
+                base.getVariables(),
+                base.getPartitioning(),
+                base.getTableScanSchedulingOrder(),
+                base.getPartitioningScheme(),
+                base.getOutputOrderingScheme(),
+                base.getStageExecutionDescriptor(),
+                base.isOutputTableWriterFragment(),
+                base.getStatsAndCosts(),
+                Optional.of(jsonRepresentation));
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -70,12 +70,16 @@ public class PrestoSparkServiceFactory
     }
 
     // Presto on Spark bootstraps here instead of PrestoServer.run(); relax Jackson's default read
-    // name-length and write nesting-depth limits so large plan fragments (de)serialize. Mutates
-    // JVM-global Jackson defaults, so it must run before any JsonFactory is constructed.
+    // name-length, read string-length and write nesting-depth limits so large plan fragments
+    // (de)serialize. Mutates JVM-global Jackson defaults, so it must run before any JsonFactory
+    // is constructed.
     static void overrideJacksonStreamConstraints()
     {
         StreamReadConstraints.overrideDefaultStreamReadConstraints(
-                StreamReadConstraints.builder().maxNameLength(Integer.MAX_VALUE).build());
+                StreamReadConstraints.builder()
+                        .maxNameLength(Integer.MAX_VALUE)
+                        .maxStringLength(Integer.MAX_VALUE)
+                        .build());
         StreamWriteConstraints.overrideDefaultStreamWriteConstraints(
                 StreamWriteConstraints.builder().maxNestingDepth(Integer.MAX_VALUE).build());
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -475,7 +475,7 @@ public abstract class AbstractPrestoSparkQueryExecution
         PrestoSparkTaskDescriptor taskDescriptor = new PrestoSparkTaskDescriptor(
                 session.toSessionRepresentation(),
                 session.getIdentity().getExtraCredentials(),
-                rootFragment,
+                rootFragment.withoutJsonRepresentation(),
                 tableWriteInfo,
                 nativeTempStorage.serializeHandle(nativeTempStorage.getRootDirectoryHandle()));
         SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor = new SerializedPrestoSparkTaskDescriptor(sparkTaskDescriptorJsonCodec.toJsonBytes(taskDescriptor));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -195,7 +195,7 @@ public class PrestoSparkRddFactory
         PrestoSparkTaskDescriptor taskDescriptor = new PrestoSparkTaskDescriptor(
                 session.toSessionRepresentation(),
                 session.getIdentity().getExtraCredentials(),
-                fragment,
+                fragment.withoutJsonRepresentation(),
                 tableWriteInfo,
                 nativeTempStorage.serializeHandle(nativeTempStorage.getRootDirectoryHandle()));
         SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor = new SerializedPrestoSparkTaskDescriptor(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkServiceFactory.java
@@ -34,6 +34,7 @@ public class TestPrestoSparkServiceFactory
 {
     private static final int LONG_NAME_LENGTH = 60_000;
     private static final int NESTING_DEPTH = 1_500;
+    private static final int DEFAULT_MAX_STRING_LENGTH = 20_000_000;
 
     private StreamReadConstraints originalReadConstraints;
     private StreamWriteConstraints originalWriteConstraints;
@@ -63,6 +64,19 @@ public class TestPrestoSparkServiceFactory
 
         JsonCodec<Map<String, String>> codec = new JsonCodecFactory().mapJsonCodec(String.class, String.class);
         assertEquals(codec.fromJson(codec.toJsonBytes(value)), value);
+    }
+
+    @Test
+    public void testOverrideRelaxesJsonStringValueLimit()
+    {
+        // A plan fragment's jsonRepresentation is a single JSON string value, so the read limit
+        // that governs it is maxStringLength rather than maxNameLength. Jackson's stock default is
+        // 20_000_000, which a large enough plan exceeds.
+        assertEquals(StreamReadConstraints.defaults().getMaxStringLength(), DEFAULT_MAX_STRING_LENGTH);
+
+        PrestoSparkServiceFactory.overrideJacksonStreamConstraints();
+
+        assertEquals(StreamReadConstraints.defaults().getMaxStringLength(), Integer.MAX_VALUE);
     }
 
     @Test


### PR DESCRIPTION
Summary:
## Description

`PlanFragment` carries an optional `jsonRepresentation` field holding a pre-rendered JSON copy of the plan. It is debug-only metadata and is never read during execution.

Paths that send a fragment to a remote node strip it first. `HttpRemoteTaskWithEventLoop` and `PrestoSparkHttpTaskClient` both serialize through `PlanFragment.bytesForTaskSerialization()`, which calls `forTaskSerialization()` and clears `statsAndCosts` and `jsonRepresentation`.

The Presto on Spark RDD path does not. `PrestoSparkRddFactory` and `AbstractPrestoSparkQueryExecution` build `PrestoSparkTaskDescriptor` from the unmodified fragment, so the JSON representation is serialized into every task descriptor and sent to every executor.

This change adds `PlanFragment.withoutJsonRepresentation()` and applies it at both call sites. `statsAndCosts` is deliberately left intact, so the change is narrower than `forTaskSerialization()`. It also raises Jackson's `maxStringLength` alongside the `maxNameLength` and `maxNestingDepth` limits already relaxed in `PrestoSparkServiceFactory.overrideJacksonStreamConstraints()`, so that no other oversized string can trip the same limit.

## Motivation and Context

Once a plan is large enough, its `jsonRepresentation` exceeds Jackson's default `maxStringLength` of 20,000,000 characters. The executor then fails to deserialize the task descriptor before any Presto code runs:

```
com.fasterxml.jackson.databind.JsonMappingException: String value length (20054016)
exceeds the maximum allowed (20000000, from `StreamReadConstraints.getMaxStringLength()`)
(through reference chain: PrestoSparkTaskDescriptor["fragment"]->PlanFragment["jsonRepresentation"])
```

Because the failure happens during deserialization, the executor dies before it can report a reason. The driver records only `UnknownReason`, the task is retried until retries are exhausted, and the stage aborts with nothing pointing at the real cause.

The limit has applied since the upgrade to Jackson 2.15, so this is a latent problem rather than a recent regression. It only becomes reachable once a plan crosses the threshold, which a query can do simply by gaining more lateral unnest operators as its generated SQL grows.

Separately from the failure, the field is never read on the executor, so serializing and transferring it wastes CPU and network on every task.

## Impact

No public API or user-facing behaviour change. `jsonRepresentation` is still populated and still available on the coordinator, where `QueryStateMachine` and `PlanFragmenterUtils` consume it. Only the copy placed into Spark task descriptors is dropped.

## Contributor checklist

- [x] Please make sure your submission complies with our development, formatting, commenting, and coding conventions.
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the release notes guidelines.
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D118395671

## Summary by Sourcery

Strip unused plan JSON representations from Presto on Spark task descriptors to reduce transfer overhead and prevent failures for large plans.

Bug Fixes:
- Prevent oversized Spark task descriptors and executor deserialization failures by removing unused plan JSON representations before serialization.

Enhancements:
- Preserve plan statistics and costs while stripping only the debug-only JSON representation from Presto on Spark task descriptors.
- Relax Jackson's maximum JSON string length for Presto on Spark service initialization.

Tests:
- Add coverage for selectively removing plan JSON representations and for the Jackson string-length constraint override.