### PR TITLE
fix: Hide kafka jaas config in server startup logs

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaSaslConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaSaslConfig.java
@@ -48,6 +48,7 @@ public class KafkaSaslConfig
     }
 
     @Config("kafka.sasl.jaas.config")
+    @ConfigSecuritySensitive
     @ConfigDescription("The JAAS config of the SASL authentication")
     public KafkaSaslConfig setSaslJaasConfig(String saslJaasConfig)
     {


### PR DESCRIPTION
## Description
Kafka JAAS config gets printed in plain text in server startup logs and as a result, username and token are exposed. Here is a sample log that gets printed - 

```
2026-08-20T18:46:04.975Z	INFO	main	Bootstrap	kafka.sasl.jaas.config            ----        org.apache.kafka.common.security.plain.PlainLoginModule required username=token password=HjdE-qrdKtsr;                                                                                                               The JAAS config of the SASL authentication
```

## Motivation and Context
This PR fixes the printing of JAAS config in plain text. 

After the change - 

```
2026-09-04T19:57:05.258+0545	INFO	main	Bootstrap	kafka.sasl.jaas.config            [REDACTED]  [REDACTED]  The JAAS config of the SASL authentication
```

## Impact
NA

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Prevent Kafka JAAS configuration credentials from being exposed in server startup logs by marking the setting as security-sensitive.