### PR TITLE
fix(native): Arrow connector fails if record batch has columns with same name

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
@@ -178,13 +178,15 @@ void ArrowFlightDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       connectorQueryCtx_->sessionProperties(),
       callOptsAddHeaders);
 
-  auto result =
-      currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket);
-  if (!result.ok()) {
-    handleArrowError(result.status());
-    VELOX_FAIL(result.status().message());
-  }
-  currentReader_ = std::move(result).ValueUnsafe();
+  AFC_ASSIGN_OR_HANDLE(
+      currentReader_,
+      currentClient_->DoGet(callOptsAddHeaders, flightEndpoint.ticket),
+      handleArrowError);
+
+  AFC_ASSIGN_OR_HANDLE(
+      auto schema, currentReader_->GetSchema(), handleArrowError);
+
+  setOutputColumnIndices(schema);
 }
 
 std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
@@ -192,12 +194,7 @@ std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
     velox::ContinueFuture& /* unused */) {
   VELOX_CHECK_NOT_NULL(currentReader_, "Missing split, call addSplit() first");
 
-  auto result = currentReader_->Next();
-  if (!result.ok()) {
-    handleArrowError(result.status());
-    VELOX_FAIL(result.status().message());
-  }
-  auto chunk = std::move(result).ValueUnsafe();
+  AFC_ASSIGN_OR_HANDLE(auto chunk, currentReader_->Next(), handleArrowError);
 
   // Null values in the chunk indicates that the Flight stream is complete.
   if (!chunk.data) {
@@ -238,16 +235,47 @@ void ArrowFlightDataSource::cancel() {
   }
 }
 
+void ArrowFlightDataSource::setOutputColumnIndices(
+    const std::shared_ptr<arrow::Schema>& schema) {
+  columnIndices_.clear();
+  columnIndices_.reserve(columnMapping_.size());
+  bool projectColumnsByName = true;
+
+  // Check if Flight schema matches output columns, else project by name.
+  if (schema->num_fields() == columnMapping_.size()) {
+    auto fieldNames = schema->field_names();
+    projectColumnsByName = false;
+    for (int i = 0; i < fieldNames.size(); i++) {
+      if (fieldNames[i] != columnMapping_[i]) {
+        projectColumnsByName = true;
+        break;
+      }
+    }
+  }
+
+  if (projectColumnsByName) {
+    // Extract and convert desired columns in the correct order.
+    for (const auto& name : columnMapping_) {
+      auto idx = schema->GetFieldIndex(name);
+      VELOX_CHECK(idx >= 0, "column with name '{}' not found", name);
+      columnIndices_.emplace_back(idx);
+    }
+  } else {
+    // All output columns are aligned, project by column ordinal.
+    for (int i = 0; i < columnMapping_.size(); i++) {
+      columnIndices_.emplace_back(i);
+    }
+  }
+}
+
 velox::RowVectorPtr ArrowFlightDataSource::projectOutputColumns(
     const std::shared_ptr<arrow::RecordBatch>& input) {
   velox::memory::MemoryPool* pool = connectorQueryCtx_->memoryPool();
   std::vector<velox::VectorPtr> children;
-  children.reserve(columnMapping_.size());
+  children.reserve(columnIndices_.size());
 
-  // Extract and convert desired columns in the correct order.
-  for (const auto& name : columnMapping_) {
-    auto column = input->GetColumnByName(name);
-    VELOX_CHECK_NOT_NULL(column, "column with name '{}' not found", name);
+  for (int const idx : columnIndices_) {
+    auto column = input->column(idx);
     ArrowArray array;
     ArrowSchema schema;
     AFC_RAISE_NOT_OK(arrow::ExportArray(*column, &array, &schema));

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.h
@@ -19,6 +19,7 @@
 
 namespace arrow {
 class RecordBatch;
+class Schema;
 class Status;
 namespace flight {
 class FlightClientOptions;
@@ -113,12 +114,15 @@ class ArrowFlightDataSource : public velox::connector::DataSource {
   velox::RowTypePtr outputType_;
 
  private:
+  /// Set column indices to use for `projectOutputColumns`.
+  void setOutputColumnIndices(const std::shared_ptr<arrow::Schema>& schema);
   /// Convert an Arrow record batch to Velox RowVector.
   /// Process only those columns that are present in outputType_.
   velox::RowVectorPtr projectOutputColumns(
       const std::shared_ptr<arrow::RecordBatch>& input);
 
   std::vector<std::string> columnMapping_;
+  std::vector<int> columnIndices_;
   std::unique_ptr<arrow::flight::FlightClient> currentClient_;
   std::unique_ptr<arrow::flight::FlightStreamReader> currentReader_;
   uint64_t completedRows_ = 0;

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/Macros.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/Macros.h
@@ -48,3 +48,21 @@
     VELOX_CHECK(__r.ok(), __r.status().message()); \
     return std::move(__r).ValueUnsafe();           \
   } while (false)
+
+#define AFC_ASSIGN_OR_HANDLE_IMPL(result_name, lhs, rexpr, FUNC) \
+  auto&& result_name = (rexpr);                                  \
+  if (!(result_name).ok()) {                                     \
+    FUNC((result_name).status());                                \
+    VELOX_FAIL((result_name).status().message());                \
+  }                                                              \
+  lhs = std::move(result_name).ValueUnsafe();
+
+/// If expr returns an OK result, unwrap and assign the value to `lhs`.
+/// else call `FUNC` with arrow::Status as input to handle the error
+/// and call VELOX_FAIL with the arrow::Status message.
+#define AFC_ASSIGN_OR_HANDLE(lhs, rexpr, FUNC)                  \
+  AFC_ASSIGN_OR_HANDLE_IMPL(                                    \
+      ARROW_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), \
+      lhs,                                                      \
+      rexpr,                                                    \
+      FUNC);

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorDataTypeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorDataTypeTest.cpp
@@ -519,4 +519,63 @@ TEST_F(ArrowFlightConnectorDataTypeTest, allTypes) {
           {dateVec, timestampSecVec, stringVec, realVec, intVec, boolVec}));
 }
 
+TEST_F(ArrowFlightConnectorDataTypeTest, duplicateColumnName) {
+  std::vector<int64_t> idData = {0, 1, 2, 3};
+  std::vector<int32_t> duplicate1Data = {
+      -2147483648, 0, 2147483647, std::numeric_limits<int32_t>::max()};
+  std::vector<int32_t> duplicate2Data = {111, 222, 333, 444};
+
+  updateTable(
+      "sample-data",
+      makeArrowTable(
+          {"id", "duplicate_col", "duplicate_col"},
+          {makeNumericArray<arrow::Int64Type>(idData),
+           makeNumericArray<arrow::Int32Type>(duplicate1Data),
+           makeNumericArray<arrow::Int32Type>(duplicate2Data)}));
+
+  auto idVec = makeFlatVector<int64_t>(idData);
+  auto duplicate1Vec = makeFlatVector<int32_t>(duplicate1Data);
+  auto duplicate2Vec = makeFlatVector<int32_t>(duplicate2Data);
+
+  core::PlanNodePtr plan;
+  plan = ArrowFlightPlanBuilder()
+             .flightTableScan(
+                 velox::ROW(
+                     {"id", "duplicate_col", "duplicate_col"},
+                     {velox::BIGINT(), velox::INTEGER(), velox::INTEGER()}))
+             .planNode();
+
+  AssertQueryBuilder(plan)
+      .splits(makeSplits({"sample-data"}))
+      .assertResults(makeRowVector({idVec, duplicate1Vec, duplicate2Vec}));
+}
+
+TEST_F(ArrowFlightConnectorDataTypeTest, prunedColumns) {
+  std::vector<int64_t> idData = {0, 1, 2, 3};
+  std::vector<int32_t> intData = {1, 2, 3, 4};
+  std::vector<int32_t> prunedData = {5, 6, 7, 8};
+
+  updateTable(
+      "sample-data",
+      makeArrowTable(
+          {"id", "data_col", "pruned_col"},
+          {makeNumericArray<arrow::Int64Type>(idData),
+           makeNumericArray<arrow::Int32Type>(intData),
+           makeNumericArray<arrow::Int32Type>(prunedData)}));
+
+  auto idVec = makeFlatVector<int64_t>(idData);
+  auto dataVec = makeFlatVector<int32_t>(intData);
+
+  core::PlanNodePtr plan;
+  plan = ArrowFlightPlanBuilder()
+             .flightTableScan(
+                 velox::ROW(
+                     {"id", "data_col"}, {velox::BIGINT(), velox::INTEGER()}))
+             .planNode();
+
+  AssertQueryBuilder(plan)
+      .splits(makeSplits({"sample-data"}))
+      .assertResults(makeRowVector({idVec, dataVec}));
+}
+
 } // namespace facebook::presto::test


### PR DESCRIPTION
## Description
This fixes the case where an Arrow record batch has duplicate column names. The fix first checks if the connector output column layout matches the columns in the Arrow record batch. If they match then the Arrow vectors are retrieved by position, which allows for duplicate column names. If they do not match, then the connector will lookup each ouput column by name in the record batch. This requires the output columns to be a subset of the record batch columns, with no duplicate names. It can not support the case where there are both less output columns and duplicate names.

## Motivation and Context
The Arrow connector has been used with TVFs where the output columns are a subset of the columns in the Arrow record batches. The connector then locates the column data by looking the Arrow vector by name. This lookup fails when the record batch contains duplicate column names and returns an error:

```
Exception: VeloxRuntimeError column with name 'duplicate_col' not found
```

## Impact
NA

## Test Plan
Added native unit tests for cases where there is a duplicate column name, and additional columns in the batch that are not output columns.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Fix Arrow connector column projection when there are duplicate column names.
```

## Summary by Sourcery

Fix Arrow Flight projection for duplicate column names and pruned output columns.

Bug Fixes:
- Fix Arrow Flight column projection for record batches containing duplicate column names.

Enhancements:
- Support selecting Arrow output columns by position when the batch schema matches the requested layout, while retaining name-based projection for pruned columns.
- Use consistent Arrow result error handling when opening streams, reading schemas, and fetching record batches.

Tests:
- Add native connector coverage for duplicate column names and pruned record-batch columns.