### PR TITLE
test(plugin-iceberg): Add identifier character tests for Iceberg schema and table names

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergIdentifierCharacters.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+
+/**
+ * Identifier character coverage around which characters Presto accepts
+ * in Iceberg schema and table names
+ */
+@Test(singleThreaded = true)
+public abstract class AbstractTestIcebergIdentifierCharacters
+        extends AbstractTestQueryFramework
+{
+    /**
+     * Creates a schema and a table under the given identifiers, round-trips a row through them,
+     * confirms both are discoverable by their stored names, then drops them.
+     */
+    protected void assertIdentifiersUsable(String schemaIdentifier, String tableIdentifier, String storedSchema, String storedTable)
+    {
+        String qualified = schemaIdentifier + "." + tableIdentifier;
+        assertUpdate("CREATE SCHEMA " + schemaIdentifier);
+        try {
+            assertUpdate(format("CREATE TABLE %s (id integer, v varchar)", qualified));
+            try {
+                assertUpdate(format("INSERT INTO %s VALUES (1, 'a')", qualified), 1);
+                assertQuery(format("SELECT id, v FROM %s", qualified), "VALUES (1, 'a')");
+                // The name has to survive into the metadata the catalog reports back, not just the write path.
+                assertQuery(
+                        format("SELECT count(*) FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'",
+                                literal(storedSchema), literal(storedTable)),
+                        "VALUES 1");
+                assertQuery(
+                        format("SELECT count(*) FROM information_schema.columns WHERE table_schema = '%s' AND table_name = '%s'",
+                                literal(storedSchema), literal(storedTable)),
+                        "VALUES 2");
+            }
+            finally {
+                assertUpdate("DROP TABLE " + qualified);
+            }
+        }
+        finally {
+            assertQuerySucceeds("DROP SCHEMA " + schemaIdentifier);
+        }
+    }
+
+    /** Same as {@link #assertIdentifiersUsable}, for an identifier that is already lower case. */
+    protected void assertIdentifiersUsable(String schemaIdentifier, String tableIdentifier)
+    {
+        assertIdentifiersUsable(schemaIdentifier, tableIdentifier, undelimit(schemaIdentifier), undelimit(tableIdentifier));
+    }
+
+    private static String literal(String value)
+    {
+        return value.replace("'", "''");
+    }
+
+    /** Strips the surrounding double quotes and unescapes {@code ""}, giving the name as stored. */
+    private static String undelimit(String identifier)
+    {
+        if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
+            return identifier.substring(1, identifier.length() - 1).replace("\"\"", "\"");
+        }
+        return identifier;
+    }
+
+    @Test
+    public void testLowercaseLettersDigitsAndUnderscore()
+    {
+        assertIdentifiersUsable("ident_schema_a1", "ident_table_b2");
+    }
+
+    @Test
+    public void testUnderscoreLeadingIdentifier()
+    {
+        assertIdentifiersUsable("_ident_schema", "_ident_table");
+    }
+
+    @Test
+    public void testIdentifierStartingWithADigitMustBeDelimited()
+    {
+        assertQueryFails("CREATE SCHEMA 1ident_schema",
+                ".*identifiers must not start with a digit; surround the identifier with double quotes.*");
+        assertIdentifiersUsable("\"1ident_schema\"", "\"2ident_table\"");
+    }
+
+    @Test
+    public void testUppercaseIsAcceptedButFoldedToLowercase()
+    {
+        assertIdentifiersUsable("IDENT_SCHEMA_UPPER", "IDENT_TABLE_UPPER", "ident_schema_upper", "ident_table_upper");
+    }
+
+    @Test
+    public void testDelimitedUppercaseIsAlsoFolded()
+    {
+        // Delimiting does not preserve case in Presto, unlike most other engines.
+        assertIdentifiersUsable("\"IdentSchemaMixed\"", "\"IdentTableMixed\"", "identschemamixed", "identtablemixed");
+    }
+
+    @Test
+    public void testUppercaseAndLowercaseSpellingsNameTheSameTable()
+    {
+        assertUpdate("CREATE SCHEMA ident_folding_schema");
+        try {
+            assertUpdate("CREATE TABLE ident_folding_schema.ident_folding_table (id integer)");
+            try {
+                assertUpdate("INSERT INTO IDENT_FOLDING_SCHEMA.IDENT_FOLDING_TABLE VALUES 1", 1);
+                assertQuery("SELECT id FROM \"IDENT_FOLDING_SCHEMA\".\"IDENT_FOLDING_TABLE\"", "VALUES 1");
+            }
+            finally {
+                assertUpdate("DROP TABLE ident_folding_schema.ident_folding_table");
+            }
+        }
+        finally {
+            assertQuerySucceeds("DROP SCHEMA ident_folding_schema");
+        }
+    }
+
+    @Test
+    public void testDelimitedLowercaseLettersDigitsAndUnderscore()
+    {
+        assertIdentifiersUsable("\"ident_schema_q9\"", "\"ident_table_q9\"");
+    }
+
+    @Test
+    public void testDelimitedUnderscoreLeadingIdentifier()
+    {
+        assertIdentifiersUsable("\"_ident_schema_q\"", "\"_ident_table_q\"");
+    }
+
+    @Test
+    public void testDelimitedDot()
+    {
+        assertIdentifiersUsable("\"ident.schema\"", "\"ident.table\"");
+    }
+
+    @Test
+    public void testDelimitedHyphen()
+    {
+        assertIdentifiersUsable("\"ident-schema\"", "\"ident-table\"");
+    }
+
+    @Test
+    public void testDelimitedSpace()
+    {
+        assertIdentifiersUsable("\"ident schema\"", "\"ident table\"");
+    }
+
+    @Test
+    public void testDelimitedPercentAndPunctuation()
+    {
+        assertIdentifiersUsable("\"ident%schema!+~\"", "\"ident%table!+~\"");
+    }
+
+    @Test
+    public void testDelimitedLeadingSymbolAndDigit()
+    {
+        assertIdentifiersUsable("\"%1ident schema\"", "\"-2ident table\"");
+    }
+
+    @Test
+    public void testDelimitedEmbeddedDoubleQuote()
+    {
+        // "" is the escape for a single double quote inside a delimited identifier.
+        assertIdentifiersUsable("\"ident\"\"schema\"", "\"ident\"\"table\"", "ident\"schema", "ident\"table");
+    }
+
+    @Test
+    public void testDelimitedReservedKeyword()
+    {
+        assertIdentifiersUsable("\"select\"", "\"table\"");
+    }
+
+    @Test
+    public void testDelimitedNonLatinLetters()
+    {
+        // Accented Latin and Cyrillic. Folding uses Locale.ENGLISH, so these lower-case predictably.
+        assertIdentifiersUsable("\"schéma_accentué\"", "\"таблица\"");
+    }
+
+    @Test
+    public void testDelimitedHiraganaSyllables()
+    {
+        assertIdentifiersUsable("\"ひらがなスキーマ\"", "\"ひらがなテーブル\"");
+    }
+
+    @Test
+    public void testDelimitedIdeographs()
+    {
+        assertIdentifiersUsable("\"模式\"", "\"表名\"");
+    }
+
+    @Test
+    public void testHyphenIsRejectedUnquotedAndAcceptedDelimited()
+    {
+        // Rejected unquoted, accepted delimited
+        assertQueryFails("CREATE SCHEMA ident-schema", ".*");
+        assertIdentifiersUsable("\"ident-schema-ok\"", "\"ident-table-ok\"");
+    }
+
+    @Test
+    public void testNonLatinLetterIsRejectedUnquotedAndAcceptedDelimited()
+    {
+        assertQueryFails("CREATE SCHEMA 模式", ".*");
+        assertIdentifiersUsable("\"模式_ok\"", "\"表名_ok\"");
+    }
+
+    @Test
+    public void testDollarSignIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ident$schema", ".*");
+    }
+
+    @Test
+    public void testColonIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ident:schema", ".*identifiers must not contain ':'.*");
+    }
+
+    @Test
+    public void testAtSignIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ident@schema_bare", ".*identifiers must not contain '@'.*");
+    }
+
+    @Test
+    public void testSpaceIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ident schema", ".*mismatched input 'schema'\\. Expecting: '\\.', 'WITH', <EOF>.*");
+    }
+
+    @Test
+    public void testPercentIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ident%schema", ".*mismatched input '%'\\. Expecting: '\\.', 'WITH', <EOF>.*");
+    }
+
+    @Test
+    public void testHiraganaIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA ひらがな", ".*mismatched input 'ひ'\\. Expecting: 'IF', <identifier>.*");
+    }
+
+    @Test
+    public void testReservedKeywordIsRejectedUnquoted()
+    {
+        assertQueryFails("CREATE SCHEMA select", ".*mismatched input 'select'\\. Expecting: 'IF', <identifier>.*");
+    }
+
+    @Test
+    public void testUnquotedDotIsReadAsACatalogQualifier()
+    {
+        assertQueryFails("CREATE SCHEMA ident.schema", ".*Catalog does not exist: ident.*");
+    }
+
+    @Test
+    public void testDelimitedColonInASchemaName()
+    {
+        assertIdentifiersUsable("\"ident:schema_q\"", "ident_colon_table");
+    }
+
+    @Test
+    public void testDelimitedColonInATableName()
+    {
+        assertIdentifiersUsable("ident_colon_schema", "\"ident:table_q\"");
+    }
+
+    @Test
+    public void testDelimitedDollarSignIsUsableInASchemaName()
+    {
+        assertIdentifiersUsable("\"ident$schema\"", "ident_dollar_table");
+    }
+
+    @Test
+    public void testDelimitedDollarSignIsRejectedInATableName()
+    {
+        assertUpdate("CREATE SCHEMA ident_dollar_schema");
+        try {
+            assertQueryFails("CREATE TABLE ident_dollar_schema.\"ident$table\" (id integer)",
+                    ".*Invalid Iceberg table name \\(unknown type 'table'\\): ident\\$table.*");
+        }
+        finally {
+            assertQuerySucceeds("DROP SCHEMA ident_dollar_schema");
+        }
+    }
+
+    @Test
+    public void testDelimitedAtSignIsUsableInASchemaName()
+    {
+        assertIdentifiersUsable("\"ident@schema\"", "ident_at_table");
+    }
+
+    @Test
+    public void testDelimitedAtSignIsRejectedInATableName()
+    {
+        assertUpdate("CREATE SCHEMA ident_at_schema");
+        try {
+            assertQueryFails("CREATE TABLE ident_at_schema.\"ident@table\" (id integer)",
+                    ".*Invalid Iceberg table name: ident@table.*");
+        }
+        finally {
+            assertQuerySucceeds("DROP SCHEMA ident_at_schema");
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/AbstractTestIcebergIdentifierCharacters.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
  * Identifier character coverage around which characters Presto accepts
  * in Iceberg schema and table names
  */
-@Test(singleThreaded = true)
 public abstract class AbstractTestIcebergIdentifierCharacters
         extends AbstractTestQueryFramework
 {
@@ -32,8 +31,8 @@ public abstract class AbstractTestIcebergIdentifierCharacters
      */
     protected void assertIdentifiersUsable(String schemaIdentifier, String tableIdentifier, String storedSchema, String storedTable)
     {
-        String qualified = schemaIdentifier + "." + tableIdentifier;
-        assertUpdate("CREATE SCHEMA " + schemaIdentifier);
+        String qualified = format("%s.%s", schemaIdentifier, tableIdentifier);
+        assertUpdate(format("CREATE SCHEMA %s", schemaIdentifier));
         try {
             assertUpdate(format("CREATE TABLE %s (id integer, v varchar)", qualified));
             try {
@@ -50,11 +49,11 @@ public abstract class AbstractTestIcebergIdentifierCharacters
                         "VALUES 2");
             }
             finally {
-                assertUpdate("DROP TABLE " + qualified);
+                assertUpdate(format("DROP TABLE %s", qualified));
             }
         }
         finally {
-            assertQuerySucceeds("DROP SCHEMA " + schemaIdentifier);
+            assertQuerySucceeds(format("DROP SCHEMA %s", schemaIdentifier));
         }
     }
 
@@ -143,9 +142,15 @@ public abstract class AbstractTestIcebergIdentifierCharacters
     }
 
     @Test
-    public void testDelimitedDot()
+    public void testDelimitedDotInASchemaName()
     {
-        assertIdentifiersUsable("\"ident.schema\"", "\"ident.table\"");
+        assertIdentifiersUsable("\"ident.schema\"", "ident_dot_table");
+    }
+
+    @Test
+    public void testDelimitedDotInATableName()
+    {
+        assertIdentifiersUsable("ident_dot_schema", "\"ident.table\"");
     }
 
     @Test
@@ -205,24 +210,21 @@ public abstract class AbstractTestIcebergIdentifierCharacters
     }
 
     @Test
-    public void testHyphenIsRejectedUnquotedAndAcceptedDelimited()
+    public void testHyphenIsRejectedUnquoted()
     {
-        // Rejected unquoted, accepted delimited
-        assertQueryFails("CREATE SCHEMA ident-schema", ".*");
-        assertIdentifiersUsable("\"ident-schema-ok\"", "\"ident-table-ok\"");
+        assertQueryFails("CREATE SCHEMA ident-schema", ".*mismatched input '-'.*");
     }
 
     @Test
-    public void testNonLatinLetterIsRejectedUnquotedAndAcceptedDelimited()
+    public void testNonLatinLetterIsRejectedUnquoted()
     {
-        assertQueryFails("CREATE SCHEMA 模式", ".*");
-        assertIdentifiersUsable("\"模式_ok\"", "\"表名_ok\"");
+        assertQueryFails("CREATE SCHEMA 模式", ".*mismatched input '模'.*");
     }
 
     @Test
     public void testDollarSignIsRejectedUnquoted()
     {
-        assertQueryFails("CREATE SCHEMA ident$schema", ".*");
+        assertQueryFails("CREATE SCHEMA ident$schema", ".*mismatched input '\\$'.*");
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergHadoopIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergHadoopIdentifierCharacters.java
@@ -11,20 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg.hive;
+package com.facebook.presto.iceberg.hadoop;
 
 import com.facebook.presto.iceberg.AbstractTestIcebergIdentifierCharacters;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 
 /**
- * Identifier character coverage against an Iceberg Hive catalog
+ * Identifier character coverage against an Iceberg Hadoop catalog
  */
 @Test(singleThreaded = true)
-public class TestIcebergHiveIdentifierCharacters
+public class TestIcebergHadoopIdentifierCharacters
         extends AbstractTestIcebergIdentifierCharacters
 {
     @Override
@@ -32,33 +32,30 @@ public class TestIcebergHiveIdentifierCharacters
             throws Exception
     {
         return IcebergQueryRunner.builder()
-                .setCatalogType(HIVE)
+                .setCatalogType(HADOOP)
                 .setCreateTpchTables(false)
                 .build()
                 .getQueryRunner();
     }
 
     /**
-     * The only case where this catalog is stricter than the REST one. A Hive catalog derives the
-     * schema's warehouse directory from its name and resolves it as a URI, and a colon there reads
-     * as a scheme separator, so the schema cannot be created at all.
+     * This catalog leaves nested namespaces disabled, so a dot in a schema name is read as nesting
+     * and refused before any character check.
+     */
+    @Override
+    public void testDelimitedDotInASchemaName()
+    {
+        assertQueryFails("CREATE SCHEMA \"ident.schema\"", ".*Nested namespaces are disabled\\. Schema ident\\.schema is not valid.*");
+    }
+
+    /**
+     * {@code HadoopCatalog.createNamespace} builds the namespace directory with {@code new Path},
+     * where the leading {@code ident:} is read as a URI scheme. The table case is unaffected: it is
+     * resolved against an already absolute namespace path.
      */
     @Override
     public void testDelimitedColonInASchemaName()
     {
-        assertQueryFails("CREATE SCHEMA \"ident:schema_q\"",
-                ".*Relative path in absolute URI: ident:schema_q.*");
-    }
-
-    @Override
-    public void testDelimitedColonInATableName()
-    {
-        assertUpdate("CREATE SCHEMA ident_colon_schema");
-        try {
-            assertQueryFails("CREATE TABLE ident_colon_schema.\"ident:table_q\" (id integer)", ".*Relative path in absolute URI: ident:table_q.*");
-        }
-        finally {
-            assertQuerySucceeds("DROP SCHEMA ident_colon_schema");
-        }
+        assertQueryFails("CREATE SCHEMA \"ident:schema_q\"", ".*Relative path in absolute URI: ident:schema_q.*");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveIdentifierCharacters.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.presto.iceberg.AbstractTestIcebergIdentifierCharacters;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
+
+/**
+ * Identifier character coverage against an Iceberg Hive catalog
+ */
+@Test
+public class TestIcebergHiveIdentifierCharacters
+        extends AbstractTestIcebergIdentifierCharacters
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HIVE)
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    /**
+     * The only case where this catalog is stricter than the REST one. A Hive catalog derives the
+     * schema's warehouse directory from its name and resolves it as a URI, and a colon there reads
+     * as a scheme separator, so the schema cannot be created at all.
+     */
+    @Override
+    public void testDelimitedColonInASchemaName()
+    {
+        assertQueryFails("CREATE SCHEMA \"ident:schema_q\"",
+                ".*Relative path in absolute URI: ident:schema_q.*");
+    }
+
+    @Override
+    public void testDelimitedColonInATableName()
+    {
+        assertUpdate("CREATE SCHEMA ident_colon_schema");
+        try {
+            assertQueryFails("CREATE TABLE ident_colon_schema.\"ident:table_q\" (id integer)", ".*Relative path in absolute URI: ident:table_q.*");
+        }
+        finally {
+            assertQuerySucceeds("DROP SCHEMA ident_colon_schema");
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieIdentifierCharacters.java
@@ -11,58 +11,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg.rest;
+package com.facebook.presto.iceberg.nessie;
 
-import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.presto.iceberg.AbstractTestIcebergIdentifierCharacters;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.assertj.core.util.Files;
+import com.facebook.presto.testing.containers.NessieContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.util.Optional;
-
-import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
-import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
-import static com.google.common.io.MoreFiles.deleteRecursively;
-import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 
 /**
- * Identifier character coverage against an Iceberg REST catalog
+ * Identifier character coverage against an Iceberg Nessie catalog
  */
 @Test(singleThreaded = true)
-public class TestIcebergRestIdentifierCharacters
+public class TestIcebergNessieIdentifierCharacters
         extends AbstractTestIcebergIdentifierCharacters
 {
-    private File warehouseLocation;
-    private TestingHttpServer restServer;
-    private String serverUri;
+    private NessieContainer nessieContainer;
 
     @BeforeClass
     @Override
     public void init()
             throws Exception
     {
-        warehouseLocation = Files.newTemporaryFolder();
-        restServer = getRestServer(warehouseLocation.getAbsolutePath());
-        restServer.start();
-        serverUri = restServer.getBaseUrl().toString();
+        nessieContainer = NessieContainer.builder().build();
+        nessieContainer.start();
         super.init();
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
-            throws Exception
     {
-        if (restServer != null) {
-            restServer.stop();
-        }
-        if (warehouseLocation != null) {
-            deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+        if (nessieContainer != null) {
+            nessieContainer.stop();
         }
     }
 
@@ -71,11 +56,21 @@ public class TestIcebergRestIdentifierCharacters
             throws Exception
     {
         return IcebergQueryRunner.builder()
-                .setCatalogType(REST)
+                .setCatalogType(NESSIE)
                 .setCreateTpchTables(false)
-                .setExtraConnectorProperties(restConnectorProperties(serverUri))
-                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setExtraConnectorProperties(nessieConnectorProperties(nessieContainer.getRestApiUri()))
                 .build()
                 .getQueryRunner();
+    }
+
+    /**
+     * This catalog leaves nested namespaces disabled, so a dot in a schema name is read as nesting
+     * and refused before any character check. The only divergence here: unlike a filesystem-backed
+     * catalog, Nessie keeps namespaces in its own content model, so it takes a colon in a name.
+     */
+    @Override
+    public void testDelimitedDotInASchemaName()
+    {
+        assertQueryFails("CREATE SCHEMA \"ident.schema\"", ".*Nested namespaces are disabled\\. Schema ident\\.schema is not valid.*");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestIdentifierCharacters.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestIdentifierCharacters.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.iceberg.AbstractTestIcebergIdentifierCharacters;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+
+/**
+ * Identifier character coverage against an Iceberg REST catalog
+ */
+@Test
+public class TestIcebergRestIdentifierCharacters
+        extends AbstractTestIcebergIdentifierCharacters
+{
+    private File warehouseLocation;
+    private TestingHttpServer restServer;
+    private String serverUri;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+        serverUri = restServer.getBaseUrl().toString();
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (restServer != null) {
+            restServer.stop();
+        }
+        if (warehouseLocation != null) {
+            deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setCreateTpchTables(false)
+                .setExtraConnectorProperties(restConnectorProperties(serverUri))
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .build()
+                .getQueryRunner();
+    }
+}


### PR DESCRIPTION
## Description
Cover which characters Presto accepts in Iceberg schema and table names, run against both the REST and Hive (File Metastore), Hadoop & Nessie catalogs.

What each test does -

Every positive case runs a full round-trip through the identifier, so a name is proven to work end-to-end and not just parse:

```
CREATE SCHEMA  →  CREATE TABLE  →  INSERT  →  SELECT
→  verify in information_schema.tables
→  verify in information_schema.columns
→  DROP TABLE  →  DROP SCHEMA
```

Negative cases assert the exact error message, harvested from real runs rather than written by hand.

## Motivation and Context
More test coverage. Summary below -

<img width="815" height="311" alt="image" src="https://github.com/user-attachments/assets/0cff8630-86a0-4317-ad9d-a35075ebb0f6" />


## Impact
More test coverage

## Test Plan
Added 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Expand Iceberg catalog tests to validate supported and rejected schema and table identifier characters across catalog implementations.

Enhancements:
- Add comprehensive Iceberg identifier character coverage for schema and table names, including case folding, quoting, Unicode, punctuation, reserved words, and catalog-specific behavior.

Tests:
- Exercise identifier creation, data round-trips, metadata visibility, cleanup, and expected failures across REST, Hive, Hadoop, and Nessie catalogs.