### PR TITLE
test(native): Apply containerTimeout to all container types

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -255,6 +255,16 @@ public class ContainerQueryRunner
         }
     }
 
+    private static Duration containerStartupTimeout()
+    {
+        try {
+            return Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT));
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("containerTimeout must be a whole number of seconds, but was: " + CONTAINER_TIMEOUT, e);
+        }
+    }
+
     protected GenericContainer<?> createCoordinator(boolean isNativeCluster, boolean isSidecarEnabled)
             throws IOException
     {
@@ -278,7 +288,7 @@ public class ContainerQueryRunner
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/coordinator/etc"), "/opt/presto-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/coordinator/entrypoint.sh"), "/opt/entrypoint.sh")
                 .waitingFor(Wait.forLogMessage(".*======== SERVER STARTED ========.*", 1))
-                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)))
+                .withStartupTimeout(containerStartupTimeout())
                 .withExposedPorts(coordinatorPort);
     }
     protected GenericContainer<?> createJavaWorker(int port, String nodeId)
@@ -296,7 +306,7 @@ public class ContainerQueryRunner
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
                 // No explicit wait strategy, so the default host-port strategy applies; bound it by
                 // CONTAINER_TIMEOUT rather than the Testcontainers default.
-                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)));
+                .withStartupTimeout(containerStartupTimeout());
     }
 
     protected GenericContainer<?> createSidecar(int port, String nodeId, boolean isNativeCluster)
@@ -321,7 +331,7 @@ public class ContainerQueryRunner
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
                 .waitingFor(isSidecarNode ? Wait.forListeningPort() : Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1))
-                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)));
+                .withStartupTimeout(containerStartupTimeout());
     }
 
     protected GenericContainer<?> createFunctionServer()
@@ -337,7 +347,7 @@ public class ContainerQueryRunner
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/function-server/etc"), "/opt/function-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/function-server/entrypoint.sh"), "/opt/entrypoint.sh")
                 .waitingFor(Wait.forLogMessage(".*======== REMOTE FUNCTION SERVER STARTED at: .*", 1))
-                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)))
+                .withStartupTimeout(containerStartupTimeout())
                 .withExposedPorts(functionServerPort);
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -317,7 +317,8 @@ public class ContainerQueryRunner
                 .withNetworkAliases(nodeId)
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
-                .waitingFor(isSidecarNode ? Wait.forListeningPort() : Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1));
+                .waitingFor(isSidecarNode ? Wait.forListeningPort() : Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1))
+                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)));
     }
 
     protected GenericContainer<?> createFunctionServer()

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -293,7 +293,10 @@ public class ContainerQueryRunner
                 .withNetwork(networkExpected)
                 .withNetworkAliases(nodeId)
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
-                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh");
+                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
+                // No explicit wait strategy, so the default host-port strategy applies; bound it by
+                // CONTAINER_TIMEOUT rather than the Testcontainers default.
+                .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)));
     }
 
     protected GenericContainer<?> createSidecar(int port, String nodeId, boolean isNativeCluster)


### PR DESCRIPTION
## Description

`-DcontainerTimeout` (default `120`) is applied to the coordinator and the remote
function server, but not to the other containers `ContainerQueryRunner` starts:

* `createNativeWorker`, which builds both the native worker and the sidecar, sets
  a wait strategy but no startup timeout.
* `createJavaWorker` sets neither, so the default host-port wait strategy applies.

All three silently fall back to the Testcontainers default startup timeout of
60s. This applies `CONTAINER_TIMEOUT` to them, so the property now covers every
container the runner starts.

Since that would have taken `Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT))`
from two occurrences to four, the expression is consolidated into a single private
helper, which also turns a malformed value into an `IllegalArgumentException`
naming the property instead of a bare `NumberFormatException`.

## Motivation and Context

The property cannot currently be used to accommodate a slow worker startup,
which is the case it is most needed for: the coordinator and function server
start quickly, while a native worker has to come up and announce itself and a
Java worker has to start a JVM. On a slow or loaded machine, or with a debug
build, those containers are killed at 60s regardless of what `containerTimeout`
is set to, and the failure looks like an unexplained container startup failure
rather than a timeout the user chose.

`prestocpp-linux-container-tests.yml` runs the `TestPrestoContainer*` classes
without setting `containerTimeout`, so worker and sidecar startup in CI is
bounded at 60s today.

## Impact

Test infrastructure only; no production code is touched. Native worker, sidecar
and Java worker startup timeouts change from 60s to the `containerTimeout`
default of 120s, and become configurable. No behavior change for the coordinator
or function server, and no readiness condition is changed.

The helper is a static method rather than a `static final Duration` field on
purpose: a malformed value in a field initializer would fail class
initialization and surface as `ExceptionInInitializerError` followed by
`NoClassDefFoundError`, which is harder to diagnose under TestNG than an
exception thrown where the container is created.

`Long.parseLong(CLUSTER_SHUTDOWN_TIMEOUT)` in `close()` has the same shape but is
a different property, unrelated to startup timeouts, and is left alone.

## Test Plan

* `TestPrestoContainerBasicQueries` passes against a prebuilt coordinator and
  native worker image pair (4/4), before and after the helper extraction.
* Audited every `new GenericContainer<>` in `ContainerQueryRunner`; all four now
  take their startup timeout from `containerStartupTimeout()`, and that is the
  only place `CONTAINER_TIMEOUT` is parsed.
* `mvn test-compile` on `presto-native-execution` from clean, with checkstyle,
  license and dependency-scope checks enabled.

Note: `run-container-tests` is currently skipped on this PR because
`build-coordinator-image` fails on master for an unrelated reason (#28434), so
the container tests above were run locally.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Apply containerTimeout consistently across all containers started by the native execution test runner.

Bug Fixes:
- Apply the configurable container startup timeout to native workers, sidecars, and Java workers instead of relying on the shorter Testcontainers default.

Enhancements:
- Centralize startup-timeout parsing and provide a clear error when containerTimeout is not a whole number of seconds.