### PR TITLE
fix(testing): Pull MinIO image from Quay.io after removal from minio

### DIFF
--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
@@ -30,7 +30,7 @@ public class MinIOContainer
 {
     private static final Logger log = Logger.get(MinIOContainer.class);
 
-    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+    public static final String DEFAULT_IMAGE = "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z";
     public static final String DEFAULT_HOST_NAME = "minio";
 
     public static final int MINIO_API_PORT = 4566;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
minio/minio image has been removed from dockerhub, so use quay.io image for now. 

https://github.com/prestodb/presto/actions/workflows/tests.yml
https://github.com/prestodb/presto/actions/runs/34638763193/job/103436811992
https://github.com/prestodb/presto/actions/runs/34854738843/job/104011281351

```
[ERROR] com.facebook.presto.hive.TestHiveQueriesWithCatalogName.init  Time elapsed: 2.841 s  <<< FAILURE!
org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=minio/minio:RELEASE.2025-09-07T16-13-09Z, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@2eb7ad9e)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1308)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:346)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:317)
	at com.facebook.presto.testing.containers.TestContainers.startOrReuse(TestContainers.java:41)
	at com.facebook.presto.testing.containers.BaseTestContainer.lambda$startContainer$2(BaseTestContainer.java:113)
	at net.jodah.failsafe.Functions.lambda$get$0(Functions.java:48)
	at net.jodah.failsafe.RetryPolicyExecutor.lambda$supply$0(RetryPolicyExecutor.java:66)
	at net.jodah.failsafe.Execution.executeSync(Execution.java:128)
	at net.jodah.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:379)
	at net.jodah.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:68)
	at com.facebook.presto.testing.containers.BaseTestContainer.startContainer(BaseTestContainer.java:113)
	at com.facebook.presto.testing.containers.MinIOContainer.startContainer(MinIOContainer.java:78)
	at com.facebook.presto.testing.containers.BaseTestContainer.start(BaseTestContainer.java:124)
	at com.facebook.presto.hive.containers.HiveMinIODataLake.start(HiveMinIODataLake.java:127)
	at com.facebook.presto.hive.TestHiveQueriesWithCatalogName.createQueryRunner(TestHiveQueriesWithCatalogName.java:52)
	at com.facebook.presto.tests.AbstractTestQueryFramework.init(AbstractTestQueryFramework.java:95)
	at jdk.internal.reflect.GeneratedMethodAccessor2030.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:65)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:381)
	at org.testng.internal.invokers.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:319)
	at org.testng.internal.invokers.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:178)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:122)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}

	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:241)
	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.lambda$executeAndStream$1(DefaultInvocationBuilder.java:269)
	... 1 more
```
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fix pipeline issue where we are unable to pull minio image. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
None

## Test Plan
<!---Please fill in how you tested your change-->
Run presto-hive tests in the pipeline.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Update the default MinIO test image source to Quay.io so CI can pull it reliably without Docker Hub access limitations.