### PR TITLE
fix: Docker image build failure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ ENV PRESTO_HOME="/opt/presto-server"
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf install -y java-17-openjdk less procps python3 \
-    && ln -s $(which python3) /usr/bin/python \
     # clean cache jobs
     && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak
 


### PR DESCRIPTION
## Description
Docker image build is failing due to change in base image. The new base image comes with python3(along with the symlink) so it throws error when we try to create a symlink.
We are seeing build failures here since the base image change: 
https://github.com/prestodb/presto/actions/workflows/prestocpp-linux-container-tests.yml
Local Reproduction:
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 10 54 33 PM" src="https://github.com/user-attachments/assets/90afc2d4-2f6c-4ea2-b681-d2b644033f8b" />

## Motivation and Context
This is a bug fix for docker image build failure

## Impact
Removing the symlink command fixes the image build issue. 

## Test Plan
I built docker image after making the changes, the image build was successful. 
<img width="1728" height="1117" alt="Screenshot 2026-09-04 at 12 20 57 AM" src="https://github.com/user-attachments/assets/aa8b449b-bbc3-4219-9f61-6e83032a0d07" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

