### PR TITLE
fix(plugin-iceberg): Include source schema in MV storage table names

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -648,7 +648,10 @@ Session properties set behavior changes for queries executed within the given se
 
        ``materialized_view_storage_table_name_prefix``
      - Prefix for automatically generated materialized view storage table names.
-       Default: ``__mv_storage__``
+       Default: ``__mv_storage__``. When ``materialized_view_default_storage_schema``
+       routes storage tables into a shared schema, the generated name uses a
+       length-prefix encoding to include the source schema and avoid collisions:
+       ``<prefix><schemaLen>_<schema>__<viewName>``.
      - Yes
      - Yes
    * - .. _iceberg-sess-materialized-view-missing-base-table-behavior:
@@ -3137,7 +3140,17 @@ The Iceberg connector supports materialized views. See :doc:`/admin/materialized
 Storage
 ^^^^^^^
 
-Materialized views use a dedicated Iceberg storage table to persist the pre-computed results. By default, the storage table is created with the prefix ``__mv_storage__`` followed by the materialized view name in the same schema as the view.
+Materialized views use a dedicated Iceberg storage table to persist the pre-computed results. By
+default, the storage table is placed in the same schema as the view and its name is generated
+automatically from the configured prefix (``__mv_storage__`` by default) and the materialized view
+name.
+
+When ``iceberg.materialized-view-default-storage-schema`` is set to route storage tables into a
+shared schema, the generated name also embeds the source schema to prevent collisions between
+materialized views with the same name in different schemas. The format used is::
+
+    <prefix><schemaLength>_<sourceSchema>__<viewName>
+
 
 Catalog Configuration
 ^^^^^^^^^^^^^^^^^^^^^
@@ -3164,7 +3177,10 @@ view creation time and can be overridden per-view by using the ``storage_schema`
        ``iceberg.materialized-view-default-storage-schema``
      - Schema in which storage tables are created when the per-view ``storage_schema``
        property is not set. Point at a locked-down schema to keep storage tables out of
-       users' reach without affecting materialized view reads.
+       users' reach without affecting materialized view reads. When this property is set,
+       the auto-generated storage table name includes the source schema using a
+       length-prefix encoding (``<prefix><schemaLen>_<schema>__<viewName>``) to avoid
+       collisions between same-named views in different schemas.
      - (the view's own schema)
    * - .. _mv-cfg-max-changed-partitions:
 
@@ -3206,7 +3222,12 @@ by using :doc:`/sql/alter-materialized-view`; properties not specified in the
      - Schema name for the storage table. Defaults to the materialized view's schema.
      - No
    * - ``storage_table``
-     - Custom name for the storage table. Defaults to the prefix plus the materialized view name.
+     - Custom name for the storage table. When not set, the name is auto-generated from
+       the configured prefix and the materialized view name. If
+       ``iceberg.materialized-view-default-storage-schema`` (or the session property
+       ``materialized_view_default_storage_schema``) routes storage into a different schema,
+       the source schema is also embedded using length-prefix encoding:
+       ``<prefix><schemaLen>_<schema>__<viewName>``.
      - No
    * - ``stale_read_behavior``
      - Behavior when reading from a materialized view that is stale beyond the staleness window.

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -2753,13 +2753,17 @@ public abstract class IcebergAbstractMetadata
 
     private SchemaTableName getStorageTableName(ConnectorSession session, SchemaTableName viewName, Map<String, Object> properties)
     {
-        String tableName = getStorageTable(properties).orElseGet(() -> {
-            // Generate default storage table name using prefix
-            return getMaterializedViewStoragePrefix(session) + viewName.getTableName();
-        });
-        String schema = getStorageSchema(properties)
+        String resolvedSchema = getStorageSchema(properties)
                 .orElseGet(() -> getMaterializedViewDefaultStorageSchema(session).orElse(viewName.getSchemaName()));
-        return new SchemaTableName(schema, tableName);
+        String tableName = getStorageTable(properties).orElseGet(() -> {
+            String prefix = getMaterializedViewStoragePrefix(session);
+            if (!resolvedSchema.equals(viewName.getSchemaName())) {
+                String schema = viewName.getSchemaName();
+                return prefix + schema.length() + "_" + schema + "__" + viewName.getTableName();
+            }
+            return prefix + viewName.getTableName();
+        });
+        return new SchemaTableName(resolvedSchema, tableName);
     }
 
     private String serializeColumnMappings(List<ColumnMapping> columnMappings)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -4919,8 +4919,9 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate(sessionWithDefaultSchema, "CREATE MATERIALIZED VIEW test_default_storage_schema_mv AS " +
                 "SELECT id, name FROM test_default_storage_schema_base");
 
+        String storageTableName = "__mv_storage__11_test_schema__test_default_storage_schema_mv";
         try {
-            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"__mv_storage__test_default_storage_schema_mv\"", "SELECT 0");
+            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"" + storageTableName + "\"", "SELECT 0");
             assertQueryFails("SELECT * FROM \"__mv_storage__test_default_storage_schema_mv\"", ".*does not exist.*");
 
             assertMaterializedViewQuery(
@@ -4928,12 +4929,59 @@ public abstract class TestIcebergMaterializedViewsBase
                     "VALUES (1, 'Alice'), (2, 'Bob')");
 
             assertRefreshAndFullyMaterialized("test_default_storage_schema_mv", 2);
-            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"__mv_storage__test_default_storage_schema_mv\"", "SELECT 2");
+            assertQuery("SELECT COUNT(*) FROM mv_storage_isolated.\"" + storageTableName + "\"", "SELECT 2");
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW test_default_storage_schema_mv");
             assertUpdate("DROP TABLE test_default_storage_schema_base");
             assertUpdate("DROP SCHEMA IF EXISTS mv_storage_isolated");
+        }
+    }
+
+    @Test
+    public void testDefaultStorageSchemaNoCollisionAcrossSourceSchemas()
+    {
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS mv_shared_storage");
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS mv_src_schema1");
+        assertUpdate("CREATE SCHEMA IF NOT EXISTS mv_src_schema2");
+
+        Session sessionWithDefaultSchema = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "materialized_view_default_storage_schema", "mv_shared_storage")
+                .build();
+
+        try {
+            assertUpdate("CREATE TABLE mv_src_schema1.collision_base (id BIGINT)");
+            assertUpdate("INSERT INTO mv_src_schema1.collision_base VALUES 1, 2", 2);
+            assertUpdate("CREATE TABLE mv_src_schema2.collision_base (id BIGINT)");
+            assertUpdate("INSERT INTO mv_src_schema2.collision_base VALUES 10, 20", 2);
+
+            assertUpdate(sessionWithDefaultSchema,
+                    "CREATE MATERIALIZED VIEW mv_src_schema1.collision_mv AS SELECT id FROM mv_src_schema1.collision_base");
+            assertUpdate(sessionWithDefaultSchema,
+                    "CREATE MATERIALIZED VIEW mv_src_schema2.collision_mv AS SELECT id FROM mv_src_schema2.collision_base");
+
+            String storage1 = "mv_shared_storage.\"__mv_storage__14_mv_src_schema1__collision_mv\"";
+            String storage2 = "mv_shared_storage.\"__mv_storage__14_mv_src_schema2__collision_mv\"";
+            assertQuery("SELECT COUNT(*) FROM " + storage1, "SELECT 0");
+            assertQuery("SELECT COUNT(*) FROM " + storage2, "SELECT 0");
+
+            assertUpdate(sessionWithDefaultSchema, "REFRESH MATERIALIZED VIEW mv_src_schema1.collision_mv", 2);
+            assertUpdate(sessionWithDefaultSchema, "REFRESH MATERIALIZED VIEW mv_src_schema2.collision_mv", 2);
+
+            assertQuery("SELECT * FROM mv_src_schema1.collision_mv ORDER BY id", "VALUES 1, 2");
+            assertQuery("SELECT * FROM mv_src_schema2.collision_mv ORDER BY id", "VALUES 10, 20");
+
+            assertQuery("SELECT COUNT(*) FROM " + storage1, "SELECT 2");
+            assertQuery("SELECT COUNT(*) FROM " + storage2, "SELECT 2");
+        }
+        finally {
+            assertUpdate(sessionWithDefaultSchema, "DROP MATERIALIZED VIEW IF EXISTS mv_src_schema1.collision_mv");
+            assertUpdate(sessionWithDefaultSchema, "DROP MATERIALIZED VIEW IF EXISTS mv_src_schema2.collision_mv");
+            assertUpdate("DROP TABLE IF EXISTS mv_src_schema1.collision_base");
+            assertUpdate("DROP TABLE IF EXISTS mv_src_schema2.collision_base");
+            assertUpdate("DROP SCHEMA IF EXISTS mv_shared_storage");
+            assertUpdate("DROP SCHEMA IF EXISTS mv_src_schema1");
+            assertUpdate("DROP SCHEMA IF EXISTS mv_src_schema2");
         }
     }
 
@@ -4988,8 +5036,8 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate(sessionWithDefaultSchema, "CREATE MATERIALIZED VIEW storage_lockdown_invoker_mv SECURITY INVOKER AS " +
                 "SELECT id, value FROM storage_lockdown_base");
 
-        String definerStorage = "__mv_storage__storage_lockdown_definer_mv";
-        String invokerStorage = "__mv_storage__storage_lockdown_invoker_mv";
+        String definerStorage = "__mv_storage__11_test_schema__storage_lockdown_definer_mv";
+        String invokerStorage = "__mv_storage__11_test_schema__storage_lockdown_invoker_mv";
 
         try {
             // Wildcard deny matches every identity, including the MV creator.


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
When `iceberg.materialized-view-default-storage-schema` is configured to route all MV storage tables into a shared schema, creating two materialized views with the same unqualified name but in different source schemas fails with:
`source table already exist error`

Fix
When the resolved storage schema differs from the MV's own schema (i.e. a non-default storage schema is in play), embed the source schema in the generated storage table name
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix: users can now create materialized views with the same name in different schemas when `iceberg.materialized-view-default-storage-schema` is configured, without hitting a "Table already exists" error.
```

## Summary by Sourcery

Preserve unique Iceberg materialized-view storage tables when using a shared storage schema.

Bug Fixes:
- Prevent materialized views with identical names in different source schemas from colliding when they share a configured storage schema.

Enhancements:
- Update Iceberg materialized-view storage naming to include the source schema when storage is routed to a different schema.

Documentation:
- Document the updated materialized-view storage table naming behavior.

Tests:
- Add coverage for materialized views with matching names across source schemas and update storage-name expectations.