### PR TITLE
fix(native): Offload /v1/expressions and /v1/velox/plan to CPU executor

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1954,8 +1954,9 @@ void PrestoServer::registerSidecarEndpoints() {
       [this](
           proxygen::HTTPMessage* message,
           const std::vector<std::string>& /*pathMatch*/) {
-        // Extract header values eagerly: HTTPMessage is only valid at routing
-        // time, before the body arrives.
+        // Extract header values eagerly: the async closure must not retain a
+        // pointer into the handler object, which may be destroyed before the
+        // CPU-executor task runs.
         const auto& httpHeaders = message->getHeaders();
         auto optimizerLevel =
             httpHeaders.getSingleOrEmpty(kOptimizerLevelHeader);
@@ -1990,22 +1991,28 @@ void PrestoServer::registerSidecarEndpoints() {
                         driverExecutor_.get(),
                         nativeWorkerPool_.get());
                   })
+                  .thenValue([](auto&& result) {
+                    // Serialize on the CPU executor so the I/O thread only
+                    // transmits pre-built bytes.
+                    return util::dumpJson(json(result));
+                  })
                   .via(
                       folly::getKeepAliveToken(
                           folly::EventBaseManager::get()->getEventBase()))
-                  .thenValue([downstream, handlerState](auto&& result) {
+                  .thenValue([downstream, handlerState](std::string body) {
                     if (!handlerState->requestExpired()) {
-                      http::sendOkResponse(downstream, result);
+                      http::sendOkResponse(downstream, body);
                     }
                   })
                   .thenError(
                       folly::tag_t<std::exception>{},
                       [downstream, handlerState](auto&& e) {
+                        LOG(ERROR)
+                            << "getOptimizedExpressions error: " << e.what();
                         if (!handlerState->requestExpired()) {
                           http::sendErrorResponse(downstream, e.what());
                         }
-                      })
-                  .detach();
+                      });
             });
       });
 
@@ -2030,29 +2037,39 @@ void PrestoServer::registerSidecarEndpoints() {
                         nativeWorkerPool_.get(),
                         getVeloxPlanValidator());
                   })
+                  .thenValue([](auto&& response) {
+                    // Serialize on the CPU executor so the I/O thread only
+                    // transmits pre-built bytes.
+                    const uint16_t status = response.failures.empty()
+                        ? http::kHttpOk
+                        : http::kHttpUnprocessableContent;
+                    return std::make_pair(
+                        status, util::dumpJson(json(response)));
+                  })
                   .via(
                       folly::getKeepAliveToken(
                           folly::EventBaseManager::get()->getEventBase()))
-                  .thenValue([downstream, handlerState](auto&& response) {
+                  .thenValue([downstream, handlerState](
+                                 std::pair<uint16_t, std::string> p) {
                     if (!handlerState->requestExpired()) {
-                      if (response.failures.empty()) {
-                        http::sendOkResponse(downstream, json(response));
-                      } else {
-                        http::sendResponse(
-                            downstream,
-                            json(response),
-                            http::kHttpUnprocessableContent);
-                      }
+                      proxygen::ResponseBuilder(downstream)
+                          .status(p.first, "")
+                          .header(
+                              proxygen::HTTP_HEADER_CONTENT_TYPE,
+                              http::kMimeTypeApplicationJson)
+                          .body(p.second)
+                          .sendWithEOM();
                     }
                   })
                   .thenError(
                       folly::tag_t<std::exception>{},
                       [downstream, handlerState](auto&& e) {
+                        LOG(ERROR) << "prestoToVeloxPlanConversion error: "
+                                   << e.what();
                         if (!handlerState->requestExpired()) {
                           http::sendErrorResponse(downstream, e.what());
                         }
-                      })
-                  .detach();
+                      });
             });
       });
 }

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -2022,9 +2022,6 @@ void PrestoServer::registerSidecarEndpoints() {
                 std::shared_ptr<http::CallbackRequestHandlerState>
                     handlerState) {
               auto planFragmentJson = util::extractMessageBody(body);
-              // driverExecutor_ is intentionally passed to QueryCtx inside
-              // prestoToVeloxPlanConversion for Velox-internal parallelism;
-              // the outer CPU work runs on httpSrvCpuExecutor_.
               folly::via(
                   httpSrvCpuExecutor_.get(),
                   [this, planFragmentJson = std::move(planFragmentJson)]() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -123,6 +123,10 @@ constexpr char const* kMacOSSharedLibExt = ".dylib";
 constexpr char const* kOptimized = "OPTIMIZED";
 constexpr char const* kEvaluated = "EVALUATED";
 constexpr char const* kProtocolConnectorId = "protocol-connector.id";
+constexpr char const* kOptimizerLevelHeader =
+    "X-Presto-Expression-Optimizer-Level";
+constexpr char const* kTimezoneHeader = "X-Presto-Time-Zone";
+constexpr char const* kSessionStartTimeHeader = "X-Presto-Session-Start-Time";
 
 protocol::NodeState convertNodeState(presto::NodeState nodeState) {
   switch (nodeState) {
@@ -218,14 +222,12 @@ void unregisterVeloxCudf() {
 }
 
 json::array_t getOptimizedExpressions(
-    const proxygen::HTTPHeaders& httpHeaders,
-    const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+    const std::string& optimizerLevelString,
+    const std::string& timezone,
+    const std::string& sessionStartTime,
+    std::string body,
     folly::Executor* executor,
     velox::memory::MemoryPool* pool) {
-  static constexpr char const* kOptimizerLevelHeader =
-      "X-Presto-Expression-Optimizer-Level";
-  const auto& optimizerLevelString =
-      httpHeaders.getSingleOrEmpty(kOptimizerLevelHeader);
   VELOX_USER_CHECK(
       (optimizerLevelString == kOptimized) ||
           (optimizerLevelString == kEvaluated),
@@ -235,16 +237,8 @@ json::array_t getOptimizedExpressions(
       ? expression::OptimizerLevel::kOptimized
       : expression::OptimizerLevel::kEvaluated;
 
-  static constexpr char const* kTimezoneHeader = "X-Presto-Time-Zone";
-  const auto& timezone = httpHeaders.getSingleOrEmpty(kTimezoneHeader);
-
-  static constexpr char const* kSessionStartTimeHeader =
-      "X-Presto-Session-Start-Time";
-  const auto& sessionStartTime =
-      httpHeaders.getSingleOrEmpty(kSessionStartTimeHeader);
-
   protocol::ExpressionOptimizationRequest request =
-      json::parse(util::extractMessageBody(body));
+      json::parse(std::move(body));
 
   const std::map<std::string, std::string> sessionProperties =
       request.sessionProperties;
@@ -1959,31 +1953,110 @@ void PrestoServer::registerSidecarEndpoints() {
       "/v1/expressions",
       [this](
           proxygen::HTTPMessage* message,
-          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
-          proxygen::ResponseHandler* downstream) {
+          const std::vector<std::string>& /*pathMatch*/) {
+        // Extract header values eagerly: HTTPMessage is only valid at routing
+        // time, before the body arrives.
         const auto& httpHeaders = message->getHeaders();
-        const auto result = getOptimizedExpressions(
-            httpHeaders, body, driverExecutor_.get(), nativeWorkerPool_.get());
-        http::sendOkResponse(downstream, result);
+        auto optimizerLevel =
+            httpHeaders.getSingleOrEmpty(kOptimizerLevelHeader);
+        auto timezone = httpHeaders.getSingleOrEmpty(kTimezoneHeader);
+        auto sessionStartTime =
+            httpHeaders.getSingleOrEmpty(kSessionStartTimeHeader);
+        return new http::CallbackRequestHandler(
+            [this,
+             optimizerLevel = std::move(optimizerLevel),
+             timezone = std::move(timezone),
+             sessionStartTime = std::move(sessionStartTime)](
+                proxygen::HTTPMessage* /*message*/,
+                std::vector<std::unique_ptr<folly::IOBuf>>& body,
+                proxygen::ResponseHandler* downstream,
+                std::shared_ptr<http::CallbackRequestHandlerState>
+                    handlerState) {
+              // Extract body on the I/O thread before dispatching to the CPU
+              // executor, consistent with createOrUpdateTaskImpl.
+              auto bodyStr = util::extractMessageBody(body);
+              folly::via(
+                  httpSrvCpuExecutor_.get(),
+                  [this,
+                   optimizerLevel = std::move(optimizerLevel),
+                   timezone = std::move(timezone),
+                   sessionStartTime = std::move(sessionStartTime),
+                   bodyStr = std::move(bodyStr)]() {
+                    return getOptimizedExpressions(
+                        optimizerLevel,
+                        timezone,
+                        sessionStartTime,
+                        std::move(bodyStr),
+                        driverExecutor_.get(),
+                        nativeWorkerPool_.get());
+                  })
+                  .via(
+                      folly::getKeepAliveToken(
+                          folly::EventBaseManager::get()->getEventBase()))
+                  .thenValue([downstream, handlerState](auto&& result) {
+                    if (!handlerState->requestExpired()) {
+                      http::sendOkResponse(downstream, result);
+                    }
+                  })
+                  .thenError(
+                      folly::tag_t<std::exception>{},
+                      [downstream, handlerState](auto&& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      })
+                  .detach();
+            });
       });
 
   httpServer_->registerPost(
       "/v1/velox/plan",
-      [server = this](
-          proxygen::HTTPMessage* message,
-          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
-          proxygen::ResponseHandler* downstream) {
-        std::string planFragmentJson = util::extractMessageBody(body);
-        protocol::PlanConversionResponse response = prestoToVeloxPlanConversion(
-            planFragmentJson,
-            server->nativeWorkerPool_.get(),
-            server->getVeloxPlanValidator());
-        if (response.failures.empty()) {
-          http::sendOkResponse(downstream, json(response));
-        } else {
-          http::sendResponse(
-              downstream, json(response), http::kHttpUnprocessableContent);
-        }
+      [this](
+          proxygen::HTTPMessage* /*message*/,
+          const std::vector<std::string>& /*pathMatch*/) {
+        return new http::CallbackRequestHandler(
+            [this](
+                proxygen::HTTPMessage* /*message*/,
+                std::vector<std::unique_ptr<folly::IOBuf>>& body,
+                proxygen::ResponseHandler* downstream,
+                std::shared_ptr<http::CallbackRequestHandlerState>
+                    handlerState) {
+              auto planFragmentJson = util::extractMessageBody(body);
+              // driverExecutor_ is intentionally passed to QueryCtx inside
+              // prestoToVeloxPlanConversion for Velox-internal parallelism;
+              // the outer CPU work runs on httpSrvCpuExecutor_.
+              folly::via(
+                  httpSrvCpuExecutor_.get(),
+                  [this, planFragmentJson = std::move(planFragmentJson)]() {
+                    return prestoToVeloxPlanConversion(
+                        planFragmentJson,
+                        nativeWorkerPool_.get(),
+                        getVeloxPlanValidator());
+                  })
+                  .via(
+                      folly::getKeepAliveToken(
+                          folly::EventBaseManager::get()->getEventBase()))
+                  .thenValue([downstream, handlerState](auto&& response) {
+                    if (!handlerState->requestExpired()) {
+                      if (response.failures.empty()) {
+                        http::sendOkResponse(downstream, json(response));
+                      } else {
+                        http::sendResponse(
+                            downstream,
+                            json(response),
+                            http::kHttpUnprocessableContent);
+                      }
+                    }
+                  })
+                  .thenError(
+                      folly::tag_t<std::exception>{},
+                      [downstream, handlerState](auto&& e) {
+                        if (!handlerState->requestExpired()) {
+                          http::sendErrorResponse(downstream, e.what());
+                        }
+                      })
+                  .detach();
+            });
       });
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -78,6 +78,20 @@ void installSignalHandler() {
 #endif // __APPLE__
 }
 
+std::string dumpJson(const nlohmann::json& j) {
+  try {
+    return j.dump();
+  } catch (const std::exception&) {
+    auto body =
+        j.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
+    LOG(WARNING) << "Failed to serialize json to string. "
+                    "Will retry with 'replace' option. "
+                    "Json Dump:\n"
+                 << body;
+    return body;
+  }
+}
+
 std::string extractMessageBody(
     const std::vector<std::unique_ptr<folly::IOBuf>>& body) {
   std::string ret;

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -15,6 +15,7 @@
 #include <folly/io/IOBuf.h>
 #include <folly/io/async/SSLContext.h>
 #include <glog/logging.h>
+#include "presto_cpp/external/json/nlohmann/json.hpp"
 
 namespace facebook::presto::util {
 
@@ -48,6 +49,10 @@ long getProcessCpuTimeNs();
 /// In addition, the Velox based implementation provides additonal
 /// context such as the queryId.
 void installSignalHandler();
+
+/// Serialize 'j' to a JSON string. Falls back to the invalid-UTF-8 replace
+/// handler and logs a warning if the default dump throws.
+std::string dumpJson(const nlohmann::json& j);
 
 std::string extractMessageBody(
     const std::vector<std::unique_ptr<folly::IOBuf>>& body);

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -74,26 +74,11 @@ void sendResponse(
     proxygen::ResponseHandler* downstream,
     const json& body,
     uint16_t status) {
-  // nlohmann::json throws when it finds invalid UTF-8 characters. In that case
-  // the server will crash. We handle such situation here and generate body
-  // replacing the faulty UTF-8 sequences.
-  std::string messageBody;
-  try {
-    messageBody = body.dump();
-  } catch (const std::exception&) {
-    messageBody =
-        body.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
-    LOG(WARNING) << "Failed to serialize json to string. "
-                    "Will retry with 'replace' option. "
-                    "Json Dump:\n"
-                 << messageBody;
-  }
-
   proxygen::ResponseBuilder(downstream)
       .status(status, "")
       .header(
           proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
-      .body(messageBody)
+      .body(util::dumpJson(body))
       .sendWithEOM();
 }
 


### PR DESCRIPTION
## Description
Refactors both handlers to use the same `CallbackRequestHandler `async pattern already established by `TaskResource::createOrUpdateTaskImpl` for better throughput under concurrent load.

## Motivation and Context
Both `/v1/expression`s and `v1/velox/plan` sidecar endpoints previously ran their CPU-bound work (expression optimization, JSON parsing, Velox plan conversion) synchronously on the proxygen I/O thread. This blocks the I/O thread for the duration of the request, reducing throughput under concurrent load.

## Impact
No impact

## Test Plan
CI, already existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Offload native expression and Velox plan sidecar processing from the I/O thread to the CPU executor to improve concurrency and request throughput.

Bug Fixes:
- Prevent CPU-intensive expression optimization and Velox plan conversion from blocking the Proxygen I/O thread under concurrent load.
- Handle expired requests and asynchronous failures without attempting to send invalid responses.

Enhancements:
- Run expression optimization, plan conversion, and JSON serialization on the HTTP server CPU executor while retaining response delivery on the I/O event loop.
- Centralize resilient JSON serialization with invalid UTF-8 fallback handling.