### PR TITLE
test(native): Invoke the worker binary directly in container tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -61,9 +61,15 @@ public class ContainerQueryRunner
     protected static final Network networkExpected = Network.newNetwork();
     protected static final String PRESTO_COORDINATOR_IMAGE = System.getProperty("coordinatorImage", "presto-coordinator:latest");
     protected static final String PRESTO_WORKER_IMAGE = System.getProperty("workerImage", "presto-worker:latest");
+    // The native worker binary is invoked directly rather than through the image's entrypoint, so
+    // images that do not put it on PATH can be tested by overriding this property.
+    protected static final String NATIVE_WORKER_BINARY = System.getProperty("nativeWorkerBinary", "presto_server");
     protected static final String CONTAINER_TIMEOUT = System.getProperty("containerTimeout", "120");
     protected static final String CLUSTER_SHUTDOWN_TIMEOUT = System.getProperty("clusterShutDownTimeout", "10");
     protected static final String BASE_DIR = System.getProperty("user.dir");
+    // Where the generated worker configuration is copied to, and what the worker is pointed at with
+    // --etc-dir. The harness owns both ends, so this does not have to match the image's own layout.
+    protected static final String NATIVE_WORKER_ETC_DIR = "/opt/presto-server/etc";
     protected static final int DEFAULT_COORDINATOR_PORT = 8080;
     protected static final int DEFAULT_BASE_WORKER_PORT = 7778;
     protected static final int DEFAULT_SIDECAR_PORT = 7777;
@@ -322,14 +328,15 @@ public class ContainerQueryRunner
         if (!isSidecarEnabled) {
             ContainerQueryRunnerUtils.createNativeWorkerTpchProperties(nodeId);
         }
-        ContainerQueryRunnerUtils.createNativeWorkerEntryPointScript(nodeId);
         ContainerQueryRunnerUtils.createNativeWorkerNodeProperties(nodeId);
         return new GenericContainer<>(PRESTO_WORKER_IMAGE)
                 .withExposedPorts(port)
                 .withNetwork(isNativeCluster ? network : networkExpected)
                 .withNetworkAliases(nodeId)
-                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
-                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
+                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), NATIVE_WORKER_ETC_DIR)
+                .withEnv("GLOG_logtostderr", "1")
+                .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint(NATIVE_WORKER_BINARY))
+                .withCommand("--etc-dir=" + NATIVE_WORKER_ETC_DIR)
                 .waitingFor(isSidecarNode ? Wait.forListeningPort() : Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1))
                 .withStartupTimeout(containerStartupTimeout());
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
@@ -278,15 +278,6 @@ public class ContainerQueryRunnerUtils
         createScriptFile("testcontainers/function-server/entrypoint.sh", scriptContent);
     }
 
-    public static void createNativeWorkerEntryPointScript(String nodeId)
-            throws IOException
-    {
-        String scriptContent = "#!/bin/sh\n\n" +
-                "GLOG_logtostderr=1 presto_server \\\n" +
-                "    --etc-dir=/opt/presto-server/etc\n";
-        createScriptFile("testcontainers/" + nodeId + "/entrypoint.sh", scriptContent);
-    }
-
     public static void createJavaEntryPointScript(String nodeId)
             throws IOException
     {

--- a/presto-native-execution/testcontainers/README.md
+++ b/presto-native-execution/testcontainers/README.md
@@ -60,7 +60,7 @@ To run the functional tests using existing docker images, specify `-Dcoordinator
 ```
 The native worker is started by invoking its binary directly, so the worker image does not need to
 supply an entrypoint. The binary is looked up as `presto_server` on the image's `PATH`; if the image
-installs it elsewhere, name it explicitly:
+installs it elsewhere, name the location explicitly:
 ```
 -DnativeWorkerBinary="/opt/presto/bin/presto_server"
 ```

--- a/presto-native-execution/testcontainers/README.md
+++ b/presto-native-execution/testcontainers/README.md
@@ -58,6 +58,12 @@ To run the functional tests using existing docker images, specify `-Dcoordinator
 ```
 -DcoordinatorImage="public.ecr.aws/oss-presto/presto:0.287-20240619190653-db8458d" -DworkerImage="public.ecr.aws/oss-presto/presto-native:0.287-20240619190653-db8458d"
 ```
+The native worker is started by invoking its binary directly, so the worker image does not need to
+supply an entrypoint. The binary is looked up as `presto_server` on the image's `PATH`; if the image
+installs it elsewhere, name it explicitly:
+```
+-DnativeWorkerBinary="/opt/presto/bin/presto_server"
+```
 ##### Note
 * Existing java and native docker files are reused for functional testing. The coordinator and worker configurations are generated in the utility class.
 * The functional test framework has been tested with the tpch.tiny schema, using standard column naming. Please note that this configuration is a current limitation, as it has only been tested with this schema and does not require any data loading.


### PR DESCRIPTION
## Description

`createNativeWorker` generates a shell script and copies it over the worker
image's `/opt/entrypoint.sh`:

```sh
GLOG_logtostderr=1 presto_server \
    --etc-dir=/opt/presto-server/etc
```

That is the same command as `presto-native-execution/entrypoint.sh`, which
`prestissimo-runtime.dockerfile` already installs as the image `ENTRYPOINT`. The
harness is overwriting the image's entrypoint with a copy of itself.

This replaces the generated script with an explicit Testcontainers entrypoint
override plus `--etc-dir` passed as a command argument, and removes
`createNativeWorkerEntryPointScript()`. It is the same approach
`PrestoNativeQueryRunnerUtils.launchWorkerContainer` already uses in this module.

`GLOG_logtostderr=1` moves from the script to `withEnv`, and the in-container
config directory becomes a named constant used both as the copy target and as the
`--etc-dir` value, since the harness now owns both ends.

## Motivation and Context

Removing the redundant script also removes three assumptions the harness was
making about the worker image's internal layout: that its entrypoint lives at
`/opt/entrypoint.sh`, that overwriting that file is the way to control startup,
and that `presto_server` is resolvable from a shell on `PATH`.

`testcontainers/README.md` documents running these tests against existing
published images via `-DcoordinatorImage` and `-DworkerImage`. That only works
for images built from this repository's Dockerfile. A native build that installs
`presto_server` somewhere other than `PATH`, or stores its entrypoint elsewhere,
cannot be tested even though it is a perfectly good Presto native worker.

`-DnativeWorkerBinary` (default `presto_server`) generalizes the constraint
`launchWorkerContainer` already documents as "the worker image must have
`presto_server` on its `PATH`".

## Impact

Test infrastructure only; no production code is touched. Behavior with the
in-tree images is unchanged, and the default value of the new property preserves
the current lookup. One generated file per worker node is no longer written.

`presto_server` now runs as PID 1 in the container rather than as a child of a
shell, so it receives container stop signals directly.

## Test Plan

* `TestPrestoContainerBasicQueries` passes against a prebuilt coordinator and
  native worker image pair (4/4).
* Compared container logs from the image entrypoint against the overridden
  entrypoint on the same image: identical startup sequence and identical
  `config.properties` / `node.properties` parsing, differing only in PID.
* Confirmed the generated script was byte-for-byte equivalent to the
  `ENTRYPOINT` already baked into the native image.
* `mvn test-compile` on `presto-native-execution` from clean, with checkstyle,
  license and dependency-scope checks enabled.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Invoke the native worker binary directly in container tests while making the binary location configurable.

New Features:
- Allow native container tests to select the worker binary path through the `nativeWorkerBinary` property.

Enhancements:
- Start native workers by invoking the binary directly with an explicit configuration directory instead of overwriting the image entrypoint.
- Run the native worker as the container's PID 1 and configure its logging through the container environment.

Documentation:
- Document configuring native worker images whose binary is not available on `PATH`.

Chores:
- Remove generation of redundant native worker entrypoint scripts from the test harness.