### PR TITLE
fix(docs): Fix JMX connector docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -41,7 +41,6 @@ Commas in MBean names should be escaped in the following manner:
 
     connector.name=jmx
     jmx.dump-tables=com.facebook.presto.memory:type=memorypool\\,name=general,\
-       com.facebook.presto.memory:type=memorypool\\,name=system,\
        com.facebook.presto.memory:type=memorypool\\,name=reserved
 
 Querying JMX
@@ -97,8 +96,7 @@ returns information from the different Presto memory pools on each node::
     ------------+---------+----------------------------------------------------------
       214748364 | example | com.facebook.presto.memory:type=MemoryPool,name=reserved
      1073741825 | example | com.facebook.presto.memory:type=MemoryPool,name=general
-      858993459 | example | com.facebook.presto.memory:type=MemoryPool,name=system
-    (3 rows)
+    (2 rows)
 
 History Schema
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
JMX connector docs reference the MBean `com.facebook.presto.memory:type=MemoryPool,name=system` at multiple places and this MBean is no longer exported from Presto. The PR is raised to correct the same. 

## Motivation and Context
Fix public facing docs

## Impact
NA

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update the JMX connector documentation to remove references to the obsolete system memory pool MBean.

Bug Fixes:
- Correct outdated JMX connector documentation references to a no-longer-exported memory pool MBean.

Documentation:
- Update the public JMX connector documentation to reflect currently available MBeans.