### PR TITLE
fix(planner): Name the violated column in NOT NULL write errors

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -7111,6 +7111,11 @@ public class TestHiveIntegrationSmokeTest
         insertStmt = format("INSERT INTO %s VALUES (null, 2.3, null, 4)", tableName);
         assertUpdate(getSession(), insertStmt, 1);
 
+        // c1 and c4 read the same source column, so the page reaching the writer holds fewer channels
+        // than the table has columns and the violation is named after the column the NULL is written to.
+        insertStmt = format("INSERT INTO %s SELECT orderkey, IF(orderkey %% 2 = 0, null, totalprice), comment, orderkey FROM orders", tableName);
+        assertQueryFails(insertStmt, "NULL value not allowed for NOT NULL column: c2");
+
         assertUpdate(getSession(), dropTableStmt);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2817,8 +2817,10 @@ public class LocalExecutionPlanner
             List<Integer> inputChannels = node.getColumns().stream()
                     .map(source::variableToChannel)
                     .collect(toImmutableList());
-            List<String> notNullChannelColumnNames = node.getColumns().stream()
-                    .map(variable -> node.getNotNullColumnVariables().contains(variable) ? node.getColumnNames().get(source.variableToChannel(variable)) : null)
+            // 'columns' and 'columnNames' are parallel, so a not-null variable is named by its position
+            // in 'columns', which is unrelated to the source channel it reads from.
+            List<String> notNullChannelColumnNames = IntStream.range(0, node.getColumns().size())
+                    .mapToObj(i -> node.getNotNullColumnVariables().contains(node.getColumns().get(i)) ? node.getColumnNames().get(i) : null)
                     .collect(Collectors.toList());
 
             OperatorFactory operatorFactory = new TableWriterOperatorFactory(
@@ -2901,8 +2903,10 @@ public class LocalExecutionPlanner
                     .map(source::variableToChannel)
                     .collect(toImmutableList());
 
-            List<String> notNullChannelColumnNames = node.getColumns().stream()
-                    .map(variable -> node.getNotNullColumnVariables().contains(variable) ? node.getColumnNames().get(source.variableToChannel(variable)) : null)
+            // 'columns' and 'columnNames' are parallel, so a not-null variable is named by its position
+            // in 'columns', which is unrelated to the source channel it reads from.
+            List<String> notNullChannelColumnNames = IntStream.range(0, node.getColumns().size())
+                    .mapToObj(i -> node.getNotNullColumnVariables().contains(node.getColumns().get(i)) ? node.getColumnNames().get(i) : null)
                     .collect(Collectors.toList());
 
             OperatorFactory operatorFactory = new TableWriterOperatorFactory(


### PR DESCRIPTION
## Description

`TableWriterOperator` names the offending column when an `INSERT` writes NULL into a NOT NULL column. `LocalExecutionPlanner` resolved that name by indexing `TableWriterNode.columnNames` with the **source page channel** of the constrained variable:

```java
node.getColumnNames().get(source.variableToChannel(variable))
```

`columnNames` is parallel to `columns` by position — `columns[i]` is written to `columnNames[i]`, an invariant both `TableWriterNode` and `CallDistributedProcedureNode` assert in their constructors. Channel numbers come from the source operator's output layout and bear no relation to that ordering; the two index spaces agree only by coincidence.

This resolves the name by position instead, at both call sites (`visitTableWriter` and `visitCallDistributedProcedure`).

## Motivation and Context

An `INSERT` whose `SELECT` feeds one source column into two target columns makes the two index spaces disagree: the page reaching the writer holds fewer channels than the table has columns, and the projection is free to order them differently.

```sql
CREATE TABLE t (c1 BIGINT, c2 DOUBLE NOT NULL, c3 VARCHAR, c4 BIGINT NOT NULL);

INSERT INTO t SELECT orderkey, IF(orderkey % 2 = 0, NULL, totalprice), comment, orderkey FROM orders;
```

`c1` and `c4` both read `orderkey`, so the page carries 3 channels for 4 target columns. The NULL lands in `c2`, but the error reads:

```
NULL value not allowed for NOT NULL column: c1
```

`c1` is nullable and has no constraint at all. With the fix the error correctly names `c2`.

This regressed in 2f8bbbac06b (#26373), which introduced the mapping in both call sites.

## Impact

Error-message correctness only, and no configuration change.

Enforcement itself was never affected: which blocks get null-checked is driven by `notNullColumnVariables.contains(variable)`, which was already correct. No violation went undetected and no invalid row was written — only the reported column name was wrong.

## Test Plan

Added a regression case to `TestHiveIntegrationSmokeTest.testDMLWithEnforcedConstraints`, reusing the `c1 BIGINT, c2 DOUBLE NOT NULL, c3 VARCHAR, c4 BIGINT NOT NULL` table the test already builds. The existing cases in that test insert `VALUES` literals, which never produce a duplicated source variable and so pass with or without the fix.

Verified the new case is a true regression test by running it against both versions of the planner:

- Planner reverted to the channel-indexed mapping — fails:
  ```
  java.lang.AssertionError: Expected exception message 'NULL value not allowed for NOT NULL column: c1'
    to match 'NULL value not allowed for NOT NULL column: c2'
  ```
- Fix applied — passes:
  ```
  Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
  ```

```
./mvnw -pl presto-hive test -Dtest=TestHiveIntegrationSmokeTest#testDMLWithEnforcedConstraints
./mvnw -pl presto-main-base validate
./mvnw -pl presto-hive validate
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix the column named in ``NULL value not allowed for NOT NULL column`` errors, which could report an unrelated column when an ``INSERT`` writes one source column into more than one target column.
```

## Summary by Sourcery

Fix NOT NULL write errors to resolve column names by target-column position rather than source-page channels.

Bug Fixes:
- Correct the NOT NULL constraint error messages to identify the actual target column receiving the NULL value, including INSERTs that reuse source columns.

Tests:
- Add a Hive integration regression test covering duplicated source columns and verifying that the reported violated column is correct.