### PR TITLE
fix(planner): Make logical properties work correctly with partial Limit/TopN nodes

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/LogicalPropertiesProviderImpl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/LogicalPropertiesProviderImpl.java
@@ -276,14 +276,15 @@ public class LogicalPropertiesProviderImpl
         }
 
         LogicalPropertiesImpl sourceProperties = (LogicalPropertiesImpl) ((GroupReference) limitNode.getSource()).getLogicalProperties().get();
-        return propagateAndLimitProperties(sourceProperties, limitNode.getCount());
+        // TODO : Improve the limit for a PARTIAL Limit node if we can derive it from the implementation (e.g number-of-drivers * N)
+        return limitNode.isPartial() ? propagateProperties(sourceProperties) : propagateAndLimitProperties(sourceProperties, limitNode.getCount());
     }
 
     /**
-     * Provides the logical properties for a LimitNode. The properties reflect the application of a limit N to the source properties.
+     * Provides the logical properties for a TopNNode. The properties reflect the application of a limit N to the source properties.
      *
      * @param topNNode
-     * @return The logical properties for a LimitNode.
+     * @return The logical properties for a TopNNode.
      */
     @Override
     public LogicalProperties getTopNProperties(TopNNode topNNode)
@@ -293,7 +294,7 @@ public class LogicalPropertiesProviderImpl
         }
 
         LogicalPropertiesImpl sourceProperties = (LogicalPropertiesImpl) ((GroupReference) topNNode.getSource()).getLogicalProperties().get();
-        return propagateAndLimitProperties(sourceProperties, topNNode.getCount());
+        return topNNode.getStep() == TopNNode.Step.PARTIAL ? propagateProperties(sourceProperties) : propagateAndLimitProperties(sourceProperties, topNNode.getCount());
     }
 
     /**

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.LogicalProperties;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -2182,6 +2183,261 @@ public class TestLogicalPropertyPropagation
                             tester().getTableConstraints(customerTableHandle));
 
                     return p.topN(1, ImmutableList.of(customerCustKeyVariable), customerTableScan);
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: A FINAL TopN enforces its count globally, so it does limit the maxcard of its source.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(6L),
+                new KeyProperty());
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    VariableReferenceExpression var = p.variable("c");
+                    return p.topN(6, ImmutableList.of(var), TopNNode.Step.FINAL, p.values(10, var));
+                })
+                .matches(expectedLogicalProperties);
+    }
+
+    @Test
+    public void testPartialLimitNodeLogicalProperties()
+    {
+        //A PARTIAL LimitNode only bounds the rows produced per driver, so its count is not a bound on the
+        //cardinality of the overall result. It must propagate its source properties unchanged.
+
+        //INVARIANT: source maxcard is unknown and a PARTIAL Limit(6) comes along. Maxcard should remain unknown
+        //and the key property of the source should still propagate.
+        EquivalenceClassProperty equivalenceClasses = new EquivalenceClassProperty();
+        equivalenceClasses = equivalenceClasses.combineWith(ordersCustKeyVariable, customerCustKeyVariable);
+
+        LogicalProperties expectedLogicalProperties = new LogicalPropertiesImpl(
+                equivalenceClasses,
+                new MaxCardProperty(),
+                new KeyProperty(ImmutableSet.of(new Key(ImmutableSet.of(ordersOrderKeyVariable)))));
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    TableScanNode ordersTableScan = p.tableScan(
+                            ordersTableHandle,
+                            ImmutableList.of(ordersCustKeyVariable, ordersOrderKeyVariable),
+                            ImmutableMap.of(ordersCustKeyVariable, ordersCustKeyColumn, ordersOrderKeyVariable, ordersOrderKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(ordersTableHandle));
+
+                    JoinNode ordersCustomerJoin = p.join(JoinType.INNER, ordersTableScan, customerTableScan,
+                            new EquiJoinClause(ordersCustKeyVariable, customerCustKeyVariable));
+
+                    return p.limit(6, LimitNode.Step.PARTIAL, ordersCustomerJoin);
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: the count of a PARTIAL Limit must not clamp the maxcard of its parent. The n to 1 join
+        //propagates the properties of its left source, which are those of the orders table scan.
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    TableScanNode ordersTableScan = p.tableScan(
+                            ordersTableHandle,
+                            ImmutableList.of(ordersCustKeyVariable, ordersOrderKeyVariable),
+                            ImmutableMap.of(ordersCustKeyVariable, ordersCustKeyColumn, ordersOrderKeyVariable, ordersOrderKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(ordersTableHandle));
+
+                    return p.join(JoinType.INNER, p.limit(5, LimitNode.Step.PARTIAL, ordersTableScan), customerTableScan,
+                            new EquiJoinClause(ordersCustKeyVariable, customerCustKeyVariable));
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: maxcard is set to K by Values and a PARTIAL Limit(N<K) comes along. Should still be set to K.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(10L),
+                new KeyProperty());
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> p.limit(6, LimitNode.Step.PARTIAL, p.values(10, p.variable("c"))))
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: TableScan with key (A) and a PARTIAL Limit(1) comes along. Maxcard should remain unknown
+        //and the key property should not be emptied.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(),
+                new KeyProperty(ImmutableSet.of(new Key(ImmutableSet.of(customerCustKeyVariable)))));
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    return p.limit(1, LimitNode.Step.PARTIAL, customerTableScan);
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: a FINAL Limit above a PARTIAL Limit does enforce its count globally.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(1L),
+                new KeyProperty());
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    return p.limit(1, p.limit(1, LimitNode.Step.PARTIAL, customerTableScan));
+                })
+                .matches(expectedLogicalProperties);
+    }
+
+    @Test
+    public void testPartialTopNNodeLogicalProperties()
+    {
+        //Mirror the PARTIAL Limit tests. A PARTIAL TopN also does not bound the cardinality of the overall result.
+
+        //INVARIANT: source maxcard is unknown and a PARTIAL TopN(6) comes along. Maxcard should remain unknown
+        //and the key property of the source should still propagate.
+        EquivalenceClassProperty equivalenceClasses = new EquivalenceClassProperty();
+        equivalenceClasses = equivalenceClasses.combineWith(ordersCustKeyVariable, customerCustKeyVariable);
+
+        LogicalProperties expectedLogicalProperties = new LogicalPropertiesImpl(
+                equivalenceClasses,
+                new MaxCardProperty(),
+                new KeyProperty(ImmutableSet.of(new Key(ImmutableSet.of(ordersOrderKeyVariable)))));
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    TableScanNode ordersTableScan = p.tableScan(
+                            ordersTableHandle,
+                            ImmutableList.of(ordersCustKeyVariable, ordersOrderKeyVariable),
+                            ImmutableMap.of(ordersCustKeyVariable, ordersCustKeyColumn, ordersOrderKeyVariable, ordersOrderKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(ordersTableHandle));
+
+                    JoinNode ordersCustomerJoin = p.join(JoinType.INNER, ordersTableScan, customerTableScan,
+                            new EquiJoinClause(ordersCustKeyVariable, customerCustKeyVariable));
+
+                    return p.topN(6, ImmutableList.of(ordersCustKeyVariable, ordersOrderKeyVariable), TopNNode.Step.PARTIAL,
+                            ordersCustomerJoin);
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: the count of a PARTIAL TopN must not clamp the maxcard of its parent. The n to 1 join
+        //propagates the properties of its left source, which are those of the orders table scan.
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    TableScanNode ordersTableScan = p.tableScan(
+                            ordersTableHandle,
+                            ImmutableList.of(ordersCustKeyVariable, ordersOrderKeyVariable),
+                            ImmutableMap.of(ordersCustKeyVariable, ordersCustKeyColumn, ordersOrderKeyVariable, ordersOrderKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(ordersTableHandle));
+
+                    return p.join(JoinType.INNER,
+                            p.topN(5, ImmutableList.of(ordersCustKeyVariable), TopNNode.Step.PARTIAL, ordersTableScan),
+                            customerTableScan,
+                            new EquiJoinClause(ordersCustKeyVariable, customerCustKeyVariable));
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: maxcard is set to K by Values and a PARTIAL TopN(N<K) comes along. Should still be set to K.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(10L),
+                new KeyProperty());
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    VariableReferenceExpression var = p.variable("c");
+                    return p.topN(6, ImmutableList.of(var), TopNNode.Step.PARTIAL, p.values(10, var));
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: TableScan with key (A) and a PARTIAL TopN(1) comes along. Maxcard should remain unknown
+        //and the key property should not be emptied.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(),
+                new KeyProperty(ImmutableSet.of(new Key(ImmutableSet.of(customerCustKeyVariable)))));
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    return p.topN(1, ImmutableList.of(customerCustKeyVariable), TopNNode.Step.PARTIAL, customerTableScan);
+                })
+                .matches(expectedLogicalProperties);
+
+        //INVARIANT: a FINAL TopN above a PARTIAL TopN does enforce its count globally.
+        expectedLogicalProperties = new LogicalPropertiesImpl(
+                new EquivalenceClassProperty(),
+                new MaxCardProperty(1L),
+                new KeyProperty());
+
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    return p.topN(1, ImmutableList.of(customerCustKeyVariable), TopNNode.Step.FINAL,
+                            p.topN(1, ImmutableList.of(customerCustKeyVariable), TopNNode.Step.PARTIAL, customerTableScan));
                 })
                 .matches(expectedLogicalProperties);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantLimitRemoval.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantLimitRemoval.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.spi.TestingColumnHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -117,6 +118,29 @@ public class TestRedundantLimitRemoval
                     return p.limit(
                             10,
                             p.values(12, c));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireThroughPartialLimit()
+    {
+        // A PARTIAL limit only bounds the rows produced per driver, it does not enforce its count globally, so the
+        // FINAL limit above it is not redundant even though both have the same count. This plan shape shows up when
+        // LimitPushDown pushes a PARTIAL limit into the branches of a union, and all but one of those branches is
+        // then removed by SimplifyPlanWithEmptyInput because a filter proved its input empty.
+        // See https://github.com/prestodb/presto/issues/28166
+        tester().assertThat(new RemoveRedundantLimit(), logicalPropertiesProvider)
+                .on(p -> {
+                    VariableReferenceExpression shipmode = p.variable("shipmode");
+                    return p.limit(
+                            30000,
+                            p.limit(
+                                    30000,
+                                    LimitNode.Step.PARTIAL,
+                                    p.tableScan(
+                                            ImmutableList.of(shipmode),
+                                            ImmutableMap.of(shipmode, new TestingColumnHandle("shipmode")))));
                 })
                 .doesNotFire();
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -274,10 +274,20 @@ public class PlanBuilder
 
     public LimitNode limit(long limit, PlanNode source)
     {
-        return new LimitNode(source.getSourceLocation(), idAllocator.getNextId(), source, limit, FINAL);
+        return limit(limit, FINAL, source);
+    }
+
+    public LimitNode limit(long limit, LimitNode.Step step, PlanNode source)
+    {
+        return new LimitNode(source.getSourceLocation(), idAllocator.getNextId(), source, limit, step);
     }
 
     public TopNNode topN(long count, List<VariableReferenceExpression> orderBy, PlanNode source)
+    {
+        return topN(count, orderBy, TopNNode.Step.SINGLE, source);
+    }
+
+    public TopNNode topN(long count, List<VariableReferenceExpression> orderBy, TopNNode.Step step, PlanNode source)
     {
         return new TopNNode(
                 orderBy.get(0).getSourceLocation(),
@@ -285,7 +295,7 @@ public class PlanBuilder
                 source,
                 count,
                 new OrderingScheme(orderBy.stream().map(variable -> new Ordering(variable, ASC_NULLS_FIRST)).collect(toImmutableList())),
-                TopNNode.Step.SINGLE);
+                step);
     }
 
     public DistinctLimitNode distinctLimit(long count, List<VariableReferenceExpression> distinctSymbols, PlanNode source)


### PR DESCRIPTION
## Description
Fix for https://github.com/prestodb/presto/issues/28166

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
New CI tests added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix planner logical properties for partial Limit and TopN nodes while preserving global bounds for final nodes.

Bug Fixes:
- Correct logical property propagation for partial Limit and TopN nodes so their per-driver row counts do not incorrectly impose global cardinality bounds or discard source properties.

Enhancements:
- Clarify logical property handling and test-plan builders for final versus partial Limit and TopN nodes.

Tests:
- Add coverage for partial Limit and TopN property propagation, final nodes above partial nodes, and preservation of redundant-limit rules.