### PR TITLE
feat(connector): Add support for widening nested fields

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -2879,6 +2879,34 @@ public abstract class IcebergAbstractMetadata
         }
     }
 
+    @Override
+    public void setFieldType(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle, List<String> fieldPath, com.facebook.presto.common.type.Type type)
+    {
+        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
+        IcebergColumnHandle column = (IcebergColumnHandle) columnHandle;
+
+        Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        try {
+            Schema schema = icebergTable.schema();
+            Types.NestedField field = schema.findField(column.getId());
+            for (String pathElement : fieldPath) {
+                if (!field.type().isStructType()) {
+                    throw new IllegalArgumentException("Cannot find nested field " + pathElement);
+                }
+                field = field.type().asStructType().caseInsensitiveField(pathElement);
+                if (field == null) {
+                    throw new IllegalArgumentException("Cannot find nested field " + pathElement);
+                }
+            }
+            icebergTable.updateSchema()
+                    .updateColumn(schema.findColumnName(field.fieldId()), toIcebergType(type).asPrimitiveType())
+                    .commit();
+        }
+        catch (RuntimeException e) {
+            throw new PrestoException(ICEBERG_INCOMPATIBLE_COLUMN_TYPE, "Failed to set field type: " + firstNonNull(e.getMessage(), e), e);
+        }
+    }
+
     protected void openCreateTableTransaction(SchemaTableName tableName, Transaction transaction)
     {
         transactionContext.registerTransaction(tableName, transaction);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -97,7 +97,6 @@ import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.io.LocationProvider;
-import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -161,7 +160,6 @@ import static com.facebook.presto.iceberg.IcebergUtil.getLocationProvider;
 import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTable;
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
-import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.delete.EqualityDeleteFilter.readEqualityDeletes;
 import static com.facebook.presto.iceberg.delete.PositionDeleteFilter.readPositionDeletes;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -396,13 +394,7 @@ public class IcebergPageSourceProvider
                                 .ifPresent(value -> defaultValues.put(column.getId(), value));
                     }
                     else {
-                        Type type = column.getType();
-                        if (!parquetField.get().isPrimitive()) {
-                            MessageType parquetMessageType = new MessageType("", parquetField.get());
-                            Schema icebergSchema = ParquetSchemaUtil.convert(parquetMessageType);
-                            type = toPrestoType(icebergSchema.columns().get(0).type(), typeManager);
-                        }
-                        internalFields.add(constructField(type, lookupColumnByName(messageColumnIO, AvroSchemaUtil.makeCompatibleName(parquetField.get().getName()))));
+                        internalFields.add(constructField(column.getType(), lookupColumnByName(messageColumnIO, AvroSchemaUtil.makeCompatibleName(parquetField.get().getName()))));
                     }
                 }
                 if (column.isRowPositionColumn()) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1543,6 +1543,69 @@ public abstract class IcebergDistributedSmokeTestBase
         });
     }
 
+    @Test
+    public void testAlterNestedFieldType()
+    {
+        testWithAllFileFormats((session, fileFormat) -> {
+            String tableName = "test_alter_nested_field_type_" + fileFormat.name().toLowerCase(ENGLISH);
+            String schemaName = session.getSchema().get();
+            try {
+                assertUpdate(session, format(
+                        "CREATE TABLE %s (" +
+                                "id BIGINT, " +
+                                "info ROW(age INTEGER, name VARCHAR)" +
+                                ") WITH (format = '%s')",
+                        tableName, fileFormat));
+
+                // Insert rows before widening
+                assertUpdate(session, format(
+                        "INSERT INTO %s VALUES " +
+                                "(1, ROW(25, 'alice')), " +
+                                "(2, ROW(30, 'bob'))",
+                        tableName), 2);
+
+                // Verify initial data
+                assertQuery(session,
+                        format("SELECT info.age FROM %s WHERE id = 1", tableName),
+                        "VALUES 25");
+
+                // Widen info.age: INTEGER → BIGINT
+                assertUpdate(session, format("ALTER TABLE %s ALTER COLUMN info.age SET DATA TYPE BIGINT", tableName));
+
+                // Verify schema reflects the widened type
+                validateShowCreateTable(session.getCatalog().get(), schemaName, tableName,
+                        ImmutableList.of(
+                                columnDefinition("id", "bigint"),
+                                columnDefinition("info", "ROW(\"age\" bigint,\"name\" varchar)")),
+                        null,
+                        null);
+
+                // Old rows still readable after widening
+                assertQuery(session,
+                        format("SELECT info.age, typeof(info.age) FROM %s WHERE id = 1", tableName),
+                        "VALUES (CAST(25 AS BIGINT), 'bigint')");
+                assertQuery(session,
+                        format("SELECT info.age FROM %s WHERE id = 2", tableName),
+                        "VALUES CAST(30 AS BIGINT)");
+
+                // Insert new row after widening with a value that fits only in BIGINT
+                assertUpdate(session, format("INSERT INTO %s VALUES (3, ROW(CAST(9999999999 AS BIGINT), 'carol'))", tableName), 1);
+                assertQuery(session,
+                        format("SELECT info.age FROM %s WHERE id = 3", tableName),
+                        "VALUES CAST(9999999999 AS BIGINT)");
+
+                // Narrowing (BIGINT → INTEGER) must be rejected by Iceberg
+                assertQueryFails(
+                        session,
+                        format("ALTER TABLE %s ALTER COLUMN info.age SET DATA TYPE INTEGER", tableName),
+                        "Failed to set field type: Cannot change column type.*");
+            }
+            finally {
+                dropTable(session, tableName);
+            }
+        });
+    }
+
     private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
     {
         test.accept(getSession(), FileFormat.PARQUET);

--- a/presto-main-base/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/catalogserver/RemoteMetadataManager.java
@@ -113,6 +113,9 @@ public class RemoteMetadataManager
     public void setColumnType(Session session, TableHandle tableHandle, ColumnHandle column, Type type) {}
 
     @Override
+    public void setFieldType(Session session, TableHandle tableHandle, ColumnHandle column, List<String> fieldPath, Type type) {}
+
+    @Override
     public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
     {
         String viewsListJson = catalogServerClient.get().listViews(

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SetColumnTypeTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SetColumnTypeTask.java
@@ -82,12 +82,19 @@ public class SetColumnTypeTask
         accessControl.checkCanAlterColumn(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName);
 
         TableHandle tableHandleOptional = tableHandle.get();
+        List<String> columnPath = statement.getColumnName().getParts();
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandleOptional);
-        ColumnHandle column = columnHandles.get(statement.getColumnName().getValue());
+        ColumnHandle column = columnHandles.get(columnPath.get(0));
         if (column == null) {
             throw new SemanticException(MISSING_COLUMN, statement, "Column '%s' does not exist", statement.getColumnName());
         }
-        metadata.setColumnType(session, tableHandleOptional, column, getColumnType(statement));
+        Type type = getColumnType(statement);
+        if (columnPath.size() == 1) {
+            metadata.setColumnType(session, tableHandleOptional, column, type);
+        }
+        else {
+            metadata.setFieldType(session, tableHandleOptional, column, columnPath.subList(1, columnPath.size()), type);
+        }
 
         return immediateFuture(null);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -254,6 +254,11 @@ public interface Metadata
      */
     void setColumnType(Session session, TableHandle tableHandle, ColumnHandle column, Type type);
 
+    default void setFieldType(Session session, TableHandle tableHandle, ColumnHandle column, List<String> fieldPath, Type type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Drop the specified column.
      */

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -844,6 +844,14 @@ public class MetadataManager
     }
 
     @Override
+    public void setFieldType(Session session, TableHandle tableHandle, ColumnHandle column, List<String> fieldPath, Type type)
+    {
+        ConnectorId connectorId = tableHandle.getConnectorId();
+        ConnectorMetadata metadata = getMetadataForWrite(session, connectorId);
+        metadata.setFieldType(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), column, fieldPath, type);
+    }
+
+    @Override
     public void dropTable(Session session, TableHandle tableHandle)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -1172,6 +1172,12 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
+    public void setFieldType(Session session, TableHandle tableHandle, ColumnHandle column, List<String> fieldPath, Type type)
+    {
+        delegate.setFieldType(session, tableHandle, column, fieldPath, type);
+    }
+
+    @Override
     public void dropColumn(Session session, TableHandle tableHandle, ColumnHandle column)
     {
         long startTime = System.nanoTime();

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSetColumnTypeTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSetColumnTypeTask.java
@@ -14,233 +14,203 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
-import com.facebook.presto.connector.informationSchema.InformationSchemaTableHandle;
 import com.facebook.presto.metadata.AbstractMockMetadata;
-import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.CatalogManager;
-import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
-import com.facebook.presto.spi.ConnectorTableMetadata;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.TableHandle;
-import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.TestingColumnHandle;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.connector.ConnectorCapabilities;
-import com.facebook.presto.spi.connector.ConnectorContext;
-import com.facebook.presto.spi.security.AccessControl;
-import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SetColumnType;
-import com.facebook.presto.testing.TestingConnectorContext;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
-import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
-import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
-import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.MoreCollectors.onlyElement;
-import static com.google.common.collect.Sets.immutableEnumSet;
-import static java.util.Collections.emptySet;
-import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test(singleThreaded = true)
 public class TestSetColumnTypeTask
 {
-    public static final String SCHEMA = "schema";
     private static final String CATALOG_NAME = "catalog";
+    private static final String SCHEMA = "schema";
+
     private Session testSession;
-
-    protected TransactionManager transactionManager;
-    protected MockMetadata metadata;
-    protected AccessControl accessControl;
-    protected ConnectorContext context;
-    protected WarningCollector warningCollector;
-
-    protected static QualifiedObjectName qualifiedObjectName(String objectName)
-    {
-        return new QualifiedObjectName(CATALOG_NAME, SCHEMA, objectName);
-    }
-
-    protected static QualifiedName asQualifiedName(QualifiedObjectName qualifiedObjectName)
-    {
-        return QualifiedName.of(qualifiedObjectName.getCatalogName(), qualifiedObjectName.getSchemaName(), qualifiedObjectName.getObjectName());
-    }
+    private TransactionManager transactionManager;
+    private MockMetadata metadata;
 
     @BeforeMethod
     public void setUp()
     {
         CatalogManager catalogManager = new CatalogManager();
-        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+        catalogManager.registerCatalog(createBogusTestingCatalog(CATALOG_NAME));
         transactionManager = createTestTransactionManager(catalogManager);
-        TablePropertyManager tablePropertyManager = new TablePropertyManager();
-        ColumnPropertyManager columnPropertyManager = new ColumnPropertyManager();
-        Catalog testCatalog = createBogusTestingCatalog(CATALOG_NAME);
-        catalogManager.registerCatalog(testCatalog);
-        tablePropertyManager.addProperties(testCatalog.getConnectorId(),
-                ImmutableList.of(stringProperty("baz", "test property", null, false)));
-        columnPropertyManager.addProperties(testCatalog.getConnectorId(), ImmutableList.of());
         testSession = testSessionBuilder()
                 .setTransactionId(transactionManager.beginTransaction(false))
                 .build();
-        context = new TestingConnectorContext();
-        metadata = new MockMetadata(
-            functionAndTypeManager,
-            tablePropertyManager,
-            columnPropertyManager,
-            testCatalog.getConnectorId(),
-            emptySet(), testCatalog);
+        ConnectorId connectorId = catalogManager.getCatalog(CATALOG_NAME).get().getConnectorId();
+        metadata = new MockMetadata(createTestFunctionAndTypeManager(), connectorId);
     }
 
     @Test
     public void testSetDataTypeNotExistingTable()
     {
-        QualifiedObjectName tableName = qualifiedObjectName("not_existing_table");
-
-        assertThatThrownBy(() -> getFutureValue(executeSetColumnType(asQualifiedName(tableName), identifier("test"), "INTEGER", false)));
+        assertThatThrownBy(() -> getFutureValue(executeSetColumnType(
+                QualifiedName.of(CATALOG_NAME, SCHEMA, "not_existing_table"),
+                QualifiedName.of("test"),
+                "INTEGER",
+                false)));
     }
 
     @Test
     public void testSetDataTypeNotExistingTableIfExists()
     {
-        QualifiedObjectName tableName = qualifiedObjectName("not_existing_table");
-
-        getFutureValue(executeSetColumnType(asQualifiedName(tableName), identifier("test"), "INTEGER", true));
+        getFutureValue(executeSetColumnType(
+                QualifiedName.of(CATALOG_NAME, SCHEMA, "not_existing_table"),
+                QualifiedName.of("test"),
+                "INTEGER",
+                true));
         // no exception
+    }
+
+    @Test
+    public void testSetDataTypeNestedColumn()
+    {
+        getFutureValue(executeSetColumnType(
+                QualifiedName.of(CATALOG_NAME, SCHEMA, "existing_table"),
+                QualifiedName.of("info", "age"),
+                "BIGINT",
+                false));
+        assertThat(metadata.getFieldPath()).containsExactly("age");
+        assertThat(metadata.getFieldColumn()).isEqualTo("info");
+    }
+
+    @Test
+    public void testSetDataTypeTopLevelColumn()
+    {
+        getFutureValue(executeSetColumnType(
+                QualifiedName.of(CATALOG_NAME, SCHEMA, "existing_table"),
+                QualifiedName.of("info"),
+                "BIGINT",
+                false));
+        assertThat(metadata.getFieldPath()).isNull();
+        assertThat(metadata.isColumnTypeSet()).isTrue();
     }
 
     @Test
     public void testSetDataTypeNotExistingColumn()
     {
-        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
-        assertThatThrownBy(() -> getFutureValue(executeSetColumnType(asQualifiedName(tableName), identifier("not_existing_column"), "INTEGER", false)));
+        assertThatThrownBy(() -> getFutureValue(executeSetColumnType(
+                QualifiedName.of(CATALOG_NAME, SCHEMA, "existing_table"),
+                QualifiedName.of("not_existing_column"),
+                "INTEGER",
+                false)));
     }
 
-    private ListenableFuture<Void> executeSetColumnType(QualifiedName table, Identifier column, String type, boolean exists)
+    private ListenableFuture<Void> executeSetColumnType(QualifiedName table, QualifiedName column, String type, boolean exists)
     {
         return new SetColumnTypeTask(metadata)
-                .execute(new SetColumnType(new NodeLocation(1, 1), table, column, type, exists), transactionManager, metadata, accessControl, testSession, ImmutableList.of(), warningCollector, null);
+                .execute(new SetColumnType(new NodeLocation(1, 1), table, column, type, exists),
+                        transactionManager, metadata, new AllowAllAccessControl(),
+                        testSession, ImmutableList.of(), (WarningCollector) null, null);
     }
 
-    private static class MockMetadata
+    private static final class MockMetadata
             extends AbstractMockMetadata
     {
         private final FunctionAndTypeManager functionAndTypeManager;
-        private final TablePropertyManager tablePropertyManager;
-        private final ColumnPropertyManager columnPropertyManager;
-        private final ConnectorId catalogHandle;
-        private final Map<SchemaTableName, ConnectorTableMetadata> tables = new ConcurrentHashMap<>();
-        private final Set<ConnectorCapabilities> connectorCapabilities;
-        private final Catalog catalog;
-        public MockMetadata(
-                FunctionAndTypeManager functionAndTypeManager,
-                TablePropertyManager tablePropertyManager,
-                ColumnPropertyManager columnPropertyManager,
-                ConnectorId catalogHandle,
-                Set<ConnectorCapabilities> connectorCapabilities, Catalog testCatalog)
+        private final TableHandle tableHandle;
+
+        private List<String> fieldPath;
+        private String fieldColumn;
+        private boolean columnTypeSet;
+
+        MockMetadata(FunctionAndTypeManager functionAndTypeManager, ConnectorId connectorId)
         {
-            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
-            this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
-            this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
-            this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
-            this.catalog = testCatalog;
-            this.connectorCapabilities = requireNonNull(immutableEnumSet(connectorCapabilities), "connectorCapabilities is null");
+            this.functionAndTypeManager = functionAndTypeManager;
+            this.tableHandle = new TableHandle(connectorId, new TestingTableHandle(), TestingTransactionHandle.create(), Optional.empty());
         }
 
         @Override
-        public void setColumnType(Session session, TableHandle tableHandle, ColumnHandle columnHandle, Type type)
+        public MetadataResolver getMetadataResolver(Session session)
         {
-            SchemaTableName tableName = getTableName(tableHandle);
-            ConnectorTableMetadata metadata = tables.get(tableName);
-
-            ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builderWithExpectedSize(metadata.getColumns().size());
-            for (ColumnMetadata column : metadata.getColumns()) {
-                if (column.getName().equals(((TestingColumnHandle) columnHandle).getName())) {
-                    columns.add(ColumnMetadata.builder().setName(column.getName()).setType(type).build());
+            MetadataResolver base = super.getMetadataResolver(session);
+            return new MetadataResolver()
+            {
+                @Override
+                public boolean catalogExists(String catalogName)
+                {
+                    return base.catalogExists(catalogName);
                 }
-                else {
-                    columns.add(column);
+
+                @Override
+                public boolean schemaExists(CatalogSchemaName schemaName)
+                {
+                    return base.schemaExists(schemaName);
                 }
-            }
-            tables.put(tableName, new ConnectorTableMetadata(tableName, columns.build()));
-        }
 
-        @Override
-        public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
-        {
-            tables.put(tableMetadata.getTable(), tableMetadata);
-            if (!ignoreExisting) {
-                throw new PrestoException(ALREADY_EXISTS, "Table already exists");
-            }
-        }
+                @Override
+                public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
+                {
+                    return tableName.getObjectName().equals("existing_table") ? Optional.of(tableHandle) : Optional.empty();
+                }
 
-        @Override
-        public TablePropertyManager getTablePropertyManager()
-        {
-            return tablePropertyManager;
-        }
+                @Override
+                public List<ColumnMetadata> getColumns(TableHandle t)
+                {
+                    return base.getColumns(t);
+                }
 
-        @Override
-        public ColumnPropertyManager getColumnPropertyManager()
-        {
-            return columnPropertyManager;
-        }
+                @Override
+                public Map<String, ColumnHandle> getColumnHandles(TableHandle t)
+                {
+                    return base.getColumnHandles(t);
+                }
 
-        @Override
-        public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
-        {
-            return new TableMetadata(catalog.getConnectorId(), getTableMetadata(tableHandle));
-        }
+                @Override
+                public Optional<ViewDefinition> getView(QualifiedObjectName v)
+                {
+                    return base.getView(v);
+                }
 
-        private ConnectorTableMetadata getTableMetadata(TableHandle tableHandle)
-        {
-            return tables.get(((InformationSchemaTableHandle) tableHandle.getConnectorHandle()).getSchemaTableName());
-        }
-        private SchemaTableName getTableName(TableHandle tableHandle)
-        {
-            return ((InformationSchemaTableHandle) tableHandle.getConnectorHandle()).getSchemaTableName();
+                @Override
+                public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName v)
+                {
+                    return base.getMaterializedView(v);
+                }
+            };
         }
 
         @Override
         public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
         {
-            return getTableMetadata(tableHandle).getColumns().stream()
-                    .collect(toImmutableMap(
-                        ColumnMetadata::getName,
-                        column -> new TestingColumnHandle(column.getName())));
-        }
-
-        @Override
-        public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
-        {
-            String columnName = ((TestingColumnHandle) columnHandle).getName();
-            return getTableMetadata(tableHandle).getColumns().stream()
-                    .filter(column -> column.getName().equals(columnName))
-                    .collect(onlyElement());
+            return ImmutableMap.of("info", new TestingColumnHandle("info"));
         }
 
         @Override
@@ -250,18 +220,31 @@ public class TestSetColumnTypeTask
         }
 
         @Override
-        public Optional<ConnectorId> getCatalogHandle(Session session, String catalogName)
+        public void setColumnType(Session session, TableHandle tableHandle, ColumnHandle columnHandle, Type type)
         {
-            if (catalogHandle.getCatalogName().equals(catalogName)) {
-                return Optional.of(catalogHandle);
-            }
-            return Optional.empty();
+            this.columnTypeSet = true;
         }
 
         @Override
-        public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
+        public void setFieldType(Session session, TableHandle tableHandle, ColumnHandle columnHandle, List<String> fieldPath, Type type)
         {
-            return connectorCapabilities;
+            this.fieldPath = fieldPath;
+            this.fieldColumn = ((TestingColumnHandle) columnHandle).getName();
+        }
+
+        List<String> getFieldPath()
+        {
+            return fieldPath;
+        }
+
+        String getFieldColumn()
+        {
+            return fieldColumn;
+        }
+
+        boolean isColumnTypeSet()
+        {
+            return columnTypeSet;
         }
     }
 }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -85,7 +85,7 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP TAG (IF EXISTS)? name=string                              #dropTag
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
-        ALTER COLUMN columnName=identifier SET DATA TYPE type          #setColumnType
+        ALTER COLUMN columnName=qualifiedName SET DATA TYPE type          #setColumnType
     | ANALYZE qualifiedName (WITH properties)?                         #analyze
     | CREATE TYPE qualifiedName AS (
         '(' sqlParameterDeclaration (',' sqlParameterDeclaration)* ')'

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1123,7 +1123,7 @@ class AstBuilder
         return new SetColumnType(
                 getLocation(context),
                 getQualifiedName(context.tableName),
-                (Identifier) visit(context.columnName),
+                getQualifiedName(context.columnName),
                 getType(context.type()),
                 context.EXISTS() != null);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetColumnType.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetColumnType.java
@@ -26,11 +26,11 @@ public class SetColumnType
         extends Statement
 {
     private final QualifiedName tableName;
-    private final Identifier columnName;
+    private final QualifiedName columnName;
     private final String type;
     private final boolean tableExists;
 
-    public SetColumnType(NodeLocation location, QualifiedName tableName, Identifier columnName, String type, boolean tableExists)
+    public SetColumnType(NodeLocation location, QualifiedName tableName, QualifiedName columnName, String type, boolean tableExists)
     {
         super(Optional.of(location));
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -44,7 +44,7 @@ public class SetColumnType
         return tableName;
     }
 
-    public Identifier getColumnName()
+    public QualifiedName getColumnName()
     {
         return columnName;
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2173,16 +2173,23 @@ public class TestSqlParser
         assertStatement("ALTER TABLE foo.t ALTER COLUMN c SET DATA TYPE BIGINT", new SetColumnType(
                 new NodeLocation(1, 1),
                 QualifiedName.of("foo", "t"),
-                new Identifier("c"),
+                QualifiedName.of("c"),
                 "BIGINT",
                 false));
 
         assertStatement("ALTER TABLE IF EXISTS foo.t ALTER COLUMN b SET DATA TYPE DOUBLE", new SetColumnType(
                 new NodeLocation(1, 1),
                 QualifiedName.of("foo", "t"),
-                new Identifier("b"),
+                QualifiedName.of("b"),
                 "DOUBLE",
                 true));
+
+        assertStatement("ALTER TABLE foo.t ALTER COLUMN info.age SET DATA TYPE BIGINT", new SetColumnType(
+                new NodeLocation(1, 1),
+                QualifiedName.of("foo", "t"),
+                QualifiedName.of("info", "age"),
+                "BIGINT",
+                false));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -510,6 +510,11 @@ public interface ConnectorMetadata
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support setting column types");
     }
 
+    default void setFieldType(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, List<String> fieldPath, Type type)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support setting field types");
+    }
+
     /**
      * Describes statistics that must be collected during a write.
      */

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1018,4 +1018,12 @@ public class ClassLoaderSafeConnectorMetadata
             delegate.setColumnType(session, tableHandle, columnHandle, type);
         }
     }
+
+    @Override
+    public void setFieldType(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle, List<String> fieldPath, Type type)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.setFieldType(session, tableHandle, columnHandle, fieldPath, type);
+        }
+    }
 }


### PR DESCRIPTION
## Description

Adds support for widening nested fields in Iceberg struct columns using `ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE`.

Example:

`ALTER TABLE table_name ALTER COLUMN struct_col.field SET DATA TYPE BIGINT;`

## Context

Fixes: [#81606](https://github.ibm.com/lakehouse/tracker/issues/81606)
Partially fixes: [#75595](https://github.ibm.com/lakehouse/tracker/issues/75595)

This branch adds support for nested field type widening while preserving the existing top-level type-widening behavior.
The implementation also ensures that existing data written before the schema evolution remains readable after widening.

## Release Notes

```text
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for ``ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE`` to widen top-level column types in the Iceberg connector.
```

## Summary by Sourcery

Enable widening nested Iceberg struct fields through ALTER COLUMN while preserving existing top-level type-widening behavior.

New Features:
- Support ALTER TABLE ... ALTER COLUMN ... SET DATA TYPE for nested struct fields.
- Preserve readability of existing data after nested field type widening across supported Iceberg file formats.

Bug Fixes:
- Fix reading evolved nested Parquet fields without position-count errors while retaining compatibility with encoded field names.

Enhancements:
- Extend SQL parsing, metadata APIs, connector delegation, and execution handling to support qualified nested column paths.
- Add coverage for nested field widening, schema updates, legacy and new data reads, narrowing rejection, and SQL parsing.