### PR TITLE
fix(analyzer): Decline materialized view rewrite of a windowed query

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -468,6 +468,11 @@ where ``window_specification`` is::
     [ ORDER BY expression [ ASC | DESC ] [, ...] ]
     [ window_frame ]
 
+``existing_window_name`` is the name of a window declared earlier in the same
+``WINDOW`` clause. Naming one makes the specification start from that window's
+``PARTITION BY``, which it can then extend with an ``ORDER BY`` or a frame. See
+`Restrictions`_ below.
+
 A window function refers to a named window by writing its name after ``OVER``,
 in place of a parenthesized specification. Naming a window avoids repeating the
 same specification for every function::
@@ -505,6 +510,9 @@ when only the frame differs between uses::
            sum(totalprice) OVER (w ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS trailing_total
     FROM orders
     WINDOW w AS (PARTITION BY orderstatus ORDER BY orderkey)
+
+Restrictions
+^^^^^^^^^^^^
 
 The following restrictions apply to a specification that references an existing
 window:

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1008,7 +1008,7 @@ public class ExpressionAnalyzer
                     // Analyzers created outside of statement analysis only ever see a self-contained specification.
                     Window unresolved = node.getWindow().get();
                     if (unresolved instanceof WindowReference) {
-                        throw new SemanticException(NOT_SUPPORTED, (Node) unresolved, "Cannot resolve WINDOW name %s", ((WindowReference) unresolved).getName());
+                        throw new SemanticException(NOT_SUPPORTED, unresolved, "Cannot resolve WINDOW name %s", ((WindowReference) unresolved).getName());
                     }
                     WindowSpecification specification = (WindowSpecification) unresolved;
                     if (specification.getExistingWindowName().isPresent()) {
@@ -1017,7 +1017,7 @@ public class ExpressionAnalyzer
                     window = new ResolvedWindow(specification.getPartitionBy(), specification.getOrderBy(), specification.getFrame(), false, false, false);
                 }
 
-                analyzeWindow(window, context, (Node) node.getWindow().get());
+                analyzeWindow(window, context, node.getWindow().get());
 
                 windowFunctions.add(NodeRef.of(node));
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewExpressionRewriter.java
@@ -97,6 +97,13 @@ public class MaterializedViewExpressionRewriter
 
     public Expression rewriteFunctionCall(FunctionCall node, Function<Expression, Expression> argRewriter)
     {
+        // Only the arguments of a call are rewritten, so a window would keep referring to base table
+        // columns. This is checked here rather than in isScalarFunction because an associative
+        // aggregate such as SUM never reaches that check.
+        if (node.getWindow().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Window function is not supported for materialized view rewrite: " + node.getName());
+        }
+
         Map<Expression, Identifier> baseToViewColumnMap = mvInfo.getBaseToViewColumnMap();
 
         if (NON_ASSOCIATIVE_REWRITE_FUNCTIONS.containsKey(node.getName())) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewJoinQueryRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewJoinQueryRewriter.java
@@ -248,6 +248,12 @@ public class MaterializedViewJoinQueryRewriter
                 log.debug("JOIN MV rewrite rejected: query has HAVING. MV=%s", materializedViewName);
                 return false;
             }
+            // A WINDOW clause is carried over unchanged, so its expressions would still reference the
+            // relation the rewrite replaces.
+            if (!querySpecification.getWindows().isEmpty()) {
+                log.debug("JOIN MV rewrite rejected: query has WINDOW clause. MV=%s", materializedViewName);
+                return false;
+            }
             if (mvInfo.getGroupBy().isPresent()) {
                 if (!querySpecification.getGroupBy().isPresent()) {
                     if (!isAggregateOnlySelect(querySpecification)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -84,8 +84,6 @@ import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.WhenClause;
-import com.facebook.presto.sql.tree.WindowDefinition;
-import com.facebook.presto.sql.tree.WindowSpecification;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
 import com.google.common.collect.ImmutableList;
@@ -118,7 +116,6 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -508,6 +505,13 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitQuerySpecification(QuerySpecification node, Void context)
         {
+            // A WINDOW clause is carried over unchanged, so its expressions and frame bounds would keep
+            // referring to base table columns. Decline rather than rewrite it only in part. Window
+            // functions are declined separately, in MaterializedViewExpressionRewriter.
+            if (!node.getWindows().isEmpty()) {
+                throw new IllegalStateException("Query with WINDOW clause is not rewritable by materialized view");
+            }
+
             if (!node.getFrom().isPresent()) {
                 throw new IllegalArgumentException("visitQuerySpecification should not be invoked for an empty FROM clause");
             }
@@ -596,28 +600,10 @@ public class MaterializedViewQueryOptimizer
                     node.getWhere().map(where -> (Expression) process(where, context)),
                     node.getGroupBy().map(groupBy -> (GroupBy) process(groupBy, context)),
                     node.getHaving().map(having -> (Expression) process(having, context)),
-                    node.getWindows().stream()
-                            .map(window -> (WindowDefinition) process(window, context))
-                            .collect(toImmutableList()),
+                    node.getWindows(),
                     node.getOrderBy().map(orderBy -> (OrderBy) process(orderBy, context)),
                     node.getOffset(),
                     node.getLimit());
-        }
-
-        @Override
-        protected Node visitWindowDefinition(WindowDefinition node, Void context)
-        {
-            return new WindowDefinition(node.getName(), (WindowSpecification) process(node.getWindow(), context));
-        }
-
-        @Override
-        protected Node visitWindowSpecification(WindowSpecification node, Void context)
-        {
-            return new WindowSpecification(
-                    node.getExistingWindowName(),
-                    node.getPartitionBy().stream().map(partition -> (Expression) process(partition, context)).collect(toImmutableList()),
-                    node.getOrderBy().map(orderBy -> (OrderBy) process(orderBy, context)),
-                    node.getFrame());
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -112,6 +112,41 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testWithWindowClause()
+    {
+        // A WINDOW clause is left alone rather than partially rewritten, so the base query is kept.
+        // A window function is declined separately, see testWithWindowFunction.
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+
+        String baseQuerySql = format("SELECT a FROM %s WINDOW w AS (PARTITION BY b)", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT a FROM %s WINDOW w AS (ORDER BY b)", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        // The frame bound is the part that a partial rewrite would have missed.
+        baseQuerySql = format("SELECT a FROM %s WINDOW w AS (ORDER BY a ROWS b PRECEDING)", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithWindowFunction()
+    {
+        // Only the arguments of a call are rewritten, so rewriting a window function would leave the
+        // window referring to base table columns. Aliased columns make that visible.
+        String originalViewSql = format("SELECT a AS mv_a, b AS mv_b FROM %s", BASE_TABLE_1);
+
+        String baseQuerySql = format("SELECT SUM(a) OVER (ORDER BY b) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT SUM(a) OVER (PARTITION BY b) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT COUNT(a) OVER (ORDER BY a ROWS b PRECEDING) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithAlias()
     {
         String originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
@@ -2227,6 +2262,32 @@ public class TestMaterializedViewQueryOptimizer
                 VIEW_1, BASE_TABLE_2, VIEW_1_QUALIFIED, BASE_TABLE_2, VIEW_1, BASE_TABLE_2);
 
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithWindowFunction()
+    {
+        // The join path shares the expression rewriter, so a window function is declined there too.
+        // Aliased columns make an incorrect rewrite visible: the window would keep referring to b.
+        String originalViewSql = format("SELECT a AS mv_a, b AS mv_b, c AS mv_c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT SUM(%s.a) OVER (ORDER BY %s.b) FROM %s JOIN %s ON %s.a = %s.a",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJoinWithWindowClause()
+    {
+        // The join rewrite carries a WINDOW clause over unchanged, so its expressions would still
+        // reference the relation being replaced. The base query is kept instead.
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format(
+                "SELECT %s.a FROM %s JOIN %s ON %s.a = %s.a WINDOW w AS (PARTITION BY %s.b)",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
@@ -50,6 +51,8 @@ import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Values;
 import com.facebook.presto.sql.tree.WindowDefinition;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.facebook.presto.sql.tree.WindowReference;
 import com.facebook.presto.sql.tree.WindowSpecification;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -184,6 +187,7 @@ public class TreePrinter
                 return null;
             }
 
+            @Override
             public Void visitWindowSpecification(WindowSpecification node, Integer indentLevel)
             {
                 node.getExistingWindowName().ifPresent(name -> print(indentLevel, "Reference: " + name.getValue()));
@@ -200,7 +204,37 @@ public class TreePrinter
                     process(node.getOrderBy().get(), indentLevel + 1);
                 }
 
-                node.getFrame().ifPresent(frame -> print(indentLevel, "Frame: " + frame));
+                if (node.getFrame().isPresent()) {
+                    print(indentLevel, "Frame");
+                    process(node.getFrame().get(), indentLevel + 1);
+                }
+
+                return null;
+            }
+
+            @Override
+            public Void visitWindowReference(WindowReference node, Integer indentLevel)
+            {
+                print(indentLevel, "Reference: " + node.getName().getValue());
+
+                return null;
+            }
+
+            @Override
+            public Void visitWindowFrame(WindowFrame node, Integer indentLevel)
+            {
+                print(indentLevel, node.getType().toString());
+                process(node.getStart(), indentLevel + 1);
+                node.getEnd().ifPresent(end -> process(end, indentLevel + 1));
+
+                return null;
+            }
+
+            @Override
+            public Void visitFrameBound(FrameBound node, Integer indentLevel)
+            {
+                print(indentLevel, node.getType().toString());
+                node.getValue().ifPresent(value -> process(value, indentLevel + 1));
 
                 return null;
             }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -156,7 +156,7 @@ public abstract class DefaultTraversalVisitor<R, C>
         node.getArguments().forEach(argument -> process(argument, context));
 
         node.getOrderBy().ifPresent(orderBy -> process(orderBy, context));
-        node.getWindow().ifPresent(window -> process((Node) window, context));
+        node.getWindow().ifPresent(window -> process(window, context));
         node.getFilter().ifPresent(filter -> process(filter, context));
 
         return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class FunctionCall
@@ -83,7 +82,6 @@ public class FunctionCall
         super(location);
         requireNonNull(name, "name is null");
         requireNonNull(window, "window is null");
-        window.ifPresent(node -> checkArgument(node instanceof WindowReference || node instanceof WindowSpecification, "unexpected window: %s", node.getClass().getSimpleName()));
         requireNonNull(filter, "filter is null");
         requireNonNull(orderBy, "orderBy is null");
         requireNonNull(arguments, "arguments is null");
@@ -142,7 +140,7 @@ public class FunctionCall
     public List<Node> getChildren()
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
-        window.ifPresent(window -> nodes.add((Node) window));
+        window.ifPresent(nodes::add);
         filter.ifPresent(nodes::add);
         orderBy.map(OrderBy::getSortItems).map(nodes::addAll);
         nodes.addAll(arguments);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Window.java
@@ -13,13 +13,18 @@
  */
 package com.facebook.presto.sql.tree;
 
+import java.util.Optional;
+
 /**
- * Marker for the two forms a window can take in an OVER clause: an inline
- * {@link WindowSpecification}, or a {@link WindowReference} to a window
- * declared in the WINDOW clause of the enclosing query specification.
- * <p>
- * Both implementations also extend {@link Node}.
+ * The two forms a window can take in an OVER clause: an inline {@link WindowSpecification},
+ * or a {@link WindowReference} to a window declared in the WINDOW clause of the enclosing
+ * query specification.
  */
-public interface Window
+public abstract class Window
+        extends Node
 {
+    protected Window(Optional<NodeLocation> location)
+    {
+        super(location);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowReference.java
@@ -23,8 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class WindowReference
-        extends Node
-        implements Window
+        extends Window
 {
     private final Identifier name;
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowSpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WindowSpecification.java
@@ -23,8 +23,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class WindowSpecification
-        extends Node
-        implements Window
+        extends Window
 {
     private final Optional<Identifier> existingWindowName;
     private final List<Expression> partitionBy;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.ArrayConstructor;
 import com.facebook.presto.sql.tree.CurrentTime;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
@@ -39,6 +40,7 @@ import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.Window;
+import com.facebook.presto.sql.tree.WindowReference;
 import com.facebook.presto.sql.tree.WindowSpecification;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -56,7 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -280,6 +281,9 @@ public class FunctionCallRewriter
                 if (i < originalArguments.size()) {
                     continue;
                 }
+                if (!windowFieldsMatch((FunctionCall) substitution.originalExpression, instance)) {
+                    continue;
+                }
                 return Optional.of(substitution);
             }
 
@@ -325,8 +329,6 @@ public class FunctionCallRewriter
 
             List<Expression> patternWindowPartitionBys = windowSpecification(originalPattern.getWindow()).map(WindowSpecification::getPartitionBy).orElse(ImmutableList.of());
             List<Expression> instanceWindowPartitionBys = windowSpecification(originalInstance.getWindow()).map(WindowSpecification::getPartitionBy).orElse(ImmutableList.of());
-            checkArgument(patternWindowPartitionBys.size() <= instanceWindowPartitionBys.size(),
-                    "Function call substitute declares more window PARTITION BY fields than the query it matched");
             for (int i = 0; i < patternWindowPartitionBys.size(); i++) {
                 Identifier identifier = (Identifier) patternWindowPartitionBys.get(i);
                 if (OMIT_IDENTIFIER.equals(identifier.getValue())) {
@@ -337,8 +339,6 @@ public class FunctionCallRewriter
 
             List<SortItem> patternWindowOrderBys = windowSpecification(originalPattern.getWindow()).flatMap(WindowSpecification::getOrderBy).map(OrderBy::getSortItems).orElse(ImmutableList.of());
             List<SortItem> instanceWindowOrderBys = windowSpecification(originalInstance.getWindow()).flatMap(WindowSpecification::getOrderBy).map(OrderBy::getSortItems).orElse(ImmutableList.of());
-            checkArgument(patternWindowOrderBys.size() <= instanceWindowOrderBys.size(),
-                    "Function call substitute declares more window ORDER BY fields than the query it matched");
             for (int i = 0; i < patternWindowOrderBys.size(); i++) {
                 Identifier identifier = (Identifier) patternWindowOrderBys.get(i).getSortKey();
                 if (OMIT_IDENTIFIER.equals(identifier.getValue())) {
@@ -454,13 +454,63 @@ public class FunctionCallRewriter
     }
 
     /**
-     * A substitution pattern is parsed standalone, so its window is always an inline specification.
-     * A query instance may instead reference a window declared in the WINDOW clause, which has no
-     * fields to match against.
+     * A pattern binds window fields positionally, so it cannot match an instance that has fewer of them.
+     * An instance whose window names another window is never matched, in either form: the named window
+     * can carry partitioning, ordering and a frame that the pattern cannot see, so substituting could
+     * drop them.
+     */
+    private static boolean windowFieldsMatch(FunctionCall pattern, FunctionCall instance)
+    {
+        Optional<WindowSpecification> patternWindow = windowSpecification(pattern.getWindow());
+        Optional<WindowSpecification> instanceWindow = windowSpecification(instance.getWindow());
+
+        if (instance.getWindow().isPresent() && namesAnotherWindow(instance.getWindow().get())) {
+            return false;
+        }
+
+        int patternPartitionBys = patternWindow.map(window -> window.getPartitionBy().size()).orElse(0);
+        int instancePartitionBys = instanceWindow.map(window -> window.getPartitionBy().size()).orElse(0);
+        int patternOrderBys = patternWindow.flatMap(WindowSpecification::getOrderBy).map(orderBy -> orderBy.getSortItems().size()).orElse(0);
+        int instanceOrderBys = instanceWindow.flatMap(WindowSpecification::getOrderBy).map(orderBy -> orderBy.getSortItems().size()).orElse(0);
+
+        return patternPartitionBys <= instancePartitionBys && patternOrderBys <= instanceOrderBys;
+    }
+
+    /**
+     * Returns the window only when it is a self contained inline specification, so its fields can be
+     * bound positionally.
      */
     private static Optional<WindowSpecification> windowSpecification(Optional<Window> window)
     {
         return window.filter(WindowSpecification.class::isInstance).map(WindowSpecification.class::cast);
+    }
+
+    /**
+     * A window names another window either as a bare {@code OVER w} or as {@code OVER (w ...)}. Both hide
+     * the partitioning, ordering and frame that the named window carries, so neither can be matched or
+     * emitted safely.
+     */
+    private static boolean namesAnotherWindow(Window window)
+    {
+        if (window instanceof WindowReference) {
+            return true;
+        }
+        return ((WindowSpecification) window).getExistingWindowName().isPresent();
+    }
+
+    private static void rejectNamedWindows(Expression expression, String spec)
+    {
+        new DefaultTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitFunctionCall(FunctionCall node, Void context)
+            {
+                if (node.getWindow().isPresent() && namesAnotherWindow(node.getWindow().get())) {
+                    throw new IllegalArgumentException(String.format("Function call spec %s must not reference a named window.", spec));
+                }
+                return super.visitFunctionCall(node, context);
+            }
+        }.process(expression, null);
     }
 
     private static Expression parseOriginalFunctionCall(String functionCallSpec)
@@ -477,6 +527,9 @@ public class FunctionCallRewriter
         if (SUPPORTED_ORIGINAL_FUNCTIONS.stream().noneMatch(clazz -> clazz.equals(expression.getClass()))) {
             throw new IllegalArgumentException(String.format("Substituting %s in %s is not supported.", expression.getClass().getSimpleName(), functionCallSpec));
         }
+
+        // A spec is parsed on its own, so a window name in it has nothing to resolve against.
+        rejectNamedWindows(expression, functionCallSpec);
 
         if (expression instanceof FunctionCall) {
             FunctionCall functionCall = (FunctionCall) expression;
@@ -515,6 +568,9 @@ public class FunctionCallRewriter
         if (SUPPORTED_SUBSTITUTE_EXPRESSIONS.stream().noneMatch(clazz -> clazz.isAssignableFrom(expression.getClass()))) {
             throw new IllegalArgumentException(String.format("Substitution of with from %s is not supported.", expression.getClass().getSimpleName()));
         }
+
+        // A substitute is emitted verbatim, so a window name in it would be unresolved in the rewritten query.
+        rejectNamedWindows(expression, expressionSpec);
 
         return expression;
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -394,6 +394,12 @@ public class TestQueryRewriter
         assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/func1(a,b)//"));
         assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/func1(,,c1)/func2(c1)/"));
         assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/func1(c0,0.1)/row(1,true)/"));
+        // A spec is parsed on its own, so a window name in it has nothing to resolve against.
+        // Both sides are checked, and both spellings of a named window are rejected.
+        assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/rank() over w/dense_rank() over ()/"));
+        assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/rank() over ()/dense_rank() over w/"));
+        assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/rank() over (w)/dense_rank() over ()/"));
+        assertThrows(IllegalArgumentException.class, () -> validateAndConstructFunctionCallSubstituteMap("/rank() over ()/dense_rank() over (w)/"));
     }
 
     @Test
@@ -412,7 +418,8 @@ public class TestQueryRewriter
                         "/min_by(x,_)/min(x)/," +
                         "/now()/date_trunc('day',now())/," +
                         "/rand()/1/," +
-                        "/row_number() over (partition by x order by y)/row_number() over (partition by y)/");
+                        "/row_number() over (partition by x order by y)/row_number() over (partition by y)/," +
+                        "/rank() over ()/dense_rank() over ()/");
         QueryRewriter queryRewriter = getQueryRewriter(new QueryRewriteConfig(), verifierConfig);
 
         // Test rewriting nested function calls.
@@ -443,6 +450,36 @@ public class TestQueryRewriter
                         "SELECT RAND()",
                         CONFIGURATION, CONTROL).getQuery(),
                 "SELECT 1");
+
+        // A substitute whose pattern has an empty window still applies to an inline empty window.
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT RANK() OVER () FROM test_table",
+                        CONFIGURATION, CONTROL).getQuery(),
+                "SELECT DENSE_RANK() OVER () FROM test_table");
+
+        // It must not apply to a call over a named window. The referenced window carries partitioning
+        // that the pattern cannot see, so substituting would silently drop it.
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT RANK() OVER w FROM test_table WINDOW w AS (PARTITION BY a)",
+                        CONFIGURATION, CONTROL).getQuery(),
+                "SELECT RANK() OVER w FROM test_table WINDOW w AS (PARTITION BY a)");
+
+        // The parenthesised form of a named window is also left alone, since it hides the fields
+        // inherited from w just as the bare form does.
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT RANK() OVER (w ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) FROM test_table WINDOW w AS (PARTITION BY a)",
+                        CONFIGURATION, CONTROL).getQuery(),
+                "SELECT RANK() OVER (w ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) FROM test_table WINDOW w AS (PARTITION BY a)");
+
+        // A pattern that declares more window fields than the call has is a non match, not a failure.
+        assertCreateTableAs(
+                queryRewriter.rewriteQuery(
+                        "SELECT ROW_NUMBER() OVER (PARTITION BY a) FROM test_table",
+                        CONFIGURATION, CONTROL).getQuery(),
+                "SELECT ROW_NUMBER() OVER (PARTITION BY a) FROM test_table");
 
         // Test rewriting with if expression.
         assertCreateTableAs(


### PR DESCRIPTION
## Description

Follow up to #28471, addressing review comments that arrived after it merged.

**1. `Window` is now an abstract `Node` subclass rather than a marker interface.**

The interface did not extend `Node`, so four call sites needed a `(Node)` cast and `FunctionCall` needed a defensive `instanceof` check to make up for the missing type constraint. Presto's `Node` is an abstract class with a protected constructor, so `WindowSpecification` and `WindowReference` can extend a `Window` base class instead. All four casts and the `checkArgument` are gone, and the type system now enforces what the check asserted. This deviates from upstream, which uses an interface, but removes the casts a reviewer asked about.

**2. The materialized view rewrite now declines a windowed query, both a WINDOW clause and a window function.**

Only the arguments of a call are rewritten. `rebuildWithRewrittenArgs` passes `node.getWindow()` through unchanged, and a `WINDOW` clause was carried over verbatim, so window expressions kept referring to base table columns.

A window function was not caught by the existing `isScalarFunction` check, because an associative aggregate such as `SUM` never reaches it. `rewriteFunctionCall` returns early for `MIN`, `MAX`, `SUM` and `COUNT`. With an MV of `SELECT a AS mv_a, b AS mv_b FROM t1`, this query:

```sql
SELECT SUM(a) OVER (ORDER BY b) FROM t1
```

was rewritten to `SUM(mv_a) OVER (ORDER BY b) FROM view_1`, leaving `b` pointing at the base schema. That is pre-existing for inline windows. It is fixed here because it is the same defect, and leaving it would contradict the rationale for the WINDOW clause guard.

The check now lives in `MaterializedViewExpressionRewriter.rewriteFunctionCall`, so it applies on every branch and to both the single table and join paths. The `WINDOW` clause guard stays separate, since a clause no window function references has no call to catch.

This does cost some rewrite coverage. When the materialized view does not rename columns, the old rewrite happened to be valid, and I confirmed that: with an MV of `SELECT a, b FROM t1` the same query rewrote to `SUM(a) OVER (ORDER BY b) FROM view_1`, which is correct. Those queries are no longer rewritten. Declining is still the right trade, because whether the rewrite is safe depends on the column mapping, and the join path would additionally need `areColumnsCovered` to account for window expressions. Rewriting windows properly is worth doing on its own, not folded into a fix.

Four new tests, each verified to fail when its guard is removed:

- `#testWithWindowFunction`, aliased columns over `ORDER BY`, `PARTITION BY` and a frame bound
- `#testWithWindowClause`, the same three positions in a `WINDOW` clause
- `#testJoinWithWindowClause`, which without the guard produces `FROM view_1 JOIN t2 ... WINDOW w AS (PARTITION BY t1.b)`, referencing a relation no longer in the query
- `#testJoinWithWindowFunction`, the aliased column case on the join path, which without the guard produces `sum(view_1.mv_a) OVER (ORDER BY view_1.b)`. The argument is renamed but the sort key is not, so the relation is rewritten while the column is left behind

**3. Smaller items.**

- An incompatible window substitution is a non match in the verifier rather than a failure. A pattern binds window fields positionally, so it cannot match an instance with fewer of them. This is checked in `getSubstitution` alongside the existing argument shape check, which also covers the pre-existing case of a pattern declaring more window fields than the instance. A call over a named window is never matched, because the named window can carry partitioning, ordering and a frame that the pattern cannot see, so substituting could drop them. Without that, a pattern with an empty window such as `rank() OVER ()` would match `rank() OVER w` and the merge would take the substitute's empty window.
- A substitution spec that names another window is rejected at configuration time. A spec is parsed on its own, so the name has nothing to resolve against. Both sides of a spec are checked, and the check recurses, so a name nested inside a substitute such as `if(true, dense_rank() over w, 1)` is caught too. Previously only the original side was checked, which let a substitute like `/rank() over ()/dense_rank() over w/` through and would have emitted an unresolved `OVER w`.
- A named window is recognised in both spellings. `OVER w` is a `WindowReference`, but `OVER (w ...)` is a `WindowSpecification` carrying `existingWindowName`, and it hides the inherited fields just as the bare form does. Both are now treated the same in spec validation and in instance matching.
- `TreePrinter` traverses frames instead of printing `toString`, handles `WindowReference`, and has the missing `@Override`.
- `existing_window_name` is defined where the `SELECT` documentation first uses it, and the restrictions on referencing an existing window are under a `Restrictions` subheading so they can be linked to and found.

## Not changed

One review comment asked to remove an `@Immutable` annotation on `Analysis.Insert` as unrelated and new. It is neither. `master` already had it:

```
$ git show master:presto-analyzer/.../Analysis.java | grep -B2 "class Insert"
    @Immutable
    public static final class Insert
```

#28471 added exactly one `@Immutable`, on `ResolvedWindow`. What happened was the reverse: an insertion briefly landed between the annotation and `Insert` and detached it, and a later commit in that PR restored it. The net effect on `Insert` is zero.

## Test Plan

- `presto-main-base`, `TestMaterializedViewQueryOptimizer` green (205 tests) with `#testWithWindowFunction`, `#testWithWindowClause`, `#testJoinWithWindowClause` and `#testJoinWithWindowFunction`. Each was verified to fail when its guard is removed, so they pin the reported behaviour rather than just passing.
- `presto-parser` green (247 tests), covering the `Window` base class change and `TreePrinter`.
- `presto-main-base`, `TestAnalyzer` green (182 tests).
- `presto-tests`, `TestLocalQueries` green (546 tests).
- Full checkstyle build across parser, analyzer, main-base, verifier, tests and native-execution.
- The documentation change relies on CI. Sphinx is not installed in my environment, so I checked the pieces that break a build by hand: heading underline lengths, and that `Restrictions` is a unique target for the `` `Restrictions`_ `` reference.
- `presto-verifier` tests rely on CI. `TestQueryRewriter#setup` starts a local HTTP server that my sandbox blocks, and it fails the same way on unmodified master here. `#testRewriteFunctionCalls` gains cases asserting that a substitute with an empty window pattern applies to `OVER ()`, leaves `OVER w` alone, and does not match a call with fewer window fields than the pattern. `#testConstructMakeFunctionCallSubstituteMap` gains rejection cases for a named window on each side and in each spelling, and `#testRewriteFunctionCalls` gains a query using `OVER (w ROWS ...)`. I checked the validation directly outside that class, since it is a static call: each side and spelling is rejected, a name nested in an `if(...)` substitute is rejected, and the existing shipped specs including `/row_number() over (partition by x order by y)/.../` are still accepted.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.
- [x] Documented new properties (with unit tests to validate correctness).
- [x] If adding new dependencies, verified they are compatible with the project's license.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix the materialized view rewrite of a query that uses a window function or a ``WINDOW`` clause. Only the arguments of a call were rewritten, so a window could still reference base table columns that the materialized view does not expose, producing an invalid rewritten query. Such queries are no longer rewritten by a materialized view, including cases where the rewrite previously succeeded because the view did not rename any of the columns the window uses. :pr:`28473`

Verifier Changes
* Fix function call substitution silently dropping a named window. A substitution is no longer applied to a call whose window refers to a name declared in a ``WINDOW`` clause, because the substitution cannot see the partitioning, ordering or frame that name carries. :pr:`28473`
* Fix function call substitution failing when the substitute declares more window fields than the call it matched. This is now treated as a non match. :pr:`28473`
* Add validation rejecting a function call substitute whose window refers to a named window, for example ``rank() over w``. A substitute is parsed on its own, so the name has nothing to resolve against. :pr:`28473`
```
