### PR TITLE
[DO NOT REVIEW] feat(analyzer): Support SELECT output aliases in HAVING clause

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -443,6 +443,22 @@ with an account balance greater than the specified value::
       1272 | AUTOMOBILE |        19 |  5856939
       1253 | FURNITURE  |        14 |  5794887
       1248 | FURNITURE  |         9 |  5784628
+
+The ``HAVING`` clause can also reference output column aliases defined in
+the ``SELECT`` list. The alias is replaced by the expression it names, so
+the following query is equivalent to the previous one::
+
+    SELECT count(*), mktsegment, nationkey,
+           CAST(sum(acctbal) AS bigint) AS totalbal
+    FROM customer
+    GROUP BY mktsegment, nationkey
+    HAVING totalbal > 5700000
+    ORDER BY totalbal DESC;
+
+Column names from the ``FROM`` clause take precedence over output aliases:
+if a name in ``HAVING`` matches both an input column and an alias, it refers
+to the input column. An alias that names an aggregate expression cannot be
+used inside another aggregate function in ``HAVING``.
       1243 | FURNITURE  |        12 |  5757371
       1231 | HOUSEHOLD  |         3 |  5753216
       1251 | MACHINERY  |         2 |  5719140

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeCopier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeCopier.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.tree.ArrayConstructor;
+import com.facebook.presto.sql.tree.BinaryLiteral;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.CharLiteral;
+import com.facebook.presto.sql.tree.CurrentTime;
+import com.facebook.presto.sql.tree.CurrentUser;
+import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.EnumLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FieldReference;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.GroupingOperation;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.IntervalLiteral;
+import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
+import com.facebook.presto.sql.tree.LambdaExpression;
+import com.facebook.presto.sql.tree.Literal;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NodeLocation;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.Parameter;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Row;
+import com.facebook.presto.sql.tree.SortItem;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.TimeLiteral;
+import com.facebook.presto.sql.tree.TimestampLiteral;
+import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+/**
+ * Creates a deep copy of an expression tree.
+ * <p>
+ * The analyzer stores per-node state (types, coercions, column references, ...) keyed by
+ * node identity. When the same expression needs to be analyzed in two different contexts
+ * (for example a SELECT item and a HAVING predicate that references it by alias), each
+ * context must get its own copy of the tree, otherwise the state recorded for one context
+ * silently overwrites the state recorded for the other.
+ * <p>
+ * The copy is structurally equal to the original ({@code copy.equals(original)}) but does
+ * not share any node with it, except for the {@link com.facebook.presto.sql.tree.Query}
+ * nested inside a {@link SubqueryExpression}, which is not part of the expression tree.
+ */
+final class ExpressionTreeCopier
+        extends ExpressionRewriter<Void>
+{
+    private ExpressionTreeCopier() {}
+
+    /**
+     * @throws UnsupportedOperationException if the expression contains a node that cannot be copied
+     */
+    public static <T extends Expression> T copy(T expression)
+    {
+        T copy = ExpressionTreeRewriter.rewriteWith(new ExpressionTreeCopier(), expression);
+        verifyNoSharedNodes(expression, copy);
+        return copy;
+    }
+
+    private static void verifyNoSharedNodes(Expression original, Expression copy)
+    {
+        Set<Node> originalNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        collectNodes(original, originalNodes);
+        Set<Node> copiedNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        collectNodes(copy, copiedNodes);
+        for (Node node : copiedNodes) {
+            if (originalNodes.contains(node)) {
+                throw new UnsupportedOperationException(format("Cannot copy expression: %s (node of type %s was not copied)", original, node.getClass().getSimpleName()));
+            }
+        }
+    }
+
+    private static void collectNodes(Node node, Set<Node> nodes)
+    {
+        nodes.add(node);
+        if (node instanceof SubqueryExpression) {
+            // the nested query is intentionally shared between the original and the copy
+            return;
+        }
+        for (Node child : node.getChildren()) {
+            collectNodes(child, nodes);
+        }
+    }
+
+    @Override
+    public Expression rewriteLiteral(Literal node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        Optional<NodeLocation> location = node.getLocation();
+        if (node instanceof LongLiteral) {
+            String value = Long.toString(((LongLiteral) node).getValue());
+            return location.isPresent() ? new LongLiteral(location.get(), value) : new LongLiteral(value);
+        }
+        if (node instanceof DoubleLiteral) {
+            String value = Double.toString(((DoubleLiteral) node).getValue());
+            return location.isPresent() ? new DoubleLiteral(location.get(), value) : new DoubleLiteral(value);
+        }
+        if (node instanceof DecimalLiteral) {
+            return new DecimalLiteral(location, ((DecimalLiteral) node).getValue());
+        }
+        if (node instanceof StringLiteral) {
+            String value = ((StringLiteral) node).getValue();
+            return location.isPresent() ? new StringLiteral(location.get(), value) : new StringLiteral(value);
+        }
+        if (node instanceof CharLiteral) {
+            return new CharLiteral(location, ((CharLiteral) node).getValue());
+        }
+        if (node instanceof BooleanLiteral) {
+            String value = Boolean.toString(((BooleanLiteral) node).getValue());
+            return location.isPresent() ? new BooleanLiteral(location.get(), value) : new BooleanLiteral(value);
+        }
+        if (node instanceof NullLiteral) {
+            return location.isPresent() ? new NullLiteral(location.get()) : new NullLiteral();
+        }
+        if (node instanceof BinaryLiteral) {
+            return new BinaryLiteral(location, ((BinaryLiteral) node).toHexString());
+        }
+        if (node instanceof GenericLiteral) {
+            GenericLiteral literal = (GenericLiteral) node;
+            return location.isPresent()
+                    ? new GenericLiteral(location.get(), literal.getType(), literal.getValue())
+                    : new GenericLiteral(literal.getType(), literal.getValue());
+        }
+        if (node instanceof TimeLiteral) {
+            String value = ((TimeLiteral) node).getValue();
+            return location.isPresent() ? new TimeLiteral(location.get(), value) : new TimeLiteral(value);
+        }
+        if (node instanceof TimestampLiteral) {
+            String value = ((TimestampLiteral) node).getValue();
+            return location.isPresent() ? new TimestampLiteral(location.get(), value) : new TimestampLiteral(value);
+        }
+        if (node instanceof IntervalLiteral) {
+            IntervalLiteral literal = (IntervalLiteral) node;
+            return location.isPresent()
+                    ? new IntervalLiteral(location.get(), literal.getValue(), literal.getSign(), literal.getStartField(), literal.getEndField())
+                    : new IntervalLiteral(literal.getValue(), literal.getSign(), literal.getStartField(), literal.getEndField());
+        }
+        if (node instanceof EnumLiteral) {
+            EnumLiteral literal = (EnumLiteral) node;
+            return new EnumLiteral(location, literal.getType(), literal.getValue());
+        }
+        throw new UnsupportedOperationException("Cannot copy literal of type " + node.getClass().getName());
+    }
+
+    @Override
+    public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return copyIdentifier(node);
+    }
+
+    @Override
+    public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return new SymbolReference(node.getLocation(), node.getName());
+    }
+
+    @Override
+    public Expression rewriteParameter(Parameter node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return node.getLocation().isPresent()
+                ? new Parameter(node.getLocation().get(), node.getPosition())
+                : new Parameter(node.getPosition());
+    }
+
+    @Override
+    public Expression rewriteFieldReference(FieldReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return new FieldReference(node.getLocation(), node.getFieldIndex());
+    }
+
+    @Override
+    public Expression rewriteCurrentTime(CurrentTime node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        Optional<NodeLocation> location = node.getLocation();
+        if (node.getPrecision() == null) {
+            return location.isPresent() ? new CurrentTime(location.get(), node.getFunction()) : new CurrentTime(node.getFunction());
+        }
+        return location.isPresent()
+                ? new CurrentTime(location.get(), node.getFunction(), node.getPrecision())
+                : new CurrentTime(node.getFunction(), node.getPrecision());
+    }
+
+    @Override
+    public Expression rewriteCurrentUser(CurrentUser node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return node.getLocation().isPresent() ? new CurrentUser(node.getLocation().get()) : new CurrentUser();
+    }
+
+    @Override
+    public Expression rewriteGroupingOperation(GroupingOperation node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        // grouping columns are not children of the node and are not visited by the tree rewriter
+        List<QualifiedName> groupingColumns = node.getGroupingColumns().stream()
+                .map(column -> column instanceof Identifier
+                        ? QualifiedName.of(ImmutableList.of(copyIdentifier((Identifier) column)))
+                        : DereferenceExpression.getQualifiedName((DereferenceExpression) column))
+                .collect(ImmutableList.toImmutableList());
+        return new GroupingOperation(node.getLocation(), groupingColumns);
+    }
+
+    @Override
+    public Expression rewriteSubqueryExpression(SubqueryExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        // the nested Query is a statement, not an expression, and is shared with the original
+        return node.getLocation().isPresent()
+                ? new SubqueryExpression(node.getLocation().get(), node.getQuery())
+                : new SubqueryExpression(node.getQuery());
+    }
+
+    @Override
+    public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        // The default rewrite only creates new nodes when a child changed, which is not the case for
+        // calls without arguments (e.g. count(*)) or for window components without expressions
+        // (e.g. OVER (), UNBOUNDED PRECEDING), so all parts are rebuilt explicitly.
+        List<Expression> arguments = node.getArguments().stream()
+                .map(argument -> treeRewriter.rewrite(argument, context))
+                .collect(ImmutableList.toImmutableList());
+        Optional<Expression> filter = node.getFilter().map(expression -> treeRewriter.rewrite(expression, context));
+        Optional<OrderBy> orderBy = node.getOrderBy().map(value -> copyOrderBy(value, treeRewriter, context));
+        Optional<Window> window = node.getWindow().map(value -> copyWindow(value, treeRewriter, context));
+        return node.getLocation().isPresent()
+                ? new FunctionCall(node.getLocation().get(), node.getName(), window, filter, orderBy, node.isDistinct(), node.isIgnoreNulls(), arguments)
+                : new FunctionCall(node.getName(), window, filter, orderBy, node.isDistinct(), node.isIgnoreNulls(), arguments);
+    }
+
+    private static Window copyWindow(Window window, ExpressionTreeRewriter<Void> treeRewriter, Void context)
+    {
+        List<Expression> partitionBy = window.getPartitionBy().stream()
+                .map(expression -> treeRewriter.rewrite(expression, context))
+                .collect(ImmutableList.toImmutableList());
+        Optional<OrderBy> orderBy = window.getOrderBy().map(value -> copyOrderBy(value, treeRewriter, context));
+        Optional<WindowFrame> frame = window.getFrame().map(value -> copyWindowFrame(value, treeRewriter, context));
+        return window.getLocation().isPresent()
+                ? new Window(window.getLocation().get(), partitionBy, orderBy, frame)
+                : new Window(partitionBy, orderBy, frame);
+    }
+
+    private static WindowFrame copyWindowFrame(WindowFrame frame, ExpressionTreeRewriter<Void> treeRewriter, Void context)
+    {
+        FrameBound start = copyFrameBound(frame.getStart(), treeRewriter, context);
+        Optional<FrameBound> end = frame.getEnd().map(bound -> copyFrameBound(bound, treeRewriter, context));
+        return frame.getLocation().isPresent()
+                ? new WindowFrame(frame.getLocation().get(), frame.getType(), start, end)
+                : new WindowFrame(frame.getType(), start, end);
+    }
+
+    private static FrameBound copyFrameBound(FrameBound bound, ExpressionTreeRewriter<Void> treeRewriter, Void context)
+    {
+        Optional<Expression> value = bound.getValue().map(expression -> treeRewriter.rewrite(expression, context));
+        if (bound.getLocation().isPresent()) {
+            return value.isPresent()
+                    ? new FrameBound(bound.getLocation().get(), bound.getType(), value.get())
+                    : new FrameBound(bound.getLocation().get(), bound.getType());
+        }
+        return value.isPresent() ? new FrameBound(bound.getType(), value.get()) : new FrameBound(bound.getType());
+    }
+
+    private static OrderBy copyOrderBy(OrderBy orderBy, ExpressionTreeRewriter<Void> treeRewriter, Void context)
+    {
+        List<SortItem> sortItems = orderBy.getSortItems().stream()
+                .map(item -> {
+                    Expression sortKey = treeRewriter.rewrite(item.getSortKey(), context);
+                    return item.getLocation().isPresent()
+                            ? new SortItem(item.getLocation().get(), sortKey, item.getOrdering(), item.getNullOrdering())
+                            : new SortItem(sortKey, item.getOrdering(), item.getNullOrdering());
+                })
+                .collect(ImmutableList.toImmutableList());
+        return orderBy.getLocation().isPresent() ? new OrderBy(orderBy.getLocation().get(), sortItems) : new OrderBy(sortItems);
+    }
+
+    @Override
+    public Expression rewriteArrayConstructor(ArrayConstructor node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        if (!node.getValues().isEmpty()) {
+            return null;
+        }
+        return node.getLocation().isPresent() ? new ArrayConstructor(node.getLocation().get(), ImmutableList.of()) : new ArrayConstructor(ImmutableList.of());
+    }
+
+    @Override
+    public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        Expression base = treeRewriter.rewrite(node.getBase(), context);
+        Identifier field = copyIdentifier(node.getField());
+        return node.getLocation().isPresent()
+                ? new DereferenceExpression(node.getLocation().get(), base, field)
+                : new DereferenceExpression(base, field);
+    }
+
+    @Override
+    public Expression rewriteRow(Row node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        ImmutableList.Builder<Row.Field> fields = ImmutableList.builder();
+        for (Row.Field field : node.getFields()) {
+            fields.add(new Row.Field(
+                    field.getLocation(),
+                    field.getName().map(ExpressionTreeCopier::copyIdentifier),
+                    treeRewriter.rewrite(field.getExpression(), context)));
+        }
+        return node.getLocation().isPresent() ? new Row(node.getLocation().get(), fields.build()) : new Row(fields.build());
+    }
+
+    @Override
+    public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        List<LambdaArgumentDeclaration> arguments = node.getArguments().stream()
+                .map(argument -> new LambdaArgumentDeclaration(copyIdentifier(argument.getName())))
+                .collect(ImmutableList.toImmutableList());
+        Expression body = treeRewriter.rewrite(node.getBody(), context);
+        return new LambdaExpression(node.getLocation(), arguments, body);
+    }
+
+    private static Identifier copyIdentifier(Identifier node)
+    {
+        return node.getLocation().isPresent()
+                ? new Identifier(node.getLocation().get(), node.getValue(), node.isDelimited())
+                : new Identifier(node.getValue(), node.isDelimited());
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -161,6 +161,7 @@ import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.JoinCriteria;
 import com.facebook.presto.sql.tree.JoinOn;
 import com.facebook.presto.sql.tree.JoinUsing;
+import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.Lateral;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
@@ -241,12 +242,15 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -348,6 +352,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_MATERIA
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MUST_BE_WINDOW_FUNCTION;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NESTED_AGGREGATION;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NESTED_WINDOW;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NONDETERMINISTIC_ORDER_BY_EXPRESSION_WITH_SELECT_DISTINCT;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NON_NUMERIC_SAMPLE_PERCENTAGE;
@@ -3310,7 +3315,10 @@ class StatementAnalyzer
             analysis.setOrderByExpressions(node, orderByExpressions);
 
             List<Expression> sourceExpressions = new ArrayList<>(outputExpressions);
-            node.getHaving().ifPresent(sourceExpressions::add);
+            // use the analyzed HAVING predicate, in which output alias references have been resolved
+            if (node.getHaving().isPresent()) {
+                sourceExpressions.add(analysis.getHaving(node));
+            }
 
             analyzeGroupingOperations(node, sourceExpressions, orderByExpressions);
             List<FunctionCall> aggregates = analyzeAggregations(node, sourceExpressions, orderByExpressions);
@@ -4227,7 +4235,11 @@ class StatementAnalyzer
         private void analyzeHaving(QuerySpecification node, Scope scope)
         {
             if (node.getHaving().isPresent()) {
-                Expression predicate = node.getHaving().get();
+                // References to SELECT output aliases are replaced with a copy of the aliased expression.
+                // Input columns take precedence over output aliases, so this only affects names that
+                // cannot be resolved against the FROM clause.
+                HavingAliasRewriter aliasRewriter = new HavingAliasRewriter(extractNamedOutputExpressions(node.getSelect()), scope);
+                Expression predicate = ExpressionTreeRewriter.rewriteWith(aliasRewriter, node.getHaving().get());
 
                 ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
 
@@ -4236,6 +4248,8 @@ class StatementAnalyzer
                         .ifPresent(function -> {
                             throw new SemanticException(NESTED_WINDOW, function.getNode(), "HAVING clause cannot contain window functions");
                         });
+
+                verifyNoAggregationOverOutputAlias(predicate, aliasRewriter.getSubstitutions());
 
                 analysis.recordSubqueries(node, expressionAnalysis);
 
@@ -4246,6 +4260,134 @@ class StatementAnalyzer
 
                 analysis.setHaving(node, predicate);
                 collectIndirectSources(predicate, TransformationSubtype.FILTER);
+            }
+        }
+
+        /**
+         * Rejects HAVING predicates that apply an aggregate function to an output alias that is itself
+         * an aggregate expression, e.g. {@code SELECT sum(x) AS total ... HAVING sum(total) > 1}.
+         * The nested aggregation would also be caught later by the aggregation analyzer, but the
+         * error message there would refer to the expanded expression rather than the alias.
+         */
+        private void verifyNoAggregationOverOutputAlias(Expression predicate, Map<NodeRef<Expression>, Identifier> substitutions)
+        {
+            if (substitutions.isEmpty()) {
+                return;
+            }
+            List<FunctionCall> aggregates = extractAggregateFunctions(analysis.getFunctionHandles(), ImmutableList.of(predicate), functionAndTypeResolver);
+            for (Map.Entry<NodeRef<Expression>, Identifier> substitution : substitutions.entrySet()) {
+                Expression substituted = substitution.getKey().getNode();
+                if (extractAggregateFunctions(analysis.getFunctionHandles(), ImmutableList.of(substituted), functionAndTypeResolver).isEmpty()) {
+                    continue;
+                }
+                for (FunctionCall aggregate : aggregates) {
+                    if (aggregate != substituted && AstUtils.nodeContains(aggregate, substituted)) {
+                        Identifier reference = substitution.getValue();
+                        throw new SemanticException(
+                                NESTED_AGGREGATION,
+                                reference,
+                                "Cannot nest aggregations inside aggregation '%s': output column '%s' is an aggregate expression",
+                                aggregate.getName(),
+                                reference.getValue());
+                    }
+                }
+            }
+        }
+
+        /**
+         * Resolves references to SELECT output aliases in a HAVING predicate.
+         * <p>
+         * Unlike ORDER BY, where output columns take precedence, HAVING is evaluated against the
+         * FROM scope: a name that resolves to an input column (including correlated outer columns
+         * and lambda arguments) is left untouched, and only otherwise unresolvable names are matched
+         * against the output aliases. Each matched reference is replaced with a fresh copy of the
+         * aliased expression, so that analysis state recorded for the HAVING clause (types,
+         * coercions, ...) is never shared with the SELECT item it was copied from.
+         */
+        private static class HavingAliasRewriter
+                extends ExpressionRewriter<Void>
+        {
+            private final Multimap<QualifiedName, Expression> outputAliases;
+            private final Scope scope;
+            private final Deque<Set<QualifiedName>> lambdaArguments = new ArrayDeque<>();
+            // copied expression -> alias reference it replaced
+            private final Map<NodeRef<Expression>, Identifier> substitutions = new LinkedHashMap<>();
+
+            public HavingAliasRewriter(Multimap<QualifiedName, Expression> outputAliases, Scope scope)
+            {
+                this.outputAliases = requireNonNull(outputAliases, "outputAliases is null");
+                this.scope = requireNonNull(scope, "scope is null");
+            }
+
+            public Map<NodeRef<Expression>, Identifier> getSubstitutions()
+            {
+                return ImmutableMap.copyOf(substitutions);
+            }
+
+            @Override
+            public Expression rewriteIdentifier(Identifier reference, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                QualifiedName name = QualifiedName.of(reference.getValue());
+
+                if (lambdaArguments.stream().anyMatch(arguments -> arguments.contains(name))) {
+                    return reference;
+                }
+                // input columns (including outer query columns) take precedence over output aliases
+                if (scope.tryResolveField(reference, name).isPresent()) {
+                    return reference;
+                }
+
+                Set<Expression> candidates = ImmutableSet.copyOf(outputAliases.get(name));
+                if (candidates.size() > 1) {
+                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in HAVING is ambiguous", name);
+                }
+                if (candidates.isEmpty()) {
+                    // not an alias either; expression analysis will report the missing attribute
+                    return reference;
+                }
+
+                Expression target = candidates.stream().collect(onlyElement());
+                if (!extractWindowFunctions(ImmutableList.of(target)).isEmpty()) {
+                    throw new SemanticException(NESTED_WINDOW, reference, "HAVING clause cannot contain window functions");
+                }
+
+                Expression copy;
+                try {
+                    copy = ExpressionTreeCopier.copy(target);
+                }
+                catch (UnsupportedOperationException e) {
+                    throw new SemanticException(NOT_SUPPORTED, reference, "Reference to output column '%s' in HAVING clause is not supported: %s", name, e.getMessage());
+                }
+                substitutions.put(NodeRef.of(copy), reference);
+                return copy;
+            }
+
+            @Override
+            public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                // a qualified column reference (e.g. t.x) must not have its base rewritten as an alias
+                if (scope.tryResolveField(node).isPresent()) {
+                    return node;
+                }
+                return null;
+            }
+
+            @Override
+            public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                lambdaArguments.push(node.getArguments().stream()
+                        .map(argument -> QualifiedName.of(argument.getName().getValue()))
+                        .collect(toImmutableSet()));
+                try {
+                    Expression body = treeRewriter.rewrite(node.getBody(), context);
+                    if (body == node.getBody()) {
+                        return node;
+                    }
+                    return new LambdaExpression(node.getLocation(), node.getArguments(), body);
+                }
+                finally {
+                    lambdaArguments.pop();
+                }
             }
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -4304,7 +4304,7 @@ class StatementAnalyzer
          * aliased expression, so that analysis state recorded for the HAVING clause (types,
          * coercions, ...) is never shared with the SELECT item it was copied from.
          */
-        private static class HavingAliasRewriter
+        private class HavingAliasRewriter
                 extends ExpressionRewriter<Void>
         {
             private final Multimap<QualifiedName, Expression> outputAliases;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
@@ -271,7 +271,9 @@ public class UtilizedColumnsAnalyzer
                 process(querySpec.getGroupBy().get(), unprunableContext);
             }
             if (querySpec.getHaving().isPresent()) {
-                process(querySpec.getHaving().get(), unprunableContext);
+                // use the analyzed predicate, in which references to output aliases have been resolved
+                Expression having = analysis.getHaving(querySpec);
+                process(having != null ? having : querySpec.getHaving().get(), unprunableContext);
             }
             if (querySpec.getOrderBy().isPresent()) {
                 process(querySpec.getOrderBy().get(), context);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -317,7 +317,59 @@ public class TestAnalyzer
     @Test
     public void testHavingReferencesOutputAlias()
     {
-        assertFails(MISSING_ATTRIBUTE, "SELECT sum(a) x FROM t1 HAVING x > 5");
+        analyze("SELECT sum(a) x FROM t1 HAVING x > 5");
+        analyze("SELECT sum(a) AS total FROM t1 GROUP BY b HAVING total > 10");
+        analyze("SELECT count(*) AS cnt, sum(a) AS total FROM t1 GROUP BY b HAVING cnt > 5 AND total > 100");
+        analyze("SELECT b AS key, sum(a) AS total FROM t1 GROUP BY b HAVING key > 1 AND total > 1");
+        // alias referenced more than once, and with a coercion that differs from the SELECT item
+        analyze("SELECT count(*) AS cnt FROM t1 GROUP BY b HAVING cnt > 1.5e0 AND cnt < 10");
+        // alias used inside a lambda body (aggregations are not allowed in lambdas, so the alias must be a non-aggregate expression)
+        analyze("SELECT b + 1 AS key, sum(a) FROM t1 GROUP BY b HAVING any_match(ARRAY[1, 2], x -> x < key)");
+        // alias of an expression containing a scalar subquery
+        analyze("SELECT (SELECT max(a) FROM t2) AS m, sum(a) FROM t1 GROUP BY b HAVING m > 1");
+        // alias of a grouping operation
+        analyze("SELECT grouping(a, b) AS g, sum(c) FROM t1 GROUP BY GROUPING SETS ((a), (b)) HAVING g > 1");
+    }
+
+    @Test
+    public void testHavingInputColumnTakesPrecedenceOverOutputAlias()
+    {
+        // 'b' is an input column, so it is not replaced by the alias 'b' even though both exist
+        analyze("SELECT max(a) AS b FROM t1 GROUP BY b HAVING b > 5");
+        analyze("SELECT max(a) AS b, b FROM t1 GROUP BY b HAVING b > 5");
+        // 'c' is an input column that is not grouped, so it wins over the alias 'c' and is rejected
+        assertFails(MUST_BE_AGGREGATE_OR_GROUP_BY, "SELECT max(a) AS c FROM t1 GROUP BY b HAVING c > 5");
+        // qualified column references are never treated as aliases
+        analyze("SELECT max(a) AS b FROM t1 GROUP BY b HAVING t1.b > 5");
+        // lambda arguments shadow output aliases
+        analyze("SELECT sum(a) AS x FROM t1 GROUP BY b HAVING any_match(ARRAY[1, 2], x -> x > 1)");
+    }
+
+    @Test
+    public void testHavingAmbiguousAlias()
+    {
+        assertFails(AMBIGUOUS_ATTRIBUTE, "SELECT sum(a) AS x, count(b) AS x FROM t1 GROUP BY c HAVING x > 5");
+    }
+
+    @Test
+    public void testHavingNonExistentAlias()
+    {
+        assertFails(MISSING_ATTRIBUTE, "SELECT sum(a) AS total FROM t1 GROUP BY b HAVING unknown_alias > 5");
+    }
+
+    @Test
+    public void testHavingAggregationOverOutputAlias()
+    {
+        assertFails(NESTED_AGGREGATION, "SELECT sum(a) AS total FROM t1 GROUP BY b HAVING sum(total) > 10");
+        assertFails(NESTED_AGGREGATION, "SELECT sum(a) AS total FROM t1 GROUP BY b HAVING max(total + 1) > 10");
+        // aggregating over an alias of a non-aggregate expression is fine
+        analyze("SELECT b + 1 AS key FROM t1 GROUP BY b HAVING sum(key) > 10");
+    }
+
+    @Test
+    public void testHavingWindowFunctionViaAlias()
+    {
+        assertFails(NESTED_WINDOW, "SELECT row_number() OVER () AS rn FROM t1 GROUP BY b HAVING rn > 1");
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestExpressionTreeCopier.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestExpressionTreeCopier.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.SubqueryExpression;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+
+public class TestExpressionTreeCopier
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+
+    @DataProvider(name = "expressions")
+    public Object[][] expressions()
+    {
+        return new Object[][] {
+                {"a"},
+                {"\"Quoted\""},
+                {"t.a"},
+                {"1"},
+                {"1.5"},
+                {"1.5e0"},
+                {"'text'"},
+                {"true"},
+                {"null"},
+                {"X'0A1B'"},
+                {"DATE '2020-01-01'"},
+                {"TIME '01:02:03'"},
+                {"TIMESTAMP '2020-01-01 01:02:03'"},
+                {"INTERVAL '3' DAY"},
+                {"INTERVAL '1-2' YEAR TO MONTH"},
+                {"CHAR 'abc'"},
+                {"?"},
+                {"current_user"},
+                {"current_time"},
+                {"current_timestamp(3)"},
+                {"count(*)"},
+                {"sum(a)"},
+                {"sum(DISTINCT a)"},
+                {"array_agg(a ORDER BY b DESC)"},
+                {"count(*) FILTER (WHERE a > 1)"},
+                {"row_number() OVER ()"},
+                {"row_number() OVER (PARTITION BY a ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"},
+                {"grouping(a, t.b)"},
+                {"a + b * -c"},
+                {"a AND NOT b OR c"},
+                {"a = b"},
+                {"a BETWEEN 1 AND 2"},
+                {"a IS NULL"},
+                {"a IS NOT NULL"},
+                {"a IN (1, 2, 3)"},
+                {"a IN (SELECT x FROM t)"},
+                {"a LIKE 'x%' ESCAPE '\\'"},
+                {"nullif(a, b)"},
+                {"if(a, b, c)"},
+                {"if(a, b)"},
+                {"coalesce(a, b, c)"},
+                {"CASE WHEN a = 1 THEN 'one' WHEN a = 2 THEN 'two' ELSE 'other' END"},
+                {"CASE a WHEN 1 THEN 'one' ELSE 'other' END"},
+                {"CASE a WHEN 1 THEN 'one' END"},
+                {"CAST(a AS varchar(25))"},
+                {"TRY_CAST(a AS bigint)"},
+                {"TRY(a / b)"},
+                {"ARRAY[1, 2, 3]"},
+                {"ARRAY[]"},
+                {"a[1]"},
+                {"ROW(1, 'a')"},
+                {"ROW(1 AS x, 'a' AS y)"},
+                {"r.field"},
+                {"EXTRACT(YEAR FROM a)"},
+                {"a AT TIME ZONE 'UTC'"},
+                {"transform(a, x -> x + 1)"},
+                {"reduce(a, 0, (s, x) -> s + x, s -> s)"},
+                {"\"$internal$bind\"(a, (x, y) -> x + y)"},
+                {"EXISTS (SELECT 1 FROM t)"},
+                {"(SELECT max(x) FROM t)"},
+                {"a > ALL (SELECT x FROM t)"},
+                {"a = ANY (SELECT x FROM t)"},
+                {"CASE WHEN COALESCE(category, CAST(is_cpu AS varchar)) IS NULL THEN 'total' WHEN is_cpu THEN 'cpu_total' ELSE category END"},
+        };
+    }
+
+    @Test(dataProvider = "expressions")
+    public void testCopyIsEqualAndSharesNoNodes(@Language("SQL") String sql)
+    {
+        Expression original = SQL_PARSER.createExpression(sql, new ParsingOptions(AS_DECIMAL));
+        Expression copy = ExpressionTreeCopier.copy(original);
+
+        assertNotSame(copy, original);
+        assertEquals(copy, original);
+        assertEquals(copy.hashCode(), original.hashCode());
+        assertEquals(copy.toString(), original.toString());
+
+        Set<Node> originalNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        collectNodes(original, originalNodes);
+        Set<Node> copiedNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+        collectNodes(copy, copiedNodes);
+        assertEquals(copiedNodes.size(), originalNodes.size());
+        for (Node node : copiedNodes) {
+            assertFalse(originalNodes.contains(node), "node is shared between the original and the copy: " + node);
+        }
+    }
+
+    private static void collectNodes(Node node, Set<Node> nodes)
+    {
+        nodes.add(node);
+        if (node instanceof SubqueryExpression) {
+            // the nested query is intentionally shared
+            return;
+        }
+        for (Node child : node.getChildren()) {
+            collectNodes(child, nodes);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -113,6 +113,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.operator.scalar.ApplyFunction.APPLY_FUNCTION;
 import static com.facebook.presto.operator.scalar.InvokeFunction.INVOKE_FUNCTION;
@@ -2285,6 +2286,79 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT custkey, sum(totalprice) * 2 FROM orders GROUP BY custkey");
         assertQuery("SELECT custkey, avg(totalprice + 5) FROM orders GROUP BY custkey");
         assertQuery("SELECT custkey, sum(totalprice) * 2 FROM orders GROUP BY custkey HAVING avg(totalprice + 5) > 10");
+    }
+
+    @Test
+    public void testHavingReferencesOutputAlias()
+    {
+        assertQuery(
+                "SELECT custkey, sum(orderkey) AS total FROM orders GROUP BY custkey HAVING total > 400000",
+                "SELECT custkey, sum(orderkey) FROM orders GROUP BY custkey HAVING sum(orderkey) > 400000");
+        assertQuery(
+                "SELECT custkey, count(*) AS cnt, sum(totalprice) AS total FROM orders GROUP BY custkey HAVING cnt > 20 AND total > 1000000",
+                "SELECT custkey, count(*), sum(totalprice) FROM orders GROUP BY custkey HAVING count(*) > 20 AND sum(totalprice) > 1000000");
+        // alias of a non-aggregate expression
+        assertQuery(
+                "SELECT orderstatus || '_' || orderpriority AS key, count(*) FROM orders GROUP BY orderstatus, orderpriority HAVING key = 'O_1-URGENT'",
+                "SELECT orderstatus || '_' || orderpriority, count(*) FROM orders GROUP BY orderstatus, orderpriority HAVING orderstatus || '_' || orderpriority = 'O_1-URGENT'");
+        // alias referenced twice, with a coercion (bigint -> double) that the SELECT item itself does not have
+        assertQuery(
+                "SELECT custkey, count(*) AS cnt FROM orders GROUP BY custkey HAVING cnt > 20.5 AND cnt < 30",
+                "SELECT custkey, count(*) FROM orders GROUP BY custkey HAVING count(*) > 20.5 AND count(*) < 30");
+        // alias with a bounded varchar type used in a context that widens it to unbounded varchar
+        assertQuery(
+                "WITH data AS (" +
+                        "    SELECT CAST('cpu' AS varchar(25)) AS category, true AS is_cpu, 100.0 AS value " +
+                        "    UNION ALL SELECT CAST('gpu' AS varchar(25)), false, 200.0) " +
+                        "SELECT (CASE WHEN COALESCE(category, CAST(is_cpu AS varchar)) IS NULL THEN 'total' WHEN is_cpu THEN 'cpu_total' ELSE category END) AS label, sum(value) AS total_value " +
+                        "FROM data " +
+                        "GROUP BY GROUPING SETS ((), (category), (is_cpu)) " +
+                        "HAVING COALESCE(label, CAST(is_cpu AS varchar)) IS NOT NULL",
+                "VALUES ('total', 300.0), ('cpu', 100.0), ('gpu', 200.0), ('cpu_total', 100.0), (CAST(NULL AS varchar), 200.0)");
+        // the output column keeps its declared type
+        MaterializedResult result = computeActual("SELECT CAST('cpu' AS varchar(25)) AS category, count(*) FROM orders GROUP BY 1 HAVING COALESCE(category, CAST(1 AS varchar)) IS NOT NULL");
+        assertEquals(result.getTypes().get(0), createVarcharType(25));
+        // alias in a lambda body (aggregations are not allowed in lambdas, so the alias must be a non-aggregate expression)
+        assertQuery(
+                "SELECT custkey + 1 AS nextkey, count(*) FROM orders GROUP BY custkey HAVING any_match(ARRAY[1400, 1500], x -> x < nextkey)",
+                "SELECT custkey + 1, count(*) FROM orders GROUP BY custkey HAVING custkey + 1 > 1400");
+        // alias of an expression containing a scalar subquery
+        assertQuery(
+                "SELECT custkey, (SELECT max(nationkey) FROM nation) AS m, count(*) FROM orders GROUP BY custkey HAVING m > 20 AND count(*) > 30",
+                "SELECT custkey, 24, count(*) FROM orders GROUP BY custkey HAVING count(*) > 30");
+    }
+
+    @Test
+    public void testHavingInputColumnTakesPrecedenceOverOutputAlias()
+    {
+        // 'custkey' is an input column, so the HAVING condition applies to the group key and not to the alias
+        assertQuery(
+                "SELECT max(orderkey) AS custkey FROM orders GROUP BY custkey HAVING custkey > 1400",
+                "SELECT max(orderkey) FROM orders GROUP BY custkey HAVING custkey > 1400");
+        assertQuery(
+                "SELECT max(y) AS x FROM (VALUES (1, 10), (7, 3)) t(x, y) GROUP BY x HAVING x > 5",
+                "VALUES 3");
+        // qualified references are never resolved as aliases
+        assertQuery(
+                "SELECT max(orderkey) AS custkey FROM orders o GROUP BY custkey HAVING o.custkey > 1400",
+                "SELECT max(orderkey) FROM orders GROUP BY custkey HAVING custkey > 1400");
+    }
+
+    @Test
+    public void testHavingOutputAliasErrors()
+    {
+        assertQueryFails(
+                "SELECT sum(orderkey) AS x, count(*) AS x FROM orders GROUP BY custkey HAVING x > 5",
+                "line 1:\\d+: 'x' in HAVING is ambiguous");
+        assertQueryFails(
+                "SELECT sum(orderkey) AS total FROM orders GROUP BY custkey HAVING unknown_alias > 5",
+                "line 1:\\d+: Column 'unknown_alias' cannot be resolved");
+        assertQueryFails(
+                "SELECT region, sum(revenue) AS total FROM (VALUES ('us', 100), ('eu', 200), ('us', 150), ('eu', 50)) AS t(region, revenue) GROUP BY region HAVING sum(total) > 100",
+                "line 1:\\d+: Cannot nest aggregations inside aggregation 'sum': output column 'total' is an aggregate expression");
+        assertQueryFails(
+                "SELECT row_number() OVER () AS rn, count(*) FROM orders GROUP BY custkey HAVING rn > 1",
+                "line 1:\\d+: HAVING clause cannot contain window functions");
     }
 
     @Test


### PR DESCRIPTION
Allow a HAVING predicate to reference output column aliases defined in the SELECT list, e.g.

    SELECT custkey, sum(orderkey) AS total
    FROM orders GROUP BY custkey HAVING total > 400000

Resolution rules:
* Names are resolved against the FROM scope first (including correlated outer columns and lambda arguments). Only names that cannot be resolved as input columns are matched against output aliases, so existing queries where an alias shadows an input column keep their standard SQL semantics.
* Qualified references (t.x) are never treated as aliases.
* An ambiguous alias is rejected with AMBIGUOUS_ATTRIBUTE, an alias of a window function with NESTED_WINDOW, and applying an aggregate to an alias that is itself an aggregate (HAVING sum(total)) with a NESTED_AGGREGATION error that names the alias.

Each alias reference is replaced with a deep copy of the aliased expression (ExpressionTreeCopier) before analysis. This is what distinguishes this change from the earlier attempt in #27199 (reverted in #27372): that version spliced the very same Expression nodes from the SELECT list into the HAVING tree, and since Analysis keys types and coercions by node identity, a coercion required only in the HAVING context (e.g. varchar(25) -> varchar, bigint -> double) was also applied to the SELECT projection and made TypeValidator fail with "type of variable ... is expected to be varchar(25), but the actual type is varchar". It also let aliases shadow input columns, which changed the results of valid queries. Both regressions are covered by new tests.

The analyzed (alias-resolved) predicate is also used for aggregation analysis and by UtilizedColumnsAnalyzer.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Support resolving SELECT output aliases in HAVING predicates without changing existing input-column semantics.

New Features:
- Allow HAVING predicates to reference unqualified SELECT output aliases while preserving input-column precedence.

Bug Fixes:
- Prevent alias expansion from changing SELECT expression analysis by using independent expression copies.
- Preserve correct type coercion and column utilization analysis when aliases are referenced in HAVING.

Enhancements:
- Add validation for ambiguous aliases, window-function aliases, and nested aggregation over aggregate aliases.
- Document SELECT alias references in HAVING and expand analyzer coverage for alias resolution and expression copying.

Documentation:
- Document support for referencing SELECT output aliases from HAVING clauses.

Tests:
- Add analyzer and query tests covering alias resolution precedence, ambiguity, lambdas, coercions, scalar subqueries, grouping expressions, and semantic errors.
- Add deep-copy expression tree tests across supported expression forms.