### PR TITLE
Fix ClassNotFoundException for PrestoS3FileSystem when planning thread resolves Iceberg FileSystem

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -62,6 +62,13 @@ public class HiveCachingHdfsConfiguration
     public Configuration getConfiguration(HdfsContext context, URI uri)
     {
         Configuration defaultConfig = hiveHdfsConfiguration.getConfiguration(context, uri);
+        // Pin the plugin ClassLoader on the Configuration so that class resolution via
+        // conf.getClassByName() (e.g. PrestoS3FileSystem set as "fs.s3.impl") succeeds
+        // regardless of which thread calls getConfiguration(). Without this, calls from
+        // the Presto query-planning thread—whose context ClassLoader is the System
+        // ClassLoader, not the plugin ClassLoader—cause ClassNotFoundException when
+        // CachingJobConf.createFileSystem() later resolves the filesystem implementation.
+        defaultConfig.setClassLoader(getClass().getClassLoader());
         @SuppressWarnings("resource")
         Configuration config = new CachingJobConf((factoryConfig, factoryUri) -> {
             try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/cache/TestHiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/cache/TestHiveCachingHdfsConfiguration.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.cache;
+
+import com.facebook.presto.cache.CacheConfig;
+import com.facebook.presto.cache.CacheFactory;
+import com.facebook.presto.cache.NoOpCacheManager;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.conf.Configuration;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class TestHiveCachingHdfsConfiguration
+{
+    /**
+     * Regression test for ClassNotFoundException when IcebergFilterPushdown accesses Iceberg
+     * table metadata during query planning on the main Presto planning thread.
+     *
+     * The planning thread's context ClassLoader is the System ClassLoader, which does not have
+     * plugin classes such as PrestoS3FileSystem. HiveCachingHdfsConfiguration.getConfiguration()
+     * must pin the plugin ClassLoader on the returned Configuration so that
+     * conf.getClassByName("com.facebook.presto.hive.s3.PrestoS3FileSystem") — called internally
+     * by Hadoop when creating the S3 FileSystem — succeeds regardless of the calling thread.
+     */
+    @Test
+    public void testConfigurationClassLoaderPinnedToPluginClassLoader()
+            throws Exception
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HiveCachingHdfsConfiguration cachingConfig = new HiveCachingHdfsConfiguration(
+                new HiveHdfsConfiguration(
+                        new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()),
+                        ImmutableSet.of(),
+                        hiveClientConfig),
+                new CacheConfig(),
+                new NoOpCacheManager(),
+                new CacheFactory());
+
+        HdfsContext context = new HdfsContext(new ConnectorIdentity("user", Optional.empty(), Optional.empty()));
+        URI uri = URI.create("s3://bucket/path");
+
+        // Simulate the planning thread: give it a ClassLoader that cannot see any plugin classes.
+        // In production this is the JVM System ClassLoader; here we use an empty URLClassLoader
+        // with a null parent to achieve the same isolation.
+        ClassLoader planningThreadClassLoader = new URLClassLoader(new URL[0], null);
+
+        AtomicReference<Configuration> configRef = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        Thread planningThread = new Thread(() -> {
+            try {
+                configRef.set(cachingConfig.getConfiguration(context, uri));
+            }
+            catch (Throwable t) {
+                errorRef.set(t);
+            }
+        });
+        planningThread.setContextClassLoader(planningThreadClassLoader);
+        planningThread.start();
+        planningThread.join();
+
+        if (errorRef.get() != null) {
+            fail("getConfiguration() threw unexpectedly: " + errorRef.get());
+        }
+
+        Configuration conf = configRef.get();
+        assertNotNull(conf);
+
+        // The Configuration's ClassLoader must be the plugin ClassLoader (the one that loaded
+        // HiveCachingHdfsConfiguration), NOT the restricted planning-thread ClassLoader.
+        assertSame(
+                conf.getClassLoader(),
+                HiveCachingHdfsConfiguration.class.getClassLoader(),
+                "Configuration ClassLoader must be the plugin ClassLoader, not the calling thread's ClassLoader");
+
+        // Directly reproduce the production failure path: Hadoop calls conf.getClassByName()
+        // to resolve the filesystem implementation set by PrestoS3ConfigurationUpdater
+        // (config.set("fs.s3.impl", PrestoS3FileSystem.class.getName())).
+        // This must succeed even though we are on a thread with a restricted ClassLoader.
+        try {
+            conf.getClassByName("com.facebook.presto.hive.s3.PrestoS3FileSystem");
+        }
+        catch (ClassNotFoundException e) {
+            fail("conf.getClassByName(PrestoS3FileSystem) threw ClassNotFoundException; " +
+                    "the plugin ClassLoader was not pinned on the Configuration. " +
+                    "This reproduces the planning-thread bug: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Without the fix, calling getConfiguration() from a thread with a restricted ClassLoader
+     * leaves the Configuration's ClassLoader pointing at that restricted ClassLoader.
+     * This test documents and verifies the old (broken) behavior to show what the fix prevents.
+     */
+    @Test
+    public void testWithoutFixConfigurationInheritsCallingThreadClassLoader()
+            throws Exception
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HiveHdfsConfiguration innerConfig = new HiveHdfsConfiguration(
+                new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()),
+                ImmutableSet.of(),
+                hiveClientConfig);
+
+        HdfsContext context = new HdfsContext(new ConnectorIdentity("user", Optional.empty(), Optional.empty()));
+        URI uri = URI.create("s3://bucket/path");
+
+        // Without the fix, the inner Configuration's classLoader comes from the thread that
+        // calls innerConfig.getConfiguration(). We verify that here directly:
+        ClassLoader restrictedClassLoader = new URLClassLoader(new URL[0], null);
+        AtomicReference<Configuration> innerConfigRef = new AtomicReference<>();
+
+        Thread thread = new Thread(() -> innerConfigRef.set(innerConfig.getConfiguration(context, uri)));
+        thread.setContextClassLoader(restrictedClassLoader);
+        thread.start();
+        thread.join();
+
+        Configuration rawConf = innerConfigRef.get();
+        assertNotNull(rawConf);
+        // The inner Configuration inherits the restricted ClassLoader from the calling thread.
+        // This is why the fix must call defaultConfig.setClassLoader(getClass().getClassLoader())
+        // — to override this thread-inherited ClassLoader with the stable plugin ClassLoader.
+        assertSame(
+                rawConf.getClassLoader(),
+                restrictedClassLoader,
+                "Without the fix, the inner Configuration inherits the calling thread's ClassLoader");
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -83,7 +83,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_INDEX_LOOKUP_JOIN_MAX_PREFETCH_BATCHES = "native_index_lookup_join_max_prefetch_batches";
     public static final String NATIVE_INDEX_LOOKUP_JOIN_SPLIT_OUTPUT = "native_index_lookup_join_split_output";
     public static final String NATIVE_UNNEST_SPLIT_OUTPUT = "native_unnest_split_output";
-
+    public static final String NATIVE_SKIP_INTEGER_UPCASTS_FOR_HASHJOIN = "native_skip_integer_upcasts_for_hash_join";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -397,6 +397,11 @@ public class NativeWorkerSessionPropertyProvider
                                 "batch based on the output batch size control. Otherwise, it produces a single " +
                                 "output for each input batch.",
                         true,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_SKIP_INTEGER_UPCASTS_FOR_HASHJOIN,
+                        "Native Execution only. skip integer type upcasts if they are just used as join keys",
+                        false,
                         !nativeExecution));
     }
 

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -28,6 +28,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fsanitize=address -g -O0 ")
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 # Known warnings that are benign can be disabled.
 set(DISABLED_WARNINGS
@@ -120,9 +122,11 @@ if(PRESTO_ENABLE_CUDF)
   cmake_policy(SET CMP0104 NEW)
 endif()
 
+set(PRESTO_ENABLE_SPATIAL OFF)
 set(VELOX_ENABLE_GEO
     ${PRESTO_ENABLE_SPATIAL}
     CACHE BOOL "Enable Velox Geometry (aka spatial) support")
+message(STATUS "VELOX_ENABLE_GEO ${VELOX_ENABLE_GEO}")
 
 set(VELOX_BUILD_TESTING
     OFF

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -541,6 +541,14 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kUnnestSplitOutput,
       std::to_string(c.unnestSplitOutput()));
+
+  addSessionProperty(
+      kSkipIntegerUpCastsForHashJoin,
+      "kSkipIntegerUpCastsForHashJoin",
+      BOOLEAN(),
+      false,
+      QueryConfig::kSkipIntegerUpCastsForHashJoin,
+      boolToString(c.skipIntegerUpcastsForHashJoinEnabled()));
 }
 
 const std::string SessionProperties::toVeloxConfig(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -340,6 +340,9 @@ class SessionProperties {
   static constexpr const char* kUnnestSplitOutput =
       "native_unnest_split_output";
 
+  static constexpr const char* kSkipIntegerUpCastsForHashJoin =
+      "native_skip_integer_upcasts_for_hash_join";
+
   static SessionProperties* instance();
 
   SessionProperties();

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -61,6 +61,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_expression_max_array_size_in_reduce", "99999"},
           {"native_expression_max_compiled_regexes", "54321"},
           {"request_data_sizes_max_wait_sec", "20"},
+          {"native_skip_integer_upcasts_for_hash_join", "true"},
       }};
   protocol::TaskUpdateRequest updateRequest;
   updateRequest.session = session;
@@ -79,6 +80,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_EQ(queryCtx->queryConfig().exprMaxArraySizeInReduce(), 99999);
   EXPECT_EQ(queryCtx->queryConfig().exprMaxCompiledRegexes(), 54321);
   EXPECT_EQ(queryCtx->queryConfig().requestDataSizesMaxWaitSec(), 20);
+  EXPECT_TRUE(queryCtx->queryConfig().skipIntegerUpcastsForHashJoinEnabled());
 }
 
 TEST_F(QueryContextManagerTest, nativeConnectorSessionProperties) {

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -125,7 +125,9 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kIndexLookupJoinSplitOutput,
        core::QueryConfig::kIndexLookupJoinSplitOutput},
       {SessionProperties::kUnnestSplitOutput,
-       core::QueryConfig::kUnnestSplitOutput}};
+       core::QueryConfig::kUnnestSplitOutput},
+      {SessionProperties::kSkipIntegerUpCastsForHashJoin,
+       core::QueryConfig::kSkipIntegerUpCastsForHashJoin}};
 
   const auto sessionProperties = SessionProperties::instance();
   for (const auto& [sessionProperty, expectedVeloxConfig] : expectedMappings) {


### PR DESCRIPTION
Fixes #28478

## Problem

When `iceberg.pushdown-filter-enabled=true`, `IcebergFilterPushdown` reads Iceberg table manifests from S3 during **query planning**. Planning runs on the main Presto planning thread whose context ClassLoader is the **System ClassLoader** — not the plugin ClassLoader. This causes:

```
java.lang.ClassNotFoundException: Class com.facebook.presto.hive.s3.PrestoS3FileSystem not found
```

The failure path:

1. `IcebergFilterPushdown.getConnectorPushdownFilterResult()` calls `IcebergUtil.getPartitionKeyColumnHandles()`, which calls `table.snapshot(id).allManifests(table.io())` to read manifest files from S3.
2. Creating the S3 FileSystem requires resolving `PrestoS3FileSystem` by class name via `conf.getClassByName()`.
3. `HiveHdfsConfiguration` creates a `Configuration` whose `classLoader` field is inherited from the calling thread's context ClassLoader — the **System ClassLoader** on the planning thread.
4. `HiveCachingHdfsConfiguration` wraps this `Configuration` in a `CachingJobConf`. `PrestoFileSystemCache` detects `CachingJobConf instanceof FileSystemFactory` and calls `createFileSystem()` directly (bypassing the FileSystem cache), which invokes `conf.getClassByName("PrestoS3FileSystem")` using the System ClassLoader — which cannot see plugin classes.

This exclusively affects tables that have **never been successfully queried before** (e.g. newly registered via `system.register_table`) because previously queried tables may have a cached `Table` object whose `io()` was set up by an executor thread with the correct plugin ClassLoader.

## Fix

Pin the plugin ClassLoader on the `Configuration` in `HiveCachingHdfsConfiguration.getConfiguration()`:

```java
Configuration defaultConfig = hiveHdfsConfiguration.getConfiguration(context, uri);
defaultConfig.setClassLoader(getClass().getClassLoader());  // ← one line fix
```

`getClass().getClassLoader()` returns the ClassLoader that loaded `HiveCachingHdfsConfiguration` — the plugin ClassLoader — which is stable and always has visibility into `PrestoS3FileSystem` and other plugin classes. This overrides the thread-inherited ClassLoader, making class resolution correct regardless of the calling thread.

## Tests

`TestHiveCachingHdfsConfiguration` (new):

- **`testConfigurationClassLoaderPinnedToPluginClassLoader`**: Creates a thread with an empty `URLClassLoader(new URL[0], null)` as its context ClassLoader (simulating the planning thread with no plugin class visibility), calls `getConfiguration()` from that thread, and verifies:
  - The returned `Configuration`'s `getClassLoader()` is the plugin ClassLoader, not the restricted one.
  - `conf.getClassByName("com.facebook.presto.hive.s3.PrestoS3FileSystem")` succeeds — exactly the call that fails in production without the fix.

- **`testWithoutFixConfigurationInheritsCallingThreadClassLoader`**: Documents the root cause by showing that the inner `HiveHdfsConfiguration` inherits the calling thread's ClassLoader without the fix applied at the `HiveCachingHdfsConfiguration` layer.

## Summary by Sourcery

Fix planning-time plugin class loading for Hive filesystem access and expose native hash join integer-upcast control.

New Features:
- Add a native execution session property to optionally skip integer upcasts used only as hash join keys.

Bug Fixes:
- Prevent planning-time S3 filesystem class resolution failures by ensuring Hive configurations can load plugin filesystem classes regardless of the calling thread.

Build:
- Disable native spatial support by default and report the resulting geometry configuration during native build configuration.

Tests:
- Add regression coverage for plugin ClassLoader pinning and native session-property propagation.