### PR TITLE
fix(native): Add better error messages for unsupported operations in ArrowFederationConnector

### DIFF
--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
@@ -1162,6 +1162,18 @@ public abstract class AbstractTestArrowFederationNativeQueries
         assertThat(result).contains("information_schema").allMatch(schemaName -> ((String) schemaName).contains("_"));
     }
 
+    @Test
+    public void testUnsupportedWriteOperations()
+    {
+        @Language("RegExp") String unsupportedWriteError =
+                ".*This connector is read-only and does not support write operations.*Only SELECT is supported.*";
+
+        assertQueryFails("INSERT INTO nation VALUES (100, 'TESTLAND', 0, 'test')", unsupportedWriteError);
+        assertQueryFails("CREATE TABLE ctas_test AS SELECT * FROM nation LIMIT 1", unsupportedWriteError);
+        // We fail at the coordinator itself for deletes
+        assertQueryFails("DELETE FROM nation WHERE nationkey = 100", ".*This connector does not support deletes.*");
+    }
+
     private static void assertContainsFunctionSignature(List<MaterializedRow> functions, String returnType, String argumentTypes, String functionType)
     {
         assertTrue(

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/AbstractTestArrowFederationNativeQueries.java
@@ -1172,6 +1172,11 @@ public abstract class AbstractTestArrowFederationNativeQueries
         assertQueryFails("CREATE TABLE ctas_test AS SELECT * FROM nation LIMIT 1", unsupportedWriteError);
         // We fail at the coordinator itself for deletes
         assertQueryFails("DELETE FROM nation WHERE nationkey = 100", ".*This connector does not support deletes.*");
+        // MERGE is rejected at the coordinator via ConnectorMetadata.beginMerge() before any plan
+        // fragment reaches the native worker.
+        assertQueryFails(
+                "MERGE INTO nation USING (SELECT 1) t ON false WHEN NOT MATCHED THEN INSERT VALUES (100, 'TESTLAND', 0, 'test')",
+                ".*This connector does not support modifying table rows.*");
     }
 
     private static void assertContainsFunctionSignature(List<MaterializedRow> functions, String returnType, String argumentTypes, String functionType)

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesCassandra.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesCassandra.java
@@ -124,7 +124,7 @@ public class TestArrowFederationNativeQueriesCassandra
     public void testTableCreation()
             throws InterruptedException
     {
-        assertQueryFails("CREATE TABLE temp AS SELECT * FROM nation", ".*Not implemented: N8facebook6presto8protocol26ConnectorOutputTableHandleE.*");
+        assertQueryFails("CREATE TABLE temp AS SELECT * FROM nation", ".*This connector is read-only and does not support write operations.*Only SELECT is supported.*");
         while (true) {
             try {
                 assertQueryFails("SELECT * FROM temp", ".*Table cassandra.tpch.temp does not exist.*");

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
@@ -215,6 +215,11 @@ public class TestArrowFederationNativeQueriesRedis
         assertQueryFails("INSERT INTO nation VALUES (100, 'TESTLAND', 0, 'test')", ".*This connector does not support inserts.*");
         assertQueryFails("CREATE TABLE ctas_test AS SELECT * FROM nation LIMIT 1", ".*This connector does not support creating tables.*");
         assertQueryFails("DELETE FROM nation WHERE nationkey = 100", ".*This connector does not support deletes.*");
+        // MERGE is rejected at the coordinator via ConnectorMetadata.beginMerge() before any plan
+        // fragment reaches the native worker.
+        assertQueryFails(
+                "MERGE INTO nation USING (SELECT 1) t ON false WHEN NOT MATCHED THEN INSERT VALUES (100, 'TESTLAND', 0, 'test')",
+                ".*This connector does not support modifying table rows.*");
     }
 
     static void createTpchTables(EmbeddedRedis embeddedRedis, QueryRunner queryRunner)

--- a/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
+++ b/presto-flight-shim/src/test/java/com/facebook/presto/flightshim/TestArrowFederationNativeQueriesRedis.java
@@ -208,6 +208,15 @@ public class TestArrowFederationNativeQueriesRedis
     {
     }
 
+    // Redis connector in Java is read-only, no write operations go past the coordinator stage
+    @Test
+    public void testUnsupportedWriteOperations()
+    {
+        assertQueryFails("INSERT INTO nation VALUES (100, 'TESTLAND', 0, 'test')", ".*This connector does not support inserts.*");
+        assertQueryFails("CREATE TABLE ctas_test AS SELECT * FROM nation LIMIT 1", ".*This connector does not support creating tables.*");
+        assertQueryFails("DELETE FROM nation WHERE nationkey = 100", ".*This connector does not support deletes.*");
+    }
+
     static void createTpchTables(EmbeddedRedis embeddedRedis, QueryRunner queryRunner)
     {
         TestingPrestoClient prestoClient = ((DistributedQueryRunner) queryRunner).getRandomClient();

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_federation/ArrowFederationConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_federation/ArrowFederationConnectorProtocol.h
@@ -20,11 +20,13 @@ using ArrowFederationConnectorProtocol = ConnectorProtocolTemplate<
     ArrowFederationTableHandle,
     ArrowFederationTableLayoutHandle,
     ArrowFederationColumnHandle,
-    NotImplemented,
-    NotImplemented,
+    UnsupportedOperation, // ConnectorInsertTableHandle
+    UnsupportedOperation, // ConnectorOutputTableHandle (CTAS)
     ArrowFederationSplit,
-    NotImplemented,
+    NotImplemented, // ConnectorPartitioningHandle
     ArrowFederationTransactionHandle,
-    NotImplemented,
-    NotImplemented>;
+    NotImplemented, // ConnectorDistributedProcedureHandle
+    UnsupportedOperation, // ConnectorDeleteTableHandle
+    NotImplemented, // ConnectorIndexHandle
+    UnsupportedOperation>; // ConnectorMergeTableHandle
 } // namespace facebook::presto::protocol::arrow_federation

--- a/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
@@ -183,6 +183,7 @@ class ConnectorProtocol {
 
 namespace {
 struct NotImplemented {};
+struct UnsupportedOperation {};
 } // namespace
 
 template <
@@ -420,6 +421,12 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
   }
 
  private:
+  static void throwUnsupportedWriteOperation() {
+    VELOX_UNSUPPORTED(
+        "This connector is read-only and does not support write operations "
+        "(INSERT, CREATE TABLE AS SELECT, DELETE). Only SELECT is supported.");
+  }
+
   template <typename DERIVED, typename BASE>
   static void to_json_template(
       json& j,
@@ -437,6 +444,16 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
           std::is_same<DERIVED, NotImplemented>::value,
           BASE>::type* = 0) {
     VELOX_NYI("Not implemented: {}", typeid(BASE).name());
+  }
+
+  template <typename DERIVED, typename BASE>
+  static void to_json_template(
+      json&,
+      const std::shared_ptr<BASE>&,
+      typename std::enable_if<
+          std::is_same<DERIVED, UnsupportedOperation>::value,
+          BASE>::type* = 0) {
+    throwUnsupportedWriteOperation();
   }
 
   template <typename DERIVED, typename BASE>
@@ -461,6 +478,16 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
   }
 
   template <typename DERIVED, typename BASE>
+  static void from_json_template(
+      const json&,
+      std::shared_ptr<BASE>&,
+      typename std::enable_if<
+          std::is_same<DERIVED, UnsupportedOperation>::value,
+          BASE>::type* = 0) {
+    throwUnsupportedWriteOperation();
+  }
+
+  template <typename DERIVED, typename BASE>
   static void serializeTemplate(
       const std::shared_ptr<BASE>&,
       std::string&,
@@ -469,6 +496,17 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
           BASE>::type* = 0) {
     VELOX_NYI("Not implemented: {}", typeid(BASE).name());
   }
+
+  template <typename DERIVED, typename BASE>
+  static void serializeTemplate(
+      const std::shared_ptr<BASE>&,
+      std::string&,
+      typename std::enable_if<
+          std::is_same<DERIVED, UnsupportedOperation>::value,
+          BASE>::type* = 0) {
+    throwUnsupportedWriteOperation();
+  }
+
   template <typename DERIVED, typename BASE>
   static void deserializeTemplate(
       const std::string&,
@@ -477,6 +515,16 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
           std::is_same<DERIVED, NotImplemented>::value,
           BASE>::type* = 0) {
     VELOX_NYI("Not implemented: {}", typeid(BASE).name());
+  }
+
+  template <typename DERIVED, typename BASE>
+  static void deserializeTemplate(
+      const std::string&,
+      std::shared_ptr<BASE>&,
+      typename std::enable_if<
+          std::is_same<DERIVED, UnsupportedOperation>::value,
+          BASE>::type* = 0) {
+    throwUnsupportedWriteOperation();
   }
 
   template <typename DERIVED, typename BASE>

--- a/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
@@ -424,7 +424,7 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
   static void throwUnsupportedWriteOperation() {
     VELOX_UNSUPPORTED(
         "This connector is read-only and does not support write operations "
-        "(INSERT, CREATE TABLE AS SELECT, DELETE). Only SELECT is supported.");
+        "(INSERT, CREATE TABLE AS SELECT, DELETE, MERGE). Only SELECT is supported.");
   }
 
   template <typename DERIVED, typename BASE>


### PR DESCRIPTION
## Description
Adds a new` UnsupportedOperation` sentinel type to `ConnectorProtocolTemplate` in `ConnectorProtocol.h`. Unlike `NotImplemented` (which throws `VELOX_NYI` with a mangled C++ type name), `UnsupportedOperation` throws `VELOX_UNSUPPORTED` — a `VeloxUserError` — with a human-readable message: `This connector is read-only and does not support write operations (INSERT, CREATE TABLE AS SELECT, CREATE TABLE). Only SELECT is supported.`

## Motivation and Context
Previously, attempting a write operation `(INSERT, CTAS, DELETE, MERGE)` via the Arrow Federation connector on a native worker produced an unreadable runtime error message:
(e.g. `Not implemented: N8facebook6presto8protocol27ConnectorInsertTableHandleE`). 

This change surfaces a clear user-facing error so users know immediately that only `SELECT` is supported.

## Impact
Better user facing error message

## Test Plan
CI, Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Improve Arrow Federation's handling of unsupported write operations by surfacing readable read-only connector errors.

New Features:
- Provide clear user-facing errors when Arrow Federation rejects unsupported write operations on native workers.

Bug Fixes:
- Replace unreadable native connector protocol errors for unsupported Arrow Federation writes with actionable read-only messages.

Tests:
- Add coverage for unsupported INSERT, CTAS, DELETE, and MERGE operations across Arrow Federation native query tests and update existing CTAS expectations.