### PR TITLE
fix(security): Bump fast-uri to 3.1.7 for fixing CVE-2026-84394,CVE-2026-84292 in presto-ui

### DIFF
--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -83,6 +83,6 @@
   },
   "resolutions": {
     "d3-color": "3.1.0",
-    "fast-uri": "3.1.6"
+    "fast-uri": "3.1.7"
   }
 }

--- a/presto-ui/src/yarn.lock
+++ b/presto-ui/src/yarn.lock
@@ -4083,10 +4083,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.6, fast-uri@^3.0.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
-  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
+fast-uri@3.1.7, fast-uri@^3.0.1:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
## Description



Severity | Identifier | Package | Details | Fix
-- | -- | -- | -- | --
🔺 High | CVE-2026-84394 | fast-uri-3.1.6.tgz | fast-uri accepts a host that contains an unbalanced or misplaced authority bracket without reporting... | Upgrade to version fast-uri - 3.1.7,fast-uri - 2.4.6,fast-uri - 4.1.4,https://github.com/fastify/fast-uri.git - v2.4.6,https://github.com/fastify/fast-uri.git - v3.1.7,https://github.com/fastify/fast-uri.git - v4.1.4
🔺 High | CVE-2026-84292 | fast-uri-3.1.6.tgz | fast-uri serializes the port component of a URI without validating it. When recomposing the authorit... | Upgrade to version fast-uri - 2.4.6,fast-uri - 3.1.7,fast-uri - 4.1.4

Severity	Identifier	Package	Details	Fix
🔺 High	[CVE-2026-84394](https://www.mend.io/vulnerability-database/CVE-2026-84394)	fast-uri-3.1.6.tgz	
fast-uri accepts a host that contains an unbalanced or misplaced authority bracket without reporting...
Upgrade to version fast-uri - 3.1.7,fast-uri - 2.4.6,fast-uri - 4.1.4,https://github.com/fastify/fast-uri.git - v2.4.6,https://github.com/fastify/fast-uri.git - v3.1.7,https://github.com/fastify/fast-uri.git - v4.1.4
🔺 High	[CVE-2026-84292](https://www.mend.io/vulnerability-database/CVE-2026-84292)	fast-uri-3.1.6.tgz	
fast-uri serializes the port component of a URI without validating it. When recomposing the authorit...
Upgrade to version fast-uri - 2.4.6,fast-uri - 3.1.7,fast-uri - 4.1.4


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<img width="1466" height="1053" alt="image" src="https://github.com/user-attachments/assets/a9b63343-27d5-4dd8-b1f1-0151d5804f6a" />

<img width="1466" height="1053" alt="image" src="https://github.com/user-attachments/assets/a8dbbe1a-3674-47ba-be25-fcbcc3ebca09" />

<img width="1466" height="1053" alt="image" src="https://github.com/user-attachments/assets/f4115074-01d1-4cfb-a28d-4e32da708374" />
<img width="1466" height="424" alt="image" src="https://github.com/user-attachments/assets/c899d084-a7f3-4ac7-9d48-9272fedc17ae" />

<img width="1466" height="647" alt="image" src="https://github.com/user-attachments/assets/1fc86d6d-7482-4ace-b34c-6f9ff9e68847" />
<img width="1466" height="754" alt="image" src="https://github.com/user-attachments/assets/4057030e-cc01-4e5b-acb0-63cc06a63137" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Upgrade fast-uri to 3.1.7 to address the reported high-severity URI parsing and port validation vulnerabilities in presto-ui.