### PR TITLE
fix(protocol): Accept the wrapped ExecutionWriterTarget.MergeHandle shape (#28468)

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7608,25 +7608,36 @@ void to_json(json& j, const MergeHandle& p) {
 }
 
 void from_json(const json& j, MergeHandle& p) {
-  // The concrete com.facebook.presto.spi.MergeHandle (held by MergeTarget) is a
-  // non-polymorphic data class serialized without an "@type" key, whereas the
-  // polymorphic ExecutionWriterTarget.MergeHandle carries one. Protocol codegen
-  // conflates both into this single struct, so tolerate a missing "@type": the
-  // constructor already defaults _type to "MergeHandle". Without this, an
-  // UPDATE/MERGE fails on the worker with json type_error.302 (the missing-key
-  // read surfaces as "type must be string, but is number").
+  // Protocol codegen keys its class table by simple name, so the two Java
+  // classes both called "MergeHandle" collapse into this one struct, and it is
+  // reached with two different JSON shapes:
+  //
+  //   com.facebook.presto.spi.MergeHandle  (MergeTarget.mergeHandle)
+  //     {"tableHandle": ..., "connectorMergeTableHandle": ...}   -- no "@type"
+  //
+  //   ExecutionWriterTarget.MergeHandle    (TableWriteInfo.writerTarget)
+  //     {"@type": "MergeHandle", "handle": {<the spi.MergeHandle above>}}
+  //
+  // Tolerate the missing "@type" on the first: the constructor already defaults
+  // _type, and without this an UPDATE/MERGE fails with json type_error.302.
   if (j.contains("@type")) {
     p._type = j["@type"];
   }
+  // Unwrap the second. ExecutionWriterTarget.MergeHandle holds exactly one
+  // field, so folding it into this struct loses nothing: consumers
+  // (PrestoToVeloxQueryPlan, IcebergPrestoToVeloxConnector) only ever read
+  // tableHandle / connectorMergeTableHandle. Without this, the wrapped form
+  // fails with json out_of_range.403 "key 'tableHandle' not found".
+  const json& fields = j.contains("handle") ? j.at("handle") : j;
   from_json_key(
-      j,
+      fields,
       "tableHandle",
       p.tableHandle,
       "MergeHandle",
       "TableHandle",
       "tableHandle");
   from_json_key(
-      j,
+      fields,
       "connectorMergeTableHandle",
       p.connectorMergeTableHandle,
       "MergeHandle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/MergeHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/MergeHandle.cpp.inc
@@ -36,25 +36,36 @@ void to_json(json& j, const MergeHandle& p) {
 }
 
 void from_json(const json& j, MergeHandle& p) {
-  // The concrete com.facebook.presto.spi.MergeHandle (held by MergeTarget) is a
-  // non-polymorphic data class serialized without an "@type" key, whereas the
-  // polymorphic ExecutionWriterTarget.MergeHandle carries one. Protocol codegen
-  // conflates both into this single struct, so tolerate a missing "@type": the
-  // constructor already defaults _type to "MergeHandle". Without this, an
-  // UPDATE/MERGE fails on the worker with json type_error.302 (the missing-key
-  // read surfaces as "type must be string, but is number").
+  // Protocol codegen keys its class table by simple name, so the two Java
+  // classes both called "MergeHandle" collapse into this one struct, and it is
+  // reached with two different JSON shapes:
+  //
+  //   com.facebook.presto.spi.MergeHandle  (MergeTarget.mergeHandle)
+  //     {"tableHandle": ..., "connectorMergeTableHandle": ...}   -- no "@type"
+  //
+  //   ExecutionWriterTarget.MergeHandle    (TableWriteInfo.writerTarget)
+  //     {"@type": "MergeHandle", "handle": {<the spi.MergeHandle above>}}
+  //
+  // Tolerate the missing "@type" on the first: the constructor already defaults
+  // _type, and without this an UPDATE/MERGE fails with json type_error.302.
   if (j.contains("@type")) {
     p._type = j["@type"];
   }
+  // Unwrap the second. ExecutionWriterTarget.MergeHandle holds exactly one
+  // field, so folding it into this struct loses nothing: consumers
+  // (PrestoToVeloxQueryPlan, IcebergPrestoToVeloxConnector) only ever read
+  // tableHandle / connectorMergeTableHandle. Without this, the wrapped form
+  // fails with json out_of_range.403 "key 'tableHandle' not found".
+  const json& fields = j.contains("handle") ? j.at("handle") : j;
   from_json_key(
-      j,
+      fields,
       "tableHandle",
       p.tableHandle,
       "MergeHandle",
       "TableHandle",
       "tableHandle");
   from_json_key(
-      j,
+      fields,
       "connectorMergeTableHandle",
       p.connectorMergeTableHandle,
       "MergeHandle",

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/MergeHandleTest.cpp
@@ -135,3 +135,24 @@ TEST_F(
   ASSERT_EQ(mergeHandle->_type, kTestConnector);
   ASSERT_EQ(mergeHandle->marker, "merge-marker");
 }
+
+TEST_F(MergeHandleTest, wrappedExecutionWriterTargetShape) {
+  // TableWriteInfo.writerTarget arrives as ExecutionWriterTarget.MergeHandle,
+  // which nests the spi.MergeHandle fields under "handle" instead of inlining
+  // them. Both shapes deserialize into this one struct.
+  const MergeHandle handle =
+      json{{"@type", "MergeHandle"}, {"handle", makeMergeHandleJson(false)}};
+
+  ASSERT_EQ(handle._type, "MergeHandle");
+  ASSERT_EQ(handle.tableHandle.connectorId, kTestConnector);
+
+  auto tableHandle = std::dynamic_pointer_cast<TestConnectorTableHandle>(
+      handle.tableHandle.connectorHandle);
+  ASSERT_NE(tableHandle, nullptr);
+  ASSERT_EQ(tableHandle->table, "orders");
+
+  auto mergeHandle = std::dynamic_pointer_cast<TestConnectorMergeTableHandle>(
+      handle.connectorMergeTableHandle);
+  ASSERT_NE(mergeHandle, nullptr);
+  ASSERT_EQ(mergeHandle->marker, "merge-marker");
+}


### PR DESCRIPTION
Summary:

## Description


## Impact

`UPDATE` and `MERGE` work on native workers against Iceberg merge-on-read tables. No behavior change for `SELECT` or `DELETE`.

## Test Plan

New test `MergeHandleTest.wrappedExecutionWriterTargetShape` builds the `{"type", "handle"}` shape and asserts `tableHandle` / `connectorMergeTableHandle` deserialize from inside the wrapper. With the fix reverted it reproduces the production error exactly; with the fix applied the target goes from 54 to 57 tests, all passing.

End-to-end on a 3-worker native batch cluster (Iceberg `format-version=3`, `write.update.mode=merge-on-read`), on both DWRF and NIMBLE: CREATE/INSERT, `UPDATE ... WHERE`, `DELETE ... WHERE`, and a second arithmetic `UPDATE` all succeed and the resulting `SELECT`s return correct values. Before the fix, the same `UPDATE` failed with `out_of_range.403`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

Differential Revision: D117947944

```
== NO RELEASE NOTE ==

```
