### PR TITLE
fix(build): Make the python symlink idempotent

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ ENV PRESTO_HOME="/opt/presto-server"
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf install -y java-17-openjdk less procps python3 \
-    && ln -sf $(which python3) /usr/bin/python \
     # clean cache jobs
     && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV PRESTO_HOME="/opt/presto-server"
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf install -y java-17-openjdk less procps python3 \
-    && ln -s $(which python3) /usr/bin/python \
+    && ln -sf $(which python3) /usr/bin/python \
     # clean cache jobs
     && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak
 


### PR DESCRIPTION
`ln -s $(which python3) /usr/bin/python` fails with
```
    ln: failed to create symbolic link '/usr/bin/python': File exists
```
whenever the base image already provides that link, and the `&&` chain turns that into a fatal `exit 1`. quay.io/centos/centos:stream9 is a rolling tag and it now ships /usr/bin/python via
python-unversioned-command-3.9.25-10.el9

## Description
Use `ln -sf`, so the step is idempotent and works whether or not the base image already supplies the link. 

## Motivation and Context

`docker/Dockerfile:13` fails the image build against the current `quay.io/centos/centos:stream9`:

```
ln: failed to create symbolic link '/usr/bin/python': File exists
ERROR: failed to solve: process "/bin/sh -c dnf install -y java-17-openjdk less procps python3
        && ln -s $(which python3) /usr/bin/python
        && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak"
        did not complete successfully: exit code: 1
```

`ln -s` without `-f` refuses to replace an existing path, and because it sits in an `&&` chain that refusal fails the whole `RUN` step. amd64 and arm64 are affected alike.

## Impact

Builds are failing.

## Test Plan
On the same image:

```
$ docker run --rm quay.io/centos/centos@sha256:0ae48e0618d4e26d6d43406f923170160c72d8681ff42df9f26b2c8f3f500a94 \
    sh -c 'dnf install -y java-17-openjdk less procps python3 >/dev/null && ln -sf $(which python3) /usr/bin/python && python --version'
Python 3.9.25
```

```
== NO RELEASE NOTE ==
```

