### PR TITLE
fix(build): Copy the folly SVE patch into the dependency image

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -37,6 +37,9 @@ ENV VELOX_ARROW_CMAKE_PATCH="/velox/cmake-compatibility.patch /velox/arrow-testi
 # from https://github.com/facebookincubator/velox/pull/18470
 COPY velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /velox
 ENV VELOX_OPENZL_CMAKE_PATCH=/velox/openzl-cxx-standard.patch
+# from https://github.com/facebookincubator/velox/pull/18956
+COPY velox/CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch /velox
+ENV VELOX_FOLLY_SVE_PATCH=/velox/folly-sve-neonq-reinterpret.patch
 COPY CMake/arrow/arrow-flight.patch /scripts
 ENV EXTRA_ARROW_PATCH=/scripts/arrow-flight.patch
 RUN bash -c "mkdir build && \


### PR DESCRIPTION
## Description
Take the folly patch in velox that allows Presto C++ to compile on ARM

See https://github.com/facebookincubator/velox/pull/18956

## Motivation and Context
Building C++ Presto on ARM with GCC breaks because of this. The folly patch included in velox was submitted upstream as https://github.com/facebook/folly/pull/2698. This PR is just to enable ARM builds until the problem is fixed; drop folly-sve-neonq-reinterpret.patch and its call sites once a FB_OS_VERSION bump picks the fix up. What follows is an AI diagnosis of the problem.

## Impact
Presto C++ builds on ARM work again

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable ARM builds by packaging the Folly SVE compatibility patch with the C++ dependency image.

Bug Fixes:
- Restore ARM compatibility for Presto C++ builds by applying the required Folly SVE patch in the dependency image.

Build:
- Include the Velox Folly SVE patch in the CentOS dependency image configuration.