### PR TITLE
build(java): Reduce build time by adding maven build cache

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -10,4 +10,9 @@
         <artifactId>takari-concurrent-localrepo</artifactId>
         <version>0.0.7</version>
     </extension>
+	<extension>
+		<groupId>org.apache.maven.extensions</groupId>
+		<artifactId>maven-build-cache-extension</artifactId>
+		<version>1.3.0</version>
+	</extension>
 </extensions>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cache xmlns="http://maven.apache.org/BUILD-CACHE/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE/1.0.0 http://maven.apache.org/xsd/build-cache-1.0.0.xsd">
+	<configuration>
+		<enabled>true</enabled>
+		<hashAlgorithm>XX</hashAlgorithm>
+		<attachedOutputs>
+			<dirNames>
+				<dirName>classes</dirName>
+				<dirName>test-classes</dirName>
+				<dirName>generated-sources</dirName>
+				<dirName>generated-test-sources</dirName>
+				<dirName>maven-archiver</dirName>
+				<dirName>maven-status</dirName>
+				<dirName>site</dirName>
+				<dirName glob="checkstyle-cachefile"></dirName>
+				<dirName glob="checkstyle-checker.xml"></dirName>
+				<dirName glob="checkstyle-result.xml"></dirName>
+			</dirNames>
+		</attachedOutputs>
+	</configuration>
+	<executionControl>
+		<runAlways>
+			<plugins>
+				<!-- Forces Takari plugins to execute normally instead of failing on state restoration -->
+				<plugin groupId="io.takari.maven.plugins" artifactId="takari-lifecycle-plugin"/>
+			</plugins>
+		</runAlways>
+	</executionControl>
+</cache>


### PR DESCRIPTION
Maven build cache is an extension that allows caching non changing modules, speeding up subsequent builds. This will help reducing local build time during development for developers, especially for the ones with low-end/older machines.

 - Added maven build cache extension
 - Added build cache config

Build time comparision:
 - Hardware:  nmve, i71165G7, 16 GB@3200Mhz
 - Software: fedora workstation 44, maven 3.9.11, temurin-17-jdk
 - Build command: `mvn install/compile -DskipTests -pl '!presto-docs'`

No code changes in neither case

```
+------------+----------+---------+
| Operation  | no cache |  cache  |
+------------+----------+---------+
|  install   | 5:02 min | 26.438 s|
+------------+----------+---------+
|  compile   | 50:419 s | 17.590 s|
+------------+----------+---------+
```

When there are changes in a module, only that module is recompiled.

Issues addressed in the cache configuration:
 - `dirNames` to avoid `clean install` on cached build to remove target data
 - Added custom execution control to avoid build errors due to interference between takari build system and maven build cache

The maven build cache plugin requires maven 3.9.0, but the projects maven wrapper has been updated to 3.9.12
(https://github.com/prestodb/presto/pull/27030)

In case of issues, maven build cache can be disabled with:

`-Dmaven.build.cache.enabled=false`

This will make compilation the same as before this patch

```
== NO RELEASE NOTE ==
```

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```