### PR TITLE
feat: Report which columns differ on SCHEMA_MISMATCH (#28440)

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
@@ -16,8 +16,12 @@ package com.facebook.presto.verifier.framework;
 import com.facebook.presto.verifier.checksum.ChecksumResult;
 import com.facebook.presto.verifier.checksum.ColumnMatchResult;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -27,7 +31,9 @@ import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.R
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.SCHEMA_MISMATCH;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.SNAPSHOT_DOES_NOT_EXIST;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.lang.String.join;
 import static java.util.Objects.requireNonNull;
 
 public class DataMatchResult
@@ -57,6 +63,9 @@ public class DataMatchResult
     private final OptionalLong controlRowCount;
     private final OptionalLong testRowCount;
     private final List<ColumnMatchResult<?>> mismatchedColumns;
+    // Populated for SCHEMA_MISMATCH only; the two schemas being compared, in declaration order.
+    private final List<Column> controlColumns;
+    private final List<Column> testColumns;
 
     public DataMatchResult(
             DataType dataType,
@@ -67,6 +76,20 @@ public class DataMatchResult
             OptionalLong testRowCount,
             List<ColumnMatchResult<?>> mismatchedColumns)
     {
+        this(dataType, matchType, controlChecksum, testChecksum, controlRowCount, testRowCount, mismatchedColumns, ImmutableList.of(), ImmutableList.of());
+    }
+
+    private DataMatchResult(
+            DataType dataType,
+            MatchType matchType,
+            Optional<ChecksumResult> controlChecksum,
+            Optional<ChecksumResult> testChecksum,
+            OptionalLong controlRowCount,
+            OptionalLong testRowCount,
+            List<ColumnMatchResult<?>> mismatchedColumns,
+            List<Column> controlColumns,
+            List<Column> testColumns)
+    {
         this.dataType = requireNonNull(dataType, "data type is null");
         this.matchType = requireNonNull(matchType, "match type is null");
         this.controlChecksum = requireNonNull(controlChecksum, "controlChecksum is null");
@@ -74,6 +97,22 @@ public class DataMatchResult
         this.controlRowCount = requireNonNull(controlRowCount, "controlRowCount is null");
         this.testRowCount = requireNonNull(testRowCount, "testRowCount is null");
         this.mismatchedColumns = ImmutableList.copyOf(mismatchedColumns);
+        this.controlColumns = ImmutableList.copyOf(requireNonNull(controlColumns, "controlColumns is null"));
+        this.testColumns = ImmutableList.copyOf(requireNonNull(testColumns, "testColumns is null"));
+    }
+
+    public static DataMatchResult schemaMismatch(DataType dataType, List<Column> controlColumns, List<Column> testColumns)
+    {
+        return new DataMatchResult(
+                dataType,
+                SCHEMA_MISMATCH,
+                Optional.empty(),
+                Optional.empty(),
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                ImmutableList.of(),
+                controlColumns,
+                testColumns);
     }
 
     @Override
@@ -133,7 +172,10 @@ public class DataMatchResult
         StringBuilder message = new StringBuilder()
                 .append(matchType.name().replace("_", " "))
                 .append('\n');
-        if (matchType == SCHEMA_MISMATCH || matchType == SNAPSHOT_DOES_NOT_EXIST) {
+        if (matchType == SCHEMA_MISMATCH) {
+            return message.append(getSchemaDifference()).toString();
+        }
+        if (matchType == SNAPSHOT_DOES_NOT_EXIST) {
             return message.toString();
         }
 
@@ -154,5 +196,79 @@ public class DataMatchResult
                         columnMismatch.getControlChecksum(),
                         columnMismatch.getTestChecksum())));
         return message.toString();
+    }
+
+    // Describes how the control and test schemas differ. Columns are keyed by name, which is unique
+    // because both schemas come from a CREATE TABLE AS. Emits one line per column so that failures
+    // can be aggregated across a verifier run.
+    private String getSchemaDifference()
+    {
+        MapDifference<String, String> difference = Maps.difference(toTypesByName(controlColumns), toTypesByName(testColumns));
+
+        StringBuilder message = new StringBuilder();
+        if (!difference.entriesDiffering().isEmpty()) {
+            message.append("Differing Columns:\n");
+            difference.entriesDiffering().forEach((name, types) ->
+                    message.append(format("  %s: %s -> %s\n", name, types.leftValue(), types.rightValue())));
+        }
+        appendColumns(message, "Only in Control", difference.entriesOnlyOnLeft());
+        appendColumns(message, "Only in Test", difference.entriesOnlyOnRight());
+
+        // Identical names and types in both schemas means the columns are merely ordered differently.
+        if (message.length() == 0 && !controlColumns.isEmpty()) {
+            appendColumnOrderDifference(message);
+        }
+        return message.toString();
+    }
+
+    private static void appendColumns(StringBuilder message, String header, Map<String, String> columns)
+    {
+        if (columns.isEmpty()) {
+            return;
+        }
+        message.append(header).append(":\n");
+        columns.forEach((name, type) -> message.append(format("  %s: %s\n", name, type)));
+    }
+
+    // Reports the shortest window of positions containing the reordering, by dropping the prefix
+    // and suffix the two schemas agree on. Positions are 1-based.
+    private void appendColumnOrderDifference(StringBuilder message)
+    {
+        // Equal type maps but unequal lengths means a name repeats, which collapsed in the map.
+        if (controlColumns.size() != testColumns.size()) {
+            message.append(format("Column Count Differs: control %s, test %s\n", controlColumns.size(), testColumns.size()));
+            return;
+        }
+
+        List<String> controlNames = toNames(controlColumns);
+        List<String> testNames = toNames(testColumns);
+        int size = controlNames.size();
+
+        int start = 0;
+        while (start < size && controlNames.get(start).equals(testNames.get(start))) {
+            start++;
+        }
+        int end = size;
+        while (end > start && controlNames.get(end - 1).equals(testNames.get(end - 1))) {
+            end--;
+        }
+
+        message.append(format("Column Order Differs (positions %s-%s):\n", start + 1, end))
+                .append(format("  control: %s\n", join(", ", controlNames.subList(start, end))))
+                .append(format("  test: %s\n", join(", ", testNames.subList(start, end))));
+    }
+
+    // Not an ImmutableMap: reporting a failure must not itself fail should a schema ever carry
+    // duplicate column names.
+    private static Map<String, String> toTypesByName(List<Column> columns)
+    {
+        Map<String, String> types = new LinkedHashMap<>();
+        columns.forEach(column -> types.put(column.getName(), column.getType().getDisplayName()));
+        return types;
+    }
+
+    private static List<String> toNames(List<Column> columns)
+    {
+        return columns.stream().map(Column::getName).collect(toImmutableList());
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
@@ -35,7 +35,6 @@ import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.COLUMN_MISMATCH;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.MATCH;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.ROW_COUNT_MISMATCH;
-import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.SCHEMA_MISMATCH;
 import static com.facebook.presto.verifier.framework.QueryStage.DESCRIBE;
 import static com.facebook.presto.verifier.framework.QueryStage.forTeardown;
 import static com.facebook.presto.verifier.framework.VerifierUtil.runAndConsume;
@@ -81,14 +80,7 @@ public class DataVerificationUtil
     {
         requireNonNull(controlColumns, "controlColumns is null.");
         if (!controlColumns.equals(testColumns)) {
-            return new DataMatchResult(
-                    dataType,
-                    SCHEMA_MISMATCH,
-                    Optional.empty(),
-                    Optional.empty(),
-                    OptionalLong.empty(),
-                    OptionalLong.empty(),
-                    ImmutableList.of());
+            return DataMatchResult.schemaMismatch(dataType, controlColumns, testColumns);
         }
 
         OptionalLong controlRowCount = OptionalLong.of(controlChecksum.getRowCount());

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -99,7 +99,7 @@ public class TestDataVerification
     @Test
     public void testSchemaMismatch()
     {
-        Optional<VerifierQueryEvent> event = runVerification("SELECT 1", "SELECT 1.00001");
+        Optional<VerifierQueryEvent> event = runVerification("SELECT 1 x", "SELECT BIGINT '1' x");
         assertTrue(event.isPresent());
         assertEvent(
                 event.get(),
@@ -107,7 +107,44 @@ public class TestDataVerification
                 Optional.empty(),
                 Optional.of("SCHEMA_MISMATCH"),
                 Optional.of("Test state SUCCEEDED, Control state SUCCEEDED.\n\n" +
-                        "SCHEMA MISMATCH\n"));
+                        "SCHEMA MISMATCH\n" +
+                        "Differing Columns:\n" +
+                        "  x: integer -> bigint\n"));
+    }
+
+    @Test
+    public void testSchemaMismatchDifferentColumns()
+    {
+        Optional<VerifierQueryEvent> event = runVerification("SELECT 1 x, 2 y", "SELECT 1 x, 2 z");
+        assertTrue(event.isPresent());
+        assertEvent(
+                event.get(),
+                FAILED,
+                Optional.empty(),
+                Optional.of("SCHEMA_MISMATCH"),
+                Optional.of("Test state SUCCEEDED, Control state SUCCEEDED.\n\n" +
+                        "SCHEMA MISMATCH\n" +
+                        "Only in Control:\n" +
+                        "  y: integer\n" +
+                        "Only in Test:\n" +
+                        "  z: integer\n"));
+    }
+
+    @Test
+    public void testSchemaMismatchColumnOrder()
+    {
+        Optional<VerifierQueryEvent> event = runVerification("SELECT 1 w, 2 x, 3 y, 4 z", "SELECT 1 w, 3 y, 2 x, 4 z");
+        assertTrue(event.isPresent());
+        assertEvent(
+                event.get(),
+                FAILED,
+                Optional.empty(),
+                Optional.of("SCHEMA_MISMATCH"),
+                Optional.of("Test state SUCCEEDED, Control state SUCCEEDED.\n\n" +
+                        "SCHEMA MISMATCH\n" +
+                        "Column Order Differs \\(positions 2-3\\):\n" +
+                        "  control: x, y\n" +
+                        "  test: y, x\n"));
     }
 
     @Test


### PR DESCRIPTION
Summary:

A `SCHEMA_MISMATCH` failure reported only the string `SCHEMA MISMATCH`, with no indication of which columns differed. Diagnosing one meant running `DESCRIBE` against both the control and test output tables by hand, and because the detail never reached `error_message` there was no way to aggregate failures across a verifier run to see whether many of them shared a single root cause.

`DataMatchResult` now carries both schemas and renders a per-column diff in `getReport()`. Columns are keyed by name, unique because both schemas come from a `CREATE TABLE AS`, and compared with `Maps.difference`:

```
SCHEMA MISMATCH
Differing Columns:
  agg_num: integer -> bigint
Only in Control:
  y: integer
Only in Test:
  z: integer
```

When the names and types are identical and only the order differs, the report instead drops the prefix and suffix the two schemas agree on and shows the remaining 1-based position range, so a swap deep in a wide schema stays readable:

```
SCHEMA MISMATCH
Column Order Differs (positions 2-3):
  control: x, y
  test: y, x
```

One line per column keeps the output greppable, so a whole test run can be grouped by type pair with SQL over `error_message`.

Differential Revision: D118635040

```
== RELEASE NOTES ==

Verifier Changes
* Improve ``SCHEMA_MISMATCH`` failure reports to identify the columns that differ.
```

## Summary by Sourcery

Expose actionable column-level details in schema mismatch reports.

New Features:
- Report the specific schema differences causing verifier SCHEMA_MISMATCH failures, including differing types, missing columns, and column order changes.

Enhancements:
- Preserve control and test schemas in match results so schema mismatch details are included in error reports and can be aggregated across verifier runs.

Tests:
- Add coverage for mismatched column types, different column names, and reordered columns.