### PR TITLE
feat(connector): Add opt-in ORC reader option to read out-of-bounds timestamps as null (#28448)

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
@@ -44,6 +44,7 @@ public class HiveCommonClientConfig
     private DataSize parquetMaxReadBlockSize = new DataSize(16, MEGABYTE);
     private boolean rangeFiltersOnSubscriptsEnabled;
     private boolean readNullMaskedParquetEncryptedValueEnabled;
+    private boolean readNullForOutOfBoundsTimestamp;
     private boolean useParquetColumnNames;
     private boolean zstdJniDecompressionEnabled;
     private String catalogName;
@@ -273,6 +274,19 @@ public class HiveCommonClientConfig
     public boolean getReadNullMaskedParquetEncryptedValue()
     {
         return this.readNullMaskedParquetEncryptedValueEnabled;
+    }
+
+    @Config("hive.read-null-for-out-of-bounds-timestamp")
+    @ConfigDescription("Read null instead of failing the read when a timestamp value is outside the supported range")
+    public HiveCommonClientConfig setReadNullForOutOfBoundsTimestamp(boolean readNullForOutOfBoundsTimestamp)
+    {
+        this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
+        return this;
+    }
+
+    public boolean getReadNullForOutOfBoundsTimestamp()
+    {
+        return this.readNullForOutOfBoundsTimestamp;
     }
 
     public boolean isUseParquetColumnNames()

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
@@ -62,6 +62,7 @@ public class HiveCommonSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
+    public static final String READ_NULL_FOR_OUT_OF_BOUNDS_TIMESTAMP = "read_null_for_out_of_bounds_timestamp";
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -185,6 +186,11 @@ public class HiveCommonSessionProperties
                         "Return null when access is denied for an encrypted parquet column",
                         hiveCommonClientConfig.getReadNullMaskedParquetEncryptedValue(),
                         false),
+                booleanProperty(
+                        READ_NULL_FOR_OUT_OF_BOUNDS_TIMESTAMP,
+                        "Return null instead of failing the read when a timestamp value is outside the supported range",
+                        hiveCommonClientConfig.getReadNullForOutOfBoundsTimestamp(),
+                        false),
                 dataSizeSessionProperty(
                         AFFINITY_SCHEDULING_FILE_SECTION_SIZE,
                         "Size of file section for affinity scheduling",
@@ -302,6 +308,11 @@ public class HiveCommonSessionProperties
     public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
     {
         return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isReadNullForOutOfBoundsTimestamp(ConnectorSession session)
+    {
+        return session.getProperty(READ_NULL_FOR_OUT_OF_BOUNDS_TIMESTAMP, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveCommonClientConfig.java
+++ b/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveCommonClientConfig.java
@@ -50,6 +50,7 @@ public class TestHiveCommonClientConfig
                 .setParquetBatchReaderVerificationEnabled(false)
                 .setParquetBatchReadOptimizationEnabled(false)
                 .setReadNullMaskedParquetEncryptedValue(false)
+                .setReadNullForOutOfBoundsTimestamp(false)
                 .setCatalogName(null)
                 .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE)));
     }
@@ -77,6 +78,7 @@ public class TestHiveCommonClientConfig
                 .put("hive.enable-parquet-batch-reader-verification", "true")
                 .put("hive.parquet-batch-read-optimization-enabled", "true")
                 .put("hive.read-null-masked-parquet-encrypted-value-enabled", "true")
+                .put("hive.read-null-for-out-of-bounds-timestamp", "true")
                 .put("hive.metastore.catalog.name", "catalogName")
                 .put("hive.affinity-scheduling-file-section-size", "512MB")
                 .build();
@@ -101,6 +103,7 @@ public class TestHiveCommonClientConfig
                 .setParquetBatchReaderVerificationEnabled(true)
                 .setParquetBatchReadOptimizationEnabled(true)
                 .setReadNullMaskedParquetEncryptedValue(true)
+                .setReadNullForOutOfBoundsTimestamp(true)
                 .setCatalogName("catalogName")
                 .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE));
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxMerg
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxReadBlockSize;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcZstdJniDecompressionEnabled;
+import static com.facebook.presto.hive.HiveCommonSessionProperties.isReadNullForOutOfBoundsTimestamp;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.orc.OrcBatchPageSourceFactory.createOrcPageSource;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
@@ -129,6 +130,7 @@ public class DwrfBatchPageSourceFactory
                         .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
                         .withMaxBlockSize(getOrcMaxReadBlockSize(session))
                         .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .withReadNullForOutOfBoundsTimestamp(isReadNullForOutOfBoundsTimestamp(session))
                         .build(),
                 encryptionInformation,
                 dwrfEncryptionProvider,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxMerg
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxReadBlockSize;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcZstdJniDecompressionEnabled;
+import static com.facebook.presto.hive.HiveCommonSessionProperties.isReadNullForOutOfBoundsTimestamp;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isUseOrcColumnNames;
 import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
 import static com.facebook.presto.hive.orc.OrcPageSourceFactoryUtils.getOrcDataSource;
@@ -156,6 +157,7 @@ public class OrcAggregatedPageSourceFactory
                 .withMaxBlockSize(maxReadBlockSize)
                 .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
                 .withAppendRowNumber(appendRowNumberEnabled)
+                .withReadNullForOutOfBoundsTimestamp(isReadNullForOutOfBoundsTimestamp(session))
                 .build();
         try {
             OrcReader reader = getOrcReader(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -63,6 +63,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxRead
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcZstdJniDecompressionEnabled;
+import static com.facebook.presto.hive.HiveCommonSessionProperties.isReadNullForOutOfBoundsTimestamp;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isUseOrcColumnNames;
 import static com.facebook.presto.hive.HiveUtil.checkRowIDPartitionComponent;
 import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
@@ -165,6 +166,7 @@ public class OrcBatchPageSourceFactory
                         .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
                         .withMaxBlockSize(getOrcMaxReadBlockSize(session))
                         .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .withReadNullForOutOfBoundsTimestamp(isReadNullForOutOfBoundsTimestamp(session))
                         .build(),
                 encryptionInformation,
                 NO_ENCRYPTION,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -104,6 +104,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxRead
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isOrcZstdJniDecompressionEnabled;
+import static com.facebook.presto.hive.HiveCommonSessionProperties.isReadNullForOutOfBoundsTimestamp;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isUseOrcColumnNames;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
 import static com.facebook.presto.hive.HiveSessionProperties.isAdaptiveFilterReorderingEnabled;
@@ -294,6 +295,7 @@ public class OrcSelectivePageSourceFactory
                 .withMaxBlockSize(maxReadBlockSize)
                 .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
                 .withAppendRowNumber(appendRowNumberEnabled || supplyRowIDs)
+                .withReadNullForOutOfBoundsTimestamp(isReadNullForOutOfBoundsTimestamp(session))
                 .build();
         OrcAggregatedMemoryContext systemMemoryUsage = new HiveOrcAggregatedMemoryContext();
         try {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -32,6 +32,15 @@ public class OrcReaderOptions
     // slice reader will throw if the slice size is larger than this value
     private final DataSize maxSliceSize;
     private final boolean resetAllReaders;
+    // if the option is set to true, a timestamp that overflows the supported range is read back as
+    // null instead of failing the read with a TimestampOutOfBoundsException.
+    //
+    // Caveat: the column statistics written for such a value still describe it as a non-null value
+    // with a min/max, so statistics-based pruning can skip a stripe or row group that would now
+    // produce a null. A predicate such as IS NULL may therefore see different results depending on
+    // whether pruning kicks in. Only enable this to recover data from files that would otherwise be
+    // unreadable.
+    private final boolean readNullForOutOfBoundsTimestamp;
 
     /**
      * Read column statistics for flat map columns. Usually there are quite a
@@ -48,7 +57,8 @@ public class OrcReaderOptions
             boolean appendRowNumber,
             boolean readMapStatistics,
             DataSize maxSliceSize,
-            boolean resetAllReaders)
+            boolean resetAllReaders,
+            boolean readNullForOutOfBoundsTimestamp)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -59,6 +69,7 @@ public class OrcReaderOptions
         this.readMapStatistics = readMapStatistics;
         this.maxSliceSize = maxSliceSize;
         this.resetAllReaders = resetAllReaders;
+        this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
     }
 
     public DataSize getMaxMergeDistance()
@@ -106,6 +117,11 @@ public class OrcReaderOptions
         return resetAllReaders;
     }
 
+    public boolean isReadNullForOutOfBoundsTimestamp()
+    {
+        return readNullForOutOfBoundsTimestamp;
+    }
+
     @Override
     public String toString()
     {
@@ -119,6 +135,7 @@ public class OrcReaderOptions
                 .add("readMapStatistics", readMapStatistics)
                 .add("maxSliceSize", maxSliceSize)
                 .add("resetAllReaders", resetAllReaders)
+                .add("readNullForOutOfBoundsTimestamp", readNullForOutOfBoundsTimestamp)
                 .toString();
     }
 
@@ -138,6 +155,7 @@ public class OrcReaderOptions
         private boolean readMapStatistics;
         private DataSize maxSliceSize = DEFAULT_MAX_SLICE_SIZE;
         private boolean resetAllReaders;
+        private boolean readNullForOutOfBoundsTimestamp;
 
         private Builder() {}
 
@@ -195,6 +213,12 @@ public class OrcReaderOptions
             return this;
         }
 
+        public Builder withReadNullForOutOfBoundsTimestamp(boolean readNullForOutOfBoundsTimestamp)
+        {
+            this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
+            return this;
+        }
+
         public OrcReaderOptions build()
         {
             return new OrcReaderOptions(
@@ -206,7 +230,8 @@ public class OrcReaderOptions
                     appendRowNumber,
                     readMapStatistics,
                     maxSliceSize,
-                    resetAllReaders);
+                    resetAllReaders,
+                    readNullForOutOfBoundsTimestamp);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -27,6 +27,7 @@ public class OrcRecordReaderOptions
     private final boolean appendRowNumber;
     private final long maxSliceSize;
     private final boolean resetAllReaders;
+    private final boolean readNullForOutOfBoundsTimestamp;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
@@ -36,7 +37,8 @@ public class OrcRecordReaderOptions
                 options.mapNullKeysEnabled(),
                 options.appendRowNumber(),
                 options.getMaxSliceSize(),
-                options.isResetAllReaders());
+                options.isResetAllReaders(),
+                options.isReadNullForOutOfBoundsTimestamp());
     }
 
     public OrcRecordReaderOptions(
@@ -46,7 +48,8 @@ public class OrcRecordReaderOptions
             boolean mapNullKeysEnabled,
             boolean appendRowNumber,
             DataSize maxSliceSize,
-            boolean resetAllReaders)
+            boolean resetAllReaders,
+            boolean readNullForOutOfBoundsTimestamp)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -57,6 +60,7 @@ public class OrcRecordReaderOptions
         checkArgument(maxSliceSize.toBytes() > 0, "maxSliceSize must be positive");
         this.maxSliceSize = maxSliceSize.toBytes();
         this.resetAllReaders = resetAllReaders;
+        this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
     }
 
     public DataSize getMaxMergeDistance()
@@ -92,5 +96,10 @@ public class OrcRecordReaderOptions
     public boolean isResetAllReaders()
     {
         return resetAllReaders;
+    }
+
+    public boolean isReadNullForOutOfBoundsTimestamp()
+    {
+        return readNullForOutOfBoundsTimestamp;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -52,7 +52,7 @@ public final class BatchStreamReaders
             case TIMESTAMP:
             case TIMESTAMP_MICROSECONDS:
                 boolean enableMicroPrecision = type == TIMESTAMP_MICROSECONDS;
-                return new TimestampBatchStreamReader(type, streamDescriptor, enableMicroPrecision);
+                return new TimestampBatchStreamReader(type, streamDescriptor, enableMicroPrecision, options.isReadNullForOutOfBoundsTimestamp());
             case LIST:
                 return new ListBatchStreamReader(type, streamDescriptor, options, systemMemoryContext);
             case STRUCT:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -109,7 +109,8 @@ public final class SelectiveStreamReaders
                         getOptionalOnlyFilter(type, filters),
                         outputType.isPresent(),
                         systemMemoryContext.newOrcLocalMemoryContext(SelectiveStreamReaders.class.getSimpleName()),
-                        enableMicroPrecision);
+                        enableMicroPrecision,
+                        options.isReadNullForOutOfBoundsTimestamp());
             }
             case LIST:
                 verifyStreamType(streamDescriptor, outputType, ArrayType.class::isInstance);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.getBooleanMissingStreamSource;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.getLongMissingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class TimestampBatchStreamReader
@@ -68,12 +69,16 @@ public class TimestampBatchStreamReader
 
     private boolean rowGroupOpen;
     private final boolean enableMicroPrecision;
+    // When true, a timestamp that overflows the supported range is read back as null instead of
+    // failing the read with a TimestampOutOfBoundsException.
+    private final boolean readNullForOutOfBoundsTimestamp;
     private DecodeTimestampOptions decodeTimestampOptions;
 
-    public TimestampBatchStreamReader(Type type, StreamDescriptor streamDescriptor, boolean enableMicroPrecision)
+    public TimestampBatchStreamReader(Type type, StreamDescriptor streamDescriptor, boolean enableMicroPrecision, boolean readNullForOutOfBoundsTimestamp)
             throws OrcCorruptionException
     {
         this.enableMicroPrecision = enableMicroPrecision;
+        this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
         requireNonNull(type, "type is null");
         verifyStreamType(streamDescriptor, type, TimestampType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
@@ -153,11 +158,7 @@ public class TimestampBatchStreamReader
             throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is missing");
         }
 
-        long[] values = new long[nextBatchSize];
-        for (int i = 0; i < nextBatchSize; i++) {
-            values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
-        }
-        return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
+        return decodeBlock(null, nextBatchSize);
     }
 
     private Block readNullBlock(boolean[] isNull)
@@ -170,14 +171,62 @@ public class TimestampBatchStreamReader
             throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is missing");
         }
 
-        long[] values = new long[isNull.length];
+        return decodeBlock(isNull, isNull.length);
+    }
 
-        for (int i = 0; i < isNull.length; i++) {
-            if (!isNull[i]) {
-                values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
+    // Decodes positionCount values from the seconds/nanos streams, skipping the positions already
+    // marked null in isNull. isNull is null for a column with no present stream; in that case it is
+    // allocated by ensureIsNull on the first out-of-bounds timestamp, so a batch that decodes
+    // cleanly still reports no nulls and keeps the downstream no-nulls fast path.
+    private Block decodeBlock(boolean[] isNull, int positionCount)
+            throws IOException
+    {
+        long[] values = new long[positionCount];
+        boolean hasNull = isNull != null;
+
+        for (int i = 0; i < positionCount; i++) {
+            if (hasNull && isNull[i]) {
+                continue;
+            }
+            if (decodeInto(values, i)) {
+                // Out-of-bounds timestamps are read back as null instead of failing the read.
+                isNull = ensureIsNull(isNull, positionCount);
+                isNull[i] = true;
+                hasNull = true;
             }
         }
-        return new LongArrayBlock(isNull.length, Optional.of(isNull), values);
+        return new LongArrayBlock(positionCount, Optional.ofNullable(hasNull ? isNull : null), values);
+    }
+
+    // Returns the array the read loop marks out-of-bounds timestamps in, allocating it on first use.
+    // The caller's array is returned unchanged when it is already present, so present-stream nulls
+    // are never discarded.
+    private static boolean[] ensureIsNull(boolean[] isNull, int capacity)
+    {
+        checkArgument(isNull == null || isNull.length >= capacity, "isNull is smaller than capacity");
+        return isNull != null ? isNull : new boolean[capacity];
+    }
+
+    // Reads the next timestamp from the seconds/nanos streams into values[index]. Returns true when
+    // the value is an out-of-bounds timestamp that should be read back as null; in that case
+    // values[index] is left unset (0) and the caller must mark the position null. When
+    // readNullForOutOfBoundsTimestamp is disabled the overflow is rethrown, preserving the original
+    // fail-the-read behavior.
+    private boolean decodeInto(long[] values, int index)
+            throws IOException
+    {
+        long seconds = secondsStream.next();
+        long serializedNanos = nanosStream.next();
+        try {
+            values[index] = decodeTimestamp(seconds, serializedNanos, decodeTimestampOptions);
+            return false;
+        }
+        catch (TimestampOutOfBoundsException e) {
+            if (!readNullForOutOfBoundsTimestamp) {
+                throw e;
+            }
+            return true;
+        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -62,6 +62,12 @@ public class TimestampSelectiveStreamReader
     private final OrcLocalMemoryContext systemMemoryContext;
     private final boolean nonDeterministicFilter;
     private final boolean enableMicroPrecision;
+    // When true, a timestamp that overflows the supported range is read back as null instead of
+    // failing the read with a TimestampOutOfBoundsException.
+    private final boolean readNullForOutOfBoundsTimestamp;
+    // Set when the batch currently being read actually decoded an out-of-bounds timestamp into a
+    // null. Reset on every read(); see producedNulls().
+    private boolean hasOverflowNull;
     private DecodeTimestampOptions decodeTimestampOptions;
 
     private InputStreamSource<BooleanInputStream> presentStreamSource = getBooleanMissingStreamSource();
@@ -90,9 +96,11 @@ public class TimestampSelectiveStreamReader
             Optional<TupleDomainFilter> filter,
             boolean outputRequired,
             OrcLocalMemoryContext systemMemoryContext,
-            boolean enableMicroPrecision)
+            boolean enableMicroPrecision,
+            boolean readNullForOutOfBoundsTimestamp)
     {
         this.enableMicroPrecision = enableMicroPrecision;
+        this.readNullForOutOfBoundsTimestamp = readNullForOutOfBoundsTimestamp;
         requireNonNull(filter, "filter is null");
         checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
@@ -158,10 +166,17 @@ public class TimestampSelectiveStreamReader
         }
 
         allNulls = false;
+        hasOverflowNull = false;
 
         if (outputRequired) {
-            ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
+            ensureValuesCapacity(positionCount, mayProduceNulls());
         }
+
+        // The read loops below write into nulls[] whenever the reader may emit nulls (present stream
+        // or an out-of-bounds timestamp read back as null). Assert the buffer is allocated so an
+        // invariant break fails loudly here rather than as an obscure NPE mid-read.
+        checkState(!outputRequired || !mayProduceNulls() || nulls != null,
+                "nulls buffer must be allocated when the reader may produce nulls");
 
         outputPositions = initializeOutputPositions(outputPositions, positions, positionCount);
 
@@ -209,11 +224,33 @@ public class TimestampSelectiveStreamReader
                 }
             }
             else {
-                long value = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
-                if (filter.testLong(value)) {
+                long value = 0;
+                boolean overflowNull = false;
+                try {
+                    value = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
+                }
+                catch (TimestampOutOfBoundsException e) {
+                    if (!readNullForOutOfBoundsTimestamp) {
+                        throw e;
+                    }
+                    // Treat the out-of-bounds timestamp like a null value with respect to the filter.
+                    overflowNull = true;
+                }
+
+                if (overflowNull) {
+                    if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                        if (outputRequired) {
+                            nulls[outputPositionCount] = true;
+                            hasOverflowNull = true;
+                        }
+                        outputPositions[outputPositionCount] = position;
+                        outputPositionCount++;
+                    }
+                }
+                else if (filter.testLong(value)) {
                     if (outputRequired) {
                         values[outputPositionCount] = value;
-                        if (nullsAllowed && presentStream != null) {
+                        if (mayProduceNulls()) {
                             nulls[outputPositionCount] = false;
                         }
                     }
@@ -286,9 +323,23 @@ public class TimestampSelectiveStreamReader
                 nulls[i] = true;
             }
             else {
-                values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
-                if (presentStream != null) {
-                    nulls[i] = false;
+                boolean overflowNull = false;
+                try {
+                    values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), decodeTimestampOptions);
+                }
+                catch (TimestampOutOfBoundsException e) {
+                    if (!readNullForOutOfBoundsTimestamp) {
+                        throw e;
+                    }
+                    // An out-of-bounds timestamp is read back as null instead of failing the read.
+                    overflowNull = true;
+                }
+                // Set the null flag explicitly whenever the nulls array is in use to avoid stale
+                // entries. Guarded by mayProduceNulls() so the write and the allocation in
+                // ensureValuesCapacity() stay in sync.
+                if (mayProduceNulls()) {
+                    nulls[i] = overflowNull;
+                    hasOverflowNull |= overflowNull;
                 }
             }
             streamPosition++;
@@ -312,6 +363,22 @@ public class TimestampSelectiveStreamReader
             secondsStream.skip(items);
             nanosStream.skip(items);
         }
+    }
+
+    // Allocation guard: the nulls buffer has to exist before the read loop starts, so this is
+    // necessarily conservative -- whether an out-of-bounds timestamp will actually turn up in the
+    // batch is not known until it is decoded.
+    private boolean mayProduceNulls()
+    {
+        return nullsAllowed && (presentStream != null || readNullForOutOfBoundsTimestamp);
+    }
+
+    // Output guard: whether the batch just read can actually contain a null. Unlike
+    // mayProduceNulls() this is exact, so a column whose values all decoded cleanly still produces a
+    // block with no nulls and keeps the downstream mayHaveNull() == false fast path.
+    private boolean producedNulls()
+    {
+        return nullsAllowed && (presentStream != null || hasOverflowNull);
     }
 
     private void ensureValuesCapacity(int capacity, boolean recordNulls)
@@ -341,7 +408,7 @@ public class TimestampSelectiveStreamReader
             return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
-        boolean includeNulls = nullsAllowed && presentStream != null;
+        boolean includeNulls = producedNulls();
         if (positionCount == outputPositionCount) {
             Block block = new LongArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values);
             nulls = null;
@@ -392,7 +459,7 @@ public class TimestampSelectiveStreamReader
             return newLease(new RunLengthEncodedBlock(NULL_BLOCK, positionCount));
         }
 
-        boolean includeNulls = nullsAllowed && presentStream != null;
+        boolean includeNulls = producedNulls();
         if (positionCount != outputPositionCount) {
             compactValues(positions, positionCount, includeNulls);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1613,6 +1613,85 @@ public class OrcTester
         return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), initialBatchSize);
     }
 
+    static OrcBatchRecordReader createCustomOrcRecordReaderWithNullForOutOfBoundsTimestamp(
+            TempFile tempFile,
+            OrcEncoding orcEncoding,
+            OrcPredicate predicate,
+            List<Type> types,
+            int initialBatchSize)
+            throws IOException
+    {
+        OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+        OrcReader orcReader = createOrcReaderWithNullForOutOfBoundsTimestamp(orcDataSource, orcEncoding);
+
+        Map<Integer, Type> columnTypes = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableMap(Functions.identity(), types::get));
+
+        return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), initialBatchSize);
+    }
+
+    // Shared by the two helpers above/below: the only thing that distinguishes them from the
+    // regular createCustomOrc*RecordReader factories is readNullForOutOfBoundsTimestamp.
+    private static OrcReader createOrcReaderWithNullForOutOfBoundsTimestamp(OrcDataSource orcDataSource, OrcEncoding orcEncoding)
+            throws IOException
+    {
+        return new OrcReader(
+                orcDataSource,
+                orcEncoding,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                        .withMaxBlockSize(MAX_BLOCK_SIZE)
+                        .withReadNullForOutOfBoundsTimestamp(true)
+                        .build(),
+                false,
+                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
+                DwrfKeyProvider.of(ImmutableMap.of()),
+                new RuntimeStats(),
+                MODIFICATION_TIME_NOT_SET);
+    }
+
+    static OrcSelectiveRecordReader createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp(
+            TempFile tempFile,
+            OrcEncoding orcEncoding,
+            OrcPredicate predicate,
+            List<Type> types,
+            int initialBatchSize,
+            Map<Integer, Map<Subfield, TupleDomainFilter>> filters)
+            throws IOException
+    {
+        OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+        OrcReader orcReader = createOrcReaderWithNullForOutOfBoundsTimestamp(orcDataSource, orcEncoding);
+
+        Map<Integer, Type> includedColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableMap(Functions.identity(), types::get));
+        List<Integer> outputColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableList());
+
+        return orcReader.createSelectiveRecordReader(
+                includedColumns,
+                outputColumns,
+                filters,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                predicate,
+                0,
+                orcDataSource.getSize(),
+                HIVE_STORAGE_TIME_ZONE,
+                new TestingHiveOrcAggregatedMemoryContext(),
+                Optional.empty(),
+                initialBatchSize);
+    }
+
     static OrcReader createCustomOrcReader(
             TempFile tempFile,
             OrcEncoding orcEncoding,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.predicate.TupleDomainFilter;
+import com.facebook.presto.common.predicate.TupleDomainFilter.BigintRange;
 import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.metadata.CompressionKind;
@@ -22,7 +26,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -30,18 +36,25 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
+import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.assertBlockEquals;
 import static com.facebook.presto.orc.OrcTester.assertFileContentsPresto;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReaderWithNullForOutOfBoundsTimestamp;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp;
 import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static java.lang.Math.floorDiv;
+import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 public class TestTimestampWriteAndRead
 {
@@ -129,6 +142,245 @@ public class TestTimestampWriteAndRead
         // Overflows while reading with micro precision
         assertThrows(TimestampOutOfBoundsException.class,
                 () -> testPrestoRoundTrip(TIMESTAMP, millisecondValuesOverflow, TIMESTAMP_MICROSECONDS, valuesInMicroOverflow));
+    }
+
+    // When readNullForOutOfBoundsTimestamp is enabled, out-of-bounds timestamps are read back as null
+    // instead of failing the read with a TimestampOutOfBoundsException.
+    @Test
+    public void testOverflowReadingMicrosReturnsNullWhenConfigured()
+            throws Exception
+    {
+        List<SqlTimestamp> millisecondValuesOverflow = ImmutableList.of(
+                sqlTimestampOf(9_223_372_036_855_000L, SESSION, MILLISECONDS),
+                sqlTimestampOf(-9_223_372_036_855_000L, SESSION, MILLISECONDS));
+
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(TIMESTAMP),
+                        ImmutableList.of(millisecondValuesOverflow),
+                        NOOP_WRITER_STATS);
+
+                try (OrcBatchRecordReader recordReader = createCustomOrcRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE)) {
+                    int rowsProcessed = 0;
+                    for (int batchSize = toIntExact(recordReader.nextBatch()); batchSize >= 0; batchSize = toIntExact(recordReader.nextBatch())) {
+                        Block block = recordReader.readBlock(0);
+                        assertEquals(block.getPositionCount(), batchSize);
+                        for (int position = 0; position < batchSize; position++) {
+                            assertTrue(block.isNull(position), "Expected out-of-bounds timestamp to be read back as null");
+                        }
+                        rowsProcessed += batchSize;
+                    }
+                    assertEquals(rowsProcessed, millisecondValuesOverflow.size());
+                }
+            }
+        }
+    }
+
+    // Same as above, but through the selective reader (OrcSelectiveRecordReader) — this is the exact
+    // path that failed in production (TimestampSelectiveStreamReader.readNoFilter).
+    @Test
+    public void testOverflowReadingMicrosReturnsNullWhenConfiguredSelective()
+            throws Exception
+    {
+        List<SqlTimestamp> millisecondValuesOverflow = ImmutableList.of(
+                sqlTimestampOf(9_223_372_036_855_000L, SESSION, MILLISECONDS),
+                sqlTimestampOf(-9_223_372_036_855_000L, SESSION, MILLISECONDS));
+        List<SqlTimestamp> expectedNulls = Arrays.asList((SqlTimestamp) null, null);
+
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(TIMESTAMP),
+                        ImmutableList.of(millisecondValuesOverflow),
+                        NOOP_WRITER_STATS);
+
+                try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE,
+                        ImmutableMap.of())) {
+                    assertFileContentsPresto(
+                            ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                            recordReader,
+                            ImmutableList.of(expectedNulls),
+                            ImmutableList.of(0));
+                }
+            }
+        }
+    }
+
+    // Interleaves in-range, out-of-bounds, and explicitly-null timestamps to verify that only the
+    // out-of-bounds rows become null while valid values are still decoded correctly. Exercises both
+    // the batch reader (readNullBlock) and the selective reader (readNoFilter + present stream).
+    @Test
+    public void testMixedValidNullAndOverflowMicrosReturnsNullWhenConfigured()
+            throws Exception
+    {
+        SqlTimestamp valid1 = sqlTimestampOf(1_650_483_250_507L, SESSION, MILLISECONDS);
+        SqlTimestamp valid2 = sqlTimestampOf(-60_000_000_000_789L, SESSION, MILLISECONDS);
+        SqlTimestamp overflow1 = sqlTimestampOf(9_223_372_036_855_000L, SESSION, MILLISECONDS);
+        SqlTimestamp overflow2 = sqlTimestampOf(-9_223_372_036_855_000L, SESSION, MILLISECONDS);
+
+        // Written as millisecond timestamps: valid, overflow, null, valid, overflow.
+        List<SqlTimestamp> writeValues = Arrays.asList(valid1, overflow1, null, valid2, overflow2);
+
+        // Read as micros: valid values survive, overflow -> null, explicit null stays null.
+        List<SqlTimestamp> expectedValues = Arrays.asList(
+                new SqlTimestamp(valid1.getMillis() * 1000, MICROSECONDS),
+                null,
+                null,
+                new SqlTimestamp(valid2.getMillis() * 1000, MICROSECONDS),
+                null);
+
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(TIMESTAMP),
+                        ImmutableList.of(writeValues),
+                        NOOP_WRITER_STATS);
+
+                // Selective reader (the path from the reported failure).
+                try (OrcSelectiveRecordReader selectiveReader = createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE,
+                        ImmutableMap.of())) {
+                    assertFileContentsPresto(
+                            ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                            selectiveReader,
+                            ImmutableList.of(expectedValues),
+                            ImmutableList.of(0));
+                }
+
+                // Batch reader.
+                try (OrcBatchRecordReader batchReader = createCustomOrcRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE)) {
+                    int rowsProcessed = 0;
+                    for (int batchSize = toIntExact(batchReader.nextBatch()); batchSize >= 0; batchSize = toIntExact(batchReader.nextBatch())) {
+                        Block block = batchReader.readBlock(0);
+                        assertEquals(block.getPositionCount(), batchSize);
+                        assertBlockEquals(TIMESTAMP_MICROSECONDS, block, expectedValues, rowsProcessed);
+                        rowsProcessed += batchSize;
+                    }
+                    assertEquals(rowsProcessed, expectedValues.size());
+                }
+            }
+        }
+    }
+
+    // Explicitly non-nullable data: a column written with no nulls (no present stream) that contains
+    // out-of-bounds values. Verifies the reader still allocates its nulls buffer when the flag is on,
+    // decodes in-range values correctly, and reads only the overflow rows back as null.
+    @Test
+    public void testNonNullableColumnValidAndOverflowMicrosReturnsNullWhenConfigured()
+            throws Exception
+    {
+        SqlTimestamp valid1 = sqlTimestampOf(1_650_483_250_507L, SESSION, MILLISECONDS);
+        SqlTimestamp valid2 = sqlTimestampOf(-60_000_000_000_789L, SESSION, MILLISECONDS);
+        SqlTimestamp overflow = sqlTimestampOf(9_223_372_036_855_000L, SESSION, MILLISECONDS);
+
+        // No nulls written -> no present stream in the file.
+        List<SqlTimestamp> writeValues = ImmutableList.of(valid1, overflow, valid2);
+        List<SqlTimestamp> expectedValues = Arrays.asList(
+                new SqlTimestamp(valid1.getMillis() * 1000, MICROSECONDS),
+                null,
+                new SqlTimestamp(valid2.getMillis() * 1000, MICROSECONDS));
+
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(TIMESTAMP),
+                        ImmutableList.of(writeValues),
+                        NOOP_WRITER_STATS);
+
+                try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE,
+                        ImmutableMap.of())) {
+                    assertFileContentsPresto(
+                            ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                            recordReader,
+                            ImmutableList.of(expectedValues),
+                            ImmutableList.of(0));
+                }
+            }
+        }
+    }
+
+    // Exercises the selective reader's filter path (readWithFilter). The filter admits nulls, so
+    // out-of-bounds timestamps (treated as null when configured) are retained as null.
+    @Test
+    public void testOverflowReadingMicrosWithFilterReturnsNullWhenConfigured()
+            throws Exception
+    {
+        List<SqlTimestamp> millisecondValuesOverflow = ImmutableList.of(
+                sqlTimestampOf(9_223_372_036_855_000L, SESSION, MILLISECONDS),
+                sqlTimestampOf(-9_223_372_036_855_000L, SESSION, MILLISECONDS));
+        List<SqlTimestamp> expectedNulls = Arrays.asList((SqlTimestamp) null, null);
+
+        Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(
+                0,
+                ImmutableMap.of(new Subfield("c"), BigintRange.of(Long.MIN_VALUE, Long.MAX_VALUE, true)));
+
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(TIMESTAMP),
+                        ImmutableList.of(millisecondValuesOverflow),
+                        NOOP_WRITER_STATS);
+
+                try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReaderWithNullForOutOfBoundsTimestamp(
+                        tempFile,
+                        format.getOrcEncoding(),
+                        OrcPredicate.TRUE,
+                        ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                        MAX_BATCH_SIZE,
+                        filters)) {
+                    assertFileContentsPresto(
+                            ImmutableList.of(TIMESTAMP_MICROSECONDS),
+                            recordReader,
+                            ImmutableList.of(expectedNulls),
+                            ImmutableList.of(0));
+                }
+            }
+        }
     }
 
     // Flaw in ORC encoding makes timestamp between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.


### PR DESCRIPTION
Summary:

[presto-trunk] ORC: opt-in "read null for out-of-bounds timestamp"

## Why
A Spark/Plasma job reading ORC data in the arvr warehouse fails when a file
contains a timestamp whose seconds value, scaled to microseconds, overflows a
long:

  TimestampOutOfBoundsException: seconds field of timestamp exceeds maximum
  supported value, secondsWithBase: 35222083602834 unitsPerSecond: 1000000
    at ApacheHiveTimestampDecoder.getSecondsInRequiredUnits (Math.multiplyExact)
    at TimestampSelectiveStreamReader.readNoFilter

The overflow only occurs on the micro-precision decode path (unitsPerSecond =
1_000_000), where getSecondsInRequiredUnits uses Math.multiplyExact and throws.
The source file simply holds an out-of-range timestamp value, and today a single
bad row fails the entire read.

## What
Adds an opt-in reader option, readNullForOutOfBoundsTimestamp (default false),
that makes the ORC timestamp readers emit null for an out-of-bounds timestamp
instead of throwing. When disabled (the default) behavior is unchanged.

The flag is threaded through the option chain:
  OrcReaderOptions (builder withReadNullForOutOfBoundsTimestamp + getter)
    -> OrcRecordReaderOptions
    -> BatchStreamReaders / SelectiveStreamReaders
    -> TimestampBatchStreamReader / TimestampSelectiveStreamReader
    -> DecodeTimestampOptions

Both readers catch TimestampOutOfBoundsException around decodeTimestamp:
- Batch: readNonNullBlock and readNullBlock funnel through a shared decodeBlock()
  that marks the position null. The nulls array is created by a single
  ensureIsNull() helper, called lazily on the first overflow, so a batch that
  decodes cleanly still reports no nulls.
- Selective: readNoFilter and readWithFilter treat the value like a null, and the
  filter path applies the usual nullsAllowed / testNull semantics. Two predicates
  keep the hot path honest: mayProduceNulls() is the conservative allocation
  guard (whether an overflow will occur is not known until decode), while
  producedNulls() is exact and decides whether the emitted block actually carries
  a nulls array -- so enabling the flag does not cost every timestamp column its
  downstream mayHaveNull() == false fast path.

It is also exposed to the Presto engine via HiveCommon config
"hive.read-null-for-out-of-bounds-timestamp" and session property
"read_null_for_out_of_bounds_timestamp", wired into the four hive ORC
page-source factories.

## Scope / follow-up
This diff is the presto-orc + presto-hive change only. The failing Spark/Plasma
read does NOT go through HiveCommonSessionProperties; it builds OrcReaderOptions
in xldb-orc's OrcReader.createReaderOptions() from ConfVar Hadoop-conf keys. A
separate follow-up is needed to actually unblock the Spark job: publish this
presto-orc, bump xldb-presto-orc-shaded, add a ConfVar
(hive.orc.reader.read-null-for-out-of-bounds-timestamp) + wire it into
createReaderOptions, then enable via
spark.hadoop.hive.orc.reader.read-null-for-out-of-bounds-timestamp=true.

== RELEASE NOTES ==

Hive Connector Changes
* Add configuration property ``hive.read-null-for-out-of-bounds-timestamp`` and session property ``read_null_for_out_of_bounds_timestamp`` to read an ORC timestamp that falls outside the supported range as ``NULL`` instead of failing the query. Both default to ``false``, preserving the existing behavior.

Reviewed By: HuamengJiang

Differential Revision: D108171466

## Summary by Sourcery

Add an opt-in ORC timestamp recovery mode that converts out-of-bounds values to NULL while preserving the default behavior.

New Features:
- Add an opt-in ORC reader setting that returns out-of-range timestamps as NULL instead of failing reads.
- Expose the behavior through Hive configuration and session properties for all Hive ORC page-source paths.

Bug Fixes:
- Allow ORC batch and selective timestamp readers to continue processing files containing timestamps outside the supported range when enabled.

Enhancements:
- Preserve existing failure behavior and timestamp-reader fast paths when the option is disabled or no overflow occurs.

Documentation:
- Document the new Hive configuration and session properties in the release notes.

Tests:
- Add coverage for batch, selective, filtered, nullable, non-nullable, mixed, and multiple ORC encoding timestamp reads.