### PR TITLE
fix(security): Bump bouncycastle version to 1.85 to address CVEs

### DIFF
--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -16,7 +16,7 @@
         <air.test.jvmsize>5g</air.test.jvmsize>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
-        <bouncycastle.version>1.84</bouncycastle.version>
+        <bouncycastle.version>1.85</bouncycastle.version>
     </properties>
 
     <dependencies>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/SslKeystoreManager.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/SslKeystoreManager.java
@@ -136,7 +136,7 @@ public class SslKeystoreManager
         long now = System.currentTimeMillis();
         Date startDate = new Date(now);
 
-        X500Name issuer = new X500Name("CN=" + dn + ", OU=, O=, L=, ST=, C=");
+        X500Name issuer = new X500Name("CN=" + dn);
         BigInteger serialNumber = new BigInteger(64, new SecureRandom());
         Date endDate = new Date(now + validityDays * 24L * 60L * 60L * 1000L);
 


### PR DESCRIPTION
## Description
Upgrade bouncycastle version to 1.85 to address CVEs. Upgrade includes `bcprov-jdk18on` and `bcpkix-jdk18on` artifacts.

## Motivation and Context
Found multiple CVEs of severity - High, Critical and Medium. Upgrading bouncy castle version to 1.85 will resolve these.
<img width="3454" height="816" alt="b2283d53-ddec-4bac-a65a-9204e76821b2" src="https://github.com/user-attachments/assets/901ffabf-e9d7-434c-a6be-e007eb34b173" />

**Change in `com.facebook.presto.tests. SslKeystoreManager`** -
Bouncy Castle 1.85 validates `X.500` attribute values when building an X500Name and rejects an empty countryName (C=). `SslKeystoreManager` built the test certificate subject as "`CN=tls, OU=, O=, L=, ST=, C=`", which now throws IllegalArgumentException and fails setup of SSL test using it. The subject is simplified to "`CN=tls`"; the empty attributes carried no information and the generated certificate is otherwise unchanged.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Build pass. Following test suites run completed - 

- TestSslContextProvider
- TestMongoTlsConfiguration
- TestPrestoRestTLSConfigurer
- TestHiveSslWithKeyStore, TestHiveSslWithTrustStore, TestHiveSslWithTrustStoreKeyStore

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade bouncycastle version to 1.85 to address CVEs

```

## Summary by Sourcery

Upgrade Bouncy Castle to 1.85 to address reported security vulnerabilities while preserving SSL test compatibility.

Bug Fixes:
- Update SSL test certificate generation to remain compatible with stricter Bouncy Castle subject validation.

Build:
- Upgrade the Bouncy Castle dependencies used by the test suite from 1.84 to 1.85.