### PR TITLE
fix(security): Bump fast-uri to 3.1.6 to fix CVE

### DIFF
--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -83,6 +83,6 @@
   },
   "resolutions": {
     "d3-color": "3.1.0",
-    "fast-uri": "3.1.5"
+    "fast-uri": "3.1.6"
   }
 }

--- a/presto-ui/src/yarn.lock
+++ b/presto-ui/src/yarn.lock
@@ -4080,10 +4080,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.5, fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@3.1.6, fast-uri@^3.0.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
## Description
Bump fast-uri in presto-ui module to fix the vulnerabilities CVE-2026-76172, CVE-2026-75975, CVE-2026-75931 and CVE-2026-75899

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<img width="2542" height="1564" alt="image (4)" src="https://github.com/user-attachments/assets/20f07bf2-9aed-49cc-9f85-50aa3d47c92c" />
<img width="1990" height="2132" alt="image (3)" src="https://github.com/user-attachments/assets/b41db4c0-5434-4e10-ac35-2f0f86e320a3" />
<img width="1990" height="2132" alt="image (2)" src="https://github.com/user-attachments/assets/71a75fe8-668b-4ed7-8135-5131cfb0f83d" />
<img width="1990" height="2132" alt="image (1)" src="https://github.com/user-attachments/assets/0ae12816-0933-4043-bd19-6fc727cb52dd" />
<img width="1990" height="938" alt="image" src="https://github.com/user-attachments/assets/d857a6cb-cc4a-471b-a04c-9a16511eeb81" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update the frontend fast-uri dependency to remediate the reported CVE.

Bug Fixes:
- Update the fast-uri dependency to version 3.1.6 to address a known security vulnerability.

Build:
- Refresh the frontend Yarn lockfile for the dependency update.